### PR TITLE
feat(logmanager): optional S3 replication for session event logs (Phase 2)

### DIFF
--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -213,6 +213,20 @@ class SettingsConfig:
 
 
 @dataclass
+class EventLogReplicationConfig:
+    """Configuration for optional S3-compatible event log replication."""
+
+    enabled: bool = False
+    backend: str = "s3"
+    bucket: str = ""
+    prefix: str = "events/"
+    endpoint_url: str = ""
+    region: str = ""
+    upload_debounce_ms: int = 500
+    max_retries: int = 3
+
+
+@dataclass
 class UserConfig:
     """User-level configuration, such as user-specific prompts and environment variables."""
 
@@ -240,6 +254,11 @@ class UserConfig:
     # Plugin-specific configuration namespace (user-level)
     # Allows plugins to have their own config sections like [plugin.retrieval]
     plugin: dict[str, dict] = field(default_factory=dict)
+
+    # Optional S3-compatible replication of session event logs.
+    session_event_log_replication: EventLogReplicationConfig = field(
+        default_factory=EventLogReplicationConfig
+    )
 
 
 @dataclass

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 from ..util import path_with_tilde
 from .models import (
+    EventLogReplicationConfig,
     HooksConfig,
     LessonsConfig,
     MCPConfig,
@@ -339,6 +340,20 @@ def load_user_config(path: str | None = None) -> UserConfig:
         if isinstance(plugin_data, dict):
             plugin_config = plugin_data
 
+    # Parse [session_event_log_replication] section
+    replication_data = config.pop("session_event_log_replication", {})
+    if not isinstance(replication_data, dict):
+        logger.warning(
+            "[session_event_log_replication] should be a table, "
+            f"got {type(replication_data).__name__}"
+        )
+        replication_data = {}
+    replication_config = EventLogReplicationConfig(
+        **_filter_known_fields(
+            EventLogReplicationConfig, replication_data, "session_event_log_replication"
+        )
+    )
+
     if config:
         unknown = set(config.keys())
         strip_targets = str(path_with_tilde(config_file))
@@ -364,6 +379,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
         settings=settings,
         hooks=hooks,
         plugin=plugin_config,
+        session_event_log_replication=replication_config,
     )
 
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -369,11 +369,15 @@ class LogManager:
         """Write an event to the event log and optionally a checkpoint.
 
         Writes a ``message_append``, ``message_edit``, or ``undo`` event
-        followed by a checkpoint if one is due.  Writes alongside the main
-        conversation JSONL (``get_logs_dir() / chat_id / events.jsonl``).
+        followed by a checkpoint if one is due. Main events live beside
+        ``conversation.jsonl``; branch events live under
+        ``branches/<branch>/events.jsonl`` so branch histories stay isolated.
         Silent-noop when the log directory is not set up yet.
         """
-        event_dir = self.logfile.parent
+        if self.current_branch == "main":
+            event_dir = self.logdir
+        else:
+            event_dir = self.logdir / "branches" / self.current_branch
         event_dir.mkdir(parents=True, exist_ok=True)
         seq = eventlog.sequence_number(event_dir)
         if event_type == eventlog.EVENT_MESSAGE_APPEND:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -430,8 +430,12 @@ class LogManager:
                 endpoint_url=cfg.endpoint_url or None,
                 region=cfg.region or None,
             )
-            worker = replication.get_worker(backend, debounce_ms=cfg.upload_debounce_ms)
-            worker.enqueue(event_dir, self.chat_id)
+            worker = replication.get_worker(
+                backend,
+                debounce_ms=cfg.upload_debounce_ms,
+                max_retries=cfg.max_retries,
+            )
+            worker.enqueue(event_dir, self.chat_id, self.current_branch)
         except Exception:
             logger.debug("Failed to initialise replication worker", exc_info=True)
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -400,6 +400,41 @@ class LogManager:
                 [m.to_dict() for m in self.log.messages],
             )
 
+        # Enqueue remote replication (best-effort, off by default)
+        self._enqueue_replication(event_dir)
+
+    def _enqueue_replication(self, event_dir: Path) -> None:
+        """Enqueue *event_dir* for best-effort remote replication if configured."""
+        from ..config import get_config
+        from . import replication
+
+        cfg = get_config().user.session_event_log_replication
+        if not cfg.enabled:
+            return
+        if cfg.backend != "s3":
+            logger.warning(
+                "Unsupported replication backend %r (only 's3' is supported)",
+                cfg.backend,
+            )
+            return
+        if not cfg.bucket:
+            logger.warning(
+                "session_event_log_replication.bucket is not set; skipping replication"
+            )
+            return
+
+        try:
+            backend = replication.S3Backend(
+                bucket=cfg.bucket,
+                prefix=cfg.prefix,
+                endpoint_url=cfg.endpoint_url or None,
+                region=cfg.region or None,
+            )
+            worker = replication.get_worker(backend, debounce_ms=cfg.upload_debounce_ms)
+            worker.enqueue(event_dir, self.chat_id)
+        except Exception:
+            logger.debug("Failed to initialise replication worker", exc_info=True)
+
     def append(self, msg: Message) -> None:
         """Appends a message to the log, writes the log, prints the message.
 

--- a/gptme/logmanager/replication.py
+++ b/gptme/logmanager/replication.py
@@ -1,0 +1,334 @@
+"""Optional S3-compatible replication for session event logs.
+
+Phase 2 of the session event log durability feature.  Off by default;
+configure via ``[session_event_log_replication]`` in ``config.toml``.
+
+Architecture:
+
+- ``ReplicationBackend`` — protocol (interface) any backend must satisfy.
+- ``FakeBackend`` — in-process fake for tests.
+- ``S3Backend`` — uploads to an S3-compatible store via lazy ``boto3`` import.
+- ``ReplicationWorker`` — process-local background thread; debounces writes
+  and retries on transient failure.  Wired into ``LogManager._write_event_log``
+  when replication is enabled.
+
+Remote recovery:
+
+- ``recover_from_remote(conv_id, backend, logdir_fn)`` downloads the remote
+  ``events.jsonl`` into a temp dir and delegates to
+  ``eventlog.recover_messages()`` for message reconstruction.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# ── backend protocol ─────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class ReplicationBackend(Protocol):
+    """Interface a replication backend must satisfy."""
+
+    def upload(self, key: str, local_path: Path) -> None:
+        """Upload *local_path* under *key* in the remote store.
+
+        Must be idempotent (a retry replaces the same object).
+        Raise on non-transient error; the caller handles retries.
+        """
+        ...
+
+    def download(self, key: str, dest: Path) -> bool:
+        """Download the object at *key* to *dest*.
+
+        Returns ``True`` on success, ``False`` if the object does not exist.
+        Raises on non-transient errors.
+        """
+        ...
+
+
+# ── fake backend (for tests) ─────────────────────────────────────────────────
+
+
+class FakeBackend:
+    """In-process fake backend for unit tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+        self.upload_calls: list[tuple[str, Path]] = []
+        self.download_calls: list[tuple[str, Path]] = []
+        self.fail_upload: bool = False
+
+    def upload(self, key: str, local_path: Path) -> None:
+        self.upload_calls.append((key, local_path))
+        if self.fail_upload:
+            raise OSError("simulated upload failure")
+        self._store[key] = local_path.read_bytes()
+
+    def download(self, key: str, dest: Path) -> bool:
+        self.download_calls.append((key, dest))
+        if key not in self._store:
+            return False
+        dest.write_bytes(self._store[key])
+        return True
+
+
+# ── S3 backend ───────────────────────────────────────────────────────────────
+
+
+class S3Backend:
+    """S3-compatible backend using a lazy ``boto3`` import.
+
+    Credential resolution follows the standard AWS provider chain:
+    environment variables, shared credentials file, instance metadata, etc.
+    Do not store credentials in gptme config.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "events/",
+        endpoint_url: str | None = None,
+        region: str | None = None,
+    ) -> None:
+        self._bucket = bucket
+        self._prefix = prefix.rstrip("/")
+        self._endpoint_url = endpoint_url
+        self._region = region
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import boto3
+            except ImportError as exc:
+                raise ImportError(
+                    "boto3 is required for S3 replication. "
+                    "Install it with: pip install boto3"
+                ) from exc
+            kwargs: dict[str, Any] = {}
+            if self._endpoint_url:
+                kwargs["endpoint_url"] = self._endpoint_url
+            if self._region:
+                kwargs["region_name"] = self._region
+            self._client = boto3.client("s3", **kwargs)
+        return self._client
+
+    def _object_key(self, key: str) -> str:
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def upload(self, key: str, local_path: Path) -> None:
+        client = self._get_client()
+        object_key = self._object_key(key)
+        logger.debug("Uploading event log to s3://%s/%s", self._bucket, object_key)
+        client.upload_file(str(local_path), self._bucket, object_key)
+
+    def download(self, key: str, dest: Path) -> bool:
+        client = self._get_client()
+        object_key = self._object_key(key)
+        try:
+            client.download_file(self._bucket, object_key, str(dest))
+            return True
+        except client.exceptions.ClientError as exc:
+            error_code = exc.response["Error"]["Code"]
+            if error_code in ("404", "NoSuchKey"):
+                return False
+            raise
+
+
+# ── object key helpers ────────────────────────────────────────────────────────
+
+
+def _event_log_key(conversation_id: str) -> str:
+    """Remote object key for a conversation's event log."""
+    return f"{conversation_id}/events.jsonl"
+
+
+# ── background replication worker ─────────────────────────────────────────────
+
+
+class ReplicationWorker:
+    """Process-local background worker for best-effort event log replication.
+
+    Debounces repeated writes for the same logdir, then uploads the full
+    ``events.jsonl`` file.  Upload failures log a warning and retry with
+    capped exponential backoff.
+
+    The worker does **not** block the main session write path.
+    """
+
+    _DEFAULT_DEBOUNCE_S: float = 0.5  # seconds
+    _MAX_RETRIES: int = 3
+    _DEFAULT_RETRY_BACKOFF: float = 2.0  # seconds (doubles each retry)
+
+    def __init__(
+        self,
+        backend: ReplicationBackend,
+        debounce_s: float = _DEFAULT_DEBOUNCE_S,
+        max_retries: int = _MAX_RETRIES,
+        retry_backoff: float = _DEFAULT_RETRY_BACKOFF,
+    ) -> None:
+        self._backend = backend
+        self._debounce_s = debounce_s
+        self._max_retries = max_retries
+        self._retry_backoff = retry_backoff
+
+        self._pending: dict[str, Path] = {}  # logdir_key → logdir Path
+        self._lock = threading.Lock()
+        self._event = threading.Event()
+        self._stopped = False
+
+        self._thread = threading.Thread(
+            target=self._run,
+            name="gptme-replication-worker",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def enqueue(self, logdir: Path, conversation_id: str) -> None:
+        """Schedule *logdir* for replication.  Repeated calls are debounced."""
+        key = conversation_id
+        with self._lock:
+            self._pending[key] = logdir
+        self._event.set()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Request shutdown and wait for the worker thread to exit."""
+        self._stopped = True
+        self._event.set()
+        self._thread.join(timeout=timeout)
+
+    def _run(self) -> None:
+        while True:
+            self._event.wait()
+            self._event.clear()
+            # Debounce: sleep only when not stopping so we still flush on exit
+            if not self._stopped:
+                time.sleep(self._debounce_s)
+            self._flush()
+            if self._stopped:
+                break
+
+    def _flush(self) -> None:
+        with self._lock:
+            pending = dict(self._pending)
+            self._pending.clear()
+
+        for conv_id, logdir in pending.items():
+            self._upload_with_retry(conv_id, logdir)
+
+    def _upload_with_retry(self, conversation_id: str, logdir: Path) -> None:
+        from . import eventlog
+
+        local_path = logdir / eventlog.EVENT_LOG_NAME
+        if not local_path.exists():
+            return
+
+        key = _event_log_key(conversation_id)
+        delay = self._retry_backoff
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                self._backend.upload(key, local_path)
+                logger.debug(
+                    "Replicated event log for %s (attempt %d)", conversation_id, attempt
+                )
+                return
+            except Exception as exc:
+                if attempt == self._max_retries:
+                    logger.warning(
+                        "Event log replication failed for %s after %d attempts: %s",
+                        conversation_id,
+                        self._max_retries,
+                        exc,
+                    )
+                    return
+                logger.debug(
+                    "Replication attempt %d for %s failed (%s); retrying in %.1fs",
+                    attempt,
+                    conversation_id,
+                    exc,
+                    delay,
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, 30.0)
+
+
+# ── process-level singleton ───────────────────────────────────────────────────
+
+_worker: ReplicationWorker | None = None
+_worker_lock = threading.Lock()
+
+
+def get_worker(
+    backend: ReplicationBackend, debounce_ms: int = 500
+) -> ReplicationWorker:
+    """Return the process-level ReplicationWorker, creating it on first call."""
+    global _worker
+    with _worker_lock:
+        if _worker is None:
+            _worker = ReplicationWorker(backend, debounce_s=debounce_ms / 1000.0)
+    return _worker
+
+
+def reset_worker() -> None:
+    """Stop and discard the process-level worker.  Used in tests only."""
+    global _worker
+    with _worker_lock:
+        if _worker is not None:
+            _worker.stop()
+            _worker = None
+
+
+# ── remote recovery ───────────────────────────────────────────────────────────
+
+
+def recover_from_remote(
+    conversation_id: str,
+    backend: ReplicationBackend,
+) -> list[dict[str, Any]] | None:
+    """Attempt to recover messages from the remote event log replica.
+
+    Downloads the remote ``events.jsonl`` into a temp directory, then calls
+    ``eventlog.recover_messages()`` to reconstruct the message list.
+
+    Returns the recovered message dicts, or ``None`` if the remote object does
+    not exist or recovery finds no events.
+    """
+    from . import eventlog
+
+    key = _event_log_key(conversation_id)
+    with tempfile.TemporaryDirectory(prefix="gptme-recovery-") as tmp:
+        tmp_path = Path(tmp)
+        dest = tmp_path / eventlog.EVENT_LOG_NAME
+        try:
+            found = backend.download(key, dest)
+        except Exception as exc:
+            logger.warning(
+                "Remote recovery download failed for %s: %s", conversation_id, exc
+            )
+            return None
+
+        if not found:
+            logger.debug("No remote event log found for %s", conversation_id)
+            return None
+
+        messages = eventlog.recover_messages(tmp_path)
+        if messages is None:
+            logger.warning(
+                "Remote event log for %s contained no events", conversation_id
+            )
+            return None
+
+        logger.info(
+            "Remote recovery: reconstructed %d messages for %s",
+            len(messages),
+            conversation_id,
+        )
+        return messages

--- a/gptme/logmanager/replication.py
+++ b/gptme/logmanager/replication.py
@@ -21,10 +21,13 @@ Remote recovery:
 
 from __future__ import annotations
 
+import atexit
+import importlib
 import logging
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -104,10 +107,25 @@ class S3Backend:
         self._region = region
         self._client: Any = None
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, S3Backend):
+            return NotImplemented
+        return (
+            self._bucket,
+            self._prefix,
+            self._endpoint_url,
+            self._region,
+        ) == (
+            other._bucket,
+            other._prefix,
+            other._endpoint_url,
+            other._region,
+        )
+
     def _get_client(self) -> Any:
         if self._client is None:
             try:
-                import boto3
+                boto3 = importlib.import_module("boto3")
             except ImportError as exc:
                 raise ImportError(
                     "boto3 is required for S3 replication. "
@@ -146,9 +164,11 @@ class S3Backend:
 # ── object key helpers ────────────────────────────────────────────────────────
 
 
-def _event_log_key(conversation_id: str) -> str:
-    """Remote object key for a conversation's event log."""
-    return f"{conversation_id}/events.jsonl"
+def _event_log_key(conversation_id: str, branch: str = "main") -> str:
+    """Remote object key for a conversation branch's event log."""
+    if branch == "main":
+        return f"{conversation_id}/events.jsonl"
+    return f"{conversation_id}/branches/{branch}/events.jsonl"
 
 
 # ── background replication worker ─────────────────────────────────────────────
@@ -180,7 +200,7 @@ class ReplicationWorker:
         self._max_retries = max_retries
         self._retry_backoff = retry_backoff
 
-        self._pending: dict[str, Path] = {}  # logdir_key → logdir Path
+        self._pending: dict[str, tuple[Path, str]] = {}
         self._lock = threading.Lock()
         self._event = threading.Event()
         self._stopped = False
@@ -192,18 +212,23 @@ class ReplicationWorker:
         )
         self._thread.start()
 
-    def enqueue(self, logdir: Path, conversation_id: str) -> None:
-        """Schedule *logdir* for replication.  Repeated calls are debounced."""
-        key = conversation_id
+    def enqueue(self, logdir: Path, conversation_id: str, branch: str = "main") -> None:
+        """Schedule one conversation branch for replication.
+
+        Repeated calls for the same conversation and branch are debounced.
+        """
+        key = _event_log_key(conversation_id, branch)
         with self._lock:
-            self._pending[key] = logdir
+            self._pending[key] = (logdir, key)
         self._event.set()
 
-    def stop(self, timeout: float = 5.0) -> None:
-        """Request shutdown and wait for the worker thread to exit."""
+    def stop(self, timeout: float | None = None) -> None:
+        """Request shutdown, flush pending uploads, and wait for exit."""
         self._stopped = True
         self._event.set()
         self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            logger.warning("Replication worker did not stop within the timeout")
 
     def _run(self) -> None:
         while True:
@@ -221,30 +246,27 @@ class ReplicationWorker:
             pending = dict(self._pending)
             self._pending.clear()
 
-        for conv_id, logdir in pending.items():
-            self._upload_with_retry(conv_id, logdir)
+        for logdir, key in pending.values():
+            self._upload_with_retry(key, logdir)
 
-    def _upload_with_retry(self, conversation_id: str, logdir: Path) -> None:
+    def _upload_with_retry(self, key: str, logdir: Path) -> None:
         from . import eventlog
 
         local_path = logdir / eventlog.EVENT_LOG_NAME
         if not local_path.exists():
             return
 
-        key = _event_log_key(conversation_id)
         delay = self._retry_backoff
         for attempt in range(1, self._max_retries + 1):
             try:
                 self._backend.upload(key, local_path)
-                logger.debug(
-                    "Replicated event log for %s (attempt %d)", conversation_id, attempt
-                )
+                logger.debug("Replicated event log %s (attempt %d)", key, attempt)
                 return
             except Exception as exc:
                 if attempt == self._max_retries:
                     logger.warning(
                         "Event log replication failed for %s after %d attempts: %s",
-                        conversation_id,
+                        key,
                         self._max_retries,
                         exc,
                     )
@@ -252,7 +274,7 @@ class ReplicationWorker:
                 logger.debug(
                     "Replication attempt %d for %s failed (%s); retrying in %.1fs",
                     attempt,
-                    conversation_id,
+                    key,
                     exc,
                     delay,
                 )
@@ -262,28 +284,57 @@ class ReplicationWorker:
 
 # ── process-level singleton ───────────────────────────────────────────────────
 
-_worker: ReplicationWorker | None = None
+
+@dataclass(frozen=True)
+class WorkerConfig:
+    """Settings that define one process-local replication destination."""
+
+    backend: ReplicationBackend
+    debounce_ms: int
+    max_retries: int
+
+
+_workers: list[tuple[WorkerConfig, ReplicationWorker]] = []
 _worker_lock = threading.Lock()
+_atexit_registered = False
 
 
 def get_worker(
-    backend: ReplicationBackend, debounce_ms: int = 500
+    backend: ReplicationBackend,
+    debounce_ms: int = 500,
+    max_retries: int = ReplicationWorker._MAX_RETRIES,
 ) -> ReplicationWorker:
-    """Return the process-level ReplicationWorker, creating it on first call."""
-    global _worker
+    """Return a worker matching the current replication configuration.
+
+    A process can host context-local sessions with different destinations, so
+    each distinct configuration gets its own worker. Equivalent S3 settings
+    reuse a worker and preserve debounce behavior.
+    """
+    global _atexit_registered
+    config = WorkerConfig(backend, debounce_ms, max_retries)
     with _worker_lock:
-        if _worker is None:
-            _worker = ReplicationWorker(backend, debounce_s=debounce_ms / 1000.0)
-    return _worker
+        for existing_config, worker in _workers:
+            if existing_config == config:
+                return worker
+        worker = ReplicationWorker(
+            backend,
+            debounce_s=debounce_ms / 1000.0,
+            max_retries=max_retries,
+        )
+        _workers.append((config, worker))
+        if not _atexit_registered:
+            atexit.register(reset_worker)
+            _atexit_registered = True
+        return worker
 
 
 def reset_worker() -> None:
-    """Stop and discard the process-level worker.  Used in tests only."""
-    global _worker
+    """Stop, flush, and discard the process-level worker."""
     with _worker_lock:
-        if _worker is not None:
-            _worker.stop()
-            _worker = None
+        workers = [worker for _, worker in _workers]
+        _workers.clear()
+    for worker in workers:
+        worker.stop()
 
 
 # ── remote recovery ───────────────────────────────────────────────────────────
@@ -292,6 +343,7 @@ def reset_worker() -> None:
 def recover_from_remote(
     conversation_id: str,
     backend: ReplicationBackend,
+    branch: str = "main",
 ) -> list[dict[str, Any]] | None:
     """Attempt to recover messages from the remote event log replica.
 
@@ -303,7 +355,7 @@ def recover_from_remote(
     """
     from . import eventlog
 
-    key = _event_log_key(conversation_id)
+    key = _event_log_key(conversation_id, branch)
     with tempfile.TemporaryDirectory(prefix="gptme-recovery-") as tmp:
         tmp_path = Path(tmp)
         dest = tmp_path / eventlog.EVENT_LOG_NAME

--- a/gptme/logmanager/replication.py
+++ b/gptme/logmanager/replication.py
@@ -26,7 +26,6 @@ import importlib
 import logging
 import tempfile
 import threading
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -203,7 +202,7 @@ class ReplicationWorker:
         self._pending: dict[str, tuple[Path, str]] = {}
         self._lock = threading.Lock()
         self._event = threading.Event()
-        self._stopped = False
+        self._stop_event = threading.Event()
 
         self._thread = threading.Thread(
             target=self._run,
@@ -224,7 +223,7 @@ class ReplicationWorker:
 
     def stop(self, timeout: float | None = None) -> None:
         """Request shutdown, flush pending uploads, and wait for exit."""
-        self._stopped = True
+        self._stop_event.set()
         self._event.set()
         self._thread.join(timeout=timeout)
         if self._thread.is_alive():
@@ -234,11 +233,11 @@ class ReplicationWorker:
         while True:
             self._event.wait()
             self._event.clear()
-            # Debounce: sleep only when not stopping so we still flush on exit
-            if not self._stopped:
-                time.sleep(self._debounce_s)
+            # An interruptible debounce lets shutdown flush without waiting.
+            if not self._stop_event.is_set():
+                self._stop_event.wait(self._debounce_s)
             self._flush()
-            if self._stopped:
+            if self._stop_event.is_set():
                 break
 
     def _flush(self) -> None:
@@ -278,7 +277,12 @@ class ReplicationWorker:
                     exc,
                     delay,
                 )
-                time.sleep(delay)
+                if self._stop_event.wait(delay):
+                    logger.warning(
+                        "Event log replication for %s aborted during shutdown",
+                        key,
+                    )
+                    return
                 delay = min(delay * 2, 30.0)
 
 

--- a/gptme/logmanager/replication.py
+++ b/gptme/logmanager/replication.py
@@ -236,19 +236,22 @@ class ReplicationWorker:
             # An interruptible debounce lets shutdown flush without waiting.
             if not self._stop_event.is_set():
                 self._stop_event.wait(self._debounce_s)
-            self._flush()
-            if self._stop_event.is_set():
+            stopping = self._stop_event.is_set()
+            self._flush(stopping=stopping)
+            if stopping:
                 break
 
-    def _flush(self) -> None:
+    def _flush(self, *, stopping: bool = False) -> None:
         with self._lock:
             pending = dict(self._pending)
             self._pending.clear()
 
         for logdir, key in pending.values():
-            self._upload_with_retry(key, logdir)
+            self._upload_with_retry(key, logdir, stopping=stopping)
 
-    def _upload_with_retry(self, key: str, logdir: Path) -> None:
+    def _upload_with_retry(
+        self, key: str, logdir: Path, *, stopping: bool = False
+    ) -> None:
         from . import eventlog
 
         local_path = logdir / eventlog.EVENT_LOG_NAME
@@ -277,12 +280,12 @@ class ReplicationWorker:
                     exc,
                     delay,
                 )
+                if stopping:
+                    # Preserve the configured attempt budget at exit, but skip
+                    # backoff so shutdown is bounded by upload calls, not sleeps.
+                    continue
                 if self._stop_event.wait(delay):
-                    logger.warning(
-                        "Event log replication for %s aborted during shutdown",
-                        key,
-                    )
-                    return
+                    stopping = True
                 delay = min(delay * 2, 30.0)
 
 

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -22,6 +22,7 @@ from gptme.logmanager.replication import (
     recover_from_remote,
     reset_worker,
 )
+from gptme.message import Message
 
 if TYPE_CHECKING:
     pass
@@ -276,7 +277,7 @@ def test_get_worker_isolates_backend_and_retry_config(logdir: Path):
 def test_logmanager_forwards_branch_and_retry_config(
     logdir: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """LogManager forwards branch isolation and configured retry count."""
+    """LogManager forwards the production branch event source and config."""
     config = Config(
         user=UserConfig(
             session_event_log_replication=EventLogReplicationConfig(
@@ -289,11 +290,11 @@ def test_logmanager_forwards_branch_and_retry_config(
         )
     )
     token = _config_var.set(config)
-    calls: list[tuple[int, int, str]] = []
+    calls: list[tuple[Path, int, int, str]] = []
 
     class StubWorker:
         def enqueue(self, event_dir: Path, chat_id: str, branch: str) -> None:
-            calls.append((25, 7, branch))
+            calls.append((event_dir, 25, 7, branch))
 
     def stub_get_worker(backend, debounce_ms: int, max_retries: int):
         assert debounce_ms == 25
@@ -303,11 +304,36 @@ def test_logmanager_forwards_branch_and_retry_config(
     monkeypatch.setattr("gptme.logmanager.replication.get_worker", stub_get_worker)
     try:
         manager = LogManager(logdir=logdir, branch="experiment", lock=False)
-        manager._enqueue_replication(logdir)
+        manager.append(Message(role="user", content="branch message"))
     finally:
         _config_var.reset(token)
 
-    assert calls == [(25, 7, "experiment")]
+    branch_event_dir = logdir / "branches" / "experiment"
+    assert calls == [(branch_event_dir, 25, 7, "experiment")]
+    assert (branch_event_dir / eventlog.EVENT_LOG_NAME).exists()
+    assert not (logdir / "branches" / eventlog.EVENT_LOG_NAME).exists()
+
+
+def test_logmanager_keeps_non_main_branch_event_histories_separate(
+    logdir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Production writes never mix two non-main branch event streams."""
+    config = Config(user=UserConfig())
+    token = _config_var.set(config)
+    try:
+        manager = LogManager(logdir=logdir, branch="alpha", lock=False)
+        manager.append(Message(role="user", content="alpha message"))
+        manager.branch("beta")
+        manager.append(Message(role="user", content="beta message"))
+    finally:
+        _config_var.reset(token)
+
+    alpha = eventlog.recover_messages(logdir / "branches" / "alpha")
+    beta = eventlog.recover_messages(logdir / "branches" / "beta")
+    assert alpha is not None
+    assert beta is not None
+    assert [message["content"] for message in alpha] == ["alpha message"]
+    assert [message["content"] for message in beta] == ["beta message"]
 
 
 # ── recover_from_remote ───────────────────────────────────────────────────────

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 from gptme.config.core import Config, _config_var
@@ -103,6 +105,16 @@ def _write_event_log(logdir: Path, n: int = 1) -> None:
         )
 
 
+def _wait_until(predicate: Callable[[], bool], timeout: float = 1.0) -> bool:
+    """Wait for a worker-thread condition without a fixed test sleep."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.001)
+    return predicate()
+
+
 def test_worker_enqueues_upload(logdir: Path, fake_backend: FakeBackend):
     """Enqueuing a logdir leads to one upload call after debounce."""
     _write_event_log(logdir)
@@ -165,6 +177,7 @@ def test_worker_retries_on_transient_failure(logdir: Path):
         backend, debounce_s=0.01, max_retries=3, retry_backoff=0.01
     )
     worker.enqueue(logdir, "conv-abc123")
+    assert _wait_until(lambda: call_count == 3)
     worker.stop(timeout=5.0)
     assert call_count == 3
     assert "conv-abc123/events.jsonl" in backend._store
@@ -183,10 +196,30 @@ def test_worker_gives_up_after_max_retries(logdir: Path, caplog):
     )
     with caplog.at_level(logging.WARNING, logger="gptme.logmanager.replication"):
         worker.enqueue(logdir, "conv-abc123")
+        assert _wait_until(lambda: len(backend.upload_calls) == 2)
         worker.stop(timeout=5.0)
 
     assert any("after 2 attempts" in r.message for r in caplog.records)
     assert len(backend.upload_calls) == 2  # tried max_retries times
+
+
+def test_worker_stop_interrupts_retry_backoff(logdir: Path):
+    """Shutdown does not wait through the configured retry schedule."""
+    backend = FakeBackend()
+    backend.fail_upload = True
+    _write_event_log(logdir)
+    worker = ReplicationWorker(
+        backend, debounce_s=0.01, max_retries=7, retry_backoff=30.0
+    )
+    worker.enqueue(logdir, "conv-abc123")
+    assert _wait_until(lambda: len(backend.upload_calls) == 1)
+
+    started = time.monotonic()
+    worker.stop(timeout=1.0)
+
+    assert time.monotonic() - started < 1.0
+    assert not worker._thread.is_alive()
+    assert len(backend.upload_calls) == 1
 
 
 def test_worker_noop_when_log_missing(logdir: Path, fake_backend: FakeBackend):

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -204,7 +204,7 @@ def test_worker_gives_up_after_max_retries(logdir: Path, caplog):
 
 
 def test_worker_stop_interrupts_retry_backoff(logdir: Path):
-    """Shutdown does not wait through the configured retry schedule."""
+    """Shutdown preserves retry attempts without waiting through backoff."""
     backend = FakeBackend()
     backend.fail_upload = True
     _write_event_log(logdir)
@@ -219,7 +219,31 @@ def test_worker_stop_interrupts_retry_backoff(logdir: Path):
 
     assert time.monotonic() - started < 1.0
     assert not worker._thread.is_alive()
-    assert len(backend.upload_calls) == 1
+    assert len(backend.upload_calls) == 7
+
+
+def test_worker_shutdown_retries_transient_final_upload(logdir: Path):
+    """A transient final-upload failure retains its configured retry budget."""
+    backend = FakeBackend()
+    _write_event_log(logdir)
+    call_count = 0
+
+    def flaky_upload(key: str, local_path: Path) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("transient")
+        backend._store[key] = local_path.read_bytes()
+
+    backend.upload = flaky_upload  # type: ignore
+    worker = ReplicationWorker(
+        backend, debounce_s=30.0, max_retries=3, retry_backoff=30.0
+    )
+    worker.enqueue(logdir, "conv-abc123")
+    worker.stop(timeout=1.0)
+
+    assert call_count == 2
+    assert "conv-abc123/events.jsonl" in backend._store
 
 
 def test_worker_noop_when_log_missing(logdir: Path, fake_backend: FakeBackend):

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -1,0 +1,252 @@
+"""Tests for gptme/logmanager/replication.py"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.logmanager import eventlog
+from gptme.logmanager.replication import (
+    FakeBackend,
+    ReplicationWorker,
+    _event_log_key,
+    recover_from_remote,
+    reset_worker,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_worker():
+    """Ensure no process-level worker leaks between tests."""
+    reset_worker()
+    yield
+    reset_worker()
+
+
+@pytest.fixture
+def logdir(tmp_path: Path) -> Path:
+    d = tmp_path / "conv-abc123"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def fake_backend() -> FakeBackend:
+    return FakeBackend()
+
+
+# ── object key helpers ────────────────────────────────────────────────────────
+
+
+def test_event_log_key():
+    assert _event_log_key("conv-abc") == "conv-abc/events.jsonl"
+
+
+# ── FakeBackend ───────────────────────────────────────────────────────────────
+
+
+def test_fake_backend_round_trip(tmp_path: Path):
+    """FakeBackend upload then download recovers the same bytes."""
+    backend = FakeBackend()
+    src = tmp_path / "events.jsonl"
+    src.write_text('{"seq":1}\n')
+
+    backend.upload("my/key", src)
+    assert len(backend.upload_calls) == 1
+
+    dest = tmp_path / "recovered.jsonl"
+    found = backend.download("my/key", dest)
+    assert found
+    assert dest.read_text() == '{"seq":1}\n'
+
+
+def test_fake_backend_missing_key(tmp_path: Path):
+    """FakeBackend download returns False for a key that was never uploaded."""
+    backend = FakeBackend()
+    dest = tmp_path / "out.jsonl"
+    assert not backend.download("nonexistent/key", dest)
+
+
+def test_fake_backend_fail_upload(tmp_path: Path):
+    """FakeBackend raises when fail_upload is set."""
+    backend = FakeBackend()
+    backend.fail_upload = True
+    src = tmp_path / "events.jsonl"
+    src.write_text("")
+    with pytest.raises(OSError, match="simulated upload failure"):
+        backend.upload("key", src)
+
+
+# ── ReplicationWorker ─────────────────────────────────────────────────────────
+
+
+def _write_event_log(logdir: Path, n: int = 1) -> None:
+    """Write *n* dummy events into logdir for upload."""
+    for i in range(1, n + 1):
+        eventlog.append_event(
+            logdir,
+            {"seq": i, "ts": "2026-01-01T00:00:00Z", "type": "test", "payload": {}},
+        )
+
+
+def test_worker_enqueues_upload(logdir: Path, fake_backend: FakeBackend):
+    """Enqueuing a logdir leads to one upload call after debounce."""
+    _write_event_log(logdir)
+    worker = ReplicationWorker(fake_backend, debounce_s=0.05)
+    worker.enqueue(logdir, "conv-abc123")
+    worker.stop(timeout=2.0)
+    assert len(fake_backend.upload_calls) == 1
+    key, path = fake_backend.upload_calls[0]
+    assert key == "conv-abc123/events.jsonl"
+    assert path == logdir / "events.jsonl"
+
+
+def test_worker_debounces_multiple_enqueues(logdir: Path, fake_backend: FakeBackend):
+    """Many enqueues for the same logdir collapse into a single upload."""
+    _write_event_log(logdir, n=5)
+    worker = ReplicationWorker(fake_backend, debounce_s=0.1)
+    for _ in range(10):
+        worker.enqueue(logdir, "conv-abc123")
+    worker.stop(timeout=2.0)
+    assert len(fake_backend.upload_calls) == 1
+
+
+def test_worker_retries_on_transient_failure(logdir: Path):
+    """Worker retries on transient upload failure and does not raise into append."""
+    backend = FakeBackend()
+    _write_event_log(logdir)
+
+    call_count = 0
+
+    def flaky_upload(key: str, local_path: Path) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise OSError("transient")
+        backend._store[key] = local_path.read_bytes()
+
+    backend.upload = flaky_upload  # type: ignore
+
+    worker = ReplicationWorker(
+        backend, debounce_s=0.01, max_retries=3, retry_backoff=0.01
+    )
+    worker.enqueue(logdir, "conv-abc123")
+    worker.stop(timeout=5.0)
+    assert call_count == 3
+    assert "conv-abc123/events.jsonl" in backend._store
+
+
+def test_worker_gives_up_after_max_retries(logdir: Path, caplog):
+    """Worker logs a warning and gives up after max_retries failures."""
+    import logging
+
+    backend = FakeBackend()
+    backend.fail_upload = True
+    _write_event_log(logdir)
+
+    worker = ReplicationWorker(
+        backend, debounce_s=0.01, max_retries=2, retry_backoff=0.01
+    )
+    with caplog.at_level(logging.WARNING, logger="gptme.logmanager.replication"):
+        worker.enqueue(logdir, "conv-abc123")
+        worker.stop(timeout=5.0)
+
+    assert any("after 2 attempts" in r.message for r in caplog.records)
+    assert len(backend.upload_calls) == 2  # tried max_retries times
+
+
+def test_worker_noop_when_log_missing(logdir: Path, fake_backend: FakeBackend):
+    """Worker does not call upload when events.jsonl is absent."""
+    # Don't write any events — logdir exists but events.jsonl does not
+    worker = ReplicationWorker(fake_backend, debounce_s=0.01)
+    worker.enqueue(logdir, "conv-abc123")
+    worker.stop(timeout=2.0)
+    assert len(fake_backend.upload_calls) == 0
+
+
+# ── recover_from_remote ───────────────────────────────────────────────────────
+
+
+def test_recover_from_remote_missing(fake_backend: FakeBackend):
+    """Returns None when no remote object exists."""
+    result = recover_from_remote("conv-missing", fake_backend)
+    assert result is None
+
+
+def test_recover_from_remote_round_trip(tmp_path: Path, fake_backend: FakeBackend):
+    """Remote events.jsonl is downloaded and used to reconstruct messages."""
+    from gptme.message import Message
+
+    logdir = tmp_path / "local"
+    logdir.mkdir()
+
+    msg = Message(role="user", content="hello from recovery")
+    seq = eventlog.sequence_number(logdir)
+    event = eventlog.build_message_append_event(seq, msg)
+    eventlog.append_event(logdir, event)
+
+    # Upload the local event log to the fake backend
+    local_events_path = logdir / eventlog.EVENT_LOG_NAME
+    fake_backend.upload(_event_log_key("conv-recover"), local_events_path)
+
+    messages = recover_from_remote("conv-recover", fake_backend)
+    assert messages is not None
+    assert len(messages) == 1
+    assert messages[0]["content"] == "hello from recovery"
+    assert messages[0]["role"] == "user"
+
+
+def test_recover_from_remote_with_checkpoint(tmp_path: Path, fake_backend: FakeBackend):
+    """Recovery works even when the remote log contains checkpoint events."""
+    from gptme.message import Message
+
+    logdir = tmp_path / "ckpt"
+    logdir.mkdir()
+
+    msgs = [Message(role="user", content=f"msg {i}") for i in range(3)]
+    for _i, msg in enumerate(msgs):
+        seq = eventlog.sequence_number(logdir)
+        event = eventlog.build_message_append_event(seq, msg)
+        eventlog.append_event(logdir, event)
+
+    # Write a checkpoint
+    seq = eventlog.sequence_number(logdir)
+    eventlog.write_checkpoint(logdir, seq, [m.to_dict() for m in msgs])
+
+    # Append one more message after the checkpoint
+    extra = Message(role="assistant", content="after checkpoint")
+    seq = eventlog.sequence_number(logdir)
+    eventlog.append_event(logdir, eventlog.build_message_append_event(seq, extra))
+
+    local_path = logdir / eventlog.EVENT_LOG_NAME
+    fake_backend.upload(_event_log_key("conv-ckpt"), local_path)
+
+    recovered = recover_from_remote("conv-ckpt", fake_backend)
+    assert recovered is not None
+    assert len(recovered) == 4
+    assert recovered[-1]["content"] == "after checkpoint"
+
+
+def test_recover_from_remote_handles_download_failure(caplog):
+    """Returns None (no crash) when download raises unexpectedly."""
+    import logging
+
+    class BrokenBackend:
+        def download(self, key: str, dest: Path) -> bool:
+            raise RuntimeError("network error")
+
+        def upload(self, key: str, local_path: Path) -> None:
+            pass
+
+    with caplog.at_level(logging.WARNING, logger="gptme.logmanager.replication"):
+        result = recover_from_remote("conv-broken", BrokenBackend())
+
+    assert result is None
+    assert any("download failed" in r.message for r in caplog.records)

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -9,11 +9,14 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
-from gptme.logmanager import eventlog
+from gptme.config.core import Config, _config_var
+from gptme.config.models import EventLogReplicationConfig, UserConfig
+from gptme.logmanager import LogManager, eventlog
 from gptme.logmanager.replication import (
     FakeBackend,
     ReplicationWorker,
     _event_log_key,
+    get_worker,
     recover_from_remote,
     reset_worker,
 )
@@ -47,6 +50,10 @@ def fake_backend() -> FakeBackend:
 
 def test_event_log_key():
     assert _event_log_key("conv-abc") == "conv-abc/events.jsonl"
+    assert (
+        _event_log_key("conv-abc", "experiment")
+        == "conv-abc/branches/experiment/events.jsonl"
+    )
 
 
 # ── FakeBackend ───────────────────────────────────────────────────────────────
@@ -118,6 +125,26 @@ def test_worker_debounces_multiple_enqueues(logdir: Path, fake_backend: FakeBack
     assert len(fake_backend.upload_calls) == 1
 
 
+def test_worker_keeps_branches_separate(tmp_path: Path, fake_backend: FakeBackend):
+    """Branch uploads use distinct debounce entries and remote keys."""
+    main_dir = tmp_path / "conv"
+    branch_dir = main_dir / "branches" / "experiment"
+    main_dir.mkdir()
+    branch_dir.mkdir(parents=True)
+    _write_event_log(main_dir)
+    _write_event_log(branch_dir)
+
+    worker = ReplicationWorker(fake_backend, debounce_s=0.1)
+    worker.enqueue(main_dir, "conv-abc123")
+    worker.enqueue(branch_dir, "conv-abc123", "experiment")
+    worker.stop(timeout=2.0)
+
+    assert set(fake_backend._store) == {
+        "conv-abc123/events.jsonl",
+        "conv-abc123/branches/experiment/events.jsonl",
+    }
+
+
 def test_worker_retries_on_transient_failure(logdir: Path):
     """Worker retries on transient upload failure and does not raise into append."""
     backend = FakeBackend()
@@ -171,6 +198,61 @@ def test_worker_noop_when_log_missing(logdir: Path, fake_backend: FakeBackend):
     assert len(fake_backend.upload_calls) == 0
 
 
+def test_get_worker_isolates_backend_and_retry_config(logdir: Path):
+    """Context-local destinations and retry settings get isolated workers."""
+    _write_event_log(logdir)
+    first = FakeBackend()
+    first_worker = get_worker(first, debounce_ms=10, max_retries=1)
+    first_worker.enqueue(logdir, "conv-first")
+
+    second = FakeBackend()
+    second_worker = get_worker(second, debounce_ms=20, max_retries=2)
+    second_worker.enqueue(logdir, "conv-second")
+    reset_worker()
+
+    assert first_worker is not second_worker
+    assert len(first.upload_calls) == 1
+    assert len(second.upload_calls) == 1
+    assert second_worker._max_retries == 2
+
+
+def test_logmanager_forwards_branch_and_retry_config(
+    logdir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """LogManager forwards branch isolation and configured retry count."""
+    config = Config(
+        user=UserConfig(
+            session_event_log_replication=EventLogReplicationConfig(
+                enabled=True,
+                backend="s3",
+                bucket="test-bucket",
+                upload_debounce_ms=25,
+                max_retries=7,
+            )
+        )
+    )
+    token = _config_var.set(config)
+    calls: list[tuple[int, int, str]] = []
+
+    class StubWorker:
+        def enqueue(self, event_dir: Path, chat_id: str, branch: str) -> None:
+            calls.append((25, 7, branch))
+
+    def stub_get_worker(backend, debounce_ms: int, max_retries: int):
+        assert debounce_ms == 25
+        assert max_retries == 7
+        return StubWorker()
+
+    monkeypatch.setattr("gptme.logmanager.replication.get_worker", stub_get_worker)
+    try:
+        manager = LogManager(logdir=logdir, branch="experiment", lock=False)
+        manager._enqueue_replication(logdir)
+    finally:
+        _config_var.reset(token)
+
+    assert calls == [(25, 7, "experiment")]
+
+
 # ── recover_from_remote ───────────────────────────────────────────────────────
 
 
@@ -201,6 +283,28 @@ def test_recover_from_remote_round_trip(tmp_path: Path, fake_backend: FakeBacken
     assert len(messages) == 1
     assert messages[0]["content"] == "hello from recovery"
     assert messages[0]["role"] == "user"
+
+
+def test_recover_from_remote_branch(tmp_path: Path, fake_backend: FakeBackend):
+    """Recovery reads the requested branch-specific remote object."""
+    from gptme.message import Message
+
+    logdir = tmp_path / "branch"
+    logdir.mkdir()
+    eventlog.append_event(
+        logdir,
+        eventlog.build_message_append_event(
+            1, Message(role="user", content="branch message")
+        ),
+    )
+    fake_backend.upload(
+        _event_log_key("conv-recover", "experiment"),
+        logdir / eventlog.EVENT_LOG_NAME,
+    )
+
+    messages = recover_from_remote("conv-recover", fake_backend, "experiment")
+    assert messages is not None
+    assert messages[0]["content"] == "branch message"
 
 
 def test_recover_from_remote_with_checkpoint(tmp_path: Path, fake_backend: FakeBackend):


### PR DESCRIPTION
## Summary

Phase 2 of the session event log durability feature, following Phase 1 in #2956.

The S3-compatible backend was announced on #2956 on 2026-07-19 with a 7-day veto window; the window closed 2026-07-26 with no maintainer objection.

**What's new:**

- `gptme/logmanager/replication.py` — new module:
  - `ReplicationBackend` protocol (interface any backend must satisfy)
  - `FakeBackend` — in-process fake for tests, no network required
  - `S3Backend` — lazy `boto3` import, standard AWS credential chain
  - `ReplicationWorker` — daemon thread; debounces writes, retries with capped backoff, never blocks the session write path
  - `recover_from_remote()` — downloads remote `events.jsonl` into a temp dir and calls `eventlog.recover_messages()` for reconstruction
- `gptme/config/models.py` — `EventLogReplicationConfig` dataclass
- `gptme/config/user.py` — parses `[session_event_log_replication]` section
- `gptme/logmanager/manager.py` — `_enqueue_replication()` hooked after every local event write; no-op when disabled
- `tests/test_replication.py` — 13 unit tests covering protocol, debounce, retry, recovery paths, and failure isolation

**Feature is off by default.** Enable in `config.toml`:

```toml
[session_event_log_replication]
enabled = true
backend = "s3"
bucket = "gptme-session-events"
prefix = "events/"
# endpoint_url = "https://..."  # for MinIO / R2 / Cloudflare
# region = "eu-north-1"
```

Credentials follow the standard `boto3` provider chain — do not store secrets in gptme config.

## Design decisions

- **Best-effort only.** Upload failures log a warning and retry with capped backoff; they never raise into `append_event()`.
- **Full-file upload, not append.** Object stores don't support append semantics; uploading the full `events.jsonl` after each local write is idempotent and safe to retry.
- **Debounced.** Many rapid writes for the same conversation coalesce into a single upload after a configurable window (default 500 ms).
- **Lazy boto3 import.** S3 support doesn't add a hard dependency for users who don't configure it.

## Test plan

- [x] `uv run pytest tests/test_replication.py -v` — 13 tests, all green
- [x] `uv run pytest tests/test_eventlog.py -v` — 20 existing tests, no regressions
- [x] `mypy gptme/logmanager/replication.py gptme/config/models.py gptme/config/user.py` — clean
- [ ] Manual MinIO smoke test (out of scope for this slice per spec)