### PR TITLE
feat(llm): add native Kimi K3 support

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -132,9 +132,10 @@ def _get_temperature(
 ) -> float:
     """Return the temperature for a given provider/model.
 
-    Moonshot/Kimi models require temperature=1.
-    OpenAI GPT-5 class models require temperature=1.
-    All others use the caller value or global default.
+    Moonshot/Kimi models require temperature=1. K3 is marked as a reasoner, so
+    callers omit this fixed parameter rather than invoking this helper. OpenAI
+    GPT-5 class models require temperature=1. All others use the caller value
+    or global default.
     """
     if provider == "moonshot":
         return 1.0
@@ -150,9 +151,10 @@ def _get_top_p(
 ) -> float | None:
     """Return the top_p for a given provider.
 
-    Moonshot/Kimi models require top_p=0.95.
-    All others use the caller value or global default.
-    Returns None for models that don't support top_p (e.g., gpt-5.x).
+    Moonshot/Kimi models require top_p=0.95. K3 is marked as a reasoner, so
+    callers omit this fixed parameter rather than invoking this helper. All
+    others use the caller value or global default. Returns None for models
+    that don't support top_p.
     """
     if model_meta is not None and "gpt-5" in model_meta.model:
         return None
@@ -1083,6 +1085,7 @@ def extra_headers(provider: Provider) -> dict[str, str]:
 
 _OPENROUTER_REASONING_DEFAULT = 20000
 _VALID_QUANTIZATIONS = {"fp16", "bf16", "fp8", "int8", "int4", "unknown"}
+_KIMI_K3_REASONING_EFFORTS = {"low", "high", "max"}
 
 
 def extra_body(
@@ -1091,6 +1094,17 @@ def extra_body(
     """Return extra body for the OpenAI API based on the model."""
     body: dict[str, Any] = {}
     _maybe_apply_verbosity(body, model_meta)
+    if provider == "moonshot" and model_meta.model == "kimi-k3":
+        effort = get_config().get_env("GPTME_THINKING_EFFORT")
+        if effort is not None:
+            effort = effort.strip().lower()
+            if effort not in _KIMI_K3_REASONING_EFFORTS:
+                valid = ", ".join(sorted(_KIMI_K3_REASONING_EFFORTS))
+                raise ValueError(
+                    f"Invalid Kimi K3 reasoning effort: {effort!r}. "
+                    f"Must be one of: {valid}."
+                )
+            body["reasoning_effort"] = effort
     if provider == "openrouter":
         # Enable detailed usage info including cached tokens
         # See: https://openrouter.ai/docs/guides/usage-accounting
@@ -1640,10 +1654,13 @@ def _transform_msgs_for_special_provider(
                 result.append(cast(MessageDict, msg))
         return result
 
-    # OpenRouter reasoning models (e.g., Moonshot AI Kimi) need reasoning_content
-    # for assistant messages with tool_calls when thinking mode is enabled
-    # This prevents: "thinking is enabled but reasoning_content is missing in assistant tool call message"
-    if model.provider == "openrouter" and model.supports_reasoning:
+    # Reasoning models need the structured field restored from gptme's <think>
+    # representation before historical messages go back to the provider.
+    # OpenRouter requires it on tool-call turns; K3 requires it on every turn.
+    preserve_all_reasoning = model.provider == "moonshot" and model.model == "kimi-k3"
+    if (model.provider == "openrouter" and model.supports_reasoning) or (
+        preserve_all_reasoning
+    ):
 
         def _extract_and_strip_reasoning(
             content: str | None,
@@ -1685,7 +1702,7 @@ def _transform_msgs_for_special_provider(
         for msg in messages_dicts:
             if (
                 msg.get("role") == "assistant"
-                and msg.get("tool_calls")
+                and (msg.get("tool_calls") or preserve_all_reasoning)
                 and "reasoning_content" not in msg
             ):
                 # Extract reasoning and clean content to prevent context duplication
@@ -1742,6 +1759,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> ChatCompletionToolParam:
         "azure",
         "openrouter",
         "deepseek",
+        "moonshot",
         "local",
     ] or is_custom_provider(model.model.split("/")[0]):
         all_required = all(p.required for p in spec.parameters)

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -490,7 +490,17 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
         # Kimi docs list 256K context for k2.6/k2.5. max_completion_tokens
         # is constrained by input + output fitting within that context; the
         # 32K K2.5 guide value is a default, not a documented hard output cap.
-        # All kimi models require temperature=1; handled in llm_openai.py
+        "kimi-k3": {
+            "context": 1_048_576,
+            "max_output": 1_048_576,
+            "price_input": 3.00,
+            "price_output": 15.00,
+            "supports_reasoning": True,
+            "supports_vision": True,
+            "supports_parallel_tool_calls": True,
+            "supports_strict_tools": True,
+            "preferred_edit_format": "diff",
+        },
         "kimi-k2.6": {
             "context": 262_144,
             "max_output": 262_144,

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -355,6 +355,20 @@ def test_list_models_json_available_keeps_plugin_models(
 # --- Tests for closest-match heuristic ---
 
 
+def test_kimi_k3_metadata():
+    """Kimi K3 must not silently inherit the smaller K2 metadata."""
+    model = get_model("moonshot/kimi-k3")
+
+    assert model.context == 1_048_576
+    assert model.max_output == 1_048_576
+    assert model.supports_reasoning is True
+    assert model.supports_vision is True
+    assert model.supports_parallel_tool_calls is True
+    assert model.supports_strict_tools is True
+    assert model.price_input == 3.0
+    assert model.price_output == 15.0
+
+
 class TestClosestModelMatch:
     """Tests for _find_closest_model_properties and its integration in get_model."""
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1782,6 +1782,47 @@ class TestOpenAIRetryLogic:
         assert return_value == {"metadata": "value"}
 
 
+def test_prepare_kimi_k3_preserves_reasoning_across_turns():
+    """K3 requires historical reasoning content even without a tool call."""
+    messages = [
+        Message(role="user", content="Solve this."),
+        Message(
+            role="assistant",
+            content="<think>Work through it.</think>\nThe answer is 42.",
+        ),
+        Message(role="user", content="Check that answer."),
+    ]
+
+    result, _ = _prepare_messages_for_api(messages, "moonshot/kimi-k3", None)
+
+    assert result[1]["reasoning_content"] == "Work through it."
+    assert result[1]["content"] == "The answer is 42."
+
+
+def test_prepare_kimi_k3_preserves_reasoning_for_tool_calls():
+    """K3 requires complete historical assistant messages on tool turns."""
+    init_tools(allowlist=["shell"])
+    shell = get_tool("shell")
+    assert shell
+    messages = [
+        Message(role="user", content="List the files."),
+        Message(
+            role="assistant",
+            content=(
+                "<think>Inspect the directory first.</think>\n"
+                '@shell(call_123): {"command": "ls"}'
+            ),
+        ),
+        Message(role="system", content="README.md", call_id="call_123"),
+    ]
+
+    result, _ = _prepare_messages_for_api(messages, "moonshot/kimi-k3", [shell])
+
+    assert result[1]["reasoning_content"] == "Inspect the directory first."
+    assert result[1].get("content") is None
+    assert result[1]["tool_calls"][0]["id"] == "call_123"
+
+
 def test_transform_msgs_for_openrouter_reasoning_tool_calls():
     """Test that OpenRouter reasoning models get empty reasoning_content for tool_calls.
 

--- a/tests/test_llm_openai_sampling.py
+++ b/tests/test_llm_openai_sampling.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from gptme.llm import llm_openai
 from gptme.llm.models import get_model
 from gptme.message import Message
@@ -30,6 +32,51 @@ def test_sampling_helpers_keep_model_overrides():
     assert llm_openai._get_top_p("openai", gpt5, top_p=0.82) is None
     assert llm_openai._get_temperature("moonshot", moonshot, temperature=0.37) == 1.0
     assert llm_openai._get_top_p("moonshot", moonshot, top_p=0.82) == 0.95
+
+
+def test_kimi_k3_sends_configured_reasoning_effort(monkeypatch):
+    monkeypatch.setenv("GPTME_THINKING_EFFORT", "high")
+    completion = SimpleNamespace(
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    content="answer",
+                    reasoning_content="reasoning",
+                    tool_calls=None,
+                ),
+            )
+        ],
+    )
+    completions_create = Mock(return_value=completion)
+    mock_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=completions_create))
+    )
+    monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+    monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+
+    result, _ = llm_openai.chat(
+        [Message(role="user", content="Solve this.")],
+        "moonshot/kimi-k3",
+        None,
+    )
+
+    assert result == "<think>\nreasoning\n</think>\n\nanswer"
+    assert "temperature" not in completions_create.call_args.kwargs
+    assert "top_p" not in completions_create.call_args.kwargs
+    assert completions_create.call_args.kwargs["extra_body"] == {
+        "reasoning_effort": "high"
+    }
+
+
+def test_kimi_k3_rejects_unsupported_reasoning_effort(monkeypatch):
+    monkeypatch.setenv("GPTME_THINKING_EFFORT", "medium")
+
+    with pytest.raises(ValueError, match="Kimi K3 reasoning effort"):
+        llm_openai.extra_body(
+            "moonshot", get_model("moonshot/kimi-k3"), max_tokens=None
+        )
 
 
 def test_chat_completions_forwards_caller_sampling_values(monkeypatch):


### PR DESCRIPTION
## Summary

- register Moonshot's `kimi-k3` with its documented 1M context/output limits, pricing, vision, reasoning, structured-tool, and parallel-tool capabilities
- preserve `reasoning_content` across normal and tool-call turns, as required by K3's always-on preserved thinking
- expose K3's `low` / `high` / `max` reasoning effort through the existing `GPTME_THINKING_EFFORT` setting and reject unsupported levels
- enable native Moonshot tool schemas while keeping K3's fixed sampling parameters out of requests

## Why

Without an explicit registry entry, `moonshot/kimi-k3` silently inherited K2.6 metadata: 256K context, K2 pricing, no reasoning flag, and no native tools. That both misrepresented the new model and broke its required preserved-thinking/tool-call protocol.

## Verification

- `uv run --with pytest --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/test_llm_models.py tests/test_llm_openai_sampling.py tests/test_llm_openai.py -q` — 185 passed
- scoped pre-commit hooks — passed (ruff, format, mypy)
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme` — 100/100

## Scope restraint

This does not add a second trace-extraction wrapper or model-specific harness. gptme already normalizes OpenAI-compatible `reasoning_content` into `<think>` blocks; this PR makes that existing path correct for K3.

Source docs:
- https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
- https://platform.kimi.ai/docs/guide/use-reasoning-effort
- https://platform.kimi.ai/docs/pricing/chat-k3
