### PR TITLE
fix(server): actually bundle modern webui in distributions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,11 +43,12 @@ demos
 projects
 eval_results*
 
-# Frontend / desktop / static-site sources — not needed by either image.
-# The agent image (scripts/Dockerfile) copies only pyproject/gptme explicitly;
-# the self-host image (scripts/Dockerfile.selfhost) only pip-installs the
-# package. tauri (~8G) and webui (~600M) would otherwise bloat the build context.
-webui
+# Desktop/static-site sources and generated frontend files are not needed. The
+# Dockerfiles build the modern UI from source in a dedicated Node stage.
+webui/node_modules
+webui/dist
+webui/playwright-report
+webui/test-results
 tauri
 site
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,19 @@ jobs:
         make build
         poetry install --extras server --extras pyinstaller --with dev
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: webui/package-lock.json
+
+    - name: Build and bundle webui
+      run: |
+        cd webui && npm ci && npm run build
+        cd ..
+        make bundle-webui
+
     - name: Build PyInstaller executable
       run: make build-server-exe
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,9 @@ jobs:
         rm -f dist/*.whl dist/*.tar.gz
         poetry build
 
+    - name: Validate package contents
+      run: make validate-release-package
+
     - name: Validate package (dry-run publish)
       run: |
         # Dry-run validates artifact structure and metadata — no upload, no auth check

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master, 'dev/*' ]
     paths:
       - 'webui/**'
+      - 'pyproject.toml'
+      - 'Makefile'
+      - 'scripts/validate_release_package.py'
       - '.github/workflows/webui.yml'
 
 defaults:
@@ -44,6 +47,19 @@ jobs:
 
     - name: Build
       run: npm run build
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+
+    - name: Verify release package includes the built webui
+      working-directory: .
+      run: |
+        make bundle-webui
+        pipx install poetry
+        poetry build
+        make validate-release-package
 
     - name: Upload dist artifact
       if: github.ref == 'refs/heads/master'

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ bundle-webui: ## Bundle the modern webui dist into the package (run after `cd we
 	rsync -a --delete webui/dist/ gptme/server/webui-dist/
 	@echo "Bundled webui/dist → gptme/server/webui-dist/ ($(ls gptme/server/webui-dist | wc -l) files at top level)"
 
+validate-release-package: ## Verify built packages contain the modern webui
+	python3 scripts/validate_release_package.py dist/*.whl dist/*.tar.gz
+
 test: ## Run tests
 	@# if SLOW is not set, pass `-m "not slow"` to skip slow tests
 	poetry run pytest ${SRCDIRS} -v --log-level INFO --durations=5 \

--- a/README.md
+++ b/README.md
@@ -256,8 +256,7 @@ You can find more [Demos][docs-demos] and [Examples][docs-examples] in the [docu
   - Use OpenRouter for access to 100+ models, or serve locally with `llama.cpp`.
   - [Pick the right model per task][docs-model-routing] — fast/cheap for triage, powerful for coding.
 - 🌐 **Web UI and REST API**
-  - Modern web interface at [chat.gptme.org](https://chat.gptme.org) ([gptme-webui])
-  - Simple built-in web UI included in the Python package.
+  - Modern [gptme-webui] bundled with `gptme-server` and hosted at [chat.gptme.org](https://chat.gptme.org).
   - [Server][docs-server] with REST API.
   - Standalone executable builds available with PyInstaller.
 - 💻 **[Computer use][docs-tools-computer]** (see [#216](https://github.com/gptme/gptme/issues/216))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Two services are available:
 #
-#   gptme-server  — headless API server for use with the web UI:
+#   gptme-server  — API server with the modern web UI bundled at :5700:
 #
 #       docker compose up --build
 #
@@ -31,11 +31,9 @@ services:
       # configure the web UI with the same value; if blank, one is auto-generated
       # at startup — see `docker compose logs`.
       GPTME_SERVER_TOKEN: ${GPTME_SERVER_TOKEN:-}
-    # Appended to the image's entrypoint (gptme-server serve --host 0.0.0.0
-    # --port 5700). Allows the configured web UI origin to call this server.
-    command:
-      - --cors-origin
-      - ${CORS_ORIGIN:-https://chat.gptme.org}
+    # The bundled UI is same-origin and needs no CORS configuration. To use a
+    # separately hosted UI, uncomment this command and set CORS_ORIGIN.
+    # command: [--cors-origin, ${CORS_ORIGIN:-https://chat.gptme.org}]
     volumes:
       # Persist config, credentials, and conversation logs across restarts.
       - gptme-config:/home/gptme/.config/gptme

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -12,12 +12,14 @@ To use gptme's server capabilities, install with server extras:
 
     pipx install 'gptme[server]'
 
-Start the server:
+Start the server, then open http://localhost:5700:
 
 .. code-block:: bash
 
     gptme-server
 
+The server and modern web UI share one origin by default, so no separate
+frontend process or CORS configuration is required.
 
 For more CLI options, see the :ref:`CLI reference <cli:gptme-server>`.
 
@@ -43,10 +45,13 @@ The primary web interface is `gptme-webui <https://github.com/gptme/gptme/tree/m
 - Integrated computer use interface
 - Create your own persistent `agents`
 
-**Local Installation:**
-For self-hosting and local development, see the `gptme-webui README <https://github.com/gptme/gptme/tree/master/webui>`_.
+**Local use:**
 
-To use the server with a locally hosted gptme-webui, configure the CORS origin when starting the server:
+The modern UI is bundled in gptme release packages. Run ``gptme-server`` and
+open http://localhost:5700.
+
+For frontend development, see the `gptme-webui README <https://github.com/gptme/gptme/tree/master/webui>`_.
+When Vite runs separately on port 5701, allow that development origin:
 
 .. code-block:: bash
 
@@ -103,21 +108,20 @@ gptme + the ``server`` extra only — no Node/agent tooling) and runs
 
 The server listens on http://localhost:5700.
 
-The simplest way to use it is the basic web UI the server bundles at the same
-origin — just open http://localhost:5700 in a browser. Being same-origin, it
-needs no CORS setup (you will still need the server token; see below).
+The modern web UI is bundled at the same origin — just open
+http://localhost:5700 in a browser. Being same-origin, it needs no CORS setup
+(you will still need the server token; see below).
 
-To use the full-featured hosted web UI instead, open
+To use the hosted web UI instead, open
 `chat.gptme.org <https://chat.gptme.org>`_ and point it at your server. That is
-a cross-origin setup, so the server must allow the UI's origin — the default
-``CORS_ORIGIN`` already permits ``chat.gptme.org``. Set ``CORS_ORIGIN`` in
-``.env`` to a different origin if you self-host the web UI yourself.
+a cross-origin setup, so uncomment the Compose ``command`` and set
+``CORS_ORIGIN`` to the hosted UI (or your separately hosted UI).
 
 Key ``.env`` settings:
 
 - ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` / ``OPENROUTER_API_KEY`` — at least one is required.
 - ``GPTME_SERVER_TOKEN`` — auth token. The server enables auth by default when bound to ``0.0.0.0`` (as in the container), so set this and configure the web UI with the same value. If left blank, a token is auto-generated at startup — find it with ``docker compose logs``.
-- ``CORS_ORIGIN`` — origin allowed to call the server (defaults to the hosted web UI).
+- ``CORS_ORIGIN`` — only needed for a separately hosted web UI; uncomment the Compose ``command`` and set this to that UI's origin.
 - ``GPTME_SERVER_PORT`` — host port to publish (the container always listens on 5700).
 
 Production Deployment: nginx Reverse Proxy
@@ -206,9 +210,10 @@ example below uses nginx with a Let's Encrypt certificate.
    sudo nginx -t        # validate config
    sudo systemctl reload nginx
 
-The server is now reachable at ``https://gptme.example.com``. Point your web UI
-(or the hosted UI at `chat.gptme.org <https://chat.gptme.org>`_) at that URL, and
-set ``CORS_ORIGIN`` in ``.env`` to the origin the UI is served from.
+The server and bundled UI are now reachable together at
+``https://gptme.example.com``. If you instead use a separately hosted UI such
+as `chat.gptme.org <https://chat.gptme.org>`_, set ``CORS_ORIGIN`` in ``.env``
+to that UI's origin and enable the Compose ``--cors-origin`` command.
 
 .. note::
 
@@ -252,7 +257,7 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
     sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
     sudoedit /etc/gptme/server.env   # add ANTHROPIC_API_KEY=... etc.
 
-    # Download and install the unit (adjust User=, the ExecStart path, --cors-origin)
+    # Download and install the unit (adjust User= and the ExecStart path)
     sudo curl -fsSL https://raw.githubusercontent.com/gptme/gptme/master/scripts/gptme-server.service \
         -o /etc/systemd/system/gptme-server.service
     sudo systemctl daemon-reload

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -29,7 +29,7 @@ def _resolve_static_folder(webui_dir: str | Path | None = None) -> Path:
 
     Precedence: explicit ``webui_dir`` argument > ``GPTME_WEBUI_DIR`` env var >
     bundled modern webui (``gptme/server/webui-dist/``) >
-    the embedded legacy static bundle. A configured directory must exist so
+    the embedded legacy static fallback. A configured directory must exist so
     that a typo fails loudly at startup instead of silently serving 404s.
     """
     candidate = webui_dir or os.environ.get("GPTME_WEBUI_DIR")
@@ -65,10 +65,10 @@ def create_app(
             validation is active (loopback binds without auth). Adds to the
             built-in localhost/127.0.0.1/[::1] allow-list, for users who proxy
             the local server behind a hostname. See init_host_validation.
-        webui_dir: Optional directory containing a web UI build (e.g. the
-            modern React webui's ``dist/``) to serve instead of the bundled
-            legacy UI. Falls back to the ``GPTME_WEBUI_DIR`` environment
-            variable, then to the embedded legacy static bundle.
+        webui_dir: Optional directory containing a web UI build to serve
+            instead of the bundled modern UI. Falls back to the
+            ``GPTME_WEBUI_DIR`` environment variable, then to the bundled UI
+            and finally the embedded legacy static fallback.
         default_profile: Optional profile name to apply to new conversations
             that don't specify a system prompt. The profile's system_prompt is
             injected as an additional system message when the conversation is

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -198,9 +198,8 @@ def main():
     default=None,
     envvar="GPTME_WEBUI_DIR",
     help=(
-        "Directory containing a web UI build (e.g. the modern React webui's "
-        "dist/) to serve instead of the bundled legacy UI. Can also be set "
-        "via the GPTME_WEBUI_DIR environment variable."
+        "Directory containing a web UI build to serve instead of the bundled "
+        "modern UI. Can also be set via the GPTME_WEBUI_DIR environment variable."
     ),
 )
 @click.option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,15 @@ gptme-mcp-server = "gptme.cli.cmd_mcp_serve:main"
 packages = [
     { include = "gptme" },
 ]
-include = ["gptme/server/static/**/*", "gptme/server/webui-dist/**/*", "gptme/eval/tbench/setup.sh", "media/*.png", "media/*.wav"]
+include = [
+    "gptme/server/static/**/*",
+    # webui-dist is generated and gitignored; an explicit path include is
+    # required so Poetry does not silently omit it from release artifacts.
+    { path = "gptme/server/webui-dist", format = ["sdist", "wheel"] },
+    "gptme/eval/tbench/setup.sh",
+    "media/*.png",
+    "media/*.wav",
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,3 +1,11 @@
+# Build the modern web UI separately so the Python package serves it by default.
+FROM node:20-slim AS webui-builder
+WORKDIR /app/webui
+COPY webui/package.json webui/package-lock.json ./
+RUN npm ci
+COPY webui/ ./
+RUN npm run build
+
 # Build stage
 FROM python:3.12-slim AS builder
 
@@ -16,6 +24,7 @@ RUN python -m venv /opt/poetry && \
 # Copy files needed for building wheel
 COPY pyproject.toml poetry.lock README.md ./
 COPY gptme gptme/
+COPY --from=webui-builder /app/webui/dist gptme/server/webui-dist/
 
 # Install dependencies and export requirements for server
 RUN /opt/poetry/bin/poetry self add poetry-plugin-export && \

--- a/scripts/Dockerfile.selfhost
+++ b/scripts/Dockerfile.selfhost
@@ -23,7 +23,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY . /app
+# Keep frontend sources in the builder stage only. Copy the Python package inputs
+# explicitly so WebUI changes do not invalidate or bloat the runtime source layer.
+COPY pyproject.toml poetry.lock README.md ./
+COPY gptme/ gptme/
 COPY --from=webui-builder /app/webui/dist gptme/server/webui-dist/
 RUN pip install --no-cache-dir ".[server]"
 

--- a/scripts/Dockerfile.selfhost
+++ b/scripts/Dockerfile.selfhost
@@ -6,6 +6,13 @@
 #
 # Build/run via docker compose (see docker-compose.yml at the repo root):
 #   docker compose up --build
+FROM node:20-slim AS webui-builder
+WORKDIR /app/webui
+COPY webui/package.json webui/package-lock.json ./
+RUN npm ci
+COPY webui/ ./
+RUN npm run build
+
 FROM python:3.12-slim
 
 # git: gptme's git-aware features expect it at runtime. curl: container healthcheck.
@@ -16,9 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# .dockerignore trims the build context to gptme/, pyproject.toml, poetry.lock,
-# and README.md — exactly what's needed to build and install the package.
 COPY . /app
+COPY --from=webui-builder /app/webui/dist gptme/server/webui-dist/
 RUN pip install --no-cache-dir ".[server]"
 
 # Run as a non-root user; named volumes inherit this ownership.
@@ -37,7 +43,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
     CMD curl -fsS -H "Authorization: Bearer ${GPTME_SERVER_TOKEN}" http://localhost:5700/api/v2/server/health \
         || [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5700/api/v2/server/health)" = "401" ]
 
-# Bind to 0.0.0.0 so the port is reachable from the host and other containers.
-# Pass --cors-origin (see docker-compose.yml) to allow a web UI origin, and set
+# Bind to 0.0.0.0 so the bundled UI is reachable from the host. Set
 # GPTME_SERVER_TOKEN to require auth (recommended for any non-localhost exposure).
 ENTRYPOINT ["gptme-server", "serve", "--host", "0.0.0.0", "--port", "5700"]

--- a/scripts/gptme-server.service
+++ b/scripts/gptme-server.service
@@ -19,7 +19,7 @@
 #      sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
 #      # then edit /etc/gptme/server.env (see the EnvironmentFile keys below)
 #   5. sudo cp scripts/gptme-server.service /etc/systemd/system/
-#      # adjust User=, the ExecStart path, and --cors-origin to match your setup
+#      # adjust User= and the ExecStart path to match your setup
 #   6. sudo systemctl daemon-reload && sudo systemctl enable --now gptme-server
 #
 # The server binds to loopback (127.0.0.1) by design: terminate TLS and expose
@@ -46,11 +46,10 @@ Group=gptme
 EnvironmentFile=-/etc/gptme/server.env
 
 # Adjust the path to wherever pipx installed the entrypoint for User= above.
-# Bind loopback and front it with a reverse proxy; set --cors-origin to the
-# origin your web UI is served from (the hosted UI is https://chat.gptme.org).
+# The bundled UI is served at the same origin. Add --cors-origin only when a
+# separate frontend origin (for example chat.gptme.org) connects to this server.
 ExecStart=/home/gptme/.local/bin/gptme-server serve \
-    --host 127.0.0.1 --port 5700 \
-    --cors-origin https://chat.gptme.org
+    --host 127.0.0.1 --port 5700
 
 Restart=on-failure
 RestartSec=5

--- a/scripts/pyinstaller/gptme-server.spec
+++ b/scripts/pyinstaller/gptme-server.spec
@@ -9,7 +9,8 @@ sys.path.insert(0, str(project_root))
 
 # Define data files to include
 datas = [
-    # Include server static files
+    # Include the modern web UI and legacy computer.html fallback.
+    (str(project_root / 'gptme/server/webui-dist'), 'gptme/server/webui-dist'),
     (str(project_root / 'gptme/server/static'), 'gptme/server/static'),
     # Include the logo if needed
     (str(project_root / 'media/logo.png'), 'media'),

--- a/scripts/validate_release_package.py
+++ b/scripts/validate_release_package.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate that a built gptme package contains required runtime assets."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from pathlib import Path
+
+_WEBUI_INDEX = "gptme/server/webui-dist/index.html"
+_WEBUI_ASSETS_PREFIX = "gptme/server/webui-dist/assets/"
+
+
+def _archive_members(path: Path) -> set[str]:
+    """Return normalized member names from a wheel or source archive."""
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            return set(archive.namelist())
+    if path.name.endswith(".tar.gz"):
+        with tarfile.open(path, "r:gz") as archive:
+            members = archive.getnames()
+        # Source distributions wrap all files in a versioned root directory.
+        return {name.split("/", 1)[-1] for name in members if "/" in name}
+    raise ValueError(f"unsupported package archive: {path}")
+
+
+def validate_package(path: Path) -> None:
+    """Raise ValueError when a package omits the bundled modern web UI."""
+    members = _archive_members(path)
+    missing: list[str] = []
+    if _WEBUI_INDEX not in members:
+        missing.append(_WEBUI_INDEX)
+    if not any(name.startswith(_WEBUI_ASSETS_PREFIX) for name in members):
+        missing.append(f"{_WEBUI_ASSETS_PREFIX}*")
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"{path} is missing required bundled web UI assets: {joined}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archives", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    try:
+        for archive in args.archives:
+            validate_package(archive)
+            print(f"Validated bundled web UI in {archive}")
+    except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as error:
+        parser.exit(1, f"error: {error}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_release_package.py
+++ b/tests/test_validate_release_package.py
@@ -1,0 +1,73 @@
+import importlib.util
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts/validate_release_package.py"
+_SPEC = importlib.util.spec_from_file_location("validate_release_package", _SCRIPT)
+assert _SPEC and _SPEC.loader
+validate_release_package = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(validate_release_package)
+validate_package = validate_release_package.validate_package
+
+
+@pytest.mark.parametrize("archive_type", ["wheel", "sdist"])
+def test_validate_package_accepts_bundled_webui(
+    tmp_path: Path, archive_type: str
+) -> None:
+    archive = _write_archive(
+        tmp_path,
+        archive_type,
+        {
+            "gptme/server/webui-dist/index.html": b"<html>modern</html>",
+            "gptme/server/webui-dist/assets/index-abc.js": b"console.log('ok')",
+        },
+    )
+
+    validate_package(archive)
+
+
+@pytest.mark.parametrize(
+    ("members", "missing"),
+    [
+        ({"gptme/server/webui-dist/assets/index-abc.js": b"js"}, "index.html"),
+        ({"gptme/server/webui-dist/index.html": b"html"}, "assets/*"),
+    ],
+)
+def test_validate_package_rejects_incomplete_webui(
+    tmp_path: Path, members: dict[str, bytes], missing: str
+) -> None:
+    archive = _write_archive(tmp_path, "wheel", members)
+
+    with pytest.raises(ValueError, match=missing.replace("*", r"\*")):
+        validate_package(archive)
+
+
+def test_validate_package_rejects_unsupported_archive(tmp_path: Path) -> None:
+    archive = tmp_path / "gptme.zip"
+    archive.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="unsupported package archive"):
+        validate_package(archive)
+
+
+def _write_archive(
+    tmp_path: Path, archive_type: str, members: dict[str, bytes]
+) -> Path:
+    if archive_type == "wheel":
+        archive = tmp_path / "gptme-0.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(archive, "w") as wheel:
+            for name, data in members.items():
+                wheel.writestr(name, data)
+        return archive
+
+    archive = tmp_path / "gptme-0.0.0.tar.gz"
+    with tarfile.open(archive, "w:gz") as sdist:
+        for name, data in members.items():
+            info = tarfile.TarInfo(f"gptme-0.0.0/{name}")
+            info.size = len(data)
+            sdist.addfile(info, io.BytesIO(data))
+    return archive


### PR DESCRIPTION
## Problem

The modern-webui bundling path from #2633 ran successfully in release CI, but Poetry excluded the generated `gptme/server/webui-dist/` because the directory is gitignored. The released v0.32.1 wheel contains **zero** modern-webui files, so `gptme-server` silently falls back to the legacy UI.

The release pipeline only checked that the frontend build and `poetry build` exited successfully; it never inspected the resulting package.

## What changed

- explicitly include the generated `webui-dist` directory in wheel and sdist formats;
- validate both release archives contain `index.html` and at least one hashed asset before publishing;
- run that package assertion in WebUI CI too, including when packaging config changes;
- build/bundle the UI for PyInstaller and Docker distribution paths;
- make the self-host Docker image build the frontend in a dedicated Node stage;
- document `gptme-server` as a same-origin one-process setup, keeping `--cors-origin` for separate frontend origins;
- keep the legacy static bundle as a fallback for now because `computer.html` and its tests still depend on it.

## Evidence

- v0.32.1 release wheel: 1,568,388 bytes, 0 `webui-dist` entries, 4 legacy-static entries.
- Release run 29582787488 shows `npm run build` and rsync succeeded before Poetry silently omitted the directory.
- Fixed local wheel: 43 modern UI files (2,585,262 uncompressed bytes) plus the legacy fallback.
- Installed-wheel smoke test resolves `site-packages/gptme/server/webui-dist` and `/` returns the React root.
- Fresh self-host Docker build contains 64 hashed assets and `/` returns the modern UI.

## Verification

- `pytest -q tests/test_validate_release_package.py tests/test_server_webui_dir.py` — 17 passed in an isolated venv
- `mypy scripts/validate_release_package.py tests/test_validate_release_package.py` — clean
- scoped pre-commit hooks — all passed
- `poetry build && make validate-release-package` — wheel + sdist passed
- fresh `docker build -f scripts/Dockerfile.selfhost ...` + live root smoke — passed
- PR quality gate — 100/100

Closes #3386
