### PR TITLE
test(webui): add virtualization regression tests for #3379

### DIFF
--- a/webui/e2e/performance.spec.ts
+++ b/webui/e2e/performance.spec.ts
@@ -243,25 +243,29 @@ test.describe('Performance: message list virtualization', () => {
     await page.getByText('Stress test (200 messages)').click();
     await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
 
-    // Record initial rendered indices
+    // Conversations open at the bottom. Scroll the actual message viewport to
+    // the top rather than sending a wheel event to the sidebar item we clicked.
+    const messageViewport = page.getByTestId('message-scroll-viewport');
     const initialIndices = await page
       .locator('[data-message-index]')
       .evaluateAll((els) => els.map((el) => Number(el.getAttribute('data-message-index'))));
+    await messageViewport.evaluate((element) => element.scrollTo({ top: 0 }));
 
-    // Scroll down significantly using mouse wheel to trigger virtualizer
-    // to render a different set of messages.
-    await page.mouse.wheel(0, 5000);
-    await page.waitForTimeout(500);
+    // Wait for the virtualizer to replace the bottom rows with top rows.
+    await expect
+      .poll(async () =>
+        page
+          .locator('[data-message-index]')
+          .evaluateAll((els) => els.map((el) => Number(el.getAttribute('data-message-index'))))
+      )
+      .not.toEqual(initialIndices);
 
-    // After scrolling, a different set of messages should be rendered
     const scrolledIndices = await page
       .locator('[data-message-index]')
       .evaluateAll((els) => els.map((el) => Number(el.getAttribute('data-message-index'))));
 
-    // The rendered set changed — virtualization is working
-    expect(scrolledIndices).not.toEqual(initialIndices);
-
-    // Still bounded — not all 200 mounted
+    // The top of the conversation is now rendered, while the DOM stays bounded.
+    expect(scrolledIndices).toContain(0);
     expect(scrolledIndices.length).toBeLessThan(50);
   });
 

--- a/webui/e2e/performance.spec.ts
+++ b/webui/e2e/performance.spec.ts
@@ -191,3 +191,100 @@ test.describe('Performance: streaming code block rendering', () => {
     expect(result.finalText).toContain('<safe> & fast');
   });
 });
+
+test.describe('Performance: message list virtualization', () => {
+  // Regression suite for gptme/gptme#3379.
+  //
+  // Root cause: before virtualization, every message in a conversation was
+  // mounted in the DOM simultaneously. A 200-message conversation rendered
+  // 200 ChatMessage components, creating tens of thousands of DOM nodes and
+  // causing multi-second layout jank.
+  //
+  // Fix: ConversationContent uses @tanstack/react-virtual to render only the
+  // messages visible in the scroll viewport (plus overscan), keeping DOM node
+  // count bounded regardless of total conversation length.
+  //
+  // These tests guard against regressions that would re-mount all messages.
+
+  test('mounts only a bounded subset of DOM nodes for a 200-message conversation', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Virtualization behavior is browser-independent');
+    test.setTimeout(30000);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Stress test (200 messages)')).toBeVisible({ timeout: 10000 });
+
+    await page.getByText('Stress test (200 messages)').click();
+    await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
+
+    // Count rendered message rows. With virtualization only ~viewport + overscan
+    // rows are in the DOM. A non-virtualized list would mount all 200.
+    const renderedRows = await page.locator('[data-message-index]').count();
+
+    // The virtualizer renders viewport items + overscan (5). On a standard
+    // CI viewport (1280x720) this is well under 30. Use 50 as a generous
+    // ceiling that still catches a full 200-message regression.
+    expect(renderedRows).toBeLessThan(50);
+    expect(renderedRows).toBeLessThan(200);
+  });
+
+  test('scrolling reveals new messages without mounting all at once', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Virtualization behavior is browser-independent');
+    test.setTimeout(30000);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Stress test (200 messages)')).toBeVisible({ timeout: 10000 });
+
+    await page.getByText('Stress test (200 messages)').click();
+    await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
+
+    // Record initial rendered indices
+    const initialIndices = await page
+      .locator('[data-message-index]')
+      .evaluateAll((els) => els.map((el) => Number(el.getAttribute('data-message-index'))));
+
+    // Scroll down significantly using mouse wheel to trigger virtualizer
+    // to render a different set of messages.
+    await page.mouse.wheel(0, 5000);
+    await page.waitForTimeout(500);
+
+    // After scrolling, a different set of messages should be rendered
+    const scrolledIndices = await page
+      .locator('[data-message-index]')
+      .evaluateAll((els) => els.map((el) => Number(el.getAttribute('data-message-index'))));
+
+    // The rendered set changed — virtualization is working
+    expect(scrolledIndices).not.toEqual(initialIndices);
+
+    // Still bounded — not all 200 mounted
+    expect(scrolledIndices.length).toBeLessThan(50);
+  });
+
+  test('total DOM node count stays bounded for a long conversation', async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'DOM metrics require Chromium');
+    test.setTimeout(30000);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Stress test (200 messages)')).toBeVisible({ timeout: 10000 });
+
+    await page.getByText('Stress test (200 messages)').click();
+    await expect(page.locator('[data-message-index]').first()).toBeVisible({ timeout: 10000 });
+
+    // Count total DOM elements. Pre-virtualization, 200 messages with markdown
+    // rendering produced 8000+ nodes. With virtualization it should be well
+    // under 2000 even with the sidebar and chrome.
+    const totalElements = await page.evaluate(() => document.querySelectorAll('*').length);
+
+    // 3000 is a generous ceiling that still catches a non-virtualized regression
+    // (which would produce 8000+ nodes for 200 rendered messages).
+    expect(totalElements).toBeLessThan(3000);
+  });
+});

--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -822,6 +822,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
       <div
         className="flex-1 overflow-y-auto"
+        data-testid="message-scroll-viewport"
         ref={scrollContainerRef}
         onScroll={() => {
           if (!scrollContainerRef.current || isAutoScrolling$.get()) return;

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -20,8 +20,13 @@ declare global {
 global.__virtualWindow = Infinity;
 const mockScrollToIndex = jest.fn();
 
+// Track the count passed to the virtualizer so tests can assert that
+// hidden/system/collapsed messages are excluded from the virtualizer geometry.
+let lastVirtualizerCount = 0;
+
 jest.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: (opts: { count: number }) => {
+    lastVirtualizerCount = opts.count;
     const win = isFinite(global.__virtualWindow) ? global.__virtualWindow : opts.count;
     const items = Array.from({ length: Math.min(opts.count, win) }, (_, i) => ({
       index: i,
@@ -560,5 +565,29 @@ describe('virtual message list', () => {
       mockConversation$.data.log.set([]);
     });
     expect(() => renderComponent()).not.toThrow();
+  });
+
+  it('passes only visible message count to the virtualizer (regression guard for #3379)', () => {
+    // 10 total messages: 2 hidden + 1 initial-system (hidden by default) + 7 visible.
+    // The virtualizer count must equal 7, not 10 — hidden messages must not
+    // reserve geometry slots (they would create blank scroll regions).
+    act(() => {
+      mockConversation$.data.log.set([
+        message('system', 'Initial system prompt'),
+        message('user', 'Question 1'),
+        message('assistant', 'Answer 1'),
+        { ...message('system', 'Hidden tool result'), hide: true },
+        message('assistant', 'Answer 1 continued'),
+        message('user', 'Question 2'),
+        { ...message('assistant', 'Hidden draft'), hide: true },
+        message('assistant', 'Answer 2'),
+        message('user', 'Question 3'),
+        message('assistant', 'Answer 3'),
+      ]);
+    });
+    renderComponent();
+
+    // 10 total - 1 initial system - 2 hidden = 7 visible
+    expect(lastVirtualizerCount).toBe(7);
   });
 });

--- a/webui/src/democonversations.ts
+++ b/webui/src/democonversations.ts
@@ -225,6 +225,15 @@ const demoMessages: Record<string, Message[]> = {
     },
     // (last message — no result, no wrap-up)
   ],
+  // Stress-test conversation: 200 alternating user/assistant messages.
+  // Used by the virtualization regression e2e test to verify that only a
+  // bounded subset of messages is mounted in the DOM regardless of total
+  // conversation length. Generated programmatically to keep the file readable.
+  'stress-test': Array.from({ length: 200 }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as Message['role'],
+    content: `Stress message ${i + 1}: ${'Lorem ipsum dolor sit amet. '.repeat(3)}`,
+    timestamp: new Date(Date.now() + i * 1000).toISOString(),
+  })),
 };
 
 // Demo conversations (as ConversationSummary objects)
@@ -250,6 +259,14 @@ export const demoConversations: ConversationSummary[] = [
     name: 'Edge cases (rendering regression bed)',
     modified: Math.floor(Date.now() / 1000),
     messages: demoMessages['edge-cases'].length,
+    readonly: true,
+    workspace: '/demo/workspace',
+  },
+  {
+    id: 'stress-test',
+    name: 'Stress test (200 messages)',
+    modified: Math.floor(Date.now() / 1000),
+    messages: demoMessages['stress-test'].length,
     readonly: true,
     workspace: '/demo/workspace',
   },


### PR DESCRIPTION
Follow-up to #3379 per @ErikBjare's request: ["Make a follow-up PR that makes sure that performance doesn't regress."](https://github.com/gptme/gptme/pull/3379#issuecomment-5096760909)

## What

Adds persistent regression coverage for the message-list virtualization shipped in #3379 (`ebbce08b9`).

### E2E tests (`performance.spec.ts`)

New `Performance: message list virtualization` describe block with 3 tests that open a new 200-message `stress-test` demo conversation:

1. **Bounded DOM nodes** — asserts `<50` message rows mounted (not all 200)
2. **Scroll reveals new messages** — scrolls down and verifies a different set of indices is rendered, while still bounded
3. **Total DOM node count** — asserts `<3000` elements (pre-virtualization was 8000+ for 200 messages)

### Unit test (`ConversationContent.test.tsx`)

New test verifying the virtualizer receives the correct `count` after hidden/system/collapsed messages are filtered from `visibleMessageIndices`. Guards against geometry regressions where filtered messages reserve blank scroll space.

### Demo data (`democonversations.ts`)

New `stress-test` conversation with 200 programmatically-generated alternating user/assistant messages.

## Verification

- `npx tsc --noEmit` — clean
- `npx jest` — 635 tests passed (64 suites)
- `npx eslint` — clean
- Pre-commit hooks passed

## Why not just unit tests?

The existing unit tests mock `@tanstack/react-virtual` with a `__virtualWindow` shim, so they cannot catch a regression where the real virtualizer is removed or bypassed. The e2e tests exercise the actual virtualizer against a real browser viewport.