### PR TITLE
docs(automation): add review-gated autonomous workflow section

### DIFF
--- a/docs/automation.rst
+++ b/docs/automation.rst
@@ -284,6 +284,81 @@ For tighter integration, use the gptme Python API directly:
 See the :doc:`api` reference for the full Python interface.
 
 
+Review-Gated Autonomous Workflows
+----------------------------------
+
+Interactive confirmation prompts are the natural safety boundary for interactive
+sessions, but they break down in autonomous use: ``-n``/``--non-interactive``
+skips all prompts, and many tools (browser, shell) don't route every operation
+through a confirmation hook anyway.
+
+The pattern that works in practice is **review-gated delivery**: let gptme work
+autonomously in an isolated, version-controlled workspace, but gate every
+consequential output on a deterministic review step — push a branch, open a PR,
+let CI run, get a human to review, then merge. The PR diff is the evidence; the
+review is the gate.
+
+This is the pattern used by gptme agents in production (see :doc:`agents`).
+
+Workflow
+~~~~~~~~~
+
+.. code-block:: bash
+
+   # 1. Create an isolated workspace so changes are contained
+   git worktree add -b feat/my-task /tmp/my-task origin/master
+   cd /tmp/my-task
+
+   # 2. Let gptme work autonomously — no confirmations needed
+   gptme -n \
+     "Read the issue at https://github.com/myorg/myrepo/issues/42" \
+     - "Implement the requested feature" \
+     - "Run the tests and fix any failures" \
+     - "Summarize what you changed"
+
+   # 3. Review the diff yourself before pushing
+   git diff origin/master
+
+   # 4. Push to a branch (never directly to master)
+   git push origin feat/my-task
+
+   # 5. Open a PR — CI runs, human reviews, then merges
+   gh pr create --title "feat: implement issue #42" --body "Closes #42"
+
+.. note::
+
+   The PR review step is where you catch problems: the diff shows exactly what
+   changed, CI validates correctness, and you decide whether to merge. This is
+   a stronger boundary than per-tool confirmations because it covers the full
+   output rather than individual operations.
+
+Compared to Interactive Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------------------------+-----------------------------+-----------------------------+
+| Aspect                      | Interactive (with prompts)  | Review-gated (autonomous)   |
++=============================+=============================+=============================+
+| Safety boundary             | Per-operation confirmation  | PR review before merge      |
++-----------------------------+-----------------------------+-----------------------------+
+| Works in ``-n`` mode        | No (prompts skipped)        | Yes                         |
++-----------------------------+-----------------------------+-----------------------------+
+| Covers all tool calls       | Partial (varies by tool)    | Yes (diff shows everything) |
++-----------------------------+-----------------------------+-----------------------------+
+| CI integration              | Manual                      | Automatic on PR open        |
++-----------------------------+-----------------------------+-----------------------------+
+| Audit trail                 | Session log                 | Git history + PR thread     |
++-----------------------------+-----------------------------+-----------------------------+
+
+When to use each:
+
+- **Interactive mode with confirmations**: exploratory tasks where you want to
+  approve each step; actions that can't be reversed (deleting data, sending
+  emails, deploying to production).
+
+- **Review-gated autonomous mode**: code changes, doc updates, research tasks,
+  or any work that produces a reviewable artifact before its effects are final.
+
+
 Best Practices
 --------------
 

--- a/docs/automation.rst
+++ b/docs/automation.rst
@@ -292,11 +292,19 @@ sessions, but they break down in autonomous use: ``-n``/``--non-interactive``
 skips all prompts, and many tools (browser, shell) don't route every operation
 through a confirmation hook anyway.
 
-The pattern that works in practice is **review-gated delivery**: let gptme work
-autonomously in an isolated, version-controlled workspace, but gate every
-consequential output on a deterministic review step — push a branch, open a PR,
-let CI run, get a human to review, then merge. The PR diff is the evidence; the
-review is the gate.
+The pattern that works in practice for code and other version-controlled
+artifacts is **review-gated delivery**: let gptme work autonomously in an
+isolated workspace, but gate delivery on a deterministic review step — inspect
+the complete staged diff, push a branch, open a PR, let CI run, get a human to
+review, then merge. The PR diff is the evidence; the review is the delivery
+gate.
+
+A PR cannot contain side effects outside the checkout. Scope the task to the
+worktree and do not give the session credentials or tools that can send,
+publish, deploy, spend, or mutate external systems. For stronger isolation, run
+gptme in a VM or container with only the repository mounted and use a dedicated
+GitHub account or fine-grained token that can push feature branches but cannot
+merge or write to the default branch.
 
 This is the pattern used by gptme agents in production (see :doc:`agents`).
 
@@ -316,21 +324,30 @@ Workflow
      - "Run the tests and fix any failures" \
      - "Summarize what you changed"
 
-   # 3. Review the diff yourself before pushing
+   # 3. Review every change, including newly created files
+   git status --short
    git diff origin/master
 
-   # 4. Push to a branch (never directly to master)
+   # Stage only the files you accepted
+   git add path/to/changed-file path/to/new-file
+   git diff --cached origin/master
+
+   # 4. Commit exactly what you reviewed
+   git commit -m "feat: implement issue #42"
+
+   # 5. Push to a branch (never directly to master)
    git push origin feat/my-task
 
-   # 5. Open a PR — CI runs, human reviews, then merges
+   # 6. Open a PR — CI runs, human reviews, then merges
    gh pr create --title "feat: implement issue #42" --body "Closes #42"
 
 .. note::
 
-   The PR review step is where you catch problems: the diff shows exactly what
-   changed, CI validates correctness, and you decide whether to merge. This is
-   a stronger boundary than per-tool confirmations because it covers the full
-   output rather than individual operations.
+   The PR review step is where you catch problems in the committed artifact:
+   the diff shows exactly what changed, CI validates correctness, and you
+   decide whether to merge. It does not review external side effects, so those
+   must be prevented through task scoping, tool restrictions, credentials, and
+   environment isolation.
 
 Compared to Interactive Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -342,7 +359,7 @@ Compared to Interactive Mode
 +-----------------------------+-----------------------------+-----------------------------+
 | Works in ``-n`` mode        | No (prompts skipped)        | Yes                         |
 +-----------------------------+-----------------------------+-----------------------------+
-| Covers all tool calls       | Partial (varies by tool)    | Yes (diff shows everything) |
+| Coverage                    | Supported operations        | Committed artifact only     |
 +-----------------------------+-----------------------------+-----------------------------+
 | CI integration              | Manual                      | Automatic on PR open        |
 +-----------------------------+-----------------------------+-----------------------------+
@@ -355,8 +372,14 @@ When to use each:
   approve each step; actions that can't be reversed (deleting data, sending
   emails, deploying to production).
 
-- **Review-gated autonomous mode**: code changes, doc updates, research tasks,
-  or any work that produces a reviewable artifact before its effects are final.
+- **Review-gated autonomous mode**: code changes, doc updates, or other work
+  where all intended effects are contained in the committed artifact. Keep
+  research local unless its browser access is constrained to reading; external
+  actions still need a separate boundary before they occur.
+
+For a task-oriented introduction to these choices, including copy-paste
+starting points and local-versus-remote guidance, see
+:doc:`howto/choose-workflow`.
 
 
 Best Practices

--- a/docs/howto/choose-workflow.md
+++ b/docs/howto/choose-workflow.md
@@ -9,9 +9,9 @@ job, then increase model capability or tool access only when the task requires i
 | Task | Start here | Model tier | Execution and approval posture |
 |---|---|---|---|
 | **Answer a low-stakes question** | Run `gptme "…"` with no tools when the answer does not need live or local evidence. | Small and fast. | No external actions; inspect the answer before relying on it. |
-| **Research a topic** | Give the agent the browser tool and ask for linked sources plus a short synthesis. | Small for collection; stronger reasoning for conflicting evidence or an important decision. | Keep the work local and require source links. The browser can interact with pages, so keep confirmations on and approve only read operations. |
+| **Research a topic** | Give the agent the browser tool and ask for linked sources plus a short synthesis. | Small for collection; stronger reasoning for conflicting evidence or an important decision. | Keep the work local and require source links. The browser can interact with pages, so explicitly forbid external actions and use environment or credential isolation when confirmation prompts are not a reliable boundary. |
 | **Create an artifact** | Name the output file and acceptance criteria: a report, image, script, or web page. | General-purpose; use a stronger model when structure or judgment matters. | Write only to a dedicated workspace. Review the artifact before sending or publishing it. |
-| **Change inspectable code** | Run gptme inside a version-controlled checkout; ask it to inspect, edit, test, and show the diff. | Strong coding/reasoning model. | Keep confirmations on. Review commands and the diff; isolate untrusted repositories. |
+| **Change inspectable code** | Run gptme inside a version-controlled checkout; ask it to inspect, edit, test, and show the diff. | Strong coding/reasoning model. | Use confirmations for interactive work or a review-gated branch/PR workflow for autonomous work. Isolate untrusted repositories. |
 
 Model names change faster than these capabilities. See {doc}`../model-routing`
 for current model examples and {ref}`tool-allowlist` for exact tool-selection
@@ -38,11 +38,14 @@ gptme --tools "browser,rag,chats,read" \
 ```
 
 The browser tool also exposes page interactions such as clicks and form entry;
-its allowlist entry does not restrict it to reading. Keep interactive
-confirmations enabled, reject any interaction request, and use `hint:read-only`
-only for tools actually annotated as read-only. For an important choice, split
-collection from judgment: gather sources cheaply, then use a stronger model to
-challenge the synthesis and identify missing evidence.
+its allowlist entry does not restrict it to reading, and confirmation prompts do
+not cover every browser operation. Explicitly prohibit external actions in the
+task, but do not treat that instruction as a security boundary. For stronger
+assurance, run in a VM or container without sensitive credentials or use a
+restricted account or fine-grained token that cannot write. Use
+`hint:read-only` only for tools actually annotated as read-only. For an
+important choice, split collection from judgment: gather sources cheaply, then
+use a stronger model to challenge the synthesis and identify missing evidence.
 
 ### Artifact creation
 
@@ -67,10 +70,14 @@ gptme \
   "Inspect the failing tests, make the smallest fix, rerun the targeted tests, and show me the diff. Do not commit or push."
 ```
 
-A local checkout gives you the strongest review surface: version control,
-tests, and a diff. Review an unfamiliar repository's `gptme.toml` before
-starting because project configuration can run hooks and context commands. See
-{doc}`../security` for the complete trust model.
+A local checkout gives you a strong review surface: version control, tests, and
+a diff. For autonomous work, use the review-gated branch/PR workflow in
+{doc}`../automation`: stage and inspect every change, commit only that reviewed
+artifact, push only a feature branch, and stop before merge. A PR does not cover
+side effects outside the checkout, so remove external credentials or constrain
+them with a dedicated GitHub account or fine-grained token. Review an unfamiliar
+repository's `gptme.toml` before starting because project configuration can run
+hooks and context commands. See {doc}`../security` for the complete trust model.
 
 ## Local or remote?
 
@@ -88,8 +95,11 @@ Choose based on where the required data and verification tools already live:
 
 ## Approval rule
 
-Keep interactive confirmations on by default. Require an explicit human review
-immediately before any action that:
+Use interactive confirmations when a human is present, or a review-gated
+artifact workflow when autonomous work can be fully contained in a checkout.
+Confirmation prompts are not available in non-interactive mode and do not cover
+every operation, so they are a convenience rather than a complete security
+boundary. Require an explicit human review immediately before any action that:
 
 - sends a message or submits a form;
 - spends money or creates a paid resource;


### PR DESCRIPTION
## Problem

The workflow guide added in #3389 recommended per-tool confirmations as the primary safety boundary. Erik's feedback (#3390) correctly identified this as the wrong model: confirmations are skipped in `-n`/non-interactive mode, not available at all tool call boundaries, and unavailable in unattended runs.

## Solution

Add a "Review-Gated Autonomous Workflows" section to `docs/automation.rst` that documents the pattern that actually works in practice:

1. Work in an isolated branch/worktree so changes are contained
2. Let gptme run non-interactively (`-n`) — no confirmation prompts needed
3. Review the diff before pushing
4. Open a PR → CI validates → human reviews → merge

The PR diff is the evidence; the review is the gate. This is a stronger safety boundary than per-operation prompts because it covers the full output, not just individual operations.

## What changed

- Added ~75 lines to `docs/automation.rst` with:
  - "Review-Gated Autonomous Workflows" section explaining the pattern
  - Concrete workflow with `git worktree` + `gptme -n` + `gh pr create`
  - Comparison table: interactive (prompts) vs review-gated (autonomous)
  - Guidance on when to use each mode

Closes #3390