### PR TITLE
feat(review-gate): add delivery target enforcement and tests

### DIFF
--- a/docs/automation.rst
+++ b/docs/automation.rst
@@ -318,7 +318,7 @@ Workflow
    cd /tmp/my-task
 
    # 2. Let gptme work autonomously — no confirmations needed
-   gptme -n \
+   gptme -n --review-gated \
      "Read the issue at https://github.com/myorg/myrepo/issues/42" \
      - "Implement the requested feature" \
      - "Run the tests and fix any failures" \
@@ -335,11 +335,16 @@ Workflow
    # 4. Commit exactly what you reviewed
    git commit -m "feat: implement issue #42"
 
-   # 5. Push to a branch (never directly to master)
-   git push origin feat/my-task
+   # 5. Push to an explicit feature branch (never directly to master)
+   git push origin HEAD:refs/heads/feat/my-task
 
    # 6. Open a PR — CI runs, human reviews, then merges
    gh pr create --title "feat: implement issue #42" --body "Closes #42"
+
+``--review-gated`` activates a fail-closed shell delivery gate. Every ``git
+push`` must name an explicit destination branch, the configured remote and its
+default branch must be discoverable, and the destination must not be that default
+branch. Commands outside this mode retain their existing behavior.
 
 .. note::
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -500,6 +500,12 @@ Run 'gptme-util --help' for all utility commands."""
     help="Skip all confirmation prompts.",
 )
 @click.option(
+    "--review-gated",
+    is_flag=True,
+    envvar="GPTME_REVIEW_GATED",
+    help="Fail closed on git pushes that do not target an explicit non-default branch.",
+)
+@click.option(
     "--gear",
     type=click.IntRange(0, 4),
     default=None,
@@ -696,6 +702,7 @@ def main(
     stream: bool,
     verbose: bool,
     no_confirm: bool,
+    review_gated: bool,
     non_interactive: bool,
     output_format: str,
     show_hidden: bool,
@@ -761,6 +768,9 @@ def main(
         from ..hooks.manifest import register_manifest_hooks  # fmt: skip
 
         register_manifest_hooks(manifest_dir)
+
+    if review_gated:
+        os.environ["GPTME_REVIEW_GATE"] = "1"
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
     # (observed to occur in some Click versions when --name "" is passed)

--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -1,0 +1,116 @@
+"""Review-gated delivery enforcement for autonomous workflows.
+
+Validates that a target branch is eligible for review-gated push: not the
+default branch, and a VCS remote is reachable. Call ``check_delivery_target``
+before pushing from any autonomous workflow.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ReviewGateStatus(Enum):
+    OK = "ok"
+    NO_REMOTE = "no_remote"
+    DEFAULT_BRANCH = "default_branch"
+
+
+@dataclass
+class ReviewGateResult:
+    status: ReviewGateStatus
+    message: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == ReviewGateStatus.OK
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def get_remote_names(repo: Path) -> list[str]:
+    """Return the configured git remote names for the repo."""
+    rc, out = _run_git(["remote"], repo)
+    if rc != 0 or not out:
+        return []
+    return out.splitlines()
+
+
+def get_default_branch(repo: Path, remote: str = "origin") -> str | None:
+    """Return the default branch name for the remote, or None if it cannot be determined."""
+    # Prefer the symbolic ref set by 'git fetch'/'git remote set-head'
+    rc, out = _run_git(["symbolic-ref", f"refs/remotes/{remote}/HEAD"], repo)
+    if rc == 0 and out:
+        return out.split("/")[-1]
+
+    # Fall back to 'git remote show' (may make a network call)
+    rc, out = _run_git(["remote", "show", remote], repo)
+    if rc == 0:
+        for line in out.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("HEAD branch:"):
+                return stripped.split(":", 1)[1].strip()
+
+    # Final heuristic: check well-known default branch names
+    for name in ("master", "main"):
+        rc, _ = _run_git(
+            ["rev-parse", "--verify", f"refs/remotes/{remote}/{name}"], repo
+        )
+        if rc == 0:
+            return name
+
+    return None
+
+
+def check_delivery_target(
+    branch: str,
+    repo: Path,
+    remote: str = "origin",
+) -> ReviewGateResult:
+    """Validate that *branch* is eligible for review-gated push to *remote*.
+
+    Returns:
+        ReviewGateResult with status OK, NO_REMOTE, or DEFAULT_BRANCH.
+    """
+    remotes = get_remote_names(repo)
+    if remote not in remotes:
+        return ReviewGateResult(
+            status=ReviewGateStatus.NO_REMOTE,
+            message=(
+                f"No remote '{remote}' configured. "
+                "Review-gated delivery requires a VCS remote."
+            ),
+        )
+
+    default = get_default_branch(repo, remote)
+    if default is not None and branch == default:
+        return ReviewGateResult(
+            status=ReviewGateStatus.DEFAULT_BRANCH,
+            message=(
+                f"Branch '{branch}' is the default branch. "
+                "Review-gated delivery requires a feature branch, not the default branch."
+            ),
+        )
+
+    return ReviewGateResult(
+        status=ReviewGateStatus.OK,
+        message=(
+            f"Branch '{branch}' is eligible for review-gated delivery "
+            f"via remote '{remote}'."
+        ),
+    )

--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -7,19 +7,21 @@ before pushing from any autonomous workflow.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-if TYPE_CHECKING:
-    from pathlib import Path
+_GIT_TIMEOUT_SECONDS = 10
+_REVIEW_GATE_ENV = "GPTME_REVIEW_GATE"
 
 
 class ReviewGateStatus(Enum):
     OK = "ok"
     NO_REMOTE = "no_remote"
     DEFAULT_BRANCH = "default_branch"
+    AMBIGUOUS_TARGET = "ambiguous_target"
 
 
 @dataclass
@@ -33,13 +35,17 @@ class ReviewGateResult:
 
 
 def _run_git(args: list[str], cwd: Path) -> tuple[int, str]:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 1, ""
     return result.returncode, result.stdout.strip()
 
 
@@ -56,7 +62,9 @@ def get_default_branch(repo: Path, remote: str = "origin") -> str | None:
     # Prefer the symbolic ref set by 'git fetch'/'git remote set-head'
     rc, out = _run_git(["symbolic-ref", f"refs/remotes/{remote}/HEAD"], repo)
     if rc == 0 and out:
-        return out.split("/")[-1]
+        prefix = f"refs/remotes/{remote}/"
+        if out.startswith(prefix):
+            return out[len(prefix) :]
 
     # Fall back to 'git remote show' (may make a network call)
     rc, out = _run_git(["remote", "show", remote], repo)
@@ -98,7 +106,16 @@ def check_delivery_target(
         )
 
     default = get_default_branch(repo, remote)
-    if default is not None and branch == default:
+    if default is None:
+        return ReviewGateResult(
+            status=ReviewGateStatus.NO_REMOTE,
+            message=(
+                f"Cannot determine the default branch for remote '{remote}'. "
+                "Review-gated delivery requires an established review boundary."
+            ),
+        )
+
+    if branch == default:
         return ReviewGateResult(
             status=ReviewGateStatus.DEFAULT_BRANCH,
             message=(
@@ -113,4 +130,165 @@ def check_delivery_target(
             f"Branch '{branch}' is eligible for review-gated delivery "
             f"via remote '{remote}'."
         ),
+    )
+
+
+def _command_words(node: object) -> list[str] | None:
+    """Return command words, marking dynamically expanded words as unknown."""
+    if getattr(node, "kind", None) != "command":
+        return None
+
+    words: list[str] = []
+    for part in getattr(node, "parts", []):
+        kind = getattr(part, "kind", None)
+        if kind == "redirect":
+            continue
+        if kind == "assignment" and not words:
+            continue
+        if kind != "word":
+            return None
+        words.append("" if getattr(part, "parts", []) else part.word)
+    return words
+
+
+def _walk_shell_nodes(node: object) -> list[object]:
+    """Return *node* and all nested bashlex nodes without following cycles."""
+    nodes: list[object] = []
+    stack = [node]
+    seen: set[int] = set()
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        nodes.append(current)
+        for value in vars(current).values():
+            if hasattr(value, "kind"):
+                stack.append(value)
+            elif isinstance(value, list):
+                stack.extend(item for item in value if hasattr(item, "kind"))
+    return nodes
+
+
+def _git_push_arguments(words: list[str]) -> list[str] | None:
+    """Extract arguments after a literal ``git push`` command."""
+    try:
+        git_index = words.index("git")
+        push_index = words.index("push", git_index + 1)
+    except ValueError:
+        return None
+
+    # Wrapper commands are allowed only when they directly execute git. This supports
+    # common ``env``, ``command``, and ``sudo`` forms without mistaking
+    # ``echo git push ...`` for delivery.
+    prefix = words[:git_index]
+    if prefix and prefix[0] not in {"command", "env", "sudo"}:
+        return None
+    return words[push_index + 1 :]
+
+
+def _git_push_targets(command: str) -> list[tuple[str, str | None]]:
+    """Return literal ``(remote, destination)`` pairs from a shell command.
+
+    The parser intentionally returns an unknown destination for any push it cannot
+    establish statically. Review-gated mode then fails closed instead of guessing.
+    """
+    import bashlex
+
+    try:
+        roots = bashlex.parse(command)
+    except Exception:
+        # A lexical push signal in an unparseable command is ambiguous and blocked.
+        return [("origin", None)] if "git" in command and "push" in command else []
+
+    targets: list[tuple[str, str | None]] = []
+    for root in roots:
+        for node in _walk_shell_nodes(root):
+            words = _command_words(node)
+            if words is None:
+                continue
+            args = _git_push_arguments(words)
+            if args is None:
+                # Shell interpreters can hide an arbitrary push in a string. Block
+                # such commands when the payload contains a push signal.
+                if words[:2] in (["bash", "-c"], ["sh", "-c"]) and any(
+                    "git push" in word for word in words[2:]
+                ):
+                    targets.append(("origin", None))
+                continue
+
+            positional: list[str] = []
+            option_remote: str | None = None
+            skip_next = False
+            for index, arg in enumerate(args):
+                if skip_next:
+                    skip_next = False
+                    continue
+                if arg == "--repo" and index + 1 < len(args):
+                    option_remote = args[index + 1]
+                    skip_next = True
+                elif arg.startswith("--repo="):
+                    option_remote = arg.split("=", 1)[1]
+                elif arg in {"--receive-pack", "--exec", "-o", "--push-option"}:
+                    skip_next = True
+                elif not arg.startswith("-"):
+                    positional.append(arg)
+
+            remote = option_remote or (positional[0] if positional else "origin")
+            refspecs = positional if option_remote else positional[1:]
+            if not refspecs:
+                targets.append((remote, None))
+                continue
+
+            for refspec in refspecs:
+                literal_destination = refspec.rsplit(":", 1)[-1].removeprefix(
+                    "refs/heads/"
+                )
+                destination: str | None = literal_destination
+                if literal_destination.startswith("+") or any(
+                    char in literal_destination for char in "$`*?[{"
+                ):
+                    destination = None
+                targets.append((remote, destination))
+    return targets
+
+
+def check_shell_delivery(
+    command: str, repo: Path | None = None
+) -> ReviewGateResult | None:
+    """Validate every git push in *command* when review-gated mode is active.
+
+    Returns ``None`` outside review-gated mode or when the command has no push.
+    Ambiguous pushes fail closed because their destination cannot be reviewed before
+    execution.
+    """
+    if os.environ.get(_REVIEW_GATE_ENV, "").lower() not in {"1", "true", "yes", "on"}:
+        return None
+
+    targets = _git_push_targets(command)
+    if not targets:
+        return None
+
+    repo = repo or Path.cwd()
+    for remote, branch in targets:
+        if (
+            not branch
+            or branch in {"HEAD", "@{push}"}
+            or branch.startswith(("+", "refs/tags/"))
+        ):
+            return ReviewGateResult(
+                status=ReviewGateStatus.AMBIGUOUS_TARGET,
+                message=(
+                    "Review-gated delivery requires an explicit literal destination "
+                    "branch: use 'git push <remote> "
+                    "HEAD:refs/heads/<feature-branch>'."
+                ),
+            )
+        result = check_delivery_target(branch, repo, remote)
+        if not result.ok:
+            return result
+
+    return ReviewGateResult(
+        status=ReviewGateStatus.OK,
+        message="All git push destinations passed the review gate.",
     )

--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -217,6 +217,11 @@ def _git_push_targets(command: str) -> list[tuple[str, str | None]]:
                 # static inspection, so review-gated mode must reject them.
                 if words and words[0] in dynamic_commands:
                     targets.append(("origin", None))
+                # A variable-expanded command word (empty string from _command_words)
+                # before a literal 'push' cannot be statically verified as non-git;
+                # e.g. `$g push origin master` bypasses the literal 'git' check.
+                elif words and words[0] == "" and "push" in words:
+                    targets.append(("origin", None))
                 continue
 
             positional: list[str] = []

--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -74,14 +74,6 @@ def get_default_branch(repo: Path, remote: str = "origin") -> str | None:
             if stripped.startswith("HEAD branch:"):
                 return stripped.split(":", 1)[1].strip()
 
-    # Final heuristic: check well-known default branch names
-    for name in ("master", "main"):
-        rc, _ = _run_git(
-            ["rev-parse", "--verify", f"refs/remotes/{remote}/{name}"], repo
-        )
-        if rc == 0:
-            return name
-
     return None
 
 

--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -182,7 +182,7 @@ def _git_push_arguments(words: list[str]) -> list[str] | None:
     # common ``env``, ``command``, and ``sudo`` forms without mistaking
     # ``echo git push ...`` for delivery.
     prefix = words[:git_index]
-    if prefix and prefix[0] not in {"command", "env", "sudo"}:
+    if prefix and prefix[0] not in {"bg", "command", "env", "sudo"}:
         return None
     return words[push_index + 1 :]
 
@@ -202,18 +202,20 @@ def _git_push_targets(command: str) -> list[tuple[str, str | None]]:
         return [("origin", None)] if "git" in command and "push" in command else []
 
     targets: list[tuple[str, str | None]] = []
+    dynamic_commands = {".", "bash", "eval", "sh", "source", "xargs"}
     for root in roots:
         for node in _walk_shell_nodes(root):
+            if getattr(node, "kind", None) != "command":
+                continue
             words = _command_words(node)
             if words is None:
+                targets.append(("origin", None))
                 continue
             args = _git_push_arguments(words)
             if args is None:
-                # Shell interpreters can hide an arbitrary push in a string. Block
-                # such commands when the payload contains a push signal.
-                if words[:2] in (["bash", "-c"], ["sh", "-c"]) and any(
-                    "git push" in word for word in words[2:]
-                ):
+                # Dynamic command loaders/evaluators can hide arbitrary pushes from
+                # static inspection, so review-gated mode must reject them.
+                if words and words[0] in dynamic_commands:
                     targets.append(("origin", None))
                 continue
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..message import Message
+from ..review_gate import check_shell_delivery
 from ..sandbox import SandboxConfig, build_env, wrap_shell_cmd
 from ..util import get_installed_programs
 from ..util.ask_execute import execute_with_confirmation
@@ -1719,6 +1720,17 @@ def execute_shell(
         # Fall through to regular shell execution for other kill commands
 
     timeout = _get_timeout()
+
+    # In review-gated mode, fail closed before an autonomous shell can push.
+    workspace = get_workspace_cwd()
+    delivery_result = check_shell_delivery(
+        cmd, Path(workspace) if workspace is not None else Path.cwd()
+    )
+    if delivery_result is not None and not delivery_result.ok:
+        yield Message(
+            "system", f"Command denied by review gate: {delivery_result.message}"
+        )
+        return
 
     # Check with shellcheck if available
     has_issues, should_block, shellcheck_msg = check_with_shellcheck(cmd)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1655,6 +1655,17 @@ def execute_shell(
     cmd_lower = cmd_stripped.lower()
     cmd_parts = cmd_stripped.split(maxsplit=1)
 
+    # Gate the full command before any special handler can execute a subset of it.
+    workspace = get_workspace_cwd()
+    delivery_result = check_shell_delivery(
+        cmd, Path(workspace) if workspace is not None else Path.cwd()
+    )
+    if delivery_result is not None and not delivery_result.ok:
+        yield Message(
+            "system", f"Command denied by review gate: {delivery_result.message}"
+        )
+        return
+
     # Check for bg command - can be on any line (Issue #992)
     # Split into lines and find if any line starts with "bg "
     lines = cmd_stripped.split("\n")
@@ -1720,17 +1731,6 @@ def execute_shell(
         # Fall through to regular shell execution for other kill commands
 
     timeout = _get_timeout()
-
-    # In review-gated mode, fail closed before an autonomous shell can push.
-    workspace = get_workspace_cwd()
-    delivery_result = check_shell_delivery(
-        cmd, Path(workspace) if workspace is not None else Path.cwd()
-    )
-    if delivery_result is not None and not delivery_result.ok:
-        yield Message(
-            "system", f"Command denied by review gate: {delivery_result.message}"
-        )
-        return
 
     # Check with shellcheck if available
     has_issues, should_block, shellcheck_msg = check_with_shellcheck(cmd)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,15 @@ def test_version(runner: CliRunner):
     assert "gptme" in result.output
 
 
+def test_review_gated_flag_activates_delivery_gate(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("GPTME_REVIEW_GATE", raising=False)
+    result = runner.invoke(cli.main, ["--review-gated", "--version"])
+    assert result.exit_code == 0
+    assert os.environ["GPTME_REVIEW_GATE"] == "1"
+
+
 def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,173 @@
+"""Tests for review-gated delivery enforcement.
+
+Covers:
+- Default-branch rejection (cannot push to master/main)
+- Feature-branch delivery allowed
+- Failure when the review gate is unavailable (no VCS remote)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.review_gate import (
+    ReviewGateStatus,
+    check_delivery_target,
+    get_default_branch,
+    get_remote_names,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    env = os.environ.copy()
+    env["ALLOW_GIT_IDENTITY"] = "1"
+    # Skip host git hooks (identity + master-commit guards) in test repos
+    subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _make_bare_remote(path: Path, default_branch: str = "master") -> Path:
+    """Create a bare git repository that acts as a remote."""
+    remote = path / "remote.git"
+    remote.mkdir()
+    _git(["init", "--bare", f"--initial-branch={default_branch}", str(remote)], path)
+    return remote
+
+
+def _make_repo_with_remote(
+    path: Path,
+    default_branch: str = "master",
+) -> tuple[Path, Path]:
+    """Create a local repo with one commit and a bare remote called 'origin'."""
+    remote = _make_bare_remote(path, default_branch)
+    repo = path / "repo"
+    repo.mkdir()
+    _git(["init", f"--initial-branch={default_branch}", str(repo)], path)
+    _git(["config", "user.email", "test@example.com"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    (repo / "README.md").write_text("hi\n")
+    _git(["add", "README.md"], repo)
+    _git(["commit", "-m", "init"], repo)
+    _git(["remote", "add", "origin", str(remote)], repo)
+    _git(["push", "-u", "origin", default_branch], repo)
+    return repo, remote
+
+
+def _make_repo_no_remote(path: Path, default_branch: str = "master") -> Path:
+    """Create a local repo with no remote configured."""
+    repo = path / "repo_no_remote"
+    repo.mkdir()
+    _git(["init", f"--initial-branch={default_branch}", str(repo)], path)
+    _git(["config", "user.email", "test@example.com"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    (repo / "README.md").write_text("hi\n")
+    _git(["add", "README.md"], repo)
+    _git(["commit", "-m", "init"], repo)
+    return repo
+
+
+# ── get_remote_names ─────────────────────────────────────────────────────────
+
+
+def test_get_remote_names_with_origin(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    assert get_remote_names(repo) == ["origin"]
+
+
+def test_get_remote_names_no_remote(tmp_path: Path) -> None:
+    repo = _make_repo_no_remote(tmp_path)
+    assert get_remote_names(repo) == []
+
+
+# ── get_default_branch ───────────────────────────────────────────────────────
+
+
+def test_get_default_branch_master(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="master")
+    branch = get_default_branch(repo)
+    assert branch == "master"
+
+
+def test_get_default_branch_main(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="main")
+    branch = get_default_branch(repo)
+    assert branch == "main"
+
+
+def test_get_default_branch_no_remote_returns_none(tmp_path: Path) -> None:
+    repo = _make_repo_no_remote(tmp_path)
+    branch = get_default_branch(repo)
+    assert branch is None
+
+
+# ── check_delivery_target ────────────────────────────────────────────────────
+
+
+def test_delivery_target_rejects_default_branch(tmp_path: Path) -> None:
+    """Pushing to the default branch must be rejected."""
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="master")
+    result = check_delivery_target("master", repo)
+    assert not result.ok
+    assert result.status == ReviewGateStatus.DEFAULT_BRANCH
+    assert "default branch" in result.message.lower()
+
+
+def test_delivery_target_rejects_main_as_default(tmp_path: Path) -> None:
+    """Same rejection applies when the default branch is 'main'."""
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="main")
+    result = check_delivery_target("main", repo)
+    assert not result.ok
+    assert result.status == ReviewGateStatus.DEFAULT_BRANCH
+
+
+def test_delivery_target_allows_feature_branch(tmp_path: Path) -> None:
+    """A non-default feature branch is allowed."""
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="master")
+    result = check_delivery_target("feat/my-task", repo)
+    assert result.ok
+    assert result.status == ReviewGateStatus.OK
+
+
+def test_delivery_target_allows_fix_branch(tmp_path: Path) -> None:
+    """Any non-default name is allowed."""
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="master")
+    result = check_delivery_target("fix-3390", repo)
+    assert result.ok
+
+
+def test_delivery_target_fails_when_no_remote(tmp_path: Path) -> None:
+    """Without a VCS remote the gate must fail closed."""
+    repo = _make_repo_no_remote(tmp_path)
+    result = check_delivery_target("feat/my-task", repo)
+    assert not result.ok
+    assert result.status == ReviewGateStatus.NO_REMOTE
+    assert "remote" in result.message.lower()
+
+
+def test_delivery_target_fails_for_missing_named_remote(tmp_path: Path) -> None:
+    """Specifying a remote that does not exist fails closed."""
+    repo, _ = _make_repo_with_remote(tmp_path)
+    result = check_delivery_target("feat/my-task", repo, remote="upstream")
+    assert not result.ok
+    assert result.status == ReviewGateStatus.NO_REMOTE
+
+
+def test_review_gate_result_ok_property(tmp_path: Path) -> None:
+    """ReviewGateResult.ok convenience property reflects status."""
+    repo, _ = _make_repo_with_remote(tmp_path)
+    ok_result = check_delivery_target("feat/my-task", repo)
+    bad_result = check_delivery_target("master", repo)
+    assert ok_result.ok is True
+    assert bad_result.ok is False

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -10,17 +10,19 @@ from __future__ import annotations
 
 import os
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-if TYPE_CHECKING:
-    from pathlib import Path
+import pytest
 
 from gptme.review_gate import (
+    ReviewGateResult,
     ReviewGateStatus,
     check_delivery_target,
+    check_shell_delivery,
     get_default_branch,
     get_remote_names,
 )
+from gptme.tools.shell import execute_shell
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -112,6 +114,12 @@ def test_get_default_branch_no_remote_returns_none(tmp_path: Path) -> None:
     assert branch is None
 
 
+def test_get_default_branch_preserves_slashes(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path, default_branch="release/stable")
+    branch = get_default_branch(repo)
+    assert branch == "release/stable"
+
+
 # ── check_delivery_target ────────────────────────────────────────────────────
 
 
@@ -171,3 +179,115 @@ def test_review_gate_result_ok_property(tmp_path: Path) -> None:
     bad_result = check_delivery_target("master", repo)
     assert ok_result.ok is True
     assert bad_result.ok is False
+
+
+def test_delivery_target_fails_when_default_is_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setattr("gptme.review_gate.get_default_branch", lambda *_: None)
+    result = check_delivery_target("feat/my-task", repo)
+    assert not result.ok
+    assert "cannot determine" in result.message.lower()
+
+
+def test_run_git_failures_are_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(*args: object, **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(["git"], 10)
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert get_remote_names(tmp_path) == []
+
+
+def test_shell_delivery_blocks_default_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery("git push origin HEAD:refs/heads/master", repo)
+    assert result is not None and not result.ok
+    assert result.status == ReviewGateStatus.DEFAULT_BRANCH
+
+
+def test_shell_delivery_allows_feature_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery("git push origin HEAD:refs/heads/feat/my-task", repo)
+    assert result is not None and result.ok
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push origin",
+        "git push origin HEAD",
+        "git push origin HEAD:refs/tags/v1",
+        'git push origin "HEAD:refs/heads/$DESTINATION"',
+        'bash -c "git push origin HEAD:refs/heads/feat/my-task"',
+    ],
+)
+def test_shell_delivery_blocks_ambiguous_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery(command, repo)
+    assert result is not None and not result.ok
+    assert result.status == ReviewGateStatus.AMBIGUOUS_TARGET
+    assert "explicit literal destination" in result.message.lower()
+
+
+def test_shell_delivery_rejects_implicit_default_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery("git push origin master", repo)
+    assert result is not None
+    assert result.status == ReviewGateStatus.DEFAULT_BRANCH
+
+
+def test_shell_delivery_finds_nested_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery(
+        "true && git push origin HEAD:refs/heads/master", repo
+    )
+    assert result is not None and result.status == ReviewGateStatus.DEFAULT_BRANCH
+
+
+def test_shell_delivery_ignores_push_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    assert check_shell_delivery("echo 'git push origin master'", repo) is None
+
+
+def test_shell_delivery_is_inactive_by_default(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    assert check_shell_delivery("git push origin master", repo) is None
+
+
+def test_execute_shell_invokes_delivery_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    blocked = ReviewGateResult(
+        ReviewGateStatus.AMBIGUOUS_TARGET, "test delivery boundary"
+    )
+    checked: list[tuple[str, Path]] = []
+
+    def block(command: str, repo: Path) -> ReviewGateResult:
+        checked.append((command, repo))
+        return blocked
+
+    monkeypatch.setattr("gptme.tools.shell.check_shell_delivery", block)
+    monkeypatch.setattr("gptme.tools.shell.get_workspace_cwd", lambda: "/workspace")
+    messages = list(execute_shell("git push origin", [], None))
+    assert checked == [("git push origin", Path("/workspace"))]
+    assert len(messages) == 1
+    assert "Command denied by review gate" in messages[0].content

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -120,6 +120,24 @@ def test_get_default_branch_preserves_slashes(tmp_path: Path) -> None:
     assert branch == "release/stable"
 
 
+def test_get_default_branch_does_not_guess_from_tracking_refs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+
+    def run_git(args: list[str], cwd: Path) -> tuple[int, str]:
+        if args == ["remote"]:
+            return 0, "origin"
+        if args[:2] == ["rev-parse", "--verify"]:
+            return 0, args[-1]
+        return 1, ""
+
+    monkeypatch.setattr("gptme.review_gate._run_git", run_git)
+    assert get_default_branch(repo) is None
+    result = check_delivery_target("main", repo)
+    assert result.status == ReviewGateStatus.NO_REMOTE
+
+
 # ── check_delivery_target ────────────────────────────────────────────────────
 
 

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -228,6 +228,9 @@ def test_shell_delivery_allows_feature_branch(
         "git push origin HEAD:refs/tags/v1",
         'git push origin "HEAD:refs/heads/$DESTINATION"',
         'bash -c "git push origin HEAD:refs/heads/feat/my-task"',
+        'eval "$COMMAND"',
+        "source ./delivery.sh",
+        ". ./delivery.sh",
     ],
 )
 def test_shell_delivery_blocks_ambiguous_push(
@@ -289,5 +292,16 @@ def test_execute_shell_invokes_delivery_gate(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr("gptme.tools.shell.get_workspace_cwd", lambda: "/workspace")
     messages = list(execute_shell("git push origin", [], None))
     assert checked == [("git push origin", Path("/workspace"))]
+    assert len(messages) == 1
+    assert "Command denied by review gate" in messages[0].content
+
+
+def test_execute_shell_gates_background_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    monkeypatch.setattr("gptme.tools.shell.get_workspace_cwd", lambda: str(repo))
+    messages = list(execute_shell("bg git push origin master", [], None))
     assert len(messages) == 1
     assert "Command denied by review gate" in messages[0].content

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -296,6 +296,17 @@ def test_execute_shell_invokes_delivery_gate(monkeypatch: pytest.MonkeyPatch) ->
     assert "Command denied by review gate" in messages[0].content
 
 
+def test_shell_delivery_blocks_variable_expanded_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Variable-expanded git command (e.g. $g push) must not bypass the gate."""
+    repo, _ = _make_repo_with_remote(tmp_path)
+    monkeypatch.setenv("GPTME_REVIEW_GATE", "1")
+    result = check_shell_delivery("$g push origin HEAD:refs/heads/master", repo)
+    assert result is not None and not result.ok
+    assert result.status == ReviewGateStatus.AMBIGUOUS_TARGET
+
+
 def test_execute_shell_gates_background_push(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

PR #3391 added the review-gated workflow documentation, but issue #3390 has two remaining acceptance criteria that require code:

- **Tests cover default-branch rejection, allowed feature-branch delivery, and failure when the review gate is unavailable.**
- **Fail closed when the configured review boundary cannot be established (for example, no VCS remote or an attempted push to the default branch).**

## Solution

Add `gptme/review_gate.py` — a small enforcement module — and `tests/test_review_gate.py` with 12 tests covering all three gate cases.

### `gptme/review_gate.py`

- `ReviewGateStatus` enum: `OK`, `NO_REMOTE`, `DEFAULT_BRANCH`
- `ReviewGateResult` dataclass with an `.ok` convenience property
- `get_remote_names(repo)` — lists configured git remotes
- `get_default_branch(repo, remote)` — detects the default branch via symbolic-ref, then `remote show`, then heuristic
- `check_delivery_target(branch, repo, remote)` — the gate: fails closed if no remote, rejects default branch, allows feature branches

### `tests/test_review_gate.py`

- `test_delivery_target_rejects_default_branch` — master rejected
- `test_delivery_target_rejects_main_as_default` — main rejected
- `test_delivery_target_allows_feature_branch` — feat/* allowed
- `test_delivery_target_allows_fix_branch` — any non-default name allowed
- `test_delivery_target_fails_when_no_remote` — no remote → NO_REMOTE
- `test_delivery_target_fails_for_missing_named_remote` — named remote absent → NO_REMOTE
- Plus 6 unit tests for `get_remote_names` and `get_default_branch`

Closes #3390

<!-- gptme-id:v1:gai_xKFB9opjYBaQ8RPXuxjUZmb7Zf0fLBLCuyMwRhPXNwT -->