### PR TITLE
feat(profiles): add review-gated profile with enforced delivery gate

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -812,6 +812,15 @@ def main(
 
         logger.info(f"Using agent profile: {selected_profile.name}")
 
+        # Activate review gate enforcement when the profile requests it
+        if selected_profile.behavior.review_gate:
+            from ..tools.shell_validation import set_review_gate
+
+            set_review_gate(True)
+            logger.info(
+                "Review gate activated: pushes to default branch and merges are blocked."
+            )
+
         # Apply profile tools if no explicit tools specified
         if (
             ctx.get_parameter_source("tool_allowlist") == ParameterSource.DEFAULT

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -1348,6 +1348,8 @@ def profile_list():
             behavior_flags.append("no-network")
         if prof.behavior.confirm_writes:
             behavior_flags.append("confirm-writes")
+        if prof.behavior.review_gate:
+            behavior_flags.append("review-gate")
         behavior_str = ", ".join(behavior_flags) if behavior_flags else "default"
 
         table.add_row(name, prof.description, tools_str, behavior_str)
@@ -1381,6 +1383,8 @@ def profile_show(name: str):
         behavior_flags.append("no-network")
     if prof.behavior.confirm_writes:
         behavior_flags.append("confirm-writes")
+    if prof.behavior.review_gate:
+        behavior_flags.append("review-gate")
     behavior_str = ", ".join(behavior_flags) if behavior_flags else "none (default)"
 
     content = f"""[cyan]Name:[/cyan] {prof.name}

--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -48,6 +48,7 @@ class ProfileBehavior:
     confirm_writes: bool = False
     read_only: bool = False
     no_network: bool = False
+    review_gate: bool = False
 
 
 @dataclass
@@ -258,6 +259,54 @@ BUILTIN_PROFILES: dict[str, Profile] = {
         ),
         tools=["read", "ipython", "shell", "chats"],
         behavior=ProfileBehavior(read_only=True, no_network=True),
+    ),
+    "review-gated": Profile(
+        name="review-gated",
+        description="Autonomous coding with enforced PR-review delivery gate — no merge/push to default branch",
+        system_prompt=(
+            "You are in REVIEW-GATED mode for autonomous coding work.\n"
+            "\n"
+            "## How this mode works\n"
+            "\n"
+            "You run without per-tool confirmation prompts (-n / non-interactive).\n"
+            "The safety boundary is the delivery gate, not interactive prompts:\n"
+            "- Work in an isolated feature branch (never push to master/main).\n"
+            "- Run tests and verify your changes before pushing.\n"
+            "- Push only to a feature branch, then open a PR.\n"
+            "- Stop after opening the PR — do not merge, deploy, or publish.\n"
+            "\n"
+            "## What is enforced\n"
+            "\n"
+            "The following are hard-blocked regardless of instructions:\n"
+            "- `git push` to master, main, trunk, or develop.\n"
+            "- `git merge` (merging must happen via PR after human/CI review).\n"
+            "\n"
+            "## Workflow\n"
+            "\n"
+            "```bash\n"
+            "# 1. Work in a feature branch\n"
+            "git checkout -b feat/my-task origin/master\n"
+            "\n"
+            "# 2. Make changes, run tests\n"
+            "# ... edit files ...\n"
+            "uv run pytest\n"
+            "\n"
+            "# 3. Commit your work\n"
+            "git add changed_file.py\n"
+            "git commit -m 'feat: description'\n"
+            "\n"
+            "# 4. Push the feature branch and open a PR\n"
+            "git push origin feat/my-task\n"
+            "gh pr create --title 'feat: ...' --body '...'\n"
+            "\n"
+            "# 5. Stop here — do not merge\n"
+            "```\n"
+            "\n"
+            "The PR diff, test results, and CI status form the reviewable artifact.\n"
+            "A human or CI pipeline approves and merges; you never do.\n"
+        ),
+        tools=None,
+        behavior=ProfileBehavior(review_gate=True),
     ),
 }
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -66,8 +66,10 @@ from .shell_background import (
 from .shell_validation import (
     _find_first_unquoted_pipe,
     check_with_shellcheck,
+    get_review_gate,
     is_allowlisted,
     is_denylisted,
+    is_review_gate_blocked,
     shell_allowlist_hook,
 )
 
@@ -1733,6 +1735,16 @@ def execute_shell(
     if is_denied:
         yield Message("system", f"Command denied: `{matched_cmd}`\n\n{deny_reason}")
         return
+
+    # Check review-gate policy when active (profile: review-gated)
+    if get_review_gate():
+        is_rg_blocked, rg_reason, rg_matched = is_review_gate_blocked(cmd)
+        if is_rg_blocked:
+            yield Message(
+                "system",
+                f"Command blocked by review gate: `{rg_matched}`\n\n{rg_reason}",
+            )
+            return
 
     # Skip confirmation for allowlisted commands
     if is_allowlisted(cmd):

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -11,6 +11,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 from typing import TYPE_CHECKING
 
 from ..util.context import md_codeblock
@@ -103,6 +104,75 @@ deny_groups = [
         "Piping to shell interpreters or script execution is blocked. This pattern can execute arbitrary code and is a security risk.",
     ),
 ]
+
+# Default branch names that the review gate protects
+_DEFAULT_BRANCHES = {"master", "main", "trunk", "develop"}
+
+# Patterns blocked when the review gate is active.
+# These prevent pushing/merging/deploying directly to the default branch or
+# triggering irreversible delivery actions without a PR-review step.
+_REVIEW_GATE_DENY_GROUPS: list[tuple[list[str], str]] = [
+    (
+        [
+            # git push [remote] <default-branch>
+            r"git\s+push\s+\S+\s+(?:" + "|".join(_DEFAULT_BRANCHES) + r")(?:\s|$)",
+            # git push [remote] HEAD:<default-branch>
+            r"git\s+push\s+\S+\s+HEAD:(?:" + "|".join(_DEFAULT_BRANCHES) + r")(?:\s|$)",
+            # git push with --set-upstream/-u to a default branch
+            r"git\s+push\s+(?:-u|--set-upstream)\s+\S+\s+(?:"
+            + "|".join(_DEFAULT_BRANCHES)
+            + r")(?:\s|$)",
+        ],
+        "Review gate: pushing directly to a default branch is blocked. "
+        "Push to a feature branch and open a PR instead.",
+    ),
+    (
+        [
+            r"git\s+merge\s+",
+        ],
+        "Review gate: merging is blocked. "
+        "Deliver changes via a PR; let the reviewer or CI trigger the merge.",
+    ),
+]
+
+# Module-level flag for review gate; set once at session startup.
+# A plain threading.local isn't needed here because the flag is set once
+# before any worker threads start and is read-only during the session.
+_review_gate_lock = threading.Lock()
+_review_gate_active: bool = False
+
+
+def set_review_gate(active: bool) -> None:
+    """Enable or disable review-gate enforcement for this process."""
+    global _review_gate_active
+    with _review_gate_lock:
+        _review_gate_active = active
+
+
+def get_review_gate() -> bool:
+    """Return True if review-gate enforcement is currently active."""
+    return _review_gate_active
+
+
+def is_review_gate_blocked(cmd: str) -> tuple[bool, str | None, str | None]:
+    """Check whether a command violates the review-gate policy.
+
+    Returns (blocked, reason, matched_pattern).
+    Only meaningful when get_review_gate() is True.
+    """
+    cmd_lower = cmd.lower().strip()
+    quoted_regions = _find_quotes(cmd)
+    heredoc_regions = _find_heredoc_regions(cmd)
+    safe_regions = quoted_regions + heredoc_regions
+
+    for patterns, reason in _REVIEW_GATE_DENY_GROUPS:
+        for pattern in patterns:
+            for match in re.finditer(pattern, cmd_lower, re.IGNORECASE):
+                if not _is_in_quoted_region(match.start(), safe_regions):
+                    return True, reason, match.group(0).strip()
+
+    return False, None, None
+
 
 # Regex to extract command names from pipeline components
 cmd_regex = re.compile(r"(?:^|[|&;]|\|\||&&|\n)\s*([^\s|&;]+)")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -4,14 +4,19 @@ Tests the allowlist/denylist logic, quote/heredoc parsing, pipe detection,
 and redirection detection in gptme/tools/shell_validation.py.
 """
 
+import pytest
+
 from gptme.tools.shell_validation import (
     _find_first_unquoted_pipe,
     _find_heredoc_regions,
     _find_quotes,
     _has_file_redirection,
     _is_in_quoted_region,
+    get_review_gate,
     is_allowlisted,
     is_denylisted,
+    is_review_gate_blocked,
+    set_review_gate,
 )
 
 # ── _find_quotes ─────────────────────────────────────────────────────
@@ -621,3 +626,196 @@ class TestEdgeCases:
         """Pipe characters in quoted arguments shouldn't trigger pipe detection."""
         result = _find_first_unquoted_pipe("grep 'a|b' file.txt")
         assert result is None
+
+
+# ── Review gate ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=False)
+def review_gate_active():
+    """Fixture that enables the review gate for the duration of a test."""
+    set_review_gate(True)
+    yield
+    set_review_gate(False)
+
+
+class TestReviewGateState:
+    """Tests for review gate enable/disable logic."""
+
+    def test_default_inactive(self):
+        set_review_gate(False)
+        assert get_review_gate() is False
+
+    def test_activate(self):
+        set_review_gate(True)
+        assert get_review_gate() is True
+        set_review_gate(False)
+
+    def test_deactivate(self):
+        set_review_gate(True)
+        set_review_gate(False)
+        assert get_review_gate() is False
+
+
+class TestReviewGateBlocked:
+    """Tests for is_review_gate_blocked() — default-branch push/merge enforcement."""
+
+    # --- Default-branch pushes are blocked ---
+
+    def test_push_to_master_blocked(self):
+        blocked, reason, matched = is_review_gate_blocked("git push origin master")
+        assert blocked
+        assert reason is not None
+        assert "review gate" in reason.lower()
+
+    def test_push_to_main_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin main")
+        assert blocked
+
+    def test_push_to_trunk_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin trunk")
+        assert blocked
+
+    def test_push_to_develop_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin develop")
+        assert blocked
+
+    def test_push_head_to_master_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin HEAD:master")
+        assert blocked
+
+    def test_push_head_to_main_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin HEAD:main")
+        assert blocked
+
+    def test_push_upstream_to_master_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push -u origin master")
+        assert blocked
+
+    def test_push_set_upstream_to_main_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git push --set-upstream origin main")
+        assert blocked
+
+    # --- Feature branch pushes are allowed ---
+
+    def test_push_feature_branch_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin feat/my-feature")
+        assert not blocked
+
+    def test_push_fix_branch_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git push origin fix/issue-123")
+        assert not blocked
+
+    def test_push_upstream_feature_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git push -u origin feat/my-task")
+        assert not blocked
+
+    def test_push_with_explicit_refspec_feature_allowed(self):
+        blocked, _, _ = is_review_gate_blocked(
+            "git push origin feat/my-task:feat/my-task"
+        )
+        assert not blocked
+
+    # --- Merge is blocked ---
+
+    def test_git_merge_blocked(self):
+        blocked, reason, _ = is_review_gate_blocked("git merge origin/master")
+        assert blocked
+        assert reason is not None
+        assert "review gate" in reason.lower()
+
+    def test_git_merge_feature_blocked(self):
+        blocked, _, _ = is_review_gate_blocked("git merge feat/some-branch")
+        assert blocked
+
+    # --- Other git operations are not blocked ---
+
+    def test_git_status_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git status")
+        assert not blocked
+
+    def test_git_add_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git add file.py")
+        assert not blocked
+
+    def test_git_commit_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git commit -m 'feat: something'")
+        assert not blocked
+
+    def test_git_checkout_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("git checkout -b feat/new-branch")
+        assert not blocked
+
+    def test_non_git_command_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("pytest tests/")
+        assert not blocked
+
+    # --- Patterns inside quotes are not blocked ---
+
+    def test_push_master_in_single_quotes_allowed(self):
+        blocked, _, _ = is_review_gate_blocked("echo 'git push origin master'")
+        assert not blocked
+
+    def test_merge_in_commit_message_allowed(self):
+        blocked, _, _ = is_review_gate_blocked(
+            "git commit -m 'fix: git merge used to fail here'"
+        )
+        assert not blocked
+
+    # --- review-gated profile exists ---
+
+
+class TestReviewGatedProfile:
+    """Tests for the built-in review-gated profile."""
+
+    def test_profile_exists(self):
+        from gptme.profiles import BUILTIN_PROFILES
+
+        assert "review-gated" in BUILTIN_PROFILES
+
+    def test_profile_has_review_gate_behavior(self):
+        from gptme.profiles import BUILTIN_PROFILES
+
+        profile = BUILTIN_PROFILES["review-gated"]
+        assert profile.behavior.review_gate is True
+
+    def test_profile_has_no_tool_restriction(self):
+        from gptme.profiles import BUILTIN_PROFILES
+
+        profile = BUILTIN_PROFILES["review-gated"]
+        assert profile.tools is None
+
+    def test_profile_system_prompt_mentions_no_merge(self):
+        from gptme.profiles import BUILTIN_PROFILES
+
+        profile = BUILTIN_PROFILES["review-gated"]
+        assert "merge" in profile.system_prompt.lower()
+        assert (
+            "pr" in profile.system_prompt.lower()
+            or "pull request" in profile.system_prompt.lower()
+        )
+
+    def test_profile_name_matches_key(self):
+        from gptme.profiles import BUILTIN_PROFILES
+
+        profile = BUILTIN_PROFILES["review-gated"]
+        assert profile.name == "review-gated"
+
+    def test_get_profile_returns_review_gated(self):
+        from gptme.profiles import get_profile
+
+        profile = get_profile("review-gated")
+        assert profile is not None
+        assert profile.name == "review-gated"
+        assert profile.behavior.review_gate is True
+
+    def test_profile_behavior_from_dict_review_gate(self):
+        from gptme.profiles import Profile
+
+        data = {
+            "name": "custom-gated",
+            "description": "Test",
+            "behavior": {"review_gate": True},
+        }
+        profile = Profile.from_dict(data)
+        assert profile.behavior.review_gate is True


### PR DESCRIPTION
## Problem

Issue #3390 identified that the workflow guide (#3389) recommended interactive confirmations as the primary safety boundary — an approach that doesn't work for autonomous/non-interactive runs and doesn't prevent the agent from pushing directly to the default branch.

The prior PR #3391 added documentation about the pattern but shipped no code enforcement: the agent could still run `git push origin master` and nothing would stop it.

## Solution

This PR implements the review-gated workflow as code:

### `review-gated` built-in profile

A new profile activated with `--agent-profile review-gated`:
- Runs without per-tool confirmation prompts (autonomous-safe)
- Hard-blocks `git push` to default branches (`master`, `main`, `trunk`, `develop`) at the shell-validation layer
- Hard-blocks `git merge` — merging must go through a PR approved by a human or CI
- Full tool access (all tools allowed — the gate is on delivery, not on capabilities)
- System prompt explains the workflow: feature branch → tests → push branch → open PR → stop

### Code enforcement

`gptme/tools/shell_validation.py`:
- New `is_review_gate_blocked(cmd)` function with pattern matching for default-branch push and merge
- Blocked patterns respect quoted regions (commit messages mentioning `git push origin master` are safe)
- `set_review_gate(active: bool)` / `get_review_gate() -> bool` module-level flag set once at session start

`gptme/tools/shell.py`:
- Calls `is_review_gate_blocked()` after `is_denylisted()` when the review gate is active

`gptme/cli/main.py`:
- When the selected profile has `behavior.review_gate=True`, calls `set_review_gate(True)` before the session starts

`gptme/profiles.py`:
- `ProfileBehavior.review_gate: bool = False` field
- `review-gated` entry in `BUILTIN_PROFILES`

`gptme/cli/util.py`:
- `profile list` and `profile show` display the `review-gate` flag

### Usage

```bash
gptme --agent-profile review-gated -n \
  "Fix the failing tests. Push your fix as a feature branch and open a PR."
```

The agent works autonomously, but cannot push to master/main or merge. It can only deliver via a feature branch + PR, which CI and a human reviewer then control.

## Tests

31 new tests in `tests/test_tools_shell_validation.py`:
- **Default-branch rejection**: `git push origin master/main/trunk/develop` blocked; `HEAD:master` and `--set-upstream origin master` variants blocked
- **Feature-branch allowance**: `git push origin feat/my-feature`, `fix/issue-123` pass through
- **Merge blocking**: `git merge origin/master`, `git merge feat/branch` blocked
- **Quote bypass safety**: patterns inside single-quoted commit messages are not blocked
- **Profile existence**: `review-gated` in `BUILTIN_PROFILES` with correct behavior flag
- **`ProfileBehavior.review_gate` round-trips through `Profile.from_dict`**

Closes #3390

<!-- gptme-id:v1:gai_LVMsXhJ3L66aFYY3byi9XaSVnrnl0RywlfcOtwXbeZ6 -->