### PR TITLE
feat(review-gate): add enforcement module and tests for review-gated delivery

### DIFF
--- a/gptme/review_gate.py
+++ b/gptme/review_gate.py
@@ -1,0 +1,275 @@
+"""Review-gated delivery enforcement for autonomous workflows.
+
+Validates that a git checkout is eligible for review-gated delivery:
+  - The checkout is inside a git repository with at least one commit.
+  - A remote with a push URL is reachable (so a branch can be pushed).
+  - The current branch is NOT the repository default branch.
+
+If any of these conditions are not met, :func:`validate` raises
+:exc:`ReviewGateError` so the caller fails closed rather than delivering
+changes silently to the wrong target.
+
+This is the enforcement layer for the pattern described in
+``docs/automation.rst`` under "Review-Gated Autonomous Workflows".
+
+Usage::
+
+    from gptme.review_gate import validate, ReviewGateError
+
+    try:
+        evidence = validate(path=Path("."), remote="origin")
+    except ReviewGateError as exc:
+        print(f"Cannot deliver: {exc}")
+        sys.exit(1)
+
+    # Inspect evidence before pushing
+    print(evidence.diff_stat)
+    print(evidence.branch)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .util.git_cmd import GIT_CMD
+
+
+class ReviewGateError(Exception):
+    """Raised when the review gate cannot be established.
+
+    All callers should treat this as a hard stop — do not catch and continue,
+    as that would bypass the safety boundary this module is designed to enforce.
+    """
+
+
+@dataclass(frozen=True)
+class DeliveryEvidence:
+    """Evidence collected for the PR description and human review."""
+
+    branch: str
+    base_ref: str
+    remote: str
+    commits: str
+    diff_stat: str
+    changed_files: list[str]
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────
+
+
+def _run(args: list[str], cwd: Path, timeout: int = 15) -> str:
+    """Run a git sub-command and return stdout, or raise on failure."""
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise ReviewGateError(
+            f"git command failed: {' '.join(args[1:])!r}\n{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _is_git_repo(path: Path) -> bool:
+    result = subprocess.run(
+        [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _get_current_branch(path: Path) -> str:
+    result = subprocess.run(
+        [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise ReviewGateError("Cannot determine current branch (no commits yet?)")
+    branch = result.stdout.strip()
+    if branch == "HEAD":
+        raise ReviewGateError(
+            "Repository is in detached HEAD state. "
+            "Check out a named feature branch before delivering."
+        )
+    return branch
+
+
+def _get_default_branch(path: Path, remote: str) -> str:
+    """Return the default branch name for *remote*, e.g. 'master' or 'main'."""
+    # Try the symbolic-ref the remote advertises (works after fetch --tags).
+    result = subprocess.run(
+        [GIT_CMD, "rev-parse", "--abbrev-ref", f"{remote}/HEAD"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        # ref is like "origin/master" → strip the remote prefix
+        prefix = f"{remote}/"
+        if ref.startswith(prefix):
+            return ref[len(prefix):]
+
+    # Fallback: ask the remote directly (network call; may be slow or fail).
+    result = subprocess.run(
+        [GIT_CMD, "remote", "show", remote],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+    if result.returncode == 0:
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("HEAD branch:"):
+                return line.split(":", 1)[1].strip()
+
+    # Last resort: check whether common default names exist on the remote.
+    for candidate in ("master", "main"):
+        r = subprocess.run(
+            [GIT_CMD, "rev-parse", "--verify", f"{remote}/{candidate}"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if r.returncode == 0:
+            return candidate
+
+    raise ReviewGateError(
+        f"Cannot determine the default branch for remote '{remote}'. "
+        "Run 'git fetch' and retry."
+    )
+
+
+def _has_remote(path: Path, remote: str) -> bool:
+    result = subprocess.run(
+        [GIT_CMD, "remote", "get-url", remote],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _collect_evidence(path: Path, remote: str, base_ref: str, branch: str) -> DeliveryEvidence:
+    """Collect diff and commit evidence relative to *base_ref*."""
+    range_spec = f"{remote}/{base_ref}...HEAD"
+
+    commits = subprocess.run(
+        [GIT_CMD, "log", "--oneline", range_spec],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    ).stdout.strip()
+
+    diff_stat = subprocess.run(
+        [GIT_CMD, "diff", "--stat", range_spec],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    ).stdout.strip()
+
+    files_out = subprocess.run(
+        [GIT_CMD, "diff", "--name-only", range_spec],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    ).stdout.strip()
+
+    changed_files = [f for f in files_out.splitlines() if f]
+
+    return DeliveryEvidence(
+        branch=branch,
+        base_ref=base_ref,
+        remote=remote,
+        commits=commits,
+        diff_stat=diff_stat,
+        changed_files=changed_files,
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────────
+
+
+def validate(
+    path: Path | str = ".",
+    remote: str = "origin",
+) -> DeliveryEvidence:
+    """Validate that delivery can proceed through the review gate.
+
+    Checks (in order):
+
+    1. *path* is inside a git working tree.
+    2. The remote *remote* is configured with a push URL.
+    3. The current branch is NOT the repository's default branch.
+
+    Returns a :class:`DeliveryEvidence` snapshot on success.
+
+    Raises :exc:`ReviewGateError` if any check fails.  All failures are
+    intended to be hard stops — callers should not catch the exception and
+    continue, as that would bypass the safety boundary.
+
+    Args:
+        path: Directory to inspect (defaults to the current working directory).
+        remote: Remote name to validate against (defaults to ``"origin"``).
+    """
+    cwd = Path(path).resolve()
+
+    # 1. Must be inside a git repository.
+    if not _is_git_repo(cwd):
+        raise ReviewGateError(
+            f"'{cwd}' is not inside a git repository. "
+            "Review-gated delivery requires version control. "
+            "No review-gated delivery guarantee is active."
+        )
+
+    # 2. Remote must be configured.
+    if not _has_remote(cwd, remote):
+        raise ReviewGateError(
+            f"Remote '{remote}' is not configured. "
+            "Review-gated delivery requires a remote so changes can be pushed "
+            "to a branch for PR review. "
+            "No review-gated delivery guarantee is active."
+        )
+
+    # 3. Current branch must not be the default branch.
+    branch = _get_current_branch(cwd)
+    default = _get_default_branch(cwd, remote)
+
+    if branch == default:
+        raise ReviewGateError(
+            f"Current branch '{branch}' is the default branch. "
+            "Pushing directly to the default branch bypasses PR review. "
+            "Create a feature branch and work from there: "
+            f"  git checkout -b feat/my-task --no-track {remote}/{default}"
+        )
+
+    evidence = _collect_evidence(cwd, remote, default, branch)
+    return evidence

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,231 @@
+"""Tests for review-gated delivery enforcement.
+
+Acceptance criteria from issue #3390:
+  - Default-branch rejection: validate() raises when on the default branch.
+  - Allowed feature-branch delivery: validate() succeeds when on a non-default branch.
+  - Failure when the review gate is unavailable:
+      - Not inside a git repository.
+      - No remote configured.
+      - Detached HEAD state.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gptme.review_gate import DeliveryEvidence, ReviewGateError, validate
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def bare_remote(tmp_path: Path) -> Path:
+    """A bare git repository acting as a remote."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    subprocess.run(["git", "init", "--bare"], cwd=remote, capture_output=True, check=True)
+    return remote
+
+
+@pytest.fixture()
+def repo_on_default(tmp_path: Path, bare_remote: Path) -> Path:
+    """A clone of bare_remote whose HEAD is on the default branch.
+
+    Uses 'trunk' as the default branch name to avoid the global pre-push hook
+    that blocks pushes to 'master'/'main' on this host.  The branch name does
+    not affect the correctness of validate() — the guard rejects whatever the
+    remote advertises as its default.
+    """
+    repo = tmp_path / "repo"
+    subprocess.run(
+        ["git", "clone", str(bare_remote), str(repo)],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    # Use 'trunk' (not 'master'/'main') to bypass the global pre-push hook.
+    subprocess.run(
+        ["git", "checkout", "-b", "trunk"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    (repo / "README.md").write_text("# Hello\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "init"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    # Push and set the remote HEAD so _get_default_branch resolves to 'trunk'.
+    subprocess.run(
+        ["git", "push", "-u", "origin", "trunk"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "remote", "set-head", "origin", "trunk"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "--all"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    return repo
+
+
+@pytest.fixture()
+def repo_on_feature(repo_on_default: Path) -> Path:
+    """Same repo but checked out on a feature branch."""
+    subprocess.run(
+        ["git", "checkout", "--no-track", "-b", "feat/my-task"],
+        cwd=repo_on_default, capture_output=True, check=True,
+    )
+    return repo_on_default
+
+
+# ── Tests: gate unavailable (fail-closed) ────────────────────────────────
+
+
+def test_fails_when_not_a_git_repo(tmp_path: Path):
+    """Directories outside a git repo have no VCS; gate must fail closed."""
+    not_a_repo = tmp_path / "plain-dir"
+    not_a_repo.mkdir()
+
+    with pytest.raises(ReviewGateError, match="not inside a git repository"):
+        validate(path=not_a_repo)
+
+
+def test_fails_when_no_remote(tmp_path: Path):
+    """A git repo with no configured remote cannot deliver; gate must fail closed."""
+    repo = tmp_path / "no-remote"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=repo, capture_output=True, check=True,
+    )
+    (repo / "f.txt").write_text("hi\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "init"],
+        cwd=repo, capture_output=True, check=True,
+    )
+
+    with pytest.raises(ReviewGateError, match="not configured"):
+        validate(path=repo)
+
+
+def test_fails_in_detached_head(repo_on_default: Path):
+    """Detached HEAD has no branch name; gate must fail closed."""
+    head_sha = _git("rev-parse", "HEAD", cwd=repo_on_default)
+    subprocess.run(
+        ["git", "checkout", "--detach", head_sha],
+        cwd=repo_on_default, capture_output=True, check=True,
+    )
+
+    with pytest.raises(ReviewGateError, match="detached HEAD"):
+        validate(path=repo_on_default)
+
+
+# ── Tests: default-branch rejection ──────────────────────────────────────
+
+
+def test_rejects_delivery_on_default_branch(repo_on_default: Path):
+    """Pushing the default branch would bypass review; must be rejected.
+
+    The fixture uses 'trunk' as the default branch so this also verifies
+    that the guard works for non-master/main default names.
+    """
+    with pytest.raises(ReviewGateError, match="default branch"):
+        validate(path=repo_on_default)
+
+
+def test_rejection_message_includes_feature_branch_guidance(repo_on_default: Path):
+    """Error message should tell the user how to fix the situation."""
+    with pytest.raises(ReviewGateError) as exc_info:
+        validate(path=repo_on_default)
+
+    msg = str(exc_info.value)
+    assert "feature branch" in msg or "checkout" in msg or "git checkout" in msg
+
+
+# ── Tests: allowed feature-branch delivery ────────────────────────────────
+
+
+def test_allows_delivery_on_feature_branch(repo_on_feature: Path):
+    """A non-default branch with a configured remote must pass validation."""
+    evidence = validate(path=repo_on_feature)
+
+    assert isinstance(evidence, DeliveryEvidence)
+    assert evidence.branch == "feat/my-task"
+    assert evidence.remote == "origin"
+
+
+def test_evidence_includes_base_ref(repo_on_feature: Path):
+    """Evidence must record the base ref so the diff is reproducible."""
+    evidence = validate(path=repo_on_feature)
+    # base_ref is the default branch name, e.g. "master" or "main"
+    assert evidence.base_ref  # non-empty
+    assert "/" not in evidence.base_ref  # should be just the branch name, not remote/branch
+
+
+def test_evidence_includes_diff_info_for_new_commits(repo_on_feature: Path):
+    """When the feature branch has commits, evidence captures them."""
+    repo = repo_on_feature
+    # Add a commit on the feature branch.
+    (repo / "new_file.py").write_text("# new\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "feat: add new_file.py"],
+        cwd=repo, capture_output=True, check=True,
+    )
+
+    evidence = validate(path=repo)
+
+    assert "new_file.py" in evidence.changed_files
+    assert "new_file.py" in evidence.diff_stat
+    assert "add new_file.py" in evidence.commits
+
+
+def test_evidence_is_empty_on_branch_with_no_new_commits(repo_on_feature: Path):
+    """A feature branch at the same point as the default has no evidence yet."""
+    evidence = validate(path=repo_on_feature)
+
+    assert evidence.commits == ""
+    assert evidence.changed_files == []
+
+
+def test_custom_remote_name_accepted(repo_on_feature: Path):
+    """validate() should respect a non-default remote name."""
+    repo = repo_on_feature
+    # Add an alias for the same remote.
+    remote_url = _git("remote", "get-url", "origin", cwd=repo)
+    subprocess.run(
+        ["git", "remote", "add", "upstream", remote_url],
+        cwd=repo, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "upstream"],
+        cwd=repo, capture_output=True, check=True,
+    )
+
+    evidence = validate(path=repo, remote="upstream")
+
+    assert evidence.remote == "upstream"


### PR DESCRIPTION
## Problem

PR #3391 added the review-gated workflow documentation but left three acceptance
criteria from #3390 unmet:

- No code enforces the boundary (no VCS, no remote, or on default branch → should fail closed).
- No tests covering default-branch rejection, feature-branch delivery, or gate unavailability.
- The prior PR on this branch (#3392) attempted shell-executor integration that Greptile
  correctly flagged as bypassable via wrapped commands (`nohup git push …`). That PR
  was closed without merging.

## Solution

A minimal, non-intercepting `validate()` function that checks **repository state** rather
than attempting to parse shell commands. Because it checks the checkout itself rather than
shell command text, it cannot be bypassed by wrapping a push in `nohup` or similar.

### `gptme/review_gate.py`

- `validate(path, remote)` — the gate. Raises `ReviewGateError` when:
  - `path` is not inside a git working tree (no VCS context → fail closed)
  - the configured remote is absent (no delivery path → fail closed)
  - the checkout is in detached HEAD state (no branch → fail closed)
  - the current branch IS the remote's default branch (would bypass review → rejected)
- Returns `DeliveryEvidence` on success: branch, base ref, commits, diff stat, changed files.
  Callers can embed this in PR descriptions.
- Default-branch detection uses `origin/HEAD` symref, falls back to `git remote show`,
  then heuristic (`master`/`main` probe) — works offline if the symref is cached.

### `tests/test_review_gate.py`

10 tests covering all acceptance criteria:

| Test | Criterion |
|------|-----------|
| `test_fails_when_not_a_git_repo` | fail-closed: no VCS |
| `test_fails_when_no_remote` | fail-closed: no remote |
| `test_fails_in_detached_head` | fail-closed: detached HEAD |
| `test_rejects_delivery_on_default_branch` | default-branch rejection |
| `test_rejection_message_includes_feature_branch_guidance` | useful error message |
| `test_allows_delivery_on_feature_branch` | feature-branch allowed |
| `test_evidence_includes_base_ref` | evidence shape |
| `test_evidence_includes_diff_info_for_new_commits` | evidence content |
| `test_evidence_is_empty_on_branch_with_no_new_commits` | evidence empty baseline |
| `test_custom_remote_name_accepted` | non-default remote name |

All 10 pass locally.

## Design note

The previous approach (#3392) wired into the shell tool executor and tried to parse git
command strings. Greptile correctly identified that this could be bypassed through
wrappers like `nohup`. This PR deliberately avoids command-parsing: the gate is a
programmatic check of the checkout's git state (branch name vs. remote default branch),
not a text filter on shell commands. There is no shell command to bypass.

Closes #3390