### PR TITLE
docs(readme): update desktop app from WIP to shipped with download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ active development.
 
 ## 📢 News
 
-- **Coming soon** - [gptme.ai](https://gptme.ai) service for running agents in the cloud; [gptme desktop](https://github.com/gptme/gptme-tauri) app for easy local use.
+- **2026-07** - [v0.32.1](https://github.com/gptme/gptme/releases/tag/v0.32.1): Desktop app for Linux (AppImage), macOS, and Windows with auto-updates — [download here](https://github.com/gptme/gptme/releases/latest); [gptme.ai](https://gptme.ai) cloud service
 - **2026-01** - [gptme-agent-template](https://github.com/gptme/gptme-agent-template) v0.4: [Bob](https://github.com/TimeToBuildBob) has run extensively as an autonomous agent, autonomous run loops, enhanced context generation
 - **2025-12** - [v0.31.0](https://github.com/gptme/gptme/releases/tag/v0.31.0): Background jobs, form tool, cost tracking, content-addressable storage
 - **2025-11** - [v0.30.0](https://github.com/gptme/gptme/releases/tag/v0.30.0): Plugin system, context compression, subagent planner mode
@@ -397,8 +397,8 @@ This stack is simple and composable: selectors improve work choice, lessons stee
 
 ### 🚧 In Progress
 
-- 🖥 **[gptme-tauri](https://github.com/gptme/gptme-tauri)** — desktop app wrapping gptme for easy local use (WIP)
-- ☁️ **[gptme.ai](https://gptme.ai)** — managed cloud service for running gptme agents (WIP; still self-hostable by running `gptme-server` + `gptme-webui` yourself)
+- 🖥 **[gptme-tauri](https://github.com/gptme/gptme-tauri)** — desktop app for Linux, macOS, and Windows with auto-updates ([download](https://github.com/gptme/gptme/releases/latest))
+- ☁️ **[gptme.ai](https://gptme.ai)** — managed cloud service for running gptme agents (early access; still self-hostable by running `gptme-server` + `gptme-webui` yourself)
 - 🌳 Tree-based conversation structure (see [#17](https://github.com/gptme/gptme/issues/17))
 - 📜 RAG to automatically include context from local files (see [#59](https://github.com/gptme/gptme/issues/59))
 - 🏆 Advanced evals for testing frontier capabilities
@@ -588,8 +588,8 @@ gptme is more than a CLI — it's a platform with a growing ecosystem:
 | [gptme-agent-template][agent-template] | Template for building persistent autonomous agents |
 | [gptme-rag] | RAG integration for semantic search over local files |
 | [gptme.vim] | Vim plugin for in-editor gptme integration |
-| [gptme-tauri] | Desktop app (WIP) |
-| [gptme.ai](https://gptme.ai) | Managed cloud service (WIP) |
+| [gptme-tauri] | Desktop app for Linux, macOS, and Windows ([download](https://github.com/gptme/gptme/releases/latest)) |
+| [gptme.ai](https://gptme.ai) | Managed cloud service (early access) |
 
 **Community agents powered by gptme:**
 - [Bob](https://github.com/TimeToBuildBob) — autonomous AI agent, running continuously since late 2024, contributes to open source and manages his own tasks

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,7 +43,7 @@ Interfaces
 Besides the CLI, gptme can be used through:
 
 - :ref:`server:gptme-webui` - A web-based interface
-- A `desktop app <https://github.com/gptme/gptme-tauri>`_ (WIP)
+- A `desktop app <https://github.com/gptme/gptme-tauri>`_ for Linux, macOS, and Windows (`download <https://github.com/gptme/gptme/releases/latest>`_)
 - :doc:`bot` - GitHub bot integration
 
 For more detailed information about specific features, check out:


### PR DESCRIPTION
## Summary

The v0.32.1 release ships desktop app artifacts for all major platforms, but the README still describes gptme-tauri as "Coming soon" and "(WIP)". This PR brings the docs in line with reality.

**Changes:**
- Replace the "Coming soon" news bullet with a 2026-07 / v0.32.1 entry mentioning the shipped desktop app with a download link
- Remove "(WIP)" from gptme-tauri in the "In Progress" section, add download link
- Remove "(WIP)" from gptme-tauri in the ecosystem table, add download link
- Soften "(WIP)" to "(early access)" for gptme.ai (functional but still evolving)

**Why:** New users reading the README see "Coming soon" for the desktop app even though stable AppImage (Linux), `.exe` (Windows), and `.dmg` (macOS) are in GitHub Releases with auto-updates. The download link was completely absent from the README.

## Test plan

- [ ] Confirm download link (`https://github.com/gptme/gptme/releases/latest`) opens latest release with desktop artifacts
- [ ] Verify no other "Coming soon" or "(WIP)" references to already-shipped features remain