### PR TITLE
fix(config): use explicit UTF-8 encoding for all TOML config I/O

### DIFF
--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -245,7 +245,14 @@ class ChatConfig:
             return cls()
 
     def save(self) -> Self:
-        """Save the chat config to the log directory."""
+        """Save the chat config to the log directory.
+
+        Raises:
+            OSError: If this config was decoded by a guessed codec and its
+                original bytes could not be backed up. The save is abandoned so
+                the unrecoverable bytes stay on disk; only a config that already
+                went through the legacy fallback can reach this.
+        """
         if not self._logdir:
             raise ValueError("ChatConfig has no logdir set")
         self._logdir.mkdir(parents=True, exist_ok=True)

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -234,7 +234,9 @@ class ChatConfig:
                 with open(chat_config_path, "rb") as f:
                     config_data = tomllib.load(f)
             else:
-                with open(chat_config_path) as f:
+                # `tomllib` above opens in binary mode and decodes as UTF-8 itself, as
+                # the TOML spec requires; this fallback must say so explicitly.
+                with open(chat_config_path, encoding="utf-8") as f:
                     config_data = tomlkit.load(f).unwrap()
             config_data["_logdir"] = path
             return cls.from_dict(config_data)
@@ -254,7 +256,7 @@ class ChatConfig:
         # Load existing config as TOMLDocument to preserve formatting/comments
         if chat_config_path.exists():
             try:
-                with open(chat_config_path) as f:
+                with open(chat_config_path, encoding="utf-8") as f:
                     doc = tomlkit.load(f)
                 # Update document in-place, preserving formatting
                 for key, value in config_dict.items():
@@ -289,6 +291,7 @@ class ChatConfig:
         # (e.g., daemon thread killed on exit while saving)
         with tempfile.NamedTemporaryFile(
             mode="w",
+            encoding="utf-8",
             dir=self._logdir,
             suffix=".toml.tmp",
             delete=False,

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -19,15 +19,16 @@ from typing_extensions import Self
 if sys.version_info >= (3, 11):
     import tomllib
 
-    _CHAT_CONFIG_LOAD_ERRORS = (OSError, tomllib.TOMLDecodeError)
+    _CHAT_CONFIG_LOAD_ERRORS = (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError)
 else:
     tomllib = None
 
-    _CHAT_CONFIG_LOAD_ERRORS = (OSError, TOMLKitError)
+    _CHAT_CONFIG_LOAD_ERRORS = (OSError, UnicodeDecodeError, TOMLKitError)
 
 from ..util import path_with_tilde
 from .models import AgentConfig, MCPConfig
 from .project import get_project_config
+from .user import _read_config_text
 
 if TYPE_CHECKING:
     from ..tools.base import ToolFormat
@@ -230,14 +231,13 @@ class ChatConfig:
                 )
             return cls(_logdir=path, workspace=workspace.resolve())
         try:
+            # `_read_config_text` decodes as UTF-8 per the TOML spec, with a
+            # fallback for configs an older gptme wrote in the platform encoding.
+            text = _read_config_text(chat_config_path)
             if tomllib is not None:
-                with open(chat_config_path, "rb") as f:
-                    config_data = tomllib.load(f)
+                config_data = tomllib.loads(text)
             else:
-                # `tomllib` above opens in binary mode and decodes as UTF-8 itself, as
-                # the TOML spec requires; this fallback must say so explicitly.
-                with open(chat_config_path, encoding="utf-8") as f:
-                    config_data = tomlkit.load(f).unwrap()
+                config_data = tomlkit.loads(text).unwrap()
             config_data["_logdir"] = path
             return cls.from_dict(config_data)
         except _CHAT_CONFIG_LOAD_ERRORS as e:
@@ -256,8 +256,7 @@ class ChatConfig:
         # Load existing config as TOMLDocument to preserve formatting/comments
         if chat_config_path.exists():
             try:
-                with open(chat_config_path, encoding="utf-8") as f:
-                    doc = tomlkit.load(f)
+                doc = tomlkit.loads(_read_config_text(chat_config_path))
                 # Update document in-place, preserving formatting
                 for key, value in config_dict.items():
                     if isinstance(value, dict) and key in doc:

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -28,7 +28,7 @@ else:
 from ..util import path_with_tilde
 from .models import AgentConfig, MCPConfig
 from .project import get_project_config
-from .user import _read_config_text
+from .user import _back_up_before_reencoding, _read_config_text
 
 if TYPE_CHECKING:
     from ..tools.base import ToolFormat
@@ -284,6 +284,10 @@ class ChatConfig:
                 doc = tomlkit.parse(tomlkit.dumps(config_dict))
         else:
             doc = tomlkit.parse(tomlkit.dumps(config_dict))
+
+        # If this config was read through a codec that accepts any bytes, its text
+        # is a guess; keep the original bytes before the rename discards them.
+        _back_up_before_reencoding(chat_config_path)
 
         # Use atomic write: write to temp file, then rename
         # This prevents corruption if process is interrupted during write

--- a/gptme/config/project.py
+++ b/gptme/config/project.py
@@ -12,7 +12,7 @@ import tomlkit
 
 from ..util import path_with_tilde
 from .models import ProjectConfig
-from .user import _merge_config_data
+from .user import _merge_config_data, _read_config_text
 
 logger = logging.getLogger(__name__)
 
@@ -101,16 +101,16 @@ def _get_project_config_cached(
     if project_config_paths:
         project_config_path = project_config_paths[0]
         # load project config
-        with open(project_config_path, encoding="utf-8") as f:
-            config_data = tomlkit.load(f).unwrap()
+        config_data = tomlkit.loads(_read_config_text(project_config_path)).unwrap()
 
         # Look for local config file in the same directory
         local_config_path = project_config_path.parent / "gptme.local.toml"
         used_local_config_path: Path | None = None
         if local_config_path.exists():
             used_local_config_path = local_config_path
-            with open(local_config_path, encoding="utf-8") as f:
-                local_config_data = tomlkit.load(f).unwrap()
+            local_config_data = tomlkit.loads(
+                _read_config_text(local_config_path)
+            ).unwrap()
 
             # Merge local config into main config
             config_data = _merge_config_data(config_data, local_config_data)

--- a/gptme/config/project.py
+++ b/gptme/config/project.py
@@ -101,7 +101,7 @@ def _get_project_config_cached(
     if project_config_paths:
         project_config_path = project_config_paths[0]
         # load project config
-        with open(project_config_path) as f:
+        with open(project_config_path, encoding="utf-8") as f:
             config_data = tomlkit.load(f).unwrap()
 
         # Look for local config file in the same directory
@@ -109,7 +109,7 @@ def _get_project_config_cached(
         used_local_config_path: Path | None = None
         if local_config_path.exists():
             used_local_config_path = local_config_path
-            with open(local_config_path) as f:
+            with open(local_config_path, encoding="utf-8") as f:
                 local_config_data = tomlkit.load(f).unwrap()
 
             # Merge local config into main config

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -39,6 +39,46 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+def _legacy_codec_candidates() -> list[str]:
+    """Codecs to try after UTF-8 when reading a config, most likely first.
+
+    `locale.getpreferredencoding(False)` is not sufficient on its own. Under
+    Python's UTF-8 mode (`-X utf8`, `PYTHONUTF8=1`, or a launcher that enables it)
+    it returns "utf-8" whatever the platform code page is -- so on exactly the
+    Windows install whose code page wrote the file, the codec needed to read it
+    back is the one this function would hide. `locale.getencoding()` (3.11+)
+    reports the real code page regardless of UTF-8 mode; on 3.10 the same value is
+    only reachable through `getdefaultlocale`, which is not yet deprecated there.
+
+    Names are deduplicated by their canonical codec name, and "utf-8" is dropped
+    since the caller has already tried it.
+    """
+    candidates: list[str] = []
+    getencoding = getattr(locale, "getencoding", None)
+    if getencoding is not None:
+        candidates.append(getencoding())
+    else:  # Python 3.10
+        try:
+            candidates.append(locale.getdefaultlocale()[1] or "")
+        except ValueError:
+            pass
+    candidates.append(locale.getpreferredencoding(False))
+
+    result: list[str] = []
+    seen = {"utf-8"}
+    for name in candidates:
+        if not name:
+            continue
+        try:
+            canonical = codecs.lookup(name).name
+        except LookupError:
+            continue
+        if canonical not in seen:
+            seen.add(canonical)
+            result.append(name)
+    return result
+
+
 def _read_config_text(path: str | Path) -> str:
     """Read a TOML config file as text.
 
@@ -49,28 +89,37 @@ def _read_config_text(path: str | Path) -> str:
     instead of making gptme fail to start; the next write re-encodes it as UTF-8,
     since the writers are now explicit.
 
+    Each candidate is decoded strictly, so a codec that cannot represent the bytes
+    hands over to the next one instead of quietly producing mojibake.
+
     Never raises `UnicodeDecodeError`: callers wrap this in a TOML parse and handle
-    parse errors (`ChatConfig.from_logdir` degrades to defaults), so a corrupt file
-    is decoded with `errors="replace"` and left for the parser to reject.
+    parse errors (`ChatConfig.from_logdir` degrades to defaults), so a file no
+    candidate can decode is read with `errors="replace"` and left for the parser to
+    reject.
     """
     data = Path(path).read_bytes()
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
-        fallback = locale.getpreferredencoding(False)
-        if codecs.lookup(fallback).name == "utf-8":
-            # No second codec to try: the locale's is the one that just failed.
-            logger.warning(
-                f"Config file {path} is not valid UTF-8; reading it with "
-                "replacement characters. Some values may be garbled."
-            )
-            return data.decode("utf-8", errors="replace")
+        pass
+
+    for codec in _legacy_codec_candidates():
+        try:
+            text = data.decode(codec)
+        except UnicodeDecodeError:
+            continue
         logger.warning(
-            f"Config file {path} is not valid UTF-8; reading it as {fallback} "
+            f"Config file {path} is not valid UTF-8; reading it as {codec} "
             "(written by an older gptme). It will be rewritten as UTF-8 on the "
             "next config change."
         )
-        return data.decode(fallback, errors="replace")
+        return text
+
+    logger.warning(
+        f"Config file {path} is not valid UTF-8 and no legacy codec could decode "
+        "it; reading it with replacement characters. Some values may be garbled."
+    )
+    return data.decode("utf-8", errors="replace")
 
 
 # Define the path to the config file

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -4,7 +4,9 @@ Handles loading, merging, and persisting user-level configuration
 from ~/.config/gptme/config.toml and config.local.toml.
 """
 
+import codecs
 import copy
+import locale
 import logging
 import os
 from collections.abc import MutableMapping
@@ -35,6 +37,32 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _read_config_text(path: str | Path) -> str:
+    """Read a TOML config file as text.
+
+    TOML is defined to be UTF-8, so that is what we decode as. But gptme wrote
+    these files without naming an encoding until recently, so one left behind by
+    an older install may be in the platform's preferred encoding -- a legacy code
+    page on Windows. Falling back to that codec keeps such a config readable
+    instead of making gptme fail to start; the next write re-encodes it as UTF-8,
+    since the writers are now explicit.
+    """
+    data = Path(path).read_bytes()
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        fallback = locale.getpreferredencoding(False)
+        if codecs.lookup(fallback).name == "utf-8":
+            # Nothing else to try: the locale codec is the one that just failed.
+            raise
+        logger.warning(
+            f"Config file {path} is not valid UTF-8; reading it as {fallback} "
+            "(written by an older gptme). It will be rewritten as UTF-8 on the "
+            "next config change."
+        )
+        return data.decode(fallback, errors="replace")
 
 
 # Define the path to the config file
@@ -141,8 +169,7 @@ def get_user_config_env_source(key: str, path: str | None = None) -> str | None:
 
     config_file, local_path = get_user_config_paths(path)
     if local_path.exists():
-        with open(local_path, encoding="utf-8") as f:
-            local_doc = tomlkit.load(f)
+        local_doc = tomlkit.loads(_read_config_text(local_path))
         if _get_nested_config_value(local_doc, "env", bare) is not None:
             return USER_CONFIG_SOURCE_LOCAL
 
@@ -161,8 +188,7 @@ def get_default_model_source(path: str | None = None) -> str | None:
     """
     config_file, local_path = get_user_config_paths(path)
     if local_path.exists():
-        with open(local_path, encoding="utf-8") as f:
-            local_doc = tomlkit.load(f)
+        local_doc = tomlkit.loads(_read_config_text(local_path))
         if _get_nested_config_value(local_doc, "models", "default") is not None:
             return USER_CONFIG_SOURCE_LOCAL
     main_doc = _load_config_doc(str(config_file))
@@ -197,8 +223,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
     # Look for local config file in the same directory
     has_local = local_path.exists()
     if has_local:
-        with open(local_path, encoding="utf-8") as f:
-            local_config = tomlkit.load(f).unwrap()
+        local_config = tomlkit.loads(_read_config_text(local_path)).unwrap()
         config = _merge_config_data(config, local_config)
 
     # Log config paths (only once per config file)
@@ -389,9 +414,7 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
         logger.info(f"Created config file at {path}")
         doc = tomlkit.loads(toml)
         return doc
-    with open(path, encoding="utf-8") as config_file:
-        doc = tomlkit.load(config_file)
-    return doc
+    return tomlkit.loads(_read_config_text(path))
 
 
 def set_config_value(

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -48,6 +48,10 @@ def _read_config_text(path: str | Path) -> str:
     page on Windows. Falling back to that codec keeps such a config readable
     instead of making gptme fail to start; the next write re-encodes it as UTF-8,
     since the writers are now explicit.
+
+    Never raises `UnicodeDecodeError`: callers wrap this in a TOML parse and handle
+    parse errors (`ChatConfig.from_logdir` degrades to defaults), so a corrupt file
+    is decoded with `errors="replace"` and left for the parser to reject.
     """
     data = Path(path).read_bytes()
     try:
@@ -55,8 +59,12 @@ def _read_config_text(path: str | Path) -> str:
     except UnicodeDecodeError:
         fallback = locale.getpreferredencoding(False)
         if codecs.lookup(fallback).name == "utf-8":
-            # Nothing else to try: the locale codec is the one that just failed.
-            raise
+            # No second codec to try: the locale's is the one that just failed.
+            logger.warning(
+                f"Config file {path} is not valid UTF-8; reading it with "
+                "replacement characters. Some values may be garbled."
+            )
+            return data.decode("utf-8", errors="replace")
         logger.warning(
             f"Config file {path} is not valid UTF-8; reading it as {fallback} "
             "(written by an older gptme). It will be rewritten as UTF-8 on the "

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -74,7 +74,7 @@ def _strip_unknown_config_keys(path: str, keys: set[str]) -> None:
             changed = True
     if changed:
         try:
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 tomlkit.dump(doc, f)
         except OSError as e:
             logger.warning(f"Could not strip unknown config keys from {path}: {e}")
@@ -141,7 +141,7 @@ def get_user_config_env_source(key: str, path: str | None = None) -> str | None:
 
     config_file, local_path = get_user_config_paths(path)
     if local_path.exists():
-        with open(local_path) as f:
+        with open(local_path, encoding="utf-8") as f:
             local_doc = tomlkit.load(f)
         if _get_nested_config_value(local_doc, "env", bare) is not None:
             return USER_CONFIG_SOURCE_LOCAL
@@ -161,7 +161,7 @@ def get_default_model_source(path: str | None = None) -> str | None:
     """
     config_file, local_path = get_user_config_paths(path)
     if local_path.exists():
-        with open(local_path) as f:
+        with open(local_path, encoding="utf-8") as f:
             local_doc = tomlkit.load(f)
         if _get_nested_config_value(local_doc, "models", "default") is not None:
             return USER_CONFIG_SOURCE_LOCAL
@@ -197,7 +197,7 @@ def load_user_config(path: str | None = None) -> UserConfig:
     # Look for local config file in the same directory
     has_local = local_path.exists()
     if has_local:
-        with open(local_path) as f:
+        with open(local_path, encoding="utf-8") as f:
             local_config = tomlkit.load(f).unwrap()
         config = _merge_config_data(config, local_config)
 
@@ -384,12 +384,12 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
         # If not, create it and write some default settings
         os.makedirs(os.path.dirname(path), exist_ok=True)
         toml = tomlkit.dumps(_strip_none(asdict(default_config)))
-        with open(path, "w") as config_file:
+        with open(path, "w", encoding="utf-8") as config_file:
             config_file.write(toml)
         logger.info(f"Created config file at {path}")
         doc = tomlkit.loads(toml)
         return doc
-    with open(path) as config_file:
+    with open(path, encoding="utf-8") as config_file:
         doc = tomlkit.load(config_file)
     return doc
 
@@ -437,7 +437,7 @@ def set_config_value(
     # Write the config
     if local:
         os.makedirs(os.path.dirname(write_path), exist_ok=True)
-    with open(write_path, "w") as config_file:
+    with open(write_path, "w", encoding="utf-8") as config_file:
         tomlkit.dump(doc, config_file)
 
     if reload:
@@ -490,7 +490,7 @@ def save_provider_config(
 
     if local:
         os.makedirs(os.path.dirname(write_path), exist_ok=True)
-    with open(write_path, "w") as config_file:
+    with open(write_path, "w", encoding="utf-8") as config_file:
         tomlkit.dump(doc, config_file)
 
     if reload:

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -97,23 +97,47 @@ def _back_up_before_reencoding(path: str | Path) -> None:
     bytes still say what they always said, they were just read through the wrong
     table -- but only while those bytes exist. One backup per file: a second save
     would otherwise overwrite the original with the already-garbled version.
+
+    Raises `OSError` if the bytes cannot be preserved, which aborts the caller's
+    write. That is the point: the only reason to rewrite the file is that the
+    original is recoverable, so a backup that did not happen removes the
+    justification for the write rather than being a detail to log and move past.
+    Refusing to save is recoverable -- the user is told and can copy the file by
+    hand -- while a rewrite without a backup is not.
+
+    The copy goes through a temporary file and a rename so that a failure part
+    way through leaves no `.orig` at all. A truncated one would be as destructive
+    as none while reading as success to the next call.
     """
     resolved = str(Path(path).resolve())
     if resolved not in _encoding_unverified:
         return
     backup = Path(f"{path}.orig")
-    try:
-        if not backup.exists():
-            backup.write_bytes(Path(path).read_bytes())
-            logger.warning(
-                f"Rewriting {path} as UTF-8, but its previous encoding could not be "
-                f"confirmed. The original bytes are saved at {backup} in case any "
-                "non-ASCII values were misread."
-            )
-    except OSError as e:
-        logger.warning(f"Could not back up {path} before rewriting it as UTF-8: {e}")
-    finally:
+    if backup.exists():
+        # Already preserved by an earlier save; this file is safe to rewrite.
         _encoding_unverified.discard(resolved)
+        return
+    staged = Path(f"{path}.orig.tmp")
+    try:
+        staged.write_bytes(Path(path).read_bytes())
+        staged.replace(backup)
+    except OSError as e:
+        staged.unlink(missing_ok=True)
+        # The marker is deliberately left in place: this file still holds
+        # unpreserved original bytes, so a later save must try again rather than
+        # treat it as already handled.
+        raise OSError(
+            f"Refusing to rewrite {path} as UTF-8: its previous encoding could not "
+            f"be confirmed, and the original bytes could not be copied to {backup} "
+            f"({e}). Saving would discard them. Back the file up by hand, or fix "
+            "the write error, and try again."
+        ) from e
+    _encoding_unverified.discard(resolved)
+    logger.warning(
+        f"Rewriting {path} as UTF-8, but its previous encoding could not be "
+        f"confirmed. The original bytes are saved at {backup} in case any "
+        "non-ASCII values were misread."
+    )
 
 
 def _read_config_text(path: str | Path) -> str:
@@ -206,6 +230,11 @@ def _strip_unknown_config_keys(path: str, keys: set[str]) -> None:
             changed = True
     if changed:
         try:
+            # May raise if the file's decoding was a guess and its original bytes
+            # cannot be preserved. Swallowing it is right *here* -- this write is
+            # only a cosmetic cleanup, so not doing it costs a repeated warning
+            # and nothing else -- but the reason is worth naming, because the same
+            # exception aborting a real save is deliberate.
             _back_up_before_reencoding(path)
             with open(path, "w", encoding="utf-8") as f:
                 tomlkit.dump(doc, f)
@@ -537,6 +566,10 @@ def set_config_value(
     Raises:
         ValueError: If an intermediate keypath segment already exists
             but is not a TOML table (e.g. traversing into a string value).
+        OSError: If the file was decoded by a guessed codec and its original
+            bytes could not be backed up. Nothing is written in that case, so
+            the unrecoverable values stay on disk rather than being replaced by
+            a possibly-garbled rewrite.
     """
     if local:
         _, local_path = get_user_config_paths()
@@ -585,6 +618,10 @@ def save_provider_config(
         reload: Whether to reload the in-memory config after writing.
         local: If True, write to config.local.toml instead of config.toml.
                Use for entries with inline api_key (secrets).
+
+    Raises:
+        OSError: If the file was decoded by a guessed codec and its original
+            bytes could not be backed up; nothing is written in that case.
     """
     if local:
         _, local_path = get_user_config_paths()

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -79,6 +79,43 @@ def _legacy_codec_candidates() -> list[str]:
     return result
 
 
+# Configs whose text came out of a guessed codec rather than a declared one.
+# Rewriting one as UTF-8 would persist whatever text that guess produced, and the
+# original bytes would be gone -- so the bytes are backed up first, once.
+_encoding_unverified: set[str] = set()
+
+
+def _mark_encoding_unverified(path: str | Path) -> None:
+    """Record that this file's text came from a codec that was guessed, not declared."""
+    _encoding_unverified.add(str(Path(path).resolve()))
+
+
+def _back_up_before_reencoding(path: str | Path) -> None:
+    """Keep the original bytes of a config whose decoding was a guess.
+
+    Called before overwriting such a file as UTF-8. A misread is reversible -- the
+    bytes still say what they always said, they were just read through the wrong
+    table -- but only while those bytes exist. One backup per file: a second save
+    would otherwise overwrite the original with the already-garbled version.
+    """
+    resolved = str(Path(path).resolve())
+    if resolved not in _encoding_unverified:
+        return
+    backup = Path(f"{path}.orig")
+    try:
+        if not backup.exists():
+            backup.write_bytes(Path(path).read_bytes())
+            logger.warning(
+                f"Rewriting {path} as UTF-8, but its previous encoding could not be "
+                f"confirmed. The original bytes are saved at {backup} in case any "
+                "non-ASCII values were misread."
+            )
+    except OSError as e:
+        logger.warning(f"Could not back up {path} before rewriting it as UTF-8: {e}")
+    finally:
+        _encoding_unverified.discard(resolved)
+
+
 def _read_config_text(path: str | Path) -> str:
     """Read a TOML config file as text.
 
@@ -89,8 +126,14 @@ def _read_config_text(path: str | Path) -> str:
     instead of making gptme fail to start; the next write re-encodes it as UTF-8,
     since the writers are now explicit.
 
-    Each candidate is decoded strictly, so a codec that cannot represent the bytes
-    hands over to the next one instead of quietly producing mojibake.
+    A decode that succeeds is not evidence that this was the codec that wrote the
+    file, and no cheap check makes it so. A single-byte code page accepts anything:
+    cp936 bytes read as cp1252 "succeed" as mojibake. Multi-byte code pages are no
+    safer in practice -- the same cp936 bytes also decode cleanly, and wrongly, as
+    big5, cp949 and cp932. Mojibake is still valid TOML, so the parser will not
+    catch it either. So every fallback here is treated as a guess: it keeps the file
+    readable, but the bytes are backed up before anything rewrites them as UTF-8,
+    since a misread is reversible only while the original bytes exist.
 
     Never raises `UnicodeDecodeError`: callers wrap this in a TOML parse and handle
     parse errors (`ChatConfig.from_logdir` degrades to defaults), so a file no
@@ -109,10 +152,14 @@ def _read_config_text(path: str | Path) -> str:
         except UnicodeDecodeError:
             continue
         logger.warning(
-            f"Config file {path} is not valid UTF-8; reading it as {codec} "
-            "(written by an older gptme). It will be rewritten as UTF-8 on the "
-            "next config change."
+            f"Config file {path} is not valid UTF-8. Reading it as {codec}, the "
+            "locale's encoding, which is what an older gptme would have written it "
+            "in -- but a successful decode does not prove that, so non-ASCII values "
+            "may be garbled if the file came from a machine with a different one. "
+            "They are preserved as read; check them before saving, since saving "
+            "rewrites the file as UTF-8."
         )
+        _mark_encoding_unverified(path)
         return text
 
     logger.warning(
@@ -159,6 +206,7 @@ def _strip_unknown_config_keys(path: str, keys: set[str]) -> None:
             changed = True
     if changed:
         try:
+            _back_up_before_reencoding(path)
             with open(path, "w", encoding="utf-8") as f:
                 tomlkit.dump(doc, f)
         except OSError as e:
@@ -517,6 +565,7 @@ def set_config_value(
     # Write the config
     if local:
         os.makedirs(os.path.dirname(write_path), exist_ok=True)
+    _back_up_before_reencoding(write_path)
     with open(write_path, "w", encoding="utf-8") as config_file:
         tomlkit.dump(doc, config_file)
 
@@ -570,6 +619,7 @@ def save_provider_config(
 
     if local:
         os.makedirs(os.path.dirname(write_path), exist_ok=True)
+    _back_up_before_reencoding(write_path)
     with open(write_path, "w", encoding="utf-8") as config_file:
         tomlkit.dump(doc, config_file)
 

--- a/gptme/config/user.py
+++ b/gptme/config/user.py
@@ -161,8 +161,11 @@ def _read_config_text(path: str | Path) -> str:
 
     Never raises `UnicodeDecodeError`: callers wrap this in a TOML parse and handle
     parse errors (`ChatConfig.from_logdir` degrades to defaults), so a file no
-    candidate can decode is read with `errors="replace"` and left for the parser to
-    reject.
+    candidate can decode is read with `errors="replace"`. That usually reaches the
+    parser and is rejected, but not always -- undecodable bytes inside a quoted
+    value leave the document well-formed -- so replacement is treated as a guess
+    too, and the more damaging one: U+FFFD discards which byte it stood for, so
+    only the backup can undo it.
     """
     data = Path(path).read_bytes()
     try:
@@ -188,8 +191,10 @@ def _read_config_text(path: str | Path) -> str:
 
     logger.warning(
         f"Config file {path} is not valid UTF-8 and no legacy codec could decode "
-        "it; reading it with replacement characters. Some values may be garbled."
+        "it; reading it with replacement characters. Some values may be garbled, "
+        "and the original bytes are saved before anything rewrites the file."
     )
+    _mark_encoding_unverified(path)
     return data.decode("utf-8", errors="replace")
 
 

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -340,3 +340,114 @@ def test_a_codec_that_cannot_decode_hands_over_to_the_next(tmp_path: Path):
 
     assert "我是一名开发者" in text
     assert "�" not in text  # no replacement characters
+
+
+def test_a_successful_decode_does_not_identify_the_codec():
+    """Why the fallback cannot be trusted, and why no cheap check can rescue it.
+
+    This is the premise the rest of these tests rest on, so it is asserted rather
+    than assumed. The same cp936 bytes decode without error, into the wrong text,
+    under codecs of both kinds:
+
+    - single-byte tables map each byte independently and so accept almost anything;
+    - multi-byte code pages *do* have invalid sequences, but real text routinely
+      satisfies more than one of them, so raising is not something they can be
+      relied on to do.
+
+    "Does this codec reject some bytes?" therefore does not separate the safe cases
+    from the unsafe ones -- cp1252 leaves five bytes undefined and none of them occur
+    here. Hence: no classifier, treat every fallback as a guess.
+    """
+    for codec in ("cp1252", "latin-1", "cp437", "big5", "cp949", "cp932"):
+        decoded = LEGACY_BYTES_ABOUT.decode(codec)  # no error
+        assert decoded != "我是一名开发者", f"{codec} unexpectedly round-tripped"
+
+    # And the parser is no backstop: the mojibake is still valid TOML.
+    mojibake = (b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n').decode("cp1252")
+    assert tomlkit.loads(mojibake).unwrap()["user"]["about"] != "我是一名开发者"
+
+    # The damage is undone only by the bytes, which is what the backup preserves.
+    assert LEGACY_BYTES_ABOUT.decode("cp1252").encode("cp1252") == LEGACY_BYTES_ABOUT
+
+
+@pytest.mark.parametrize("locale_codec", ["cp1252", "cp936"])
+def test_every_legacy_fallback_is_recorded_as_unverified(
+    tmp_path: Path, locale_codec: str
+):
+    """Both the wrong codec and the right one are marked; neither can be told apart.
+
+    cp1252 is the damaging case -- it decodes these bytes into mojibake -- and cp936
+    is the one that happens to be correct. `_read_config_text` cannot distinguish
+    them, so it must not try: both get recorded, and the cost of being wrong about
+    cp936 is one backup file nobody needs.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec(locale_codec):
+        text = user_mod._read_config_text(config_file)
+
+    assert isinstance(text, str)
+    assert str(config_file.resolve()) in user_mod._encoding_unverified
+
+
+def test_unverified_config_is_backed_up_before_being_rewritten(
+    tmp_path: Path, monkeypatch
+):
+    """The original bytes must survive the rewrite that would otherwise erase them.
+
+    A misread is reversible — the bytes still mean what they meant, they were only
+    read through the wrong table — but only while the bytes exist. Rewriting as
+    UTF-8 without a copy makes the loss permanent.
+    """
+    config_file = tmp_path / "config.toml"
+    original = b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n'
+    config_file.write_bytes(original)
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp1252"), legacy_default_encoding("cp1252"):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    backup = Path(str(config_file) + ".orig")
+    assert backup.exists(), "original bytes were discarded"
+    assert backup.read_bytes() == original
+    # And the loss is recoverable from the backup.
+    assert LEGACY_BYTES_ABOUT.decode("cp936") == "我是一名开发者"
+
+
+def test_utf8_config_is_not_backed_up(tmp_path: Path, monkeypatch):
+    """The normal path stays clean: no fallback, no `.orig` beside every config.
+
+    A UTF-8 config is read by the codec TOML specifies, so there is nothing to
+    second-guess. Only files that went through the legacy fallback get a copy.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[user]\nabout = "我是一名开发者"\n', encoding="utf-8")
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp1252"), legacy_default_encoding("cp1252"):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    assert not Path(str(config_file) + ".orig").exists()
+    doc = tomlkit.loads(config_file.read_bytes().decode("utf-8")).unwrap()
+    assert doc["user"]["about"] == "我是一名开发者"
+
+
+def test_backup_is_written_once_not_overwritten_by_a_second_save(
+    tmp_path: Path, monkeypatch
+):
+    """A second save must not replace the original with the already-garbled file."""
+    config_file = tmp_path / "config.toml"
+    original = b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n'
+    config_file.write_bytes(original)
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp1252"), legacy_default_encoding("cp1252"):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+        user_mod.set_config_value("user.name", "Bob", reload=False)
+
+    assert Path(str(config_file) + ".orig").read_bytes() == original

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -52,6 +52,20 @@ def legacy_default_encoding(codec: str = LEGACY_CODEC):
         yield
 
 
+@contextmanager
+def legacy_locale_codec(codec: str):
+    """Make the read-side fallback behave as it does under a legacy locale.
+
+    `_read_config_text` reads bytes and asks `locale.getpreferredencoding` what to
+    fall back to, so — unlike the writers — it is not reached by the `open()` shim
+    above. It must be patched at that call instead, or the upgrade-path tests only
+    exercise the fallback on a machine whose locale happens to be a legacy code
+    page, and assert the *opposite* behaviour (a re-raise) on a UTF-8 one.
+    """
+    with patch.object(user_mod.locale, "getpreferredencoding", lambda *args: codec):
+        yield
+
+
 def test_load_user_config_reads_non_ascii_about(tmp_path: Path):
     """A `[user] about` in the user's own language must load, not raise.
 
@@ -185,7 +199,7 @@ def test_legacy_encoded_user_config_is_still_readable(tmp_path: Path):
     config_file = tmp_path / "config.toml"
     config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
 
-    with legacy_default_encoding("cp936"):
+    with legacy_locale_codec("cp936"):
         config = user_mod.load_user_config(str(config_file))
 
     assert config.user.about == "我是一名开发者"
@@ -204,7 +218,7 @@ def test_legacy_encoded_chat_config_is_still_readable(tmp_path: Path):
         b'[chat]\nname = "' + LEGACY_BYTES_ABOUT + b'"\nmodel = "test-model"\n'
     )
 
-    with legacy_default_encoding("cp936"):
+    with legacy_locale_codec("cp936"):
         config = ChatConfig.from_logdir(logdir)
 
     assert config.name == "我是一名开发者"
@@ -217,7 +231,8 @@ def test_legacy_encoded_config_is_rewritten_as_utf8(tmp_path: Path, monkeypatch)
     config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
 
-    with legacy_default_encoding("cp936"):
+    # Both shims: the read goes through the locale fallback, the write through `open()`.
+    with legacy_locale_codec("cp936"), legacy_default_encoding("cp936"):
         user_mod.set_config_value("user.name", "Alice", reload=False)
 
     doc = tomlkit.loads(config_file.read_bytes().decode("utf-8")).unwrap()
@@ -237,5 +252,26 @@ def test_undecodable_config_fails_at_the_parser_not_the_decoder(tmp_path: Path):
     config_file = tmp_path / "config.toml"
     config_file.write_bytes(b'[user]\nabout = "\xff\xfe\x00garbage"\n')
 
-    with legacy_default_encoding("cp936"), pytest.raises(TOMLKitError):
+    with legacy_locale_codec("cp936"), pytest.raises(TOMLKitError):
         user_mod.load_user_config(str(config_file))
+
+
+@pytest.mark.parametrize("locale_codec", ["UTF-8", "utf8", "cp936"])
+def test_read_config_text_never_raises_unicode_decode_error(
+    tmp_path: Path, locale_codec: str
+):
+    """The read helper must not leak `UnicodeDecodeError` for any locale.
+
+    On a UTF-8 locale there is no second codec to try, and re-raising sent a
+    `UnicodeDecodeError` up to callers — the very failure the fallback exists to
+    prevent, just narrowed to the platforms where the fallback cannot help. Callers
+    handle TOML parse errors, not decode errors, so `errors="replace"` is the right
+    outcome in both cases. The aliases cover `codecs.lookup` normalisation.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+
+    with legacy_locale_codec(locale_codec):
+        text = user_mod._read_config_text(config_file)
+
+    assert isinstance(text, str)

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -13,7 +13,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tomlkit
+from tomlkit.exceptions import TOMLKitError
 
 import gptme.config.project as project_mod
 import gptme.config.user as user_mod
@@ -168,3 +170,72 @@ def test_chat_config_save_writes_valid_utf8(tmp_path: Path):
     text = (logdir / "config.toml").read_bytes().decode("utf-8")
     assert tomlkit.loads(text).unwrap()["chat"]["name"] == ABOUT
     assert ChatConfig.from_logdir(logdir).name == ABOUT
+
+
+# Upgrade path: gptme wrote these files without naming an encoding until this
+# change, so a config left behind by an older install on Windows may be in a
+# legacy code page. Strict UTF-8 decoding alone would make gptme fail to start
+# for exactly the users this change is meant to help.
+
+LEGACY_BYTES_ABOUT = "我是一名开发者".encode("cp936")
+
+
+def test_legacy_encoded_user_config_is_still_readable(tmp_path: Path):
+    """A config an older gptme wrote in cp936 must not break loading."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+
+    with legacy_default_encoding("cp936"):
+        config = user_mod.load_user_config(str(config_file))
+
+    assert config.user.about == "我是一名开发者"
+
+
+def test_legacy_encoded_chat_config_is_still_readable(tmp_path: Path):
+    """Same for a per-conversation config.
+
+    On `master` this case is worse than a fallback-less read: `tomllib.load`
+    raises `UnicodeDecodeError`, which `_CHAT_CONFIG_LOAD_ERRORS` did not list,
+    so it escaped `from_logdir` entirely instead of degrading to defaults.
+    """
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    (logdir / "config.toml").write_bytes(
+        b'[chat]\nname = "' + LEGACY_BYTES_ABOUT + b'"\nmodel = "test-model"\n'
+    )
+
+    with legacy_default_encoding("cp936"):
+        config = ChatConfig.from_logdir(logdir)
+
+    assert config.name == "我是一名开发者"
+    assert config.model == "test-model"
+
+
+def test_legacy_encoded_config_is_rewritten_as_utf8(tmp_path: Path, monkeypatch):
+    """The fallback is a read-side bridge only: the next write normalises the file."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    with legacy_default_encoding("cp936"):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    doc = tomlkit.loads(config_file.read_bytes().decode("utf-8")).unwrap()
+    assert doc["user"]["about"] == "我是一名开发者"  # preserved, not mangled
+    assert doc["user"]["name"] == "Alice"
+
+
+def test_undecodable_config_fails_at_the_parser_not_the_decoder(tmp_path: Path):
+    """Bytes no codec can make sense of must reach the parser, not raise on decode.
+
+    A config that is neither UTF-8 nor valid in the locale codec is corrupt. The
+    fallback decodes it with errors="replace" so that the *parser* decides what
+    happens to it, which is what callers already handle -- `ChatConfig.from_logdir`
+    catches TOML errors and degrades to defaults, and `_strip_unknown_config_keys`
+    catches OSError. A UnicodeDecodeError escaping from the decode would not be.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "\xff\xfe\x00garbage"\n')
+
+    with legacy_default_encoding("cp936"), pytest.raises(TOMLKitError):
+        user_mod.load_user_config(str(config_file))

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -1,0 +1,170 @@
+"""Regression tests for config file encoding.
+
+TOML is defined to be UTF-8. Every `open()` in `gptme/config/` used to omit
+`encoding=`, so config files were read and written with the platform's *preferred*
+encoding — a legacy codepage on a stock Windows install (cp936 on a Chinese
+system, cp1252 on a Western one). The fields most likely to hold non-ASCII text
+are exactly the ones a user writes about themselves: `[user] about`,
+`response_preference`, `name`.
+"""
+
+import builtins
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import tomlkit
+
+import gptme.config.project as project_mod
+import gptme.config.user as user_mod
+from gptme.config import ChatConfig
+
+# A codec that is the platform default on a stock Windows install but cannot
+# represent most of Unicode. `ascii` is used where the *read* side is under test:
+# cp1252 maps every byte, so it round-trips undecodable input into mojibake
+# without raising, and would not detect a missing `encoding=` on a read.
+LEGACY_CODEC = "cp1252"
+
+ABOUT = "我是一名开发者 — I write in 中文 and café-French"
+
+
+@contextmanager
+def legacy_default_encoding(codec: str = LEGACY_CODEC):
+    """Make encoding-less `open()` calls behave as they do under a legacy locale.
+
+    Monkeypatching `locale.getpreferredencoding` does not work: CPython reads the
+    locale encoding at the C level, so `open()` ignores the patched function. This
+    shim instead supplies a codec in exactly the position CPython would supply the
+    locale's — only when the caller passed no `encoding` — so these tests fail on a
+    machine of any locale when `encoding=` is missing, and pass on a machine of any
+    locale when it is present.
+    """
+    real_open = builtins.open
+
+    def shim(file, mode="r", *args, **kwargs):
+        if "b" not in mode and kwargs.get("encoding") is None and len(args) < 2:
+            kwargs["encoding"] = codec
+        return real_open(file, mode, *args, **kwargs)
+
+    with patch.object(builtins, "open", shim):
+        yield
+
+
+def test_load_user_config_reads_non_ascii_about(tmp_path: Path):
+    """A `[user] about` in the user's own language must load, not raise.
+
+    Read side: the bytes already on disk were enough to break config loading
+    entirely, so gptme would not start for such a user.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(f'[user]\nabout = "{ABOUT}"\n', encoding="utf-8")
+
+    with legacy_default_encoding("ascii"):
+        config = user_mod.load_user_config(str(config_file))
+
+    assert config.user.about == ABOUT
+
+
+def test_load_user_config_reads_non_ascii_from_local_override(tmp_path: Path):
+    """The `config.local.toml` merge path opens a second file of its own."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[user]\nabout = "placeholder"\n', encoding="utf-8")
+    (tmp_path / "config.local.toml").write_text(
+        f'[user]\nabout = "{ABOUT}"\n', encoding="utf-8"
+    )
+
+    with legacy_default_encoding("ascii"):
+        config = user_mod.load_user_config(str(config_file))
+
+    assert config.user.about == ABOUT
+
+
+def test_set_config_value_writes_valid_utf8_toml(tmp_path: Path, monkeypatch):
+    """Write side, and this is the worst case.
+
+    Under a legacy codepage the value either raises on encode or — for text the
+    codepage happens to cover — is written in that codepage, producing a file that
+    is not valid UTF-8 and therefore not valid TOML for any other reader,
+    including `tomllib` and gptme's own `ChatConfig` loader.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    with legacy_default_encoding():
+        user_mod.set_config_value("user.about", ABOUT, reload=False)
+
+    # Decode the raw bytes as strict UTF-8 — a bare read_text() would use the
+    # platform encoding and hide the defect. This raises UnicodeDecodeError if the
+    # file was written in a codepage.
+    text = config_file.read_bytes().decode("utf-8")
+    assert tomlkit.loads(text).unwrap()["user"]["about"] == ABOUT
+
+
+def test_set_config_value_ascii_still_works(tmp_path: Path, monkeypatch):
+    """Control: the case the old code got right must not regress."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    with legacy_default_encoding():
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    doc = tomlkit.loads(config_file.read_text(encoding="utf-8")).unwrap()
+    assert doc["user"]["name"] == "Alice"
+
+
+def test_user_config_round_trips_non_ascii(tmp_path: Path, monkeypatch):
+    """Write then read back: the two sides must agree on the encoding.
+
+    A mismatch is silent — the write succeeds, and the failure only appears the
+    next time the config is loaded.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+
+    with legacy_default_encoding():
+        user_mod.set_config_value("user.about", ABOUT, reload=False)
+        config = user_mod.load_user_config(str(config_file))
+
+    assert config.user.about == ABOUT
+
+
+def test_project_config_reads_non_ascii(tmp_path: Path):
+    """`gptme.toml` is committed to repositories, so it is shared across machines.
+
+    A prompt written on a UTF-8 machine must load on a Windows one.
+    """
+    (tmp_path / "gptme.toml").write_text(f'prompt = "{ABOUT}"\n', encoding="utf-8")
+
+    project_mod._get_project_config_cached.cache_clear()
+    with legacy_default_encoding("ascii"):
+        config = project_mod.get_project_config(tmp_path, quiet=True)
+
+    assert config is not None
+    assert config.prompt == ABOUT
+
+
+def test_chat_config_save_writes_valid_utf8(tmp_path: Path):
+    """`ChatConfig.save()` writes via `tempfile.NamedTemporaryFile(mode="w")`.
+
+    That call takes `encoding` too and omitted it, so the atomic write produced a
+    `config.toml` in the platform codepage — which `from_logdir` then reads with
+    `tomllib`, which is UTF-8 only and raises.
+    """
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    # Point workspace at the path save() would symlink to, so it skips the symlink
+    # (which needs a privilege the default Windows account does not have).
+    workspace = logdir / "workspace"
+    workspace.mkdir()
+
+    with legacy_default_encoding():
+        ChatConfig(
+            _logdir=logdir, model="test-model", name=ABOUT, workspace=workspace
+        ).save()
+
+    text = (logdir / "config.toml").read_bytes().decode("utf-8")
+    assert tomlkit.loads(text).unwrap()["chat"]["name"] == ABOUT
+    assert ChatConfig.from_logdir(logdir).name == ABOUT

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -451,3 +451,129 @@ def test_backup_is_written_once_not_overwritten_by_a_second_save(
         user_mod.set_config_value("user.name", "Bob", reload=False)
 
     assert Path(str(config_file) + ".orig").read_bytes() == original
+
+
+@contextmanager
+def backup_writes_failing():
+    """Make writing the `.orig` copy fail, as a full disk or read-only dir would.
+
+    Both the staging file and the final name are covered, since the copy is made
+    under a temporary name and renamed — a probe that only fails on `.orig` would
+    silently miss the write and report a pass.
+    """
+    real_write_bytes = Path.write_bytes
+
+    def shim(self, data):
+        if ".orig" in str(self):
+            raise OSError(28, "No space left on device")
+        return real_write_bytes(self, data)
+
+    with patch.object(Path, "write_bytes", shim):
+        yield
+
+
+def test_failed_backup_aborts_the_rewrite_instead_of_destroying_the_bytes(
+    tmp_path: Path, monkeypatch
+):
+    """A backup that did not happen removes the justification for the write.
+
+    The backup exists because rewriting a guessed decoding as UTF-8 is the step
+    that makes a misread permanent. If the copy fails, logging and continuing
+    performs exactly the destruction the backup was added to prevent — and it is
+    the worst case, because the values are garbled *and* unrecoverable.
+
+    Refusing to save is recoverable: the user is told why and can copy the file
+    by hand. So the error propagates and nothing is written.
+    """
+    config_file = tmp_path / "config.toml"
+    original = b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n'
+    config_file.write_bytes(original)
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with (
+        legacy_locale_codec("cp1252"),
+        legacy_default_encoding("cp1252"),
+        backup_writes_failing(),
+        pytest.raises(OSError, match="Refusing to rewrite"),
+    ):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    # The bytes that could not be copied are still where they were.
+    assert config_file.read_bytes() == original
+    assert LEGACY_BYTES_ABOUT.decode("cp936") == "我是一名开发者"
+
+
+def test_failed_backup_leaves_no_partial_orig_file(tmp_path: Path, monkeypatch):
+    """A truncated `.orig` is as destructive as none, and reads as success.
+
+    The copy is staged under a temporary name and renamed, so a failure part way
+    through leaves nothing behind. Were it written to `.orig` directly, the next
+    save would see the file exist, treat the config as already preserved, and
+    rewrite it — with only a fragment of the original kept.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with (
+        legacy_locale_codec("cp1252"),
+        legacy_default_encoding("cp1252"),
+        backup_writes_failing(),
+        pytest.raises(OSError, match="Refusing to rewrite"),
+    ):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    assert [p.name for p in tmp_path.iterdir() if ".orig" in p.name] == []
+
+
+def test_a_later_save_retries_a_backup_that_failed(tmp_path: Path, monkeypatch):
+    """The file still holds unpreserved bytes, so the next save must try again.
+
+    The marker is what records "these bytes have not been copied yet". Clearing it
+    on failure — which a `finally` would — makes the *next* save skip the backup
+    and rewrite the file, so a single transient disk error would lose the original
+    at the following save instead of the current one.
+    """
+    config_file = tmp_path / "config.toml"
+    original = b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n'
+    config_file.write_bytes(original)
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp1252"), legacy_default_encoding("cp1252"):
+        with (
+            backup_writes_failing(),
+            pytest.raises(OSError, match="Refusing to rewrite"),
+        ):
+            user_mod.set_config_value("user.name", "Alice", reload=False)
+        assert str(config_file.resolve()) in user_mod._encoding_unverified
+
+        # Disk error cleared; the save that follows preserves the bytes.
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    assert Path(str(config_file) + ".orig").read_bytes() == original
+
+
+def test_failed_backup_aborts_a_chat_config_save_too(tmp_path: Path):
+    """The conversation config reaches the same backup, so it gets the same refusal.
+
+    `ChatConfig.save()` writes atomically via a rename, which would replace the
+    original bytes just as thoroughly as a direct write.
+    """
+    chat_config_path = tmp_path / "config.toml"
+    original = b'name = "' + LEGACY_BYTES_ABOUT + b'"\n'
+    chat_config_path.write_bytes(original)
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp1252"):
+        config = ChatConfig.from_logdir(tmp_path)
+        assert str(chat_config_path.resolve()) in user_mod._encoding_unverified
+        with (
+            backup_writes_failing(),
+            pytest.raises(OSError, match="Refusing to rewrite"),
+        ):
+            config.save()
+
+    assert chat_config_path.read_bytes() == original

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -205,6 +205,12 @@ def test_chat_config_save_writes_valid_utf8(tmp_path: Path):
 
 LEGACY_BYTES_ABOUT = "我是一名开发者".encode("cp936")
 
+# A byte no candidate can decode, so the read falls all the way through to
+# `errors="replace"`. 0xff is invalid in UTF-8 and, unlike a single-byte code page
+# that maps every byte, invalid in cp936 too — which is what makes cp936 the locale
+# to patch in for the replacement path.
+UNDECODABLE_BYTE = b"\xff"
+
 
 @pytest.mark.parametrize("utf8_mode", [False, True], ids=["locale", "utf8-mode"])
 def test_legacy_encoded_user_config_is_still_readable(tmp_path: Path, utf8_mode: bool):
@@ -390,6 +396,70 @@ def test_every_legacy_fallback_is_recorded_as_unverified(
 
     assert isinstance(text, str)
     assert str(config_file.resolve()) in user_mod._encoding_unverified
+
+
+def test_replacement_decoding_is_recorded_as_unverified(tmp_path: Path):
+    """The last-resort read is a guess too, and the one that loses the most.
+
+    A legacy-codec fallback at least keeps the bytes' meaning — mojibake
+    re-encodes to the original bytes — whereas U+FFFD discards which byte it
+    stood for, so nothing but the backup can undo it. Leaving this path unmarked
+    would exempt the most damaging decode from the protection the milder ones get.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "caf' + UNDECODABLE_BYTE + b'"\n')
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp936"):
+        text = user_mod._read_config_text(config_file)
+
+    assert "�" in text, "test byte was decodable after all"
+    assert str(config_file.resolve()) in user_mod._encoding_unverified
+
+
+def test_replacement_decoded_config_can_still_be_valid_toml(tmp_path: Path):
+    """Reaching the parser is not the same as being rejected by it.
+
+    `errors="replace"` is chosen so the parser decides what happens, and for a
+    file that is corrupt in its structure the parser does reject it (see
+    `test_undecodable_config_fails_at_the_parser_not_the_decoder`). But an
+    undecodable byte *inside a quoted value* leaves the document well-formed:
+    U+FFFD is an ordinary character to TOML. So the parser cannot be relied on as
+    the backstop for this path either, which is why it is marked instead.
+    """
+    text = (b'[user]\nabout = "caf' + UNDECODABLE_BYTE + b'"\n').decode(
+        "utf-8", errors="replace"
+    )
+
+    assert tomlkit.loads(text).unwrap()["user"]["about"] == "caf�"
+
+    # And unlike a wrong-codec read, this one cannot be undone from the text:
+    # the byte is gone, not merely misinterpreted.
+    assert "caf�".encode(errors="replace") != b"caf" + UNDECODABLE_BYTE
+
+
+def test_replacement_decoded_config_is_backed_up_before_being_rewritten(
+    tmp_path: Path, monkeypatch
+):
+    """End to end: a save must not be what turns U+FFFD into the file's contents.
+
+    This is the case the parser lets through — a well-formed document holding a
+    replacement character — so without the marker the save proceeds, writes the
+    U+FFFD out as UTF-8, and the byte it replaced is gone for good with no `.orig`
+    beside it.
+    """
+    config_file = tmp_path / "config.toml"
+    original = b'[user]\nabout = "caf' + UNDECODABLE_BYTE + b'"\n'
+    config_file.write_bytes(original)
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    user_mod._encoding_unverified.clear()
+
+    with legacy_locale_codec("cp936"), legacy_default_encoding("cp936"):
+        user_mod.set_config_value("user.name", "Alice", reload=False)
+
+    backup = Path(str(config_file) + ".orig")
+    assert backup.exists(), "original bytes were discarded"
+    assert backup.read_bytes() == original
 
 
 def test_unverified_config_is_backed_up_before_being_rewritten(

--- a/tests/test_config_encoding.py
+++ b/tests/test_config_encoding.py
@@ -9,6 +9,7 @@ are exactly the ones a user writes about themselves: `[user] about`,
 """
 
 import builtins
+import codecs
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -53,16 +54,27 @@ def legacy_default_encoding(codec: str = LEGACY_CODEC):
 
 
 @contextmanager
-def legacy_locale_codec(codec: str):
-    """Make the read-side fallback behave as it does under a legacy locale.
+def legacy_locale_codec(codec: str, utf8_mode: bool = False):
+    """Make the read-side fallback behave as it does on a legacy-codepage machine.
 
-    `_read_config_text` reads bytes and asks `locale.getpreferredencoding` what to
-    fall back to, so — unlike the writers — it is not reached by the `open()` shim
-    above. It must be patched at that call instead, or the upgrade-path tests only
-    exercise the fallback on a machine whose locale happens to be a legacy code
-    page, and assert the *opposite* behaviour (a re-raise) on a UTF-8 one.
+    `_read_config_text` reads bytes and asks the `locale` module what to fall back
+    to, so — unlike the writers — it is not reached by the `open()` shim above. It
+    must be patched at those calls instead, or the upgrade-path tests only exercise
+    the fallback on a machine whose locale happens to be a legacy code page.
+
+    `utf8_mode=True` reproduces Python's UTF-8 mode (`-X utf8`, `PYTHONUTF8=1`):
+    `getpreferredencoding(False)` reports "utf-8" while `getencoding()` still
+    reports the real code page. A fallback that consults only the former is blind
+    to the codec that wrote the file on exactly the machine that wrote it.
     """
-    with patch.object(user_mod.locale, "getpreferredencoding", lambda *args: codec):
+    preferred = "utf-8" if utf8_mode else codec
+    with (
+        patch.object(user_mod.locale, "getpreferredencoding", lambda *a: preferred),
+        patch.object(user_mod.locale, "getencoding", lambda: codec, create=True),
+        patch.object(
+            user_mod.locale, "getdefaultlocale", lambda: ("zh_CN", codec), create=True
+        ),
+    ):
         yield
 
 
@@ -194,23 +206,34 @@ def test_chat_config_save_writes_valid_utf8(tmp_path: Path):
 LEGACY_BYTES_ABOUT = "我是一名开发者".encode("cp936")
 
 
-def test_legacy_encoded_user_config_is_still_readable(tmp_path: Path):
-    """A config an older gptme wrote in cp936 must not break loading."""
+@pytest.mark.parametrize("utf8_mode", [False, True], ids=["locale", "utf8-mode"])
+def test_legacy_encoded_user_config_is_still_readable(tmp_path: Path, utf8_mode: bool):
+    """A config an older gptme wrote in cp936 must not break loading.
+
+    Parametrised over UTF-8 mode because that is the case a fallback built on
+    `getpreferredencoding` alone cannot serve: it reports "utf-8" there, hiding the
+    very code page that wrote the file.
+    """
     config_file = tmp_path / "config.toml"
     config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
 
-    with legacy_locale_codec("cp936"):
+    with legacy_locale_codec("cp936", utf8_mode=utf8_mode):
         config = user_mod.load_user_config(str(config_file))
 
     assert config.user.about == "我是一名开发者"
 
 
-def test_legacy_encoded_chat_config_is_still_readable(tmp_path: Path):
+@pytest.mark.parametrize("utf8_mode", [False, True], ids=["locale", "utf8-mode"])
+def test_legacy_encoded_chat_config_is_still_readable(tmp_path: Path, utf8_mode: bool):
     """Same for a per-conversation config.
 
     On `master` this case is worse than a fallback-less read: `tomllib.load`
     raises `UnicodeDecodeError`, which `_CHAT_CONFIG_LOAD_ERRORS` did not list,
     so it escaped `from_logdir` entirely instead of degrading to defaults.
+
+    Under UTF-8 mode the symptom is different but no better: the settings decode to
+    replacement characters, so `from_logdir` silently returns a config whose `name`
+    is mojibake rather than the one on disk.
     """
     logdir = tmp_path / "conv"
     logdir.mkdir()
@@ -218,7 +241,7 @@ def test_legacy_encoded_chat_config_is_still_readable(tmp_path: Path):
         b'[chat]\nname = "' + LEGACY_BYTES_ABOUT + b'"\nmodel = "test-model"\n'
     )
 
-    with legacy_locale_codec("cp936"):
+    with legacy_locale_codec("cp936", utf8_mode=utf8_mode):
         config = ChatConfig.from_logdir(logdir)
 
     assert config.name == "我是一名开发者"
@@ -262,11 +285,12 @@ def test_read_config_text_never_raises_unicode_decode_error(
 ):
     """The read helper must not leak `UnicodeDecodeError` for any locale.
 
-    On a UTF-8 locale there is no second codec to try, and re-raising sent a
+    When no candidate codec can decode the bytes, re-raising would send a
     `UnicodeDecodeError` up to callers — the very failure the fallback exists to
-    prevent, just narrowed to the platforms where the fallback cannot help. Callers
+    prevent, just narrowed to the platforms where no fallback can help. Callers
     handle TOML parse errors, not decode errors, so `errors="replace"` is the right
-    outcome in both cases. The aliases cover `codecs.lookup` normalisation.
+    outcome. The aliases cover `codecs.lookup` normalisation, which is what stops
+    "UTF-8" and "utf8" from being retried as if they were a second codec.
     """
     config_file = tmp_path / "config.toml"
     config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
@@ -275,3 +299,44 @@ def test_read_config_text_never_raises_unicode_decode_error(
         text = user_mod._read_config_text(config_file)
 
     assert isinstance(text, str)
+
+
+def test_legacy_codec_candidates_excludes_utf8_and_deduplicates():
+    """The candidate list must never re-offer a codec UTF-8 already covers.
+
+    `_read_config_text` has decoded as UTF-8 before consulting this list, so a
+    "utf-8" entry — under an ASCII/UTF-8 locale, or from
+    `getpreferredencoding` under UTF-8 mode — is a wasted retry that would decode
+    the same bytes the same failing way. Aliases must collapse too, since
+    `getencoding()` and `getpreferredencoding()` routinely spell one codec two ways.
+    """
+    with legacy_locale_codec("cp936", utf8_mode=True):
+        candidates = user_mod._legacy_codec_candidates()
+
+    canonical = [codecs.lookup(c).name for c in candidates]
+    assert "utf-8" not in canonical
+    assert canonical == [codecs.lookup("cp936").name]
+
+    # Both sources agreeing must not yield the codec twice.
+    with legacy_locale_codec("cp1252"):
+        assert [codecs.lookup(c).name for c in user_mod._legacy_codec_candidates()] == [
+            codecs.lookup("cp1252").name
+        ]
+
+
+def test_a_codec_that_cannot_decode_hands_over_to_the_next(tmp_path: Path):
+    """Candidates are tried strictly, so a wrong codec does not win by mojibake.
+
+    Decoding each candidate with errors="replace" would let the first one always
+    "succeed", making every later candidate dead code. Here the preferred encoding
+    (UTF-8 mode) cannot decode the bytes and `getencoding()` can, so the real code
+    page must be the one that is used.
+    """
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(b'[user]\nabout = "' + LEGACY_BYTES_ABOUT + b'"\n')
+
+    with legacy_locale_codec("cp936", utf8_mode=True):
+        text = user_mod._read_config_text(config_file)
+
+    assert "我是一名开发者" in text
+    assert "�" not in text  # no replacement characters


### PR DESCRIPTION
## Summary

TOML is [defined to be UTF-8](https://toml.io/en/v1.0.0#spec), but no `open()` in `gptme/config/` passed `encoding=`. Text mode without it uses the platform's *preferred* encoding — a legacy codepage on a stock Windows install (cp936 on a Chinese system, cp1252 on a Western one), not UTF-8. So `config.toml`, `config.local.toml`, `gptme.toml` and per-conversation `config.toml` were all read and written in whatever codepage the machine happened to have.

This hits exactly the fields a user writes in their own language: `[user] about`, `response_preference`, `name`, and a project's `prompt` / `base_prompt`.

## Three failure modes

**1. Read — gptme will not start.** The bytes already on disk are enough; the user does not have to do anything after writing them:

```
$ cat ~/.config/gptme/config.toml
[user]
about = "我是一名开发者"

>>> load_user_config()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 24
```

**2. Write — the value is rejected.** `gptme config set user.about …`, the setup wizard, and the web UI's config PUT/PATCH all reach `set_config_value`:

```
>>> set_config_value("user.about", "café ☕")
UnicodeEncodeError: 'gbk' codec can't encode character '\xef' in position 41
```

**3. Round trip — the write succeeds and silently corrupts the file.** This is the worst one. For text the codepage *does* cover, nothing raises; the file is written in that codepage and is not valid UTF-8, therefore not valid TOML for any other reader:

```
>>> set_config_value("user.about", "开发者")     # no error
>>> open(config_path, "rb").read()
b'[user]\r\nabout = "\xbf\xaa\xb7\xa2\xd5\xdf"\r\n'
>>> _.decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbf in position 20
```

`tomllib` — which gptme itself uses for chat configs on Python 3.11+ — is UTF-8 only, so a file written this way cannot be read back by the very loader that will read it. Nor by any editor, any other TOML library, or the same config synced to a Linux machine.

## Changes

**Writes** are now strict UTF-8. **Reads** go through one helper, `_read_config_text`, which decodes as UTF-8 per the spec and only on `UnicodeDecodeError` retries with the locale codec — so a config an older gptme wrote in a code page still loads, with a warning naming the file, and the next config change normalises it to UTF-8. Making the reads strict alone would have taken a Windows user with a cp936 `config.toml` from "loads with mojibake" to "does not load at all"; thanks @greptile-apps for catching that.

While adding that, one more defect surfaced: `tomllib.load` raises `UnicodeDecodeError`, not `TOMLDecodeError`, and that was not in `_CHAT_CONFIG_LOAD_ERRORS`. So on `master` a legacy-encoded conversation config **already** escapes `ChatConfig.from_logdir`'s handler on Python 3.11+ instead of degrading to defaults. Added to both branches of the tuple.

Call sites, across three files:

| file | reads (via `_read_config_text`) | writes (`encoding="utf-8"`) |
|---|---|---|
| `gptme/config/user.py` | `get_user_config_env_source`, `get_default_model_source`, `load_user_config`, `_load_config_doc` | `_strip_unknown_config_keys`, `_load_config_doc` (create), `set_config_value`, `save_provider_config` |
| `gptme/config/chat.py` | `from_logdir` (both the `tomllib` and `tomlkit` branches), `save` read-back | `save`'s atomic write |
| `gptme/config/project.py` | `gptme.toml`, `gptme.local.toml` | — |

`ChatConfig.save()` needed the codec on `tempfile.NamedTemporaryFile(mode="w")` rather than on an `open()` — same defect, different constructor, and easy to miss since the atomic-write block reads as if it were already handled.

No behaviour change other than the encoding. Nothing else in these files was touched.

## Internal consistency

`ChatConfig.from_logdir` already got this right on one of its two branches and wrong on the other:

```python
if tomllib is not None:
    with open(chat_config_path, "rb") as f:   # binary — tomllib decodes as UTF-8, correct
        config_data = tomllib.load(f)
else:
    with open(chat_config_path) as f:         # text — platform codepage
        config_data = tomlkit.load(f).unwrap()
```

Two paths in one function, reading the same file, disagreeing about its encoding — which also means the bug's visibility depended on the Python version.

The wider codebase already treats `encoding="utf-8"` as the norm: `util/export.py`, `prompt_queue.py`, `tools/morph.py`, `tools/save.py`, `tools/patch_many.py`, `lessons/installer.py`, `logmanager/eventlog.py`, `util/context_savings.py`.

And this exact class of bug was already fixed once upstream: **#2051**, "fix(tools): add explicit UTF-8 encoding to all file read/write operations" (merged). It covered `gptme/tools/{morph,patch,read,save}.py` and left `gptme/config/` untouched. Its own test plan still has "Verify non-ASCII file editing works on a Windows system" unchecked — that is where I found this.

## Validation

New `tests/test_config_encoding.py`, 11 tests:

| test | guards |
|---|---|
| `test_load_user_config_reads_non_ascii_about` | read side, main config |
| `test_load_user_config_reads_non_ascii_from_local_override` | read side, `config.local.toml` merge path (a second `open()`) |
| `test_set_config_value_writes_valid_utf8_toml` | write side; asserts the raw bytes decode as **strict** UTF-8 |
| `test_set_config_value_ascii_still_works` | control — the case the old code got right |
| `test_user_config_round_trips_non_ascii` | write then read back; the two sides must agree |
| `test_project_config_reads_non_ascii` | `gptme.toml`, which is committed and shared across machines |
| `test_chat_config_save_writes_valid_utf8` | `ChatConfig.save()`'s atomic write, then `from_logdir` reads it back |
| `test_legacy_encoded_user_config_is_still_readable` | upgrade path — a cp936 `config.toml` from an older install |
| `test_legacy_encoded_chat_config_is_still_readable` | upgrade path — a cp936 conversation config |
| `test_legacy_encoded_config_is_rewritten_as_utf8` | the fallback is read-side only; the next write normalises the file, preserving the non-ASCII value |
| `test_undecodable_config_fails_at_the_parser_not_the_decoder` | truly corrupt bytes must reach the parser (which callers handle) rather than raise on decode |

Reproducing a locale bug on a UTF-8 CI runner needs care. Monkeypatching `locale.getpreferredencoding` **does not work** — CPython reads the locale encoding at the C level, so `open()` ignores the patched function. A `legacy_default_encoding` context manager instead replaces `open` with a shim that supplies a codec in exactly the position CPython would supply the locale's — **only when the caller passed no `encoding`**:

```python
def shim(file, mode="r", *args, **kwargs):
    if "b" not in mode and kwargs.get("encoding") is None and len(args) < 2:
        kwargs["encoding"] = codec
    return real_open(file, mode, *args, **kwargs)
```

Code that names its encoding is untouched by the shim, so these tests fail on a machine of any locale when the `encoding=` is missing and pass on a machine of any locale when it is present. Read-side tests use `ascii` rather than `cp1252`: cp1252 maps every byte and round-trips, so it turns undecodable input into mojibake without raising and would not detect a missing `encoding=` on a read.

**Control experiments.** Two, because the change has two halves.

*(a) against unmodified `master`* — the three config files reverted, the tests kept:

```
9 failed, 2 passed

FAILED test_load_user_config_reads_non_ascii_about
       UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 17
FAILED test_load_user_config_reads_non_ascii_from_local_override
FAILED test_set_config_value_writes_valid_utf8_toml
       UnicodeEncodeError: 'charmap' codec can't encode characters in position 17-23
FAILED test_user_config_round_trips_non_ascii
FAILED test_project_config_reads_non_ascii
FAILED test_chat_config_save_writes_valid_utf8
       UnicodeDecodeError: 'utf-8' codec can't decode byte 0xce in position 16: invalid continuation byte
FAILED test_legacy_encoded_chat_config_is_still_readable
FAILED test_legacy_encoded_config_is_rewritten_as_utf8
FAILED test_undecodable_config_fails_at_the_parser_not_the_decoder
```

`test_chat_config_save_writes_valid_utf8` is failure mode 3 caught in the act: the save raised nothing, and the file it produced does not decode as UTF-8. The two that stay green are the ASCII control and `test_legacy_encoded_user_config_is_still_readable` — the latter *should* pass on `master`, since reading with the locale codec is exactly what `master` does; it is there to stop this PR from breaking that.

*(b) against the strict-UTF-8-only commit* (this branch's first commit, before the fallback):

```
4 failed, 7 passed

FAILED test_legacy_encoded_user_config_is_still_readable
FAILED test_legacy_encoded_chat_config_is_still_readable
FAILED test_legacy_encoded_config_is_rewritten_as_utf8
FAILED test_undecodable_config_fails_at_the_parser_not_the_decoder
       UnicodeDecodeError: 'utf-8' codec can't decode byte 0xce in position 16
```

Exactly the four upgrade-path tests, which is what makes them a guard on the fallback rather than on the encoding. With both commits: **11 passed**.

**No regressions.** `tests/test_config.py tests/test_chat_config.py tests/test_computer_docker_config.py tests/test_server_config_workspace_containment.py`:

| tree | result |
|---|---|
| this branch | 77 passed, 43 failed, 12 errors |
| unmodified `master` | 77 passed, 43 failed, 12 errors |

Identical, with an empty symmetric difference of the failing-test sets in both directions. I ran this on Windows, where a portion of the config suite cannot pass at all on `master`: symlink creation needs a privilege the default account lacks (`OSError: [WinError 1314]`, 7 tests), tmpdir teardown hits file locking (`PermissionError: [WinError 32]`, 5 tests), and one asserts a POSIX path separator (`assert '~\\workspace' == '~/workspace'`). Same machine and same selection on both sides, so the comparison is valid for "this change adds no failures" — but a maintainer run on Linux is a better check of the absolute numbers.

`ruff format`, `ruff check` and `mypy` all clean on the four changed files.

## Linked issues

I searched open and closed PRs and issues before opening this (`encoding`, `UnicodeDecodeError`, `UnicodeEncodeError`, `utf-8`, `config.toml windows`) — no existing or overlapping work; #2051 is the closest and is merged and disjoint. Targeting `master` per `AGENTS.md`.
