### PR TITLE
feat(cli): add global stats for CLI subcommand for usage & cost analytics

### DIFF
--- a/gptme/cli/cmd_stats.py
+++ b/gptme/cli/cmd_stats.py
@@ -1,0 +1,243 @@
+"""CLI command for global LLM usage and cost analytics."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from ..logmanager.conversations import get_conversations
+
+
+@dataclass
+class ModelStats:
+    """Statistics aggregated for a specific model."""
+
+    model: str
+    sessions: int = 0
+    cost: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens across input, output, and cache read."""
+        return self.input_tokens + self.output_tokens + self.cache_read_tokens
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert ModelStats to a dictionary."""
+        d = asdict(self)
+        d["total_tokens"] = self.total_tokens
+        return d
+
+
+@dataclass
+class StatsSummary:
+    """Aggregated global usage and cost statistics."""
+
+    total_sessions: int = 0
+    total_cost: float = 0.0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    by_model: list[ModelStats] = field(default_factory=list)
+    days: int | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens across all conversations."""
+        return (
+            self.total_input_tokens
+            + self.total_output_tokens
+            + self.total_cache_read_tokens
+        )
+
+    @property
+    def avg_cost_per_session(self) -> float:
+        """Average cost per session in USD."""
+        if self.total_sessions == 0:
+            return 0.0
+        return self.total_cost / self.total_sessions
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert StatsSummary to a dictionary for JSON serialization."""
+        return {
+            "total_sessions": self.total_sessions,
+            "total_cost": round(self.total_cost, 4),
+            "total_tokens": {
+                "total": self.total_tokens,
+                "input": self.total_input_tokens,
+                "output": self.total_output_tokens,
+                "cache_read": self.total_cache_read_tokens,
+            },
+            "avg_cost_per_session": round(self.avg_cost_per_session, 4),
+            "days": self.days,
+            "by_model": [m.to_dict() for m in self.by_model],
+        }
+
+
+def gather_global_stats(
+    days: int | None = None, include_test: bool = False
+) -> StatsSummary:
+    """Gather aggregated usage and cost statistics across stored conversation logs.
+
+    Args:
+        days: Optional number of past days to restrict statistics to (based on modification date).
+        include_test: If True, include test/eval conversations in the statistics.
+
+    Returns:
+        StatsSummary containing total sessions, cost, token counts, and per-model breakdown.
+    """
+    cutoff_timestamp: float | None = None
+    if days is not None:
+        cutoff_timestamp = time.time() - (days * 86400)
+
+    summary = StatsSummary(days=days)
+    model_map: dict[str, ModelStats] = {}
+
+    for conv in get_conversations(detail=True, include_test=include_test):
+        if cutoff_timestamp is not None and conv.modified < cutoff_timestamp:
+            continue
+
+        summary.total_sessions += 1
+        summary.total_cost += conv.total_cost
+        summary.total_input_tokens += conv.total_input_tokens
+        summary.total_output_tokens += conv.total_output_tokens
+        summary.total_cache_read_tokens += conv.total_cache_read_tokens
+
+        model_name = conv.model or "unknown"
+        if model_name not in model_map:
+            model_map[model_name] = ModelStats(model=model_name)
+
+        ms = model_map[model_name]
+        ms.sessions += 1
+        ms.cost += conv.total_cost
+        ms.input_tokens += conv.total_input_tokens
+        ms.output_tokens += conv.total_output_tokens
+        ms.cache_read_tokens += conv.total_cache_read_tokens
+
+    # Sort models by cost descending, then total tokens descending
+    summary.by_model = sorted(
+        model_map.values(), key=lambda m: (m.cost, m.total_tokens), reverse=True
+    )
+
+    return summary
+
+
+def _format_tokens(count: int) -> str:
+    """Format token count into a human-readable string."""
+    return f"{count:,}"
+
+
+def _format_cost(cost: float) -> str:
+    """Format USD cost."""
+    if cost == 0:
+        return "$0.0000"
+    if 0 < cost < 0.0001:
+        return "<$0.0001"
+    return f"${cost:.4f}"
+
+
+def display_stats(summary: StatsSummary, console: Console | None = None) -> None:
+    """Display aggregated statistics in a Rich formatted layout.
+
+    Args:
+        summary: Aggregated stats to render.
+        console: Optional Rich Console instance to print to.
+    """
+    if console is None:
+        console = Console()
+
+    time_period = (
+        f"Last {summary.days} days" if summary.days is not None else "All-time"
+    )
+
+    summary_table = Table(
+        title=f"gptme Usage & Cost Analytics ({time_period})",
+        show_header=False,
+        box=None,
+        padding=(0, 1),
+    )
+    summary_table.add_column("Property", style="bold cyan")
+    summary_table.add_column("Value", style="white")
+
+    summary_table.add_row("Total Sessions", str(summary.total_sessions))
+    summary_table.add_row("Total Cost", _format_cost(summary.total_cost))
+    summary_table.add_row(
+        "Total Tokens",
+        f"{_format_tokens(summary.total_tokens)} "
+        f"([dim]in: {_format_tokens(summary.total_input_tokens)} / "
+        f"out: {_format_tokens(summary.total_output_tokens)} / "
+        f"cache: {_format_tokens(summary.total_cache_read_tokens)}[/dim])",
+    )
+    summary_table.add_row(
+        "Avg Cost/Session", _format_cost(summary.avg_cost_per_session)
+    )
+
+    console.print()
+    console.print(summary_table)
+    console.print()
+
+    if not summary.by_model:
+        console.print("[dim]No conversation logs found.[/dim]")
+        return
+
+    table = Table(
+        title="Breakdown by Model", title_style="bold yellow", show_lines=True
+    )
+    table.add_column("Model", style="cyan")
+    table.add_column("Sessions", justify="right", style="green")
+    table.add_column("Tokens", justify="right", style="white")
+    table.add_column("Cost (USD)", justify="right", style="bold magenta")
+
+    for ms in summary.by_model:
+        table.add_row(
+            ms.model,
+            str(ms.sessions),
+            _format_tokens(ms.total_tokens),
+            _format_cost(ms.cost),
+        )
+
+    console.print(table)
+    console.print()
+
+
+@click.command("stats")
+@click.option(
+    "-d",
+    "--days",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Filter statistics to conversations modified in the last N days.",
+)
+@click.option(
+    "--include-test",
+    is_flag=True,
+    default=False,
+    help="Include test/eval conversations in statistics.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Output statistics as JSON.",
+)
+def stats(days: int | None, include_test: bool, output_json: bool) -> None:
+    """Show global LLM usage and cost statistics across all conversation logs."""
+    summary = gather_global_stats(days=days, include_test=include_test)
+
+    if output_json:
+        click.echo(json.dumps(summary.to_dict(), indent=2))
+    else:
+        display_stats(summary)
+
+
+if __name__ == "__main__":
+    stats()

--- a/gptme/cli/cmd_stats.py
+++ b/gptme/cli/cmd_stats.py
@@ -108,16 +108,27 @@ def gather_global_stats(
         summary.total_output_tokens += conv.total_output_tokens
         summary.total_cache_read_tokens += conv.total_cache_read_tokens
 
-        model_name = conv.model or "unknown"
-        if model_name not in model_map:
-            model_map[model_name] = ModelStats(model=model_name)
+        if conv.models_usage:
+            for m_name, mu in conv.models_usage.items():
+                if m_name not in model_map:
+                    model_map[m_name] = ModelStats(model=m_name)
+                ms = model_map[m_name]
+                ms.sessions += 1
+                ms.cost += mu.get("cost", 0.0)
+                ms.input_tokens += mu.get("input_tokens", 0)
+                ms.output_tokens += mu.get("output_tokens", 0)
+                ms.cache_read_tokens += mu.get("cache_read_tokens", 0)
+        else:
+            model_name = conv.model or "unknown"
+            if model_name not in model_map:
+                model_map[model_name] = ModelStats(model=model_name)
 
-        ms = model_map[model_name]
-        ms.sessions += 1
-        ms.cost += conv.total_cost
-        ms.input_tokens += conv.total_input_tokens
-        ms.output_tokens += conv.total_output_tokens
-        ms.cache_read_tokens += conv.total_cache_read_tokens
+            ms = model_map[model_name]
+            ms.sessions += 1
+            ms.cost += conv.total_cost
+            ms.input_tokens += conv.total_input_tokens
+            ms.output_tokens += conv.total_output_tokens
+            ms.cache_read_tokens += conv.total_cache_read_tokens
 
     # Sort models by cost descending, then total tokens descending
     summary.by_model = sorted(
@@ -189,7 +200,7 @@ def display_stats(summary: StatsSummary, console: Console | None = None) -> None
         title="Breakdown by Model", title_style="bold yellow", show_lines=True
     )
     table.add_column("Model", style="cyan")
-    table.add_column("Sessions", justify="right", style="green")
+    table.add_column("Chats", justify="right", style="green")
     table.add_column("Tokens", justify="right", style="white")
     table.add_column("Cost (USD)", justify="right", style="bold magenta")
 

--- a/gptme/cli/cmd_stats.py
+++ b/gptme/cli/cmd_stats.py
@@ -1,4 +1,10 @@
-"""CLI command for global LLM usage and cost analytics."""
+"""CLI command for global LLM usage and cost analytics.
+
+Aggregates usage across gptme's own stored conversation logs.
+
+See also: ``gptme-sessions cost`` (gptme-contrib) for cross-backend analytics
+(Claude Code, OpenRouter, Bedrock, etc.) and ``gptme-usage`` for pricing tables.
+"""
 
 from __future__ import annotations
 
@@ -54,7 +60,6 @@ class StatsSummary:
         """Total tokens across all conversations."""
         return self.total_input_tokens + self.total_output_tokens
 
-
     @property
     def avg_cost_per_session(self) -> float:
         """Average cost per session in USD."""
@@ -63,7 +68,11 @@ class StatsSummary:
         return self.total_cost / self.total_sessions
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert StatsSummary to a dictionary for JSON serialization."""
+        """Convert StatsSummary to a dictionary for JSON serialization.
+
+        Note: ``cache_read`` is a *subset* of ``input`` (cache reads are counted
+        as input tokens), so the fields do not sum to ``total``.
+        """
         return {
             "total_sessions": self.total_sessions,
             "total_cost": round(self.total_cost, 4),
@@ -180,9 +189,9 @@ def display_stats(summary: StatsSummary, console: Console | None = None) -> None
     summary_table.add_row(
         "Total Tokens",
         f"{_format_tokens(summary.total_tokens)} "
-        f"([dim]in: {_format_tokens(summary.total_input_tokens)} / "
-        f"out: {_format_tokens(summary.total_output_tokens)} / "
-        f"cache: {_format_tokens(summary.total_cache_read_tokens)}[/dim])",
+        f"([dim]in: {_format_tokens(summary.total_input_tokens)} "
+        f"(incl. {_format_tokens(summary.total_cache_read_tokens)} cached) / "
+        f"out: {_format_tokens(summary.total_output_tokens)}[/dim])",
     )
     summary_table.add_row(
         "Avg Cost/Session", _format_cost(summary.avg_cost_per_session)
@@ -238,7 +247,14 @@ def display_stats(summary: StatsSummary, console: Console | None = None) -> None
     help="Output statistics as JSON.",
 )
 def stats(days: int | None, include_test: bool, output_json: bool) -> None:
-    """Show global LLM usage and cost statistics across all conversation logs."""
+    """Show global LLM usage and cost statistics across all conversation logs.
+
+    Cache-read tokens are included in the input-token count, not added on top.
+
+    See also: ``gptme-sessions cost`` (gptme-contrib) for cross-backend
+    analytics (Claude Code, OpenRouter, Bedrock, etc.) and ``gptme-usage`` for
+    pricing tables.
+    """
     summary = gather_global_stats(days=days, include_test=include_test)
 
     if output_json:

--- a/gptme/cli/cmd_stats.py
+++ b/gptme/cli/cmd_stats.py
@@ -27,8 +27,8 @@ class ModelStats:
 
     @property
     def total_tokens(self) -> int:
-        """Total tokens across input, output, and cache read."""
-        return self.input_tokens + self.output_tokens + self.cache_read_tokens
+        """Total tokens across input and output."""
+        return self.input_tokens + self.output_tokens
 
     def to_dict(self) -> dict[str, Any]:
         """Convert ModelStats to a dictionary."""
@@ -52,11 +52,8 @@ class StatsSummary:
     @property
     def total_tokens(self) -> int:
         """Total tokens across all conversations."""
-        return (
-            self.total_input_tokens
-            + self.total_output_tokens
-            + self.total_cache_read_tokens
-        )
+        return self.total_input_tokens + self.total_output_tokens
+
 
     @property
     def avg_cost_per_session(self) -> float:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -58,6 +58,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "skills": (".cmd_skills", "skills"),
     "slop": (".cmd_slop", "slop"),
     "snapshot": (".cmd_snapshot", "snapshot"),
+    "stats": (".cmd_stats", "stats"),
     "status": (".cmd_status", "status"),
 }
 

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -11,10 +11,11 @@ import re
 import shutil
 import sys
 from collections.abc import Generator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
+from typing import Any
 
 import tomlkit
 
@@ -85,6 +86,7 @@ class ConversationMeta:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cache_read_tokens: int = 0
+    models_usage: dict[str, dict[str, Any]] = field(default_factory=dict)
     last_message_role: str | None = None
     last_message_preview: str | None = None
 
@@ -237,14 +239,23 @@ def _fast_scan_tail(
 
 def _full_scan(
     conv_fn: Path,
-) -> tuple[int, str | None, float, int, int, int, bytes | None]:
+) -> tuple[
+    int,
+    str | None,
+    float,
+    int,
+    int,
+    int,
+    dict[str, dict[str, Any]],
+    bytes | None,
+]:
     """Full JSONL scan: counts messages and accumulates cost/token metadata.
 
     Both scan modes return the most recently used model (last model wins),
     which is more useful for display than the first model used.
 
     Returns (len_msgs, model, cost, input_tokens, output_tokens,
-             cache_read_tokens, last_user_or_assistant_line).
+             cache_read_tokens, models_usage, last_user_or_assistant_line).
     """
     len_msgs = 0
     conv_model: str | None = None
@@ -252,6 +263,7 @@ def _full_scan(
     conv_input_tokens = 0
     conv_output_tokens = 0
     conv_cache_read_tokens = 0
+    models_usage: dict[str, dict[str, Any]] = {}
     last_msg_line: bytes | None = None
     with open(conv_fn, "rb") as f:
         for line in f:
@@ -266,19 +278,38 @@ def _full_scan(
                     msg = json.loads(line)
                     meta = msg.get("metadata")
                     if meta:
-                        if meta.get("model"):
-                            conv_model = meta["model"]
-                        conv_cost += meta.get("cost", 0) or 0
+                        msg_model = meta.get("model")
+                        if msg_model:
+                            conv_model = msg_model
+                        cost = meta.get("cost", 0) or 0
+                        conv_cost += cost
                         usage = meta.get("usage", {})
                         src = usage or meta
                         cache_read = src.get("cache_read_tokens", 0) or 0
-                        conv_input_tokens += (
+                        in_tok = (
                             (src.get("input_tokens", 0) or 0)
                             + cache_read
                             + (src.get("cache_creation_tokens", 0) or 0)
                         )
-                        conv_output_tokens += src.get("output_tokens", 0) or 0
+                        out_tok = src.get("output_tokens", 0) or 0
+                        conv_input_tokens += in_tok
+                        conv_output_tokens += out_tok
                         conv_cache_read_tokens += cache_read
+
+                        # Accumulate per-model nested usage dictionary
+                        target_model = msg_model or conv_model or "unknown"
+                        if target_model not in models_usage:
+                            models_usage[target_model] = {
+                                "cost": 0.0,
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                                "cache_read_tokens": 0,
+                            }
+                        mu = models_usage[target_model]
+                        mu["cost"] += cost
+                        mu["input_tokens"] += in_tok
+                        mu["output_tokens"] += out_tok
+                        mu["cache_read_tokens"] += cache_read
                 except (json.JSONDecodeError, TypeError):
                     pass
     return (
@@ -288,6 +319,7 @@ def _full_scan(
         conv_input_tokens,
         conv_output_tokens,
         conv_cache_read_tokens,
+        models_usage,
         last_msg_line,
     )
 
@@ -313,6 +345,7 @@ def _meta_from_file(conv_fn: Path, *, detail: bool = True) -> ConversationMeta:
             conv_input_tokens,
             conv_output_tokens,
             conv_cache_read_tokens,
+            models_usage,
             last_msg_line,
         ) = _full_scan(conv_fn)
     else:
@@ -322,6 +355,7 @@ def _meta_from_file(conv_fn: Path, *, detail: bool = True) -> ConversationMeta:
         conv_input_tokens = 0
         conv_output_tokens = 0
         conv_cache_read_tokens = 0
+        models_usage = {}
 
     last_msg_role, last_msg_preview = (
         _parse_preview(last_msg_line) if last_msg_line else (None, None)
@@ -376,6 +410,7 @@ def _meta_from_file(conv_fn: Path, *, detail: bool = True) -> ConversationMeta:
         total_input_tokens=conv_input_tokens,
         total_output_tokens=conv_output_tokens,
         total_cache_read_tokens=conv_cache_read_tokens,
+        models_usage=models_usage,
         last_message_role=last_msg_role,
         last_message_preview=last_msg_preview,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ gptme-eval-trends = "gptme.eval.trends:main"
 gptme-status = "gptme.cli.cmd_status:status"
 gptme-resume = "gptme.cli.cmd_resume:resume"
 gptme-mcp-server = "gptme.cli.cmd_mcp_serve:main"
+gptme-stats = "gptme.cli.cmd_stats:stats"
 
 [tool.poetry]
 packages = [

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -1,0 +1,227 @@
+"""Tests for global LLM usage and cost analytics CLI command (`gptme stats`)."""
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_stats import gather_global_stats, stats
+
+
+def _create_mock_conversation(
+    conv_dir: Path,
+    conv_id: str,
+    model: str,
+    cost: float,
+    input_tokens: int,
+    output_tokens: int,
+    modified_offset_seconds: float = 0,
+) -> Path:
+    """Helper to write a mock conversation.jsonl file."""
+    log_dir = conv_dir / conv_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+    conv_file = log_dir / "conversation.jsonl"
+
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Hello agent"},
+        {
+            "role": "assistant",
+            "content": "Hello user",
+            "metadata": {
+                "model": model,
+                "cost": cost,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                },
+            },
+        },
+    ]
+
+    with open(conv_file, "w", encoding="utf-8") as f:
+        f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+    if modified_offset_seconds != 0:
+        mtime = time.time() + modified_offset_seconds
+        import os
+
+        os.utime(conv_file, (mtime, mtime))
+
+    return conv_file
+
+
+def test_gather_global_stats_empty(tmp_path: Path, monkeypatch: Any) -> None:
+    """Test gathering stats when no conversation logs exist."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    summary = gather_global_stats()
+    assert summary.total_sessions == 0
+    assert summary.total_cost == 0.0
+    assert summary.total_tokens == 0
+    assert summary.avg_cost_per_session == 0.0
+    assert summary.by_model == []
+
+
+
+def test_gather_global_stats_aggregation(tmp_path: Path, monkeypatch: Any) -> None:
+    """Test gathering stats across multiple conversation logs with different models."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    # Conversation 1: OpenAI
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="2026-07-01-test-openai",
+        model="openai/gpt-4o",
+        cost=0.05,
+        input_tokens=1000,
+        output_tokens=200,
+    )
+
+    # Conversation 2: Anthropic
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="2026-07-02-test-anthropic",
+        model="anthropic/claude-3-5-sonnet",
+        cost=0.10,
+        input_tokens=2000,
+        output_tokens=500,
+    )
+
+    # Conversation 3: Second OpenAI session
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="2026-07-03-test-openai-2",
+        model="openai/gpt-4o",
+        cost=0.02,
+        input_tokens=400,
+        output_tokens=100,
+    )
+
+    summary = gather_global_stats()
+    assert summary.total_sessions == 3
+    assert abs(summary.total_cost - 0.17) < 1e-6
+    assert summary.total_input_tokens == 3400
+    assert summary.total_output_tokens == 800
+    assert summary.total_tokens == 4200
+
+    # Model breakdown assertions
+    assert len(summary.by_model) == 2
+
+    # Anthropic should be first (highest cost = 0.10)
+    anthropic_stats = summary.by_model[0]
+    assert anthropic_stats.model == "anthropic/claude-3-5-sonnet"
+    assert anthropic_stats.sessions == 1
+    assert abs(anthropic_stats.cost - 0.10) < 1e-6
+
+    # OpenAI should be second (total cost = 0.07 across 2 sessions)
+    openai_stats = summary.by_model[1]
+    assert openai_stats.model == "openai/gpt-4o"
+    assert openai_stats.sessions == 2
+    assert abs(openai_stats.cost - 0.07) < 1e-6
+
+
+def test_gather_global_stats_time_filtering(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Test filtering stats by N days."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    # Recent session (today)
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="recent-session",
+        model="openai/gpt-4o",
+        cost=0.05,
+        input_tokens=1000,
+        output_tokens=200,
+        modified_offset_seconds=0,
+    )
+
+    # Old session (10 days ago)
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="old-session",
+        model="openai/gpt-4o",
+        cost=0.50,
+        input_tokens=10000,
+        output_tokens=2000,
+        modified_offset_seconds=-(10 * 86400 + 3600),
+    )
+
+    # All-time stats
+    all_summary = gather_global_stats(days=None)
+    assert all_summary.total_sessions == 2
+
+    # Stats for last 7 days (should exclude the 10-day old session)
+    recent_summary = gather_global_stats(days=7)
+    assert recent_summary.total_sessions == 1
+    assert abs(recent_summary.total_cost - 0.05) < 1e-6
+
+
+def test_cli_stats_json_output(tmp_path: Path, monkeypatch: Any) -> None:
+    """Test CLI output in JSON format."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="cli-json-session",
+        model="openai/gpt-4o",
+        cost=0.03,
+        input_tokens=600,
+        output_tokens=150,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(stats, ["--json"])
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    assert data["total_sessions"] == 1
+    assert data["total_cost"] == 0.03
+    assert data["total_tokens"]["input"] == 600
+    assert data["total_tokens"]["output"] == 150
+    assert len(data["by_model"]) == 1
+    assert data["by_model"][0]["model"] == "openai/gpt-4o"
+
+
+def test_cli_stats_human_readable_output(tmp_path: Path, monkeypatch: Any) -> None:
+    """Test CLI output in human-readable table format."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    _create_mock_conversation(
+        tmp_path,
+        conv_id="cli-table-session",
+        model="anthropic/claude-3-5-sonnet",
+        cost=0.08,
+        input_tokens=1500,
+        output_tokens=300,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(stats, [])
+    assert result.exit_code == 0
+    assert "gptme Usage & Cost Analytics" in result.output
+    assert "Total Sessions" in result.output
+    assert "anthropic/claude-3-5-sonnet" in result.output
+
+
+def test_format_cost_edge_cases() -> None:
+    """Test cost formatting edge cases ($0.0000 and <$0.0001)."""
+    from gptme.cli.cmd_stats import _format_cost
+
+    assert _format_cost(0.0) == "$0.0000"
+    assert _format_cost(0.00005) == "<$0.0001"
+
+
+def test_display_stats_empty(capsys: Any) -> None:
+    """Test display_stats when no conversation logs exist."""
+    from gptme.cli.cmd_stats import StatsSummary, display_stats
+
+    summary = StatsSummary()
+    display_stats(summary)
+    captured = capsys.readouterr()
+    assert "No conversation logs found" in captured.out
+
+

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -64,7 +64,6 @@ def test_gather_global_stats_empty(tmp_path: Path, monkeypatch: Any) -> None:
     assert summary.by_model == []
 
 
-
 def test_gather_global_stats_aggregation(tmp_path: Path, monkeypatch: Any) -> None:
     """Test gathering stats across multiple conversation logs with different models."""
     monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
@@ -122,9 +121,7 @@ def test_gather_global_stats_aggregation(tmp_path: Path, monkeypatch: Any) -> No
     assert abs(openai_stats.cost - 0.07) < 1e-6
 
 
-def test_gather_global_stats_time_filtering(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_gather_global_stats_time_filtering(tmp_path: Path, monkeypatch: Any) -> None:
     """Test filtering stats by N days."""
     monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
 
@@ -225,7 +222,9 @@ def test_display_stats_empty(capsys: Any) -> None:
     assert "No conversation logs found" in captured.out
 
 
-def test_gather_global_stats_mixed_model_session(tmp_path: Path, monkeypatch: Any) -> None:
+def test_gather_global_stats_mixed_model_session(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
     """Test exact per-message model attribution for cost and tokens in multi-model sessions."""
     monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
 
@@ -279,4 +278,46 @@ def test_gather_global_stats_mixed_model_session(tmp_path: Path, monkeypatch: An
     assert claude.output_tokens == 200
 
 
+def test_display_stats_marks_cache_as_subset_of_input():
+    """Cache-read tokens are counted inside input tokens, so the display must
+    say so explicitly rather than listing `cache` as a third additive term."""
+    from rich.console import Console
 
+    from gptme.cli.cmd_stats import StatsSummary, display_stats
+
+    summary = StatsSummary(
+        total_sessions=1,
+        total_cost=0.5,
+        total_input_tokens=150,
+        total_output_tokens=50,
+        total_cache_read_tokens=50,
+    )
+    # total is in + out only; cache is already inside in
+    assert summary.total_tokens == 200
+
+    console = Console(record=True, width=200, no_color=True)
+    display_stats(summary, console=console)
+    output = console.export_text()
+
+    # cache figure is nested inside the input term, marked as included
+    assert "incl. 50 cached" in output
+    # and is not presented as a separate additive term
+    assert "/ cache: 50" not in output
+
+
+def test_stats_json_documents_cache_subset_relationship():
+    """JSON output keeps cache_read alongside input; the two must not be
+    expected to sum to total."""
+    from gptme.cli.cmd_stats import StatsSummary
+
+    summary = StatsSummary(
+        total_sessions=1,
+        total_cost=0.5,
+        total_input_tokens=150,
+        total_output_tokens=50,
+        total_cache_read_tokens=50,
+    )
+    d = summary.to_dict()
+    tokens = d["total_tokens"]
+    assert tokens["total"] == tokens["input"] + tokens["output"]
+    assert tokens["cache_read"] <= tokens["input"]

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -225,3 +225,58 @@ def test_display_stats_empty(capsys: Any) -> None:
     assert "No conversation logs found" in captured.out
 
 
+def test_gather_global_stats_mixed_model_session(tmp_path: Path, monkeypatch: Any) -> None:
+    """Test exact per-message model attribution for cost and tokens in multi-model sessions."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    log_dir = tmp_path / "mixed-model-session"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    conv_file = log_dir / "conversation.jsonl"
+
+    messages = [
+        {"role": "user", "content": "Question 1"},
+        {
+            "role": "assistant",
+            "content": "Answer 1",
+            "metadata": {
+                "model": "openai/gpt-4o",
+                "cost": 0.04,
+                "usage": {"input_tokens": 400, "output_tokens": 100},
+            },
+        },
+        {"role": "user", "content": "Question 2"},
+        {
+            "role": "assistant",
+            "content": "Answer 2",
+            "metadata": {
+                "model": "anthropic/claude-3-5-sonnet",
+                "cost": 0.10,
+                "usage": {"input_tokens": 1000, "output_tokens": 200},
+            },
+        },
+    ]
+
+    with open(conv_file, "w", encoding="utf-8") as f:
+        f.writelines(json.dumps(msg) + "\n" for msg in messages)
+
+    summary = gather_global_stats()
+    assert summary.total_sessions == 1
+    assert abs(summary.total_cost - 0.14) < 1e-6
+
+    by_model_map = {m.model: m for m in summary.by_model}
+    assert "openai/gpt-4o" in by_model_map
+    assert "anthropic/claude-3-5-sonnet" in by_model_map
+
+    gpt4o = by_model_map["openai/gpt-4o"]
+    claude = by_model_map["anthropic/claude-3-5-sonnet"]
+
+    assert abs(gpt4o.cost - 0.04) < 1e-6
+    assert gpt4o.input_tokens == 400
+    assert gpt4o.output_tokens == 100
+
+    assert abs(claude.cost - 0.10) < 1e-6
+    assert claude.input_tokens == 1000
+    assert claude.output_tokens == 200
+
+
+

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -368,3 +368,89 @@ def test_list_conversations_limit_bounds(logs_dir, limit, expected):
     # Previously list_conversations(-5) raised ValueError from islice().
     convs = list_conversations(limit)
     assert len(convs) == expected
+
+
+def test_conversation_meta_models_usage_interleaved(logs_dir):
+    """ConversationMeta should accurately accumulate per-model usage across interleaved messages."""
+    _make_conversation(
+        logs_dir,
+        "interleaved-models",
+        [
+            {"role": "user", "content": "Q1"},
+            {
+                "role": "assistant",
+                "content": "A1",
+                "metadata": {
+                    "model": "openai/gpt-4o",
+                    "cost": 0.04,
+                    "usage": {
+                        "input_tokens": 300,
+                        "output_tokens": 100,
+                        "cache_read_tokens": 100,
+                    },
+                },
+            },
+            {"role": "user", "content": "Q2"},
+            {
+                "role": "assistant",
+                "content": "A2",
+                "metadata": {
+                    "model": "anthropic/claude-3-5-sonnet",
+                    "cost": 0.10,
+                    "usage": {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "cache_read_tokens": 0,
+                    },
+                },
+            },
+            {"role": "user", "content": "Q3"},
+            {
+                "role": "assistant",
+                "content": "A3",
+                "metadata": {
+                    "model": "openai/gpt-4o",
+                    "cost": 0.06,
+                    "usage": {
+                        "input_tokens": 400,
+                        "output_tokens": 150,
+                        "cache_read_tokens": 200,
+                    },
+                },
+            },
+            {"role": "user", "content": "Q4"},
+            {
+                "role": "assistant",
+                "content": "A4",
+                "metadata": {
+                    "model": "anthropic/claude-3-5-sonnet",
+                    "cost": 0.05,
+                    "usage": {
+                        "input_tokens": 450,
+                        "output_tokens": 100,
+                        "cache_read_tokens": 50,
+                    },
+                },
+            },
+        ],
+    )
+
+    convs = list(get_conversations())
+    assert len(convs) == 1
+    meta = convs[0]
+
+    assert "openai/gpt-4o" in meta.models_usage
+    assert "anthropic/claude-3-5-sonnet" in meta.models_usage
+
+    gpt4o = meta.models_usage["openai/gpt-4o"]
+    assert abs(gpt4o["cost"] - 0.10) < 1e-6
+    assert gpt4o["input_tokens"] == 1000  # (300 + 100) + (400 + 200)
+    assert gpt4o["output_tokens"] == 250  # 100 + 150
+    assert gpt4o["cache_read_tokens"] == 300  # 100 + 200
+
+    claude = meta.models_usage["anthropic/claude-3-5-sonnet"]
+    assert abs(claude["cost"] - 0.15) < 1e-6
+    assert claude["input_tokens"] == 1500  # (1000 + 0) + (450 + 50)
+    assert claude["output_tokens"] == 300  # 200 + 100
+    assert claude["cache_read_tokens"] == 50  # 0 + 50
+


### PR DESCRIPTION
## Summary

Adds a new `stats` command to the CLI to provide global aggregated usage and cost analytics across stored conversation logs.

Display includes:
- Total sessions, total cost, input/output/cache token breakdown, and average cost per session.
- Per-model breakdown table sorted by descending cost.
- Date range filtering via `-d N` / `--days N`
- Structured JSON output option via `--json` flag.

---

## Motivation

Until now, users could only see costs and token usage for a single session at a time. With the changes in this PR, I've introduced a global analytics subcommand. This allows users to audit historical spending and total token usage across all past sessions, with optional date filtering (e.g., last N days) or JSON output.

---

## Changes

- **`gptme/cli/cmd_stats.py`**: New module containing dataclasses (`ModelStats`, `StatsSummary`) and functions (`gather_global_stats()`, `display_stats()`, `stats()`).
- **`gptme/cli/util.py`**: Registered `stats` subcommand in `_LAZY_COMMANDS` dictionary for lazy loading 
- **`pyproject.toml`**: Registered `gptme-stats` binary entry point under `[project.scripts]`.
- **`tests/test_cli_stats.py`** : Comprehensive unit tests covering empty state, stats aggregation, time filtering, JSON/table outputs, and cost edge cases.
---

## Usage

```bash
# View all-time global analytics table
gptme stats

# Filter analytics to the last 7 days
gptme-stats -d 7
gptme-util stats -d 7

# Export machine-readable JSON
gptme-stats --json
gptme-util stats --json
