### PR TITLE
fix(server): acquire step_lock when checking generating flag in fork/edit/delete/config

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2703,20 +2703,19 @@ def api_conversation_config_patch(conversation_id: str):
             404,
         )
 
-    # Load conversation log BEFORE any side effects (config write, global state).
-    # A directory can exist without a valid log file (partial deletion, corruption),
-    # so we must verify the log is loadable before committing changes.
-    try:
-        manager = LogManager.load(conversation_id, lock=False)
-    except FileNotFoundError:
-        return (
-            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
-            404,
-        )
-
     # Keep all config, process-global tool state, and log mutations atomic
     # with respect to /step, which takes the same lock before generation.
     with SessionManager.conversation_lock(conversation_id):
+        # Load under the lock. Loading before acquisition can leave a stale
+        # snapshot that overwrites messages generated while PATCH waited.
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
         if any(sess.generating for sess in sessions):
             return (

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1988,8 +1988,18 @@ def api_conversation_edit_message(conversation_id: str, index: int):
     if not truncate and not has_changes:
         return flask.jsonify({"error": "content or files is required"}), 400
 
+    # Reject missing conversations before allocating a persistent lock entry.
+    try:
+        manager = LogManager.load(conversation_id, lock=False)
+    except FileNotFoundError:
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
+
     # Keep the complete read-modify-write atomic with respect to /step.
-    # /step takes the same lock before reserving generation.
+    # /step takes the same lock before reserving generation. Reload inside the
+    # lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
         if any(sess.generating for sess in sessions):
@@ -2101,8 +2111,18 @@ def api_conversation_delete_message(conversation_id: str, index: int):
     if error := _validate_conversation_id(conversation_id):
         return error
 
+    # Reject missing conversations before allocating a persistent lock entry.
+    try:
+        manager = LogManager.load(conversation_id, lock=False)
+    except FileNotFoundError:
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
+
     # Keep the complete read-modify-write atomic with respect to /step.
-    # /step takes the same lock before reserving generation.
+    # /step takes the same lock before reserving generation. Reload inside the
+    # lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
         if any(sess.generating for sess in sessions):
@@ -2208,8 +2228,23 @@ def api_conversation_fork(conversation_id: str):
     if error := _validate_branch(branch):
         return error
 
+    # Reject missing conversations or branches before allocating a persistent lock.
+    try:
+        manager = LogManager.load(conversation_id, branch=branch, lock=False)
+    except FileNotFoundError:
+        if branch == "main":
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+        return (
+            flask.jsonify({"error": f"Branch not found: {branch}"}),
+            404,
+        )
+
     # Keep the source snapshot stable through copying its log, attachments, and
-    # config. /step takes the same lock before reserving generation.
+    # config. /step takes the same lock before reserving generation. Reload inside
+    # the lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
         if any(sess.generating for sess in sessions):

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1988,14 +1988,20 @@ def api_conversation_edit_message(conversation_id: str, index: int):
     if not truncate and not has_changes:
         return flask.jsonify({"error": "content or files is required"}), 400
 
-    # Check if generation is in progress
+    # Check if generation is in progress.
+    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
+    # closing the TOCTOU window where fork/edit/delete could read False just before
+    # /step sets True under its own lock.
     sessions = SessionManager.get_sessions_for_conversation(conversation_id)
     for sess in sessions:
-        if sess.generating:
-            return (
-                flask.jsonify({"error": "Cannot edit while generation is in progress"}),
-                409,
-            )
+        with sess.step_lock:
+            if sess.generating:
+                return (
+                    flask.jsonify(
+                        {"error": "Cannot edit while generation is in progress"}
+                    ),
+                    409,
+                )
 
     try:
         manager = LogManager.load(conversation_id, lock=False)
@@ -2096,16 +2102,19 @@ def api_conversation_delete_message(conversation_id: str, index: int):
     if error := _validate_conversation_id(conversation_id):
         return error
 
-    # Check if generation is in progress
+    # Check if generation is in progress.
+    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
+    # closing the TOCTOU window where delete could read False just before /step sets True.
     sessions = SessionManager.get_sessions_for_conversation(conversation_id)
     for sess in sessions:
-        if sess.generating:
-            return (
-                flask.jsonify(
-                    {"error": "Cannot delete while generation is in progress"}
-                ),
-                409,
-            )
+        with sess.step_lock:
+            if sess.generating:
+                return (
+                    flask.jsonify(
+                        {"error": "Cannot delete while generation is in progress"}
+                    ),
+                    409,
+                )
 
     try:
         manager = LogManager.load(conversation_id, lock=False)
@@ -2200,13 +2209,18 @@ def api_conversation_fork(conversation_id: str):
     if error := _validate_branch(branch):
         return error
 
+    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
+    # closing the TOCTOU window where fork could read False just before /step sets True.
     sessions = SessionManager.get_sessions_for_conversation(conversation_id)
     for sess in sessions:
-        if sess.generating:
-            return (
-                flask.jsonify({"error": "Cannot fork while generation is in progress"}),
-                409,
-            )
+        with sess.step_lock:
+            if sess.generating:
+                return (
+                    flask.jsonify(
+                        {"error": "Cannot fork while generation is in progress"}
+                    ),
+                    409,
+                )
 
     try:
         manager = LogManager.load(conversation_id, branch=branch, lock=False)
@@ -2669,15 +2683,20 @@ def api_conversation_config_patch(conversation_id: str):
 
     # Reject config changes while generation is in progress — config PATCH rewrites
     # system messages and mutates global state, which races with streaming.
+    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
+    # closing the TOCTOU window where config PATCH could read False just before /step sets True.
     sessions = SessionManager.get_sessions_for_conversation(conversation_id)
     for sess in sessions:
-        if sess.generating:
-            return (
-                flask.jsonify(
-                    {"error": "Cannot update config while generation is in progress"}
-                ),
-                409,
-            )
+        with sess.step_lock:
+            if sess.generating:
+                return (
+                    flask.jsonify(
+                        {
+                            "error": "Cannot update config while generation is in progress"
+                        }
+                    ),
+                    409,
+                )
 
     # Validate tool allowlist now that 404/409 guards have passed.
     # init_tools mutates process-wide state; must run AFTER guards, not before.

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1988,82 +1988,81 @@ def api_conversation_edit_message(conversation_id: str, index: int):
     if not truncate and not has_changes:
         return flask.jsonify({"error": "content or files is required"}), 400
 
-    # Check if generation is in progress.
-    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
-    # closing the TOCTOU window where fork/edit/delete could read False just before
-    # /step sets True under its own lock.
-    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-    for sess in sessions:
-        with sess.step_lock:
-            if sess.generating:
-                return (
-                    flask.jsonify(
-                        {"error": "Cannot edit while generation is in progress"}
-                    ),
-                    409,
-                )
-
-    try:
-        manager = LogManager.load(conversation_id, lock=False)
-    except FileNotFoundError:
-        return (
-            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
-            404,
-        )
-
-    msgs = list(manager.log.messages)
-    if index < 0 or index >= len(msgs):
-        return (
-            flask.jsonify(
-                {"error": f"Message index {index} out of range (0-{len(msgs) - 1})"}
-            ),
-            404,
-        )
-
-    # Content/file changes are only allowed on user messages.
-    # Truncation (without content change) is allowed on any message.
-    content_changed = content is not None and content != msgs[index].content
-    files_changed = files is not None and [str(f) for f in msgs[index].files] != files
-    if (content_changed or files_changed) and msgs[index].role != "user":
-        return flask.jsonify({"error": "Can only edit user messages"}), 400
-
-    if content_changed or files_changed:
-        replacements: dict = {}
-        if content_changed:
-            replacements["content"] = content
-        if files_changed and files is not None:
-            validated_files = _validate_message_file_references(
-                files, manager.workspace
+    # Keep the complete read-modify-write atomic with respect to /step.
+    # /step takes the same lock before reserving generation.
+    with SessionManager.conversation_lock(conversation_id):
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify({"error": "Cannot edit while generation is in progress"}),
+                409,
             )
-            if isinstance(validated_files, tuple):
-                return validated_files
-            replacements["files"] = validated_files
-        edited_msg = replace(msgs[index], **replacements)
-        new_msgs = msgs[:index] + [edited_msg] + ([] if truncate else msgs[index + 1 :])
-    elif truncate:
-        new_msgs = msgs[: index + 1]
-    else:
-        return flask.jsonify({"error": "No changes requested"}), 400
 
-    manager.edit(Log(new_msgs))
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
 
-    # Build response with updated conversation
-    log_dict = manager.to_dict(branches=True)
+        msgs = list(manager.log.messages)
+        if index < 0 or index >= len(msgs):
+            return (
+                flask.jsonify(
+                    {"error": f"Message index {index} out of range (0-{len(msgs) - 1})"}
+                ),
+                404,
+            )
 
-    # Emit SSE event
-    SessionManager.add_event(
-        conversation_id,
-        {
-            "type": "conversation_edited",
-            "index": index,
-            "truncated": truncate,
-            "log": log_dict.get("log", []),
-            "branches": log_dict.get("branches", {}),
-        },
-    )
+        # Content/file changes are only allowed on user messages.
+        # Truncation (without content change) is allowed on any message.
+        content_changed = content is not None and content != msgs[index].content
+        files_changed = (
+            files is not None and [str(f) for f in msgs[index].files] != files
+        )
+        if (content_changed or files_changed) and msgs[index].role != "user":
+            return flask.jsonify({"error": "Can only edit user messages"}), 400
 
-    _invalidate_conversations_cache()
-    return flask.jsonify(log_dict)
+        if content_changed or files_changed:
+            replacements: dict = {}
+            if content_changed:
+                replacements["content"] = content
+            if files_changed and files is not None:
+                validated_files = _validate_message_file_references(
+                    files, manager.workspace
+                )
+                if isinstance(validated_files, tuple):
+                    return validated_files
+                replacements["files"] = validated_files
+            edited_msg = replace(msgs[index], **replacements)
+            new_msgs = (
+                msgs[:index] + [edited_msg] + ([] if truncate else msgs[index + 1 :])
+            )
+        elif truncate:
+            new_msgs = msgs[: index + 1]
+        else:
+            return flask.jsonify({"error": "No changes requested"}), 400
+
+        manager.edit(Log(new_msgs))
+
+        # Build response with updated conversation
+        log_dict = manager.to_dict(branches=True)
+
+        # Emit SSE event
+        SessionManager.add_event(
+            conversation_id,
+            {
+                "type": "conversation_edited",
+                "index": index,
+                "truncated": truncate,
+                "log": log_dict.get("log", []),
+                "branches": log_dict.get("branches", {}),
+            },
+        )
+
+        _invalidate_conversations_cache()
+        return flask.jsonify(log_dict)
 
 
 @v2_api.route(
@@ -2102,81 +2101,81 @@ def api_conversation_delete_message(conversation_id: str, index: int):
     if error := _validate_conversation_id(conversation_id):
         return error
 
-    # Check if generation is in progress.
-    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
-    # closing the TOCTOU window where delete could read False just before /step sets True.
-    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-    for sess in sessions:
-        with sess.step_lock:
-            if sess.generating:
-                return (
-                    flask.jsonify(
-                        {"error": "Cannot delete while generation is in progress"}
-                    ),
-                    409,
-                )
+    # Keep the complete read-modify-write atomic with respect to /step.
+    # /step takes the same lock before reserving generation.
+    with SessionManager.conversation_lock(conversation_id):
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify(
+                    {"error": "Cannot delete while generation is in progress"}
+                ),
+                409,
+            )
 
-    try:
-        manager = LogManager.load(conversation_id, lock=False)
-    except FileNotFoundError:
-        return (
-            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
-            404,
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+
+        msgs = list(manager.log.messages)
+        if index < 0 or index >= len(msgs):
+            return (
+                flask.jsonify(
+                    {"error": f"Message index {index} out of range (0-{len(msgs) - 1})"}
+                ),
+                404,
+            )
+
+        # Cannot delete system messages
+        if msgs[index].role == "system":
+            return flask.jsonify({"error": "Cannot delete system messages"}), 400
+
+        new_msgs = msgs[:index] + msgs[index + 1 :]
+
+        # Validate role sequence: consecutive same-role messages break LLM APIs.
+        # Deleting a (non-system) message can only introduce a NEW adjacency at the
+        # seam — between its nearest non-system neighbours on either side. Check only
+        # that seam; scanning the whole conversation would reject valid deletions
+        # whenever an unrelated pre-existing adjacency exists elsewhere in the log.
+        prev_role = next(
+            (m.role for m in reversed(msgs[:index]) if m.role != "system"), None
+        )
+        next_role = next(
+            (m.role for m in msgs[index + 1 :] if m.role != "system"), None
+        )
+        if prev_role is not None and prev_role == next_role:
+            return (
+                flask.jsonify(
+                    {
+                        "error": f"Deleting this message would create consecutive {next_role!r} messages, which is not supported by LLM APIs"
+                    }
+                ),
+                400,
+            )
+
+        manager.edit(Log(new_msgs))
+
+        # Build response with updated conversation
+        log_dict = manager.to_dict(branches=True)
+
+        # Emit SSE event (reuse conversation_edited — client handles log replacement)
+        SessionManager.add_event(
+            conversation_id,
+            {
+                "type": "conversation_edited",
+                "index": index,
+                "truncated": False,
+                "log": log_dict.get("log", []),
+                "branches": log_dict.get("branches", {}),
+            },
         )
 
-    msgs = list(manager.log.messages)
-    if index < 0 or index >= len(msgs):
-        return (
-            flask.jsonify(
-                {"error": f"Message index {index} out of range (0-{len(msgs) - 1})"}
-            ),
-            404,
-        )
-
-    # Cannot delete system messages
-    if msgs[index].role == "system":
-        return flask.jsonify({"error": "Cannot delete system messages"}), 400
-
-    new_msgs = msgs[:index] + msgs[index + 1 :]
-
-    # Validate role sequence: consecutive same-role messages break LLM APIs.
-    # Deleting a (non-system) message can only introduce a NEW adjacency at the
-    # seam — between its nearest non-system neighbours on either side. Check only
-    # that seam; scanning the whole conversation would reject valid deletions
-    # whenever an unrelated pre-existing adjacency exists elsewhere in the log.
-    prev_role = next(
-        (m.role for m in reversed(msgs[:index]) if m.role != "system"), None
-    )
-    next_role = next((m.role for m in msgs[index + 1 :] if m.role != "system"), None)
-    if prev_role is not None and prev_role == next_role:
-        return (
-            flask.jsonify(
-                {
-                    "error": f"Deleting this message would create consecutive {next_role!r} messages, which is not supported by LLM APIs"
-                }
-            ),
-            400,
-        )
-
-    manager.edit(Log(new_msgs))
-
-    # Build response with updated conversation
-    log_dict = manager.to_dict(branches=True)
-
-    # Emit SSE event (reuse conversation_edited — client handles log replacement)
-    SessionManager.add_event(
-        conversation_id,
-        {
-            "type": "conversation_edited",
-            "index": index,
-            "truncated": False,
-            "log": log_dict.get("log", []),
-            "branches": log_dict.get("branches", {}),
-        },
-    )
-
-    _invalidate_conversations_cache()
-    return flask.jsonify(log_dict)
+        _invalidate_conversations_cache()
+        return flask.jsonify(log_dict)
 
 
 @v2_api.route("/api/v2/conversations/<string:conversation_id>/fork", methods=["POST"])
@@ -2209,67 +2208,66 @@ def api_conversation_fork(conversation_id: str):
     if error := _validate_branch(branch):
         return error
 
-    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
-    # closing the TOCTOU window where fork could read False just before /step sets True.
-    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-    for sess in sessions:
-        with sess.step_lock:
-            if sess.generating:
+    # Keep the source snapshot stable through copying its log, attachments, and
+    # config. /step takes the same lock before reserving generation.
+    with SessionManager.conversation_lock(conversation_id):
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify({"error": "Cannot fork while generation is in progress"}),
+                409,
+            )
+
+        try:
+            manager = LogManager.load(conversation_id, branch=branch, lock=False)
+        except FileNotFoundError:
+            if branch == "main":
                 return (
                     flask.jsonify(
-                        {"error": "Cannot fork while generation is in progress"}
+                        {"error": f"Conversation not found: {conversation_id}"}
                     ),
-                    409,
+                    404,
                 )
-
-    try:
-        manager = LogManager.load(conversation_id, branch=branch, lock=False)
-    except FileNotFoundError:
-        if branch == "main":
             return (
-                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                flask.jsonify({"error": f"Branch not found: {branch}"}),
                 404,
             )
-        return (
-            flask.jsonify({"error": f"Branch not found: {branch}"}),
-            404,
+
+        source_messages = list(manager.log.messages)
+        if after_message < 0 or after_message >= len(source_messages):
+            return (
+                flask.jsonify(
+                    {
+                        "error": f"Message index {after_message} out of range (0-{len(source_messages) - 1})"
+                    }
+                ),
+                400,
+            )
+
+        new_conversation_id = _generate_fork_conversation_id()
+        new_logdir = get_logs_dir() / new_conversation_id
+
+        forked_messages = _copy_messages_for_fork(
+            source_messages[: after_message + 1], manager.logdir, new_logdir
         )
-
-    source_messages = list(manager.log.messages)
-    if after_message < 0 or after_message >= len(source_messages):
-        return (
-            flask.jsonify(
-                {
-                    "error": f"Message index {after_message} out of range (0-{len(source_messages) - 1})"
-                }
-            ),
-            400,
+        fork_manager = LogManager.load(
+            logdir=new_logdir, initial_msgs=forked_messages, create=True, lock=False
         )
+        fork_manager.write()
 
-    new_conversation_id = _generate_fork_conversation_id()
-    new_logdir = get_logs_dir() / new_conversation_id
+        source_config = ChatConfig.from_logdir(manager.logdir)
+        fork_name = f"Fork of {manager.name} @ msg {after_message + 1}"
+        replace(source_config, _logdir=new_logdir, name=fork_name).save()
 
-    forked_messages = _copy_messages_for_fork(
-        source_messages[: after_message + 1], manager.logdir, new_logdir
-    )
-    fork_manager = LogManager.load(
-        logdir=new_logdir, initial_msgs=forked_messages, create=True, lock=False
-    )
-    fork_manager.write()
-
-    source_config = ChatConfig.from_logdir(manager.logdir)
-    fork_name = f"Fork of {manager.name} @ msg {after_message + 1}"
-    replace(source_config, _logdir=new_logdir, name=fork_name).save()
-
-    session = SessionManager.create_session(new_conversation_id)
-    _invalidate_conversations_cache()
-    return flask.jsonify(
-        {
-            "status": "ok",
-            "conversation_id": new_conversation_id,
-            "session_id": session.id,
-        }
-    )
+        session = SessionManager.create_session(new_conversation_id)
+        _invalidate_conversations_cache()
+        return flask.jsonify(
+            {
+                "status": "ok",
+                "conversation_id": new_conversation_id,
+                "session_id": session.id,
+            }
+        )
 
 
 @v2_api.route("/api/v2/conversations/<string:conversation_id>", methods=["DELETE"])
@@ -2681,112 +2679,107 @@ def api_conversation_config_patch(conversation_id: str):
             404,
         )
 
-    # Reject config changes while generation is in progress — config PATCH rewrites
-    # system messages and mutates global state, which races with streaming.
-    # Acquiring step_lock per session mirrors how /step sets generating=True atomically,
-    # closing the TOCTOU window where config PATCH could read False just before /step sets True.
-    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-    for sess in sessions:
-        with sess.step_lock:
-            if sess.generating:
-                return (
-                    flask.jsonify(
-                        {
-                            "error": "Cannot update config while generation is in progress"
-                        }
-                    ),
-                    409,
-                )
+    # Keep all config, process-global tool state, and log mutations atomic
+    # with respect to /step, which takes the same lock before generation.
+    with SessionManager.conversation_lock(conversation_id):
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify(
+                    {"error": "Cannot update config while generation is in progress"}
+                ),
+                409,
+            )
 
-    # Validate tool allowlist now that 404/409 guards have passed.
-    # init_tools mutates process-wide state; must run AFTER guards, not before.
-    if tool_allowlist is not None:
+        # Validate tool allowlist now that 404/409 guards have passed.
+        # init_tools mutates process-wide state; must run AFTER guards, not before.
+        if tool_allowlist is not None:
+            try:
+                init_tools(tool_allowlist)
+            except ValueError as exc:
+                return flask.jsonify({"error": str(exc)}), 400
+            except Exception as exc:
+                return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
+
+        # Determine if workspace was explicitly provided in the request body.
+        # This check must happen BEFORE ChatConfig.from_dict, which mutates the
+        # chat_patch dict by inferring workspace from the existing logdir/workspace
+        # path when workspace is absent (adding it as a side effect via the
+        # `elif _logdir and (_logdir / "workspace").exists()` branch).
+        workspace_in_patch = isinstance(chat_patch, dict) and "workspace" in chat_patch
+
+        # Create and set config
+        req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
         try:
-            init_tools(tool_allowlist)
+            request_config = ChatConfig.from_dict(req_json)
         except ValueError as exc:
             return flask.jsonify({"error": str(exc)}), 400
-        except Exception as exc:
-            return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
 
-    # Determine if workspace was explicitly provided in the request body.
-    # This check must happen BEFORE ChatConfig.from_dict, which mutates the
-    # chat_patch dict by inferring workspace from the existing logdir/workspace
-    # path when workspace is absent (adding it as a side effect via the
-    # `elif _logdir and (_logdir / "workspace").exists()` branch).
-    workspace_in_patch = isinstance(chat_patch, dict) and "workspace" in chat_patch
+        # Enforce workspace containment: a PATCH must not *redirect* the agent of
+        # an existing conversation outside the conversation's logdir.
+        # Only enforce when workspace was explicitly provided — when absent, from_dict
+        # infers it from the existing logdir/workspace symlink (which may legitimately
+        # point outside logdir for CLI-created conversations).
+        # A round-trip of the already-persisted workspace is also allowed: the webui
+        # settings dialog echoes the full config (including workspace) on every
+        # save, and conversations legitimately have external workspaces (created
+        # via the CLI, or via PUT with an explicit workspace).
+        if workspace_in_patch:
+            existing_workspace = ChatConfig.from_logdir(logdir).workspace
+            if request_config.workspace != existing_workspace:
+                if not request_config.workspace.is_relative_to(logdir.resolve()):
+                    return flask.jsonify(
+                        {"error": "workspace escapes conversation logdir"}
+                    ), 400
 
-    # Create and set config
-    req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
-    try:
-        request_config = ChatConfig.from_dict(req_json)
-    except ValueError as exc:
-        return flask.jsonify({"error": str(exc)}), 400
+        try:
+            chat_config = ChatConfig.load_or_create(logdir, request_config).save()
+        except ValueError as exc:
+            return flask.jsonify({"error": str(exc)}), 400
+        config = Config.from_workspace(workspace=chat_config.workspace)
+        config.chat = chat_config
+        set_config(config)
 
-    # Enforce workspace containment: a PATCH must not *redirect* the agent of
-    # an existing conversation outside the conversation's logdir.
-    # Only enforce when workspace was explicitly provided — when absent, from_dict
-    # infers it from the existing logdir/workspace symlink (which may legitimately
-    # point outside logdir for CLI-created conversations).
-    # A round-trip of the already-persisted workspace is also allowed: the webui
-    # settings dialog echoes the full config (including workspace) on every
-    # save, and conversations legitimately have external workspaces (created
-    # via the CLI, or via PUT with an explicit workspace).
-    if workspace_in_patch:
-        existing_workspace = ChatConfig.from_logdir(logdir).workspace
-        if request_config.workspace != existing_workspace:
-            if not request_config.workspace.is_relative_to(logdir.resolve()):
-                return flask.jsonify(
-                    {"error": "workspace escapes conversation logdir"}
-                ), 400
+        # Initialize tools in this thread
+        init_tools(chat_config.tools)
 
-    try:
-        chat_config = ChatConfig.load_or_create(logdir, request_config).save()
-    except ValueError as exc:
-        return flask.jsonify({"error": str(exc)}), 400
-    config = Config.from_workspace(workspace=chat_config.workspace)
-    config.chat = chat_config
-    set_config(config)
+        tools = get_tools()
 
-    # Initialize tools in this thread
-    init_tools(chat_config.tools)
+        if len(manager.log.messages) >= 1 and manager.log.messages[0].role == "system":
+            # Remove leading system messages and replace with new ones
+            # Use immutable Log interface instead of mutating the frozen dataclass's list
+            first_non_system = 0
+            for m in manager.log.messages:
+                if m.role != "system":
+                    break
+                first_non_system += 1
+            remaining_msgs = list(manager.log.messages[first_non_system:])
 
-    tools = get_tools()
-
-    if len(manager.log.messages) >= 1 and manager.log.messages[0].role == "system":
-        # Remove leading system messages and replace with new ones
-        # Use immutable Log interface instead of mutating the frozen dataclass's list
-        first_non_system = 0
-        for m in manager.log.messages:
-            if m.role != "system":
-                break
-            first_non_system += 1
-        remaining_msgs = list(manager.log.messages[first_non_system:])
-
-        new_system_msgs = list(
-            get_prompt(
-                tools=tools,
-                tool_format=chat_config.tool_format or "markdown",
-                interactive=chat_config.interactive,
-                model=chat_config.model,
-                workspace=chat_config.workspace,
-                agent_path=chat_config.agent,
+            new_system_msgs = list(
+                get_prompt(
+                    tools=tools,
+                    tool_format=chat_config.tool_format or "markdown",
+                    interactive=chat_config.interactive,
+                    model=chat_config.model,
+                    workspace=chat_config.workspace,
+                    agent_path=chat_config.agent,
+                )
             )
-        )
-        _append_conversation_system_prompt(
-            new_system_msgs, _resolve_conversation_system_prompt(chat_config)
-        )
-        manager.log = Log(new_system_msgs + remaining_msgs)
-    manager.write()
+            _append_conversation_system_prompt(
+                new_system_msgs, _resolve_conversation_system_prompt(chat_config)
+            )
+            manager.log = Log(new_system_msgs + remaining_msgs)
+        manager.write()
 
-    _invalidate_conversations_cache()
-    return flask.jsonify(
-        {
-            "status": "ok",
-            "message": "Chat config updated",
-            "config": chat_config.to_dict(),
-            "tools": [t.name for t in tools],
-        }
-    )
+        _invalidate_conversations_cache()
+        return flask.jsonify(
+            {
+                "status": "ok",
+                "message": "Chat config updated",
+                "config": chat_config.to_dict(),
+                "tools": [t.name for t in tools],
+            }
+        )
 
 
 @v2_api.route(

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -329,7 +329,6 @@ def api_conversation_step(conversation_id: str):
         ), 403
 
     logdir = get_logs_dir() / conversation_id
-    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
 
     model = req_json.get("model")
     if model is not None and not isinstance(model, str):
@@ -348,7 +347,7 @@ def api_conversation_step(conversation_id: str):
                 400,
             )
     else:
-        stream = chat_config.stream
+        stream = None
 
     # ACP opt-in: sticky once enabled for a session.
     # Default can be set server-wide via GPTME_USE_ACP_DEFAULT=true env var.
@@ -366,15 +365,6 @@ def api_conversation_step(conversation_id: str):
             400,
         )
 
-    if use_acp and not session.use_acp:
-        from .acp_session_runtime import AcpSessionRuntime
-
-        session.use_acp = True
-        session.acp_runtime = AcpSessionRuntime(workspace=chat_config.workspace)
-        # Lazy-start the health monitor on first ACP session — avoids unconditional
-        # background thread and global session-eviction side-effects at app startup.
-        start_acp_health_monitor()
-
     # Validate auto_confirm type explicitly (bool OR int).
     # Reject strings/floats/etc. to avoid accidental truthy coercion.
     auto_confirm = req_json.get("auto_confirm", False)
@@ -389,27 +379,28 @@ def api_conversation_step(conversation_id: str):
             400,
         )
 
-    # If auto_confirm set, set auto_confirm_count.
-    # Check bool first: bool is a subclass of int in Python, so isinstance(True, int) is True.
-    # Use type() to distinguish them correctly.
-    if type(auto_confirm) is bool:
-        session.auto_confirm_count = 1 if auto_confirm else -1
-    else:  # int
-        session.auto_confirm_count = auto_confirm
-
-    auto_confirm_enabled = bool(session.auto_confirm_count > 0)
-
-    # Reserve generation while serialized with conversation mutations. The
-    # conversation lock is released after generating=True; mutating endpoints
-    # then reject until generation finishes.
+    # Reserve generation and capture config in the same critical section as
+    # config PATCH. A PATCH completed before this acquisition must affect the
+    # worker; one arriving afterward sees generating=True and returns 409.
     with SessionManager.conversation_lock(conversation_id), session.step_lock:
         if session.generating:
             return flask.jsonify({"error": "Generation already in progress"}), 409
-        # Mark generating early to prevent concurrent /step requests from racing
-        # through the setup code below.  _start_step_thread/_start_acp_step_thread
-        # also set this, but ~60 lines of model/branch resolution sit between the
-        # check above and those calls — enough for a second request to slip through
-        # on threaded WSGI servers.
+        chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+        if stream is None:
+            stream = chat_config.stream
+        # Check bool first: bool is a subclass of int.
+        if type(auto_confirm) is bool:
+            session.auto_confirm_count = 1 if auto_confirm else -1
+        else:
+            session.auto_confirm_count = auto_confirm
+        auto_confirm_enabled = session.auto_confirm_count > 0
+        if use_acp and not session.use_acp:
+            from .acp_session_runtime import AcpSessionRuntime
+
+            session.use_acp = True
+            session.acp_runtime = AcpSessionRuntime(workspace=chat_config.workspace)
+            # Lazy-start the health monitor on first ACP session.
+            start_acp_health_monitor()
         session.generating = True
         session.generating_since = datetime.now(tz=timezone.utc)
 
@@ -648,16 +639,18 @@ def api_conversation_tool_confirm(conversation_id: str):
         )
 
     logdir = get_logs_dir() / conversation_id
-    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
-
-    # Get model from session config, default model, or fallback to "anthropic"
-    default_model = get_default_model()
-    model = chat_config.model or (default_model.full if default_model else "anthropic")
 
     # Skip reserves its continuation before resolving hook state or consuming the
     # pending tool below. Other actions retain the existing hook resolution flow.
     if action != "skip":
         resolve_hook_confirmation(tool_id, action, req_json.get("content"))
+
+    if action in {"confirm", "edit"}:
+        chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+        default_model = get_default_model()
+        model = chat_config.model or (
+            default_model.full if default_model else "anthropic"
+        )
 
     if action == "confirm":
         # Execute the tool
@@ -702,6 +695,14 @@ def api_conversation_tool_confirm(conversation_id: str):
                     409,
                 )
 
+            # Capture the continuation config only after the shared lock is held,
+            # so a config PATCH that completed first cannot be silently ignored.
+            chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+            default_model = get_default_model()
+            model = chat_config.model or (
+                default_model.full if default_model else "anthropic"
+            )
+
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
             try:
@@ -733,6 +734,11 @@ def api_conversation_tool_confirm(conversation_id: str):
                     session.generating_since = None
 
     elif action == "auto":
+        chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+        default_model = get_default_model()
+        model = chat_config.model or (
+            default_model.full if default_model else "anthropic"
+        )
         # Enable auto-confirmation for future tools
         count = req_json.get("count", 1)
         if not isinstance(count, int) or isinstance(count, bool) or count <= 0:

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -486,6 +486,7 @@ def api_conversation_step(conversation_id: str):
                 conversation_id=conversation_id,
                 session=session,
                 workspace=chat_config.workspace,
+                reserved=True,
             )
         else:
             # model should be non-None here: the `if not model and not session.use_acp`
@@ -505,6 +506,7 @@ def api_conversation_step(conversation_id: str):
                 branch=branch,
                 auto_confirm=auto_confirm_enabled,
                 stream=stream,
+                reserved=True,
             )
         _step_dispatched = True
     finally:

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -561,7 +561,12 @@ def api_conversation_step(conversation_id: str):
     description="Confirm, edit, skip, or auto-confirm a pending tool execution. "
     "session_id is optional - if not provided, the tool will be found across all sessions for the conversation.",
     request_body=ToolConfirmRequest,
-    responses={200: StatusResponse, 400: ErrorResponse, 404: ErrorResponse},
+    responses={
+        200: StatusResponse,
+        400: ErrorResponse,
+        404: ErrorResponse,
+        409: ErrorResponse,
+    },
     parameters=[CONVERSATION_ID_PARAM],
     tags=["sessions"],
 )
@@ -649,9 +654,10 @@ def api_conversation_tool_confirm(conversation_id: str):
     default_model = get_default_model()
     model = chat_config.model or (default_model.full if default_model else "anthropic")
 
-    # Try to resolve via hook system (for hook-based confirmation flow)
-    # This enables future integration where tools use hooks for confirmation
-    resolve_hook_confirmation(tool_id, action, req_json.get("content"))
+    # Skip reserves its continuation before resolving hook state or consuming the
+    # pending tool below. Other actions retain the existing hook resolution flow.
+    if action != "skip":
+        resolve_hook_confirmation(tool_id, action, req_json.get("content"))
 
     if action == "confirm":
         # Execute the tool
@@ -682,23 +688,49 @@ def api_conversation_tool_confirm(conversation_id: str):
         )
 
     elif action == "skip":
-        # Skip the tool execution
-        tool_exec.status = ToolStatus.SKIPPED
-        session.pending_tools.pop(
-            tool_id, None
-        )  # use pop to avoid KeyError if concurrently removed
+        continuation_dispatched = False
+        # Reserve the continuation before consuming any tool or hook state. A
+        # concurrent /step may already own the reservation; then the pending tool
+        # stays untouched so the client can retry.
+        with SessionManager.conversation_lock(conversation_id), session.step_lock:
+            current_tool = session.pending_tools.get(tool_id)
+            if current_tool is None:
+                return flask.jsonify({"error": f"Tool not found: {tool_id}"}), 404
+            if session.generating:
+                return (
+                    flask.jsonify({"error": "Generation already in progress"}),
+                    409,
+                )
 
-        # Provide meaningful message to prevent LLM from re-suggesting the same tool
-        tool_name = tool_exec.tooluse.tool
-        msg = Message(
-            "system",
-            f"User chose not to execute this {tool_name} tool. "
-            "Do not re-suggest the same action unless explicitly requested.",
-        )
-        _append_and_notify(LogManager.load(conversation_id, lock=False), session, msg)
+            session.generating = True
+            session.generating_since = datetime.now(tz=timezone.utc)
+            try:
+                current_tool.status = ToolStatus.SKIPPED
+                session.pending_tools.pop(tool_id)
 
-        # Resume generation
-        _start_step_thread(conversation_id, session, model, chat_config.workspace)
+                # Persist the skip before the continuation can load the log.
+                tool_name = current_tool.tooluse.tool
+                msg = Message(
+                    "system",
+                    f"User chose not to execute this {tool_name} tool. "
+                    "Do not re-suggest the same action unless explicitly requested.",
+                )
+                manager = LogManager.load(conversation_id, lock=False)
+                _append_and_notify(manager, session, msg)
+                manager.write()
+
+                resolve_hook_confirmation(tool_id, action, req_json.get("content"))
+                continuation_dispatched = _start_step_thread(
+                    conversation_id,
+                    session,
+                    model,
+                    chat_config.workspace,
+                    reserved=True,
+                )
+            finally:
+                if not continuation_dispatched:
+                    session.generating = False
+                    session.generating_since = None
 
     elif action == "auto":
         # Enable auto-confirmation for future tools

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -399,12 +399,10 @@ def api_conversation_step(conversation_id: str):
 
     auto_confirm_enabled = bool(session.auto_confirm_count > 0)
 
-    # Atomically check-and-set generating under a per-session lock.
-    # Without the lock, two concurrent requests on a threaded WSGI server can
-    # both read False before either writes True (classic TOCTOU).  The lock is
-    # held only for the check+set — the expensive model/branch resolution that
-    # follows runs outside it.
-    with session.step_lock:
+    # Reserve generation while serialized with conversation mutations. The
+    # conversation lock is released after generating=True; mutating endpoints
+    # then reject until generation finishes.
+    with SessionManager.conversation_lock(conversation_id), session.step_lock:
         if session.generating:
             return flask.jsonify({"error": "Generation already in progress"}), 409
         # Mark generating early to prevent concurrent /step requests from racing

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -131,7 +131,21 @@ class SessionManager:
 
     _sessions: dict[str, ConversationSession] = {}
     _conversation_sessions: dict[str, set[str]] = defaultdict(set)
+    # Kept for the process lifetime. Conversation IDs are durable and their
+    # per-ID locks are tiny; retaining them avoids replacing a lock while a
+    # request still holds it after the final session is removed.
+    _conversation_locks: dict[str, threading.RLock] = {}
     _lock = threading.Lock()
+
+    @classmethod
+    def conversation_lock(cls, conversation_id: str) -> threading.RLock:
+        """Return the lock serializing generation-sensitive conversation work."""
+        with cls._lock:
+            lock = cls._conversation_locks.get(conversation_id)
+            if lock is None:
+                lock = threading.RLock()
+                cls._conversation_locks[conversation_id] = lock
+            return lock
 
     @classmethod
     def create_session(cls, conversation_id: str) -> ConversationSession:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -510,9 +510,10 @@ def _start_acp_step_thread(
     workspace: Path,
 ) -> None:
     """Start an ACP-backed step in a background thread."""
-    session.last_error = None
-    session.generating = True
-    session.generating_since = datetime.now(tz=timezone.utc)
+    with SessionManager.conversation_lock(conversation_id):
+        session.last_error = None
+        session.generating = True
+        session.generating_since = datetime.now(tz=timezone.utc)
 
     def _run() -> None:
         from ..hooks import current_conversation_id, current_session_id
@@ -1045,9 +1046,10 @@ def _start_step_thread(
     # needed because _start_step_thread is called directly from the
     # tool-confirm endpoint (api_conversation_tool_response), which bypasses
     # the /step route's guard.
-    session.last_error = None
-    session.generating = True
-    session.generating_since = datetime.now(tz=timezone.utc)
+    with SessionManager.conversation_lock(conversation_id):
+        session.last_error = None
+        session.generating = True
+        session.generating_since = datetime.now(tz=timezone.utc)
 
     def step_thread() -> None:
         # Set conversation/session context vars so hooks triggered during

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -508,12 +508,17 @@ def _start_acp_step_thread(
     conversation_id: str,
     session: "ConversationSession",
     workspace: Path,
-) -> None:
-    """Start an ACP-backed step in a background thread."""
-    with SessionManager.conversation_lock(conversation_id):
-        session.last_error = None
-        session.generating = True
-        session.generating_since = datetime.now(tz=timezone.utc)
+    *,
+    reserved: bool = False,
+) -> bool:
+    """Start an ACP-backed step unless another generation has reserved it."""
+    if not reserved:
+        with SessionManager.conversation_lock(conversation_id), session.step_lock:
+            if session.generating:
+                return False
+            session.generating = True
+            session.generating_since = datetime.now(tz=timezone.utc)
+    session.last_error = None
 
     def _run() -> None:
         from ..hooks import current_conversation_id, current_session_id
@@ -527,6 +532,7 @@ def _start_acp_step_thread(
     ctx = contextvars.copy_context()
     t = threading.Thread(target=ctx.run, args=(_run,), daemon=True)
     t.start()
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1031,25 +1037,21 @@ def _start_step_thread(
     branch: str = "main",
     auto_confirm: bool = False,
     stream: bool = True,
-) -> None:
-    """Start a step execution in a background thread.
+    *,
+    reserved: bool = False,
+) -> bool:
+    """Start a step unless another generation has already reserved it."""
 
-    Clears any previous error state before starting.
-    """
-
-    # Clear previous error and mark as generating before starting thread
-    # to avoid race condition where interrupt is called before the thread
-    # sets generating=True.
-    #
-    # NOTE: the /step route handler also sets session.generating = True early
-    # (under step_lock, with try/finally guard).  This assignment is still
-    # needed because _start_step_thread is called directly from the
-    # tool-confirm endpoint (api_conversation_tool_response), which bypasses
-    # the /step route's guard.
-    with SessionManager.conversation_lock(conversation_id):
-        session.last_error = None
-        session.generating = True
-        session.generating_since = datetime.now(tz=timezone.utc)
+    # Direct callers (tool continuations and A2A) share /step's atomic
+    # check-and-reserve protocol. The /step route reserves before setup and
+    # identifies that reservation explicitly to avoid rejecting itself.
+    if not reserved:
+        with SessionManager.conversation_lock(conversation_id), session.step_lock:
+            if session.generating:
+                return False
+            session.generating = True
+            session.generating_since = datetime.now(tz=timezone.utc)
+    session.last_error = None
 
     def step_thread() -> None:
         # Set conversation/session context vars so hooks triggered during
@@ -1075,6 +1077,7 @@ def _start_step_thread(
     thread = threading.Thread(target=ctx.run, args=(step_thread,))
     thread.daemon = True
     thread.start()
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,7 +175,6 @@ def pytest_runtest_makereport(item, call):
     #   (c) the error is specifically from _pytest.stash internals
     if (
         report.when == "teardown"
-        and report.failed
         and getattr(item, "_stash_guard_call_attempts", 0) > 1
         and getattr(item, "_stash_guard_call_passed", False)
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,7 @@ def cleanup_acp_health_monitor():
             with SessionManager._lock:
                 SessionManager._sessions.clear()
                 SessionManager._conversation_sessions.clear()
+                SessionManager._conversation_locks.clear()
         except ImportError:
             pass
     except Exception as e:

--- a/tests/test_server_session_models.py
+++ b/tests/test_server_session_models.py
@@ -41,15 +41,28 @@ def reset_session_manager(monkeypatch):
     monkeypatch.setattr("gptme.server.session_models.trigger_hook", lambda *a, **kw: [])
     SessionManager._sessions = {}
     SessionManager._conversation_sessions = defaultdict(set)
+    SessionManager._conversation_locks = {}
     yield
     # Cleanup after test as well
     SessionManager._sessions = {}
     SessionManager._conversation_sessions = defaultdict(set)
+    SessionManager._conversation_locks = {}
 
 
 def make_tooluse(tool: str = "shell", content: str = "echo hi") -> ToolUse:
     """Helper to build a minimal ToolUse."""
     return ToolUse(tool=tool, args=None, content=content)
+
+
+def test_conversation_lock_is_shared_per_conversation():
+    """Operations on one conversation must use the exact same lock."""
+    first = SessionManager.conversation_lock("conversation-a")
+    second = SessionManager.conversation_lock("conversation-a")
+    other = SessionManager.conversation_lock("conversation-b")
+
+    assert first is second
+    assert first is not other
+    assert isinstance(first, type(threading.RLock()))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2610,6 +2610,31 @@ def test_v2_fork_conversation_rejects_out_of_range_index(client: FlaskClient):
     assert "out of range" in response.get_json()["error"]
 
 
+@pytest.mark.parametrize(
+    ("method", "path", "json"),
+    [
+        ("PATCH", "/messages/0", {"content": "updated"}),
+        ("DELETE", "/messages/0", None),
+        ("POST", "/fork?after_message=0", None),
+    ],
+)
+def test_missing_conversation_mutations_do_not_allocate_locks(
+    client: FlaskClient, method: str, path: str, json: dict | None
+):
+    """Rejected mutation requests must not grow the process-wide lock registry."""
+    from gptme.server.session_models import SessionManager
+
+    before = dict(SessionManager._conversation_locks)
+    conversation_id = f"missing-{uuid.uuid4().hex}"
+
+    response = client.open(
+        f"/api/v2/conversations/{conversation_id}{path}", method=method, json=json
+    )
+
+    assert response.status_code == 404
+    assert SessionManager._conversation_locks == before
+
+
 def test_copy_messages_for_fork_copies_only_referenced_attachments(tmp_path: Path):
     """Forking should not copy attachments excluded from the retained message slice."""
     from gptme.message import Message  # fmt: skip

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2308,6 +2308,44 @@ def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     assert "generation is in progress" in response.get_json()["error"]
 
 
+def test_v2_chat_config_patch_loads_log_under_conversation_lock(
+    client: FlaskClient,
+):
+    """Config PATCH must not retain a stale log snapshot while waiting on /step."""
+    from gptme.logmanager import LogManager
+    from gptme.server.session_models import SessionManager
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    lock = unittest.mock.MagicMock()
+    lock.held = False
+    lock.__enter__.side_effect = lambda: setattr(lock, "held", True)
+    lock.__exit__.side_effect = lambda *_: setattr(lock, "held", False)
+    real_load = LogManager.load
+    loaded_while_locked: list[bool] = []
+
+    def tracking_load(*args, **kwargs):
+        if args and args[0] == conversation_id:
+            loaded_while_locked.append(lock.held)
+        return real_load(*args, **kwargs)
+
+    with (
+        unittest.mock.patch.object(
+            SessionManager, "conversation_lock", return_value=lock
+        ),
+        unittest.mock.patch(
+            "gptme.server.api_v2.LogManager.load", side_effect=tracking_load
+        ),
+    ):
+        response = client.patch(
+            f"/api/v2/conversations/{conversation_id}/config",
+            json={"chat": {"model": "openai/gpt-4o"}},
+        )
+
+    assert response.status_code == 200
+    assert loaded_while_locked == [True]
+
+
 @pytest.mark.parametrize(
     "files_payload",
     [

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -770,6 +770,35 @@ class TestToolConfirmEndpoint:
         assert response.status_code == 200
         assert tool_id not in session.pending_tools
 
+    def test_skip_does_not_dispatch_when_step_reserved_generation(
+        self, conv, client: FlaskClient
+    ):
+        """A tool continuation must not overlap a generation reserved by /step."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        tool_id = str(uuid.uuid4())
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "rm -rf /"),
+        )
+        session.generating = True
+
+        with (
+            patch("gptme.server.api_v2_sessions._append_and_notify"),
+            patch("gptme.server.session_step.threading.Thread") as thread_cls,
+        ):
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+                json={
+                    "session_id": conv["session_id"],
+                    "tool_id": tool_id,
+                    "action": "skip",
+                },
+            )
+
+        assert response.status_code == 200
+        thread_cls.assert_not_called()
+
     def test_edit_requires_content(self, conv, client: FlaskClient):
         """Edit action without content returns 400."""
         session = SessionManager.get_session(conv["session_id"])

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -745,18 +745,22 @@ class TestToolConfirmEndpoint:
             session.pending_tools.pop(tool_id, None)
 
     def test_skip_action(self, conv, client: FlaskClient):
-        """Skip action removes pending tool and appends system message."""
+        """Skip consumes the tool only after reserving its continuation."""
         session = SessionManager.get_session(conv["session_id"])
         assert session is not None
         tool_id = str(uuid.uuid4())
-        session.pending_tools[tool_id] = ToolExecution(
+        tool_exec = ToolExecution(
             tool_id=tool_id,
             tooluse=ToolUse("bash", [], "rm -rf /"),
         )
+        session.pending_tools[tool_id] = tool_exec
 
         with (
             patch("gptme.server.api_v2_sessions._append_and_notify"),
-            patch("gptme.server.api_v2_sessions._start_step_thread"),
+            patch(
+                "gptme.server.api_v2_sessions._start_step_thread", return_value=True
+            ) as start_step,
+            patch("gptme.server.api_v2_sessions.resolve_hook_confirmation") as resolve,
         ):
             response = client.post(
                 f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
@@ -769,23 +773,30 @@ class TestToolConfirmEndpoint:
 
         assert response.status_code == 200
         assert tool_id not in session.pending_tools
+        assert tool_exec.status.value == "skipped"
+        resolve.assert_called_once_with(tool_id, "skip", None)
+        assert start_step.call_count == 1
+        assert start_step.call_args.args[:2] == (conv["conversation_id"], session)
+        assert start_step.call_args.kwargs == {"reserved": True}
 
-    def test_skip_does_not_dispatch_when_step_reserved_generation(
+    def test_skip_preserves_tool_when_step_reserved_generation(
         self, conv, client: FlaskClient
     ):
-        """A tool continuation must not overlap a generation reserved by /step."""
+        """A rejected skip remains retryable while another generation runs."""
         session = SessionManager.get_session(conv["session_id"])
         assert session is not None
         tool_id = str(uuid.uuid4())
-        session.pending_tools[tool_id] = ToolExecution(
+        tool_exec = ToolExecution(
             tool_id=tool_id,
             tooluse=ToolUse("bash", [], "rm -rf /"),
         )
+        session.pending_tools[tool_id] = tool_exec
         session.generating = True
 
         with (
-            patch("gptme.server.api_v2_sessions._append_and_notify"),
-            patch("gptme.server.session_step.threading.Thread") as thread_cls,
+            patch("gptme.server.api_v2_sessions._append_and_notify") as append,
+            patch("gptme.server.api_v2_sessions._start_step_thread") as start_step,
+            patch("gptme.server.api_v2_sessions.resolve_hook_confirmation") as resolve,
         ):
             response = client.post(
                 f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
@@ -796,8 +807,44 @@ class TestToolConfirmEndpoint:
                 },
             )
 
-        assert response.status_code == 200
-        thread_cls.assert_not_called()
+        assert response.status_code == 409
+        assert session.pending_tools[tool_id] is tool_exec
+        assert tool_exec.status.value == "pending"
+        append.assert_not_called()
+        start_step.assert_not_called()
+        resolve.assert_not_called()
+
+    def test_skip_releases_reservation_when_dispatch_fails(
+        self, conv, client: FlaskClient
+    ):
+        """A failed continuation dispatch must not strand generating=True."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        tool_id = str(uuid.uuid4())
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "rm -rf /"),
+        )
+
+        with (
+            patch("gptme.server.api_v2_sessions._append_and_notify"),
+            patch(
+                "gptme.server.api_v2_sessions._start_step_thread",
+                side_effect=RuntimeError("thread start failed"),
+            ),
+        ):
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+                json={
+                    "session_id": conv["session_id"],
+                    "tool_id": tool_id,
+                    "action": "skip",
+                },
+            )
+
+        assert response.status_code == 500
+        assert session.generating is False
+        assert session.generating_since is None
 
     def test_edit_requires_content(self, conv, client: FlaskClient):
         """Edit action without content returns 400."""

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -394,6 +394,53 @@ class TestStepEndpoint:
         finally:
             session.generating = False
 
+    def test_step_reserves_generation_under_conversation_lock(
+        self, conv, client: FlaskClient
+    ):
+        """The mutation lock must be held when /step reserves generation."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        lock = MagicMock()
+        lock.__enter__.side_effect = lambda: setattr(lock, "held", True)
+        lock.__exit__.side_effect = lambda *_: setattr(lock, "held", False)
+
+        with (
+            patch.object(SessionManager, "conversation_lock", return_value=lock),
+            patch.object(
+                session,
+                "step_lock",
+                MagicMock(
+                    __enter__=MagicMock(
+                        side_effect=lambda: setattr(
+                            lock, "step_entered_while_held", lock.held
+                        )
+                    )
+                ),
+            ),
+            patch("gptme.server.api_v2_sessions.get_default_model", return_value=None),
+            patch(
+                "gptme.server.api_v2_sessions.ChatConfig.load_or_create"
+            ) as mock_config,
+            patch(
+                "gptme.server.api_v2_sessions.Config.from_workspace"
+            ) as mock_ws_config,
+        ):
+            from gptme.config import ChatConfig
+
+            cfg = ChatConfig()
+            cfg.model = None
+            mock_config.return_value = cfg
+            mock_ws_config.return_value = MagicMock(
+                get_env=MagicMock(return_value=None)
+            )
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/step",
+                json={"session_id": conv["session_id"]},
+            )
+
+        assert response.status_code == 400
+        assert lock.step_entered_while_held is True
+
 
 # --- Interrupt endpoint tests ---
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -394,10 +394,10 @@ class TestStepEndpoint:
         finally:
             session.generating = False
 
-    def test_step_reserves_generation_under_conversation_lock(
+    def test_step_loads_config_and_reserves_under_conversation_lock(
         self, conv, client: FlaskClient
     ):
-        """The mutation lock must be held when /step reserves generation."""
+        """Config snapshot and generation reservation share the mutation lock."""
         session = SessionManager.get_session(conv["session_id"])
         assert session is not None
         lock = MagicMock()
@@ -429,7 +429,12 @@ class TestStepEndpoint:
 
             cfg = ChatConfig()
             cfg.model = None
-            mock_config.return_value = cfg
+
+            def load_config(*_args, **_kwargs):
+                lock.config_loaded_while_held = lock.held
+                return cfg
+
+            mock_config.side_effect = load_config
             mock_ws_config.return_value = MagicMock(
                 get_env=MagicMock(return_value=None)
             )
@@ -439,6 +444,7 @@ class TestStepEndpoint:
             )
 
         assert response.status_code == 400
+        assert lock.config_loaded_while_held is True
         assert lock.step_entered_while_held is True
 
 
@@ -743,6 +749,52 @@ class TestToolConfirmEndpoint:
             assert "unknown action" in data["error"].lower()
         finally:
             session.pending_tools.pop(tool_id, None)
+
+    def test_skip_loads_config_after_reserving_continuation(
+        self, conv, client: FlaskClient
+    ):
+        """Skip captures model/workspace while holding the mutation lock."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        tool_id = str(uuid.uuid4())
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "rm -rf /"),
+        )
+        lock = MagicMock()
+        lock.__enter__.side_effect = lambda: setattr(lock, "held", True)
+        lock.__exit__.side_effect = lambda *_: setattr(lock, "held", False)
+        from gptme.config import ChatConfig
+
+        cfg = ChatConfig(model="fresh/model")
+
+        def load_config(*_args, **_kwargs):
+            lock.config_loaded_while_held = lock.held
+            return cfg
+
+        with (
+            patch.object(SessionManager, "conversation_lock", return_value=lock),
+            patch(
+                "gptme.server.api_v2_sessions.ChatConfig.load_or_create",
+                side_effect=load_config,
+            ),
+            patch(
+                "gptme.server.api_v2_sessions._start_step_thread", return_value=True
+            ) as start_step,
+            patch("gptme.server.api_v2_sessions._append_and_notify"),
+        ):
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+                json={
+                    "session_id": conv["session_id"],
+                    "tool_id": tool_id,
+                    "action": "skip",
+                },
+            )
+        assert response.status_code == 200
+        assert lock.config_loaded_while_held is True
+        assert start_step.call_args.args[2] == "fresh/model"
+        assert start_step.call_args.args[3] == cfg.workspace
 
     def test_skip_action(self, conv, client: FlaskClient):
         """Skip consumes the tool only after reserving its continuation."""


### PR DESCRIPTION
## Summary

- Fixes a TOCTOU race in the fork, edit, delete, and config-PATCH endpoints
- All four endpoints check `sess.generating` WITHOUT holding `sess.step_lock`, while `/step` sets `generating=True` atomically UNDER `sess.step_lock`
- Wraps the generating guard in all four places inside `with sess.step_lock:`, closing the race window

## The Bug

The `/step` endpoint uses an atomic check-and-set under `sess.step_lock`:

```python
with session.step_lock:
    if session.generating:
        return flask.jsonify({"error": "..."}), 409
    session.generating = True
```

But the fork, edit, delete, and config-PATCH endpoints read `sess.generating` without the lock:

```python
for sess in sessions:
    if sess.generating:   # TOCTOU: no lock held
        return ..., 409
```

This creates a race window:

1. Fork reads `generating=False` (lock not held)
2. `/step` acquires `step_lock`, sets `generating=True`, releases lock
3. Fork proceeds to read/copy the log while step is actively writing it

## Fix

Wrap the generating check in all four mutating endpoints inside `with sess.step_lock:`, mirroring how `/step` itself does it.

## Testing

202 passed, 5 skipped (`tests/test_server_v2.py`) — no regressions.