### PR TITLE
feat(hooks): CLODEx Phase 3a — approval gates for destructive operations

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -682,6 +682,17 @@ Run 'gptme-util --help' for all utility commands."""
     help="Write a JSON record before and after each tool call to this directory. "
     "Records can be committed alongside session artifacts for tool-call-level attribution.",
 )
+@click.option(
+    "--approval-mode",
+    "approval_mode",
+    default=None,
+    type=click.Choice(["audit", "interactive", "block"]),
+    envvar="GPTME_APPROVAL_MODE",
+    help="Approval gate for destructive/risky tool operations (requires --manifest-dir). "
+    "audit: classify only, add approval_class to manifest records. "
+    "interactive: prompt user before DESTRUCTIVE/RISKY ops (TTY only). "
+    "block: skip DESTRUCTIVE/RISKY ops without a prior approval registry entry.",
+)
 def main(
     ctx: click.Context,
     prompts: list[str],
@@ -716,6 +727,7 @@ def main(
     output_schema: str | None,
     injection_hygiene: str | None,
     manifest_dir: Path | None,
+    approval_mode: str | None,
 ):
     """Main entrypoint for the CLI."""
 
@@ -761,6 +773,15 @@ def main(
         from ..hooks.manifest import register_manifest_hooks  # fmt: skip
 
         register_manifest_hooks(manifest_dir)
+
+    # Register approval gates (Phase 3) when --approval-mode is set.
+    # Requires --manifest-dir so approval_class fields land in the manifest chain.
+    if approval_mode is not None:
+        if manifest_dir is None:
+            raise click.UsageError("--approval-mode requires --manifest-dir")
+        from ..hooks.approval import register_approval_hooks  # fmt: skip
+
+        register_approval_hooks(approval_mode=approval_mode)
 
     # Defense-in-depth: handle empty/whitespace names in case Click bypasses convert()
     # (observed to occur in some Click versions when --name "" is passed)

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -73,6 +73,9 @@ _RISKY_SHELL_PATTERNS: tuple[str, ...] = (
     "curl -X DELETE",
     "curl -X POST",
     "curl -X PUT",
+    "curl --request DELETE",
+    "curl --request POST",
+    "curl --request PUT",
     "wget --post",
 )
 
@@ -93,11 +96,13 @@ def classify_tool(tool: str, args: dict[str, Any]) -> str:
 
     if tool == "shell":
         cmd = str(args.get("command") or "")
+        # Normalize whitespace so tab/multi-space variants match the same patterns
+        normalized = " ".join(cmd.split())
         for pattern in _DESTRUCTIVE_SHELL_PATTERNS:
-            if pattern in cmd:
+            if pattern in normalized:
                 return OP_DESTRUCTIVE
         for pattern in _RISKY_SHELL_PATTERNS:
-            if pattern in cmd:
+            if pattern in normalized:
                 return OP_RISKY
         return OP_MODIFYING
 
@@ -138,11 +143,16 @@ class ApprovalRegistry:
                     status        TEXT NOT NULL DEFAULT 'pending',
                     approved_by   TEXT,
                     approval_mechanism TEXT,
+                    workspace     TEXT,
                     created_at    TEXT NOT NULL,
                     approved_at   TEXT,
                     notes         TEXT
                 )
             """)
+            # Migrate tables created before the workspace column was added
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(approvals)")}
+            if "workspace" not in cols:
+                conn.execute("ALTER TABLE approvals ADD COLUMN workspace TEXT")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_intent ON approvals(intent_hash)"
             )
@@ -160,10 +170,21 @@ class ApprovalRegistry:
             ).fetchone()
             return dict(row) if row else None
 
-    def is_approved(self, intent_hash: str) -> bool:
-        """Return ``True`` iff an approved record exists for *intent_hash*."""
+    def is_approved(self, intent_hash: str, workspace: Path | None = None) -> bool:
+        """Return ``True`` iff an approved record exists for *intent_hash*.
+
+        When *workspace* is provided AND the stored record has a workspace, both
+        must resolve to the same path.  This prevents a cross-workspace approval
+        (e.g. ``rm ./data`` approved in workspace A) from silently authorising
+        the same relative command in workspace B.
+        """
         record = self.get(intent_hash)
-        return record is not None and record["status"] == "approved"
+        if record is None or record["status"] != "approved":
+            return False
+        stored_ws = record.get("workspace")
+        if workspace is not None and stored_ws is not None:
+            return str(workspace.resolve()) == stored_ws
+        return True
 
     def approve(
         self,
@@ -174,18 +195,20 @@ class ApprovalRegistry:
         approved_by: str = "user",
         mechanism: str = "interactive_prompt",
         notes: str = "",
+        workspace: Path | None = None,
     ) -> str:
         """Insert or replace an approval record.  Returns the approval UUID."""
         approval_id = str(uuid.uuid4())
         now = datetime.now(tz=timezone.utc).isoformat()
+        ws_str = str(workspace.resolve()) if workspace is not None else None
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO approvals
                   (id, session_id, intent_hash, operation_class, tool,
-                   status, approved_by, approval_mechanism,
+                   status, approved_by, approval_mechanism, workspace,
                    created_at, approved_at, notes)
-                VALUES (?, ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     approval_id,
@@ -195,6 +218,7 @@ class ApprovalRegistry:
                     tool,
                     approved_by,
                     mechanism,
+                    ws_str,
                     now,
                     now,
                     notes,
@@ -273,7 +297,7 @@ def register_approval_hooks(
 
         intent = _intent_hash(tool_use.tool, kw)
 
-        if registry.is_approved(intent):
+        if registry.is_approved(intent, workspace=workspace):
             logger.debug(
                 "Approval gate: pre-approved %s op %s", op_class, tool_use.tool
             )
@@ -296,6 +320,7 @@ def register_approval_hooks(
                     intent_hash=intent,
                     operation_class=op_class,
                     tool=tool_use.tool,
+                    workspace=workspace,
                 )
                 return None  # approved — fall through to tool execution
             return ConfirmationResult(

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -1,0 +1,334 @@
+"""Approval gates for destructive tool operations (CLODEx Phase 3a).
+
+When activated via ``--approval-mode``, registers a TOOL_CONFIRM hook that
+intercepts DESTRUCTIVE and RISKY tool calls before they execute.  The hook
+checks a local SQLite approval registry and, depending on mode:
+
+- ``interactive``: Prompts the user when stdin is a TTY; blocks on denial.
+- ``block``:  Always blocks DESTRUCTIVE/RISKY ops unless pre-approved in the DB.
+- ``audit``:  Classification only — no blocking; ``approval_class`` is still
+  injected into manifest pre-records by ``manifest.py``.
+
+This complements the Phase 2 hash-linked manifest chain (``manifest.py``) by
+adding an explicit, durable authorisation trail for irreversible operations.
+
+Operation classes
+-----------------
+SAFE        Read-only operations: ``read``, ``browser``.
+MODIFYING   Non-destructive mutations: ``write``, ``patch``, most shell commands.
+DESTRUCTIVE Irreversible deletions or hard resets: ``rm``, ``git reset --hard``,
+            ``git push --force``, ``git branch -D``.
+RISKY       External-state mutations that are hard to undo: ``gh pr merge``,
+            ``git push origin master``, REST DELETE/POST calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..tools.base import ToolUse
+
+logger = logging.getLogger(__name__)
+
+# Operation-class constants
+OP_SAFE = "SAFE"
+OP_MODIFYING = "MODIFYING"
+OP_DESTRUCTIVE = "DESTRUCTIVE"
+OP_RISKY = "RISKY"
+
+_DESTRUCTIVE_SHELL_PATTERNS: tuple[str, ...] = (
+    "rm ",
+    "rm -",
+    "rmdir ",
+    "git reset --hard",
+    "git push --force",
+    "git push -f ",
+    "git branch -D ",
+    "git branch -d ",
+    "dd if=",
+    "mkfs",
+    "shred ",
+    "truncate -s",
+)
+
+_RISKY_SHELL_PATTERNS: tuple[str, ...] = (
+    "gh pr merge",
+    "gh pr close",
+    "gh issue close",
+    "gh issue delete",
+    "gh release delete",
+    "git push origin master",
+    "git push origin main",
+    "curl -X DELETE",
+    "curl -X POST",
+    "curl -X PUT",
+    "wget --post",
+)
+
+
+def classify_tool(tool: str, args: dict[str, Any]) -> str:
+    """Return the operation class for *tool* + *args*.
+
+    Args:
+        tool: Tool name (``shell``, ``write``, ``read``, …)
+        args: Tool argument dict.
+
+    Returns:
+        One of :data:`OP_SAFE`, :data:`OP_MODIFYING`,
+        :data:`OP_DESTRUCTIVE`, :data:`OP_RISKY`.
+    """
+    if tool in ("read", "browser"):
+        return OP_SAFE
+
+    if tool == "shell":
+        cmd = str(args.get("command") or "")
+        for pattern in _DESTRUCTIVE_SHELL_PATTERNS:
+            if pattern in cmd:
+                return OP_DESTRUCTIVE
+        for pattern in _RISKY_SHELL_PATTERNS:
+            if pattern in cmd:
+                return OP_RISKY
+        return OP_MODIFYING
+
+    # write/patch modify files but do not delete them
+    return OP_MODIFYING
+
+
+def _intent_hash(tool: str, args: dict[str, Any]) -> str:
+    """Deterministic hash of (tool, args) — links approval record to manifest."""
+    payload = json.dumps({"tool": tool, "args": args}, sort_keys=True, default=str)
+    return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+class ApprovalRegistry:
+    """Local SQLite-backed registry for tool-call approval records.
+
+    Each record is keyed by ``intent_hash`` (a deterministic hash of the tool
+    name and arguments) so that re-running the same operation with an existing
+    approval does not require a second interactive prompt.
+
+    The database is created on first access; no explicit migration is needed.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS approvals (
+                    id            TEXT PRIMARY KEY,
+                    session_id    TEXT NOT NULL,
+                    intent_hash   TEXT NOT NULL UNIQUE,
+                    operation_class TEXT NOT NULL,
+                    tool          TEXT NOT NULL,
+                    status        TEXT NOT NULL DEFAULT 'pending',
+                    approved_by   TEXT,
+                    approval_mechanism TEXT,
+                    created_at    TEXT NOT NULL,
+                    approved_at   TEXT,
+                    notes         TEXT
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_intent ON approvals(intent_hash)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_session ON approvals(session_id)"
+            )
+
+    def get(self, intent_hash: str) -> dict[str, Any] | None:
+        """Return approval record for *intent_hash*, or ``None`` if absent."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM approvals WHERE intent_hash = ?",
+                (intent_hash,),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def is_approved(self, intent_hash: str) -> bool:
+        """Return ``True`` iff an approved record exists for *intent_hash*."""
+        record = self.get(intent_hash)
+        return record is not None and record["status"] == "approved"
+
+    def approve(
+        self,
+        session_id: str,
+        intent_hash: str,
+        operation_class: str,
+        tool: str,
+        approved_by: str = "user",
+        mechanism: str = "interactive_prompt",
+        notes: str = "",
+    ) -> str:
+        """Insert or replace an approval record.  Returns the approval UUID."""
+        approval_id = str(uuid.uuid4())
+        now = datetime.now(tz=timezone.utc).isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO approvals
+                  (id, session_id, intent_hash, operation_class, tool,
+                   status, approved_by, approval_mechanism,
+                   created_at, approved_at, notes)
+                VALUES (?, ?, ?, ?, ?, 'approved', ?, ?, ?, ?, ?)
+                """,
+                (
+                    approval_id,
+                    session_id,
+                    intent_hash,
+                    operation_class,
+                    tool,
+                    approved_by,
+                    mechanism,
+                    now,
+                    now,
+                    notes,
+                ),
+            )
+        return approval_id
+
+    def list_session(self, session_id: str) -> list[dict[str, Any]]:
+        """Return all approval records for *session_id*, ordered by creation."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM approvals WHERE session_id = ? ORDER BY created_at",
+                (session_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+
+def _default_registry_path() -> Path:
+    from ..dirs import get_data_dir
+
+    return get_data_dir() / "approvals.db"
+
+
+def register_approval_hooks(
+    approval_mode: str,
+    db_path: Path | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Register a TOOL_CONFIRM hook that gates destructive operations.
+
+    Call this after the manifest hooks have been registered (i.e. when
+    ``--manifest-dir`` is provided).  Priority 5 places the approval gate
+    *before* ``cli_confirm`` (priority 0) so the approval decision is made
+    before the normal tool-preview prompt fires.
+
+    Args:
+        approval_mode: ``"audit"`` (classify, no blocking),
+            ``"interactive"`` (TTY prompt), or ``"block"`` (always block
+            DESTRUCTIVE/RISKY without a prior registry entry).
+        db_path: SQLite database path.  Defaults to
+            ``<gptme-data-dir>/approvals.db``.
+        session_id: Session identifier for the approval record.
+    """
+    if approval_mode == "audit":
+        logger.debug("Approval mode 'audit': classification only, gate not registered")
+        return
+
+    from . import HookType, register_hook
+    from .confirm import ConfirmAction, ConfirmationResult
+
+    _db_path = db_path or _default_registry_path()
+    _session_id = (
+        session_id or os.environ.get("GPTME_SESSION_ID") or uuid.uuid4().hex[:8]
+    )
+    registry = ApprovalRegistry(_db_path)
+
+    def _approval_gate(
+        tool_use: ToolUse,
+        preview: str | None = None,
+        workspace: Path | None = None,
+    ) -> ConfirmationResult | None:
+        if tool_use is None:
+            return None
+
+        # Normalize args: tool-format calls use kwargs; markdown-format shell
+        # calls embed the command in content rather than a kwargs["command"] key.
+        kw: dict[str, Any] = dict(tool_use.kwargs or {})
+        if tool_use.tool == "shell" and "command" not in kw and tool_use.content:
+            kw["command"] = tool_use.content
+
+        op_class = classify_tool(tool_use.tool, kw)
+
+        if op_class not in (OP_DESTRUCTIVE, OP_RISKY):
+            return None  # safe/modifying ops fall through
+
+        intent = _intent_hash(tool_use.tool, kw)
+
+        if registry.is_approved(intent):
+            logger.debug(
+                "Approval gate: pre-approved %s op %s", op_class, tool_use.tool
+            )
+            return None  # already approved, fall through
+
+        if approval_mode == "interactive" and sys.stdin.isatty():
+            cmd_detail = kw.get("command") or kw.get("path") or tool_use.tool
+            print(f"\n⚠️  {op_class} operation requires approval:")
+            print(f"   Tool:    {tool_use.tool}")
+            print(f"   Details: {str(cmd_detail)[:120]}")
+            print(f"   Hash:    {intent[:36]}…")
+            try:
+                answer = input("   Approve? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = "n"
+
+            if answer in ("y", "yes"):
+                registry.approve(
+                    session_id=_session_id,
+                    intent_hash=intent,
+                    operation_class=op_class,
+                    tool=tool_use.tool,
+                )
+                return None  # approved — fall through to tool execution
+            return ConfirmationResult(
+                action=ConfirmAction.SKIP,
+                message=f"Denied {op_class} op '{tool_use.tool}' (user said no)",
+            )
+
+        # block mode or non-TTY interactive: skip without prompting
+        reason = "non-interactive session" if not sys.stdin.isatty() else "block mode"
+        logger.warning(
+            "Approval gate: blocking %s op '%s' (%s)",
+            op_class,
+            tool_use.tool,
+            reason,
+        )
+        return ConfirmationResult(
+            action=ConfirmAction.SKIP,
+            message=(
+                f"Blocked {op_class} op '{tool_use.tool}': "
+                f"no prior approval in registry ({reason})"
+            ),
+        )
+
+    register_hook(
+        name="approval.gate",
+        hook_type=HookType.TOOL_CONFIRM,
+        func=_approval_gate,
+        priority=5,  # fires before cli_confirm (priority 0)
+        enabled=True,
+    )
+    logger.debug(
+        "Approval gate registered (mode=%s, db=%s, session=%s)",
+        approval_mode,
+        _db_path,
+        _session_id,
+    )

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import sys
 import uuid
@@ -80,6 +81,24 @@ _RISKY_SHELL_PATTERNS: tuple[str, ...] = (
 )
 
 
+def _unescape_first_word(word: str) -> str:
+    """Strip common shell escaping from a single command word (the executable name).
+
+    Handles:
+    - Backslash-escaped characters: ``r\\m`` → ``rm``, ``\\rm`` → ``rm``
+    - Surrounding single quotes: ``'rm'`` → ``rm``
+    - Surrounding double quotes: ``"rm"`` → ``rm``
+
+    This is intentionally narrow (first word only, common forms only).  A full
+    shell word-expansion is out of scope — see :func:`classify_tool` note.
+    """
+    # Strip surrounding matching quotes first (outermost pair only)
+    if len(word) >= 2 and word[0] == word[-1] and word[0] in ('"', "'"):
+        word = word[1:-1]
+    # Remove backslash escaping inside the word: \X → X
+    return re.sub(r"\\(.)", r"\1", word)
+
+
 def classify_tool(tool: str, args: dict[str, Any]) -> str:
     """Return the operation class for *tool* + *args*.
 
@@ -92,20 +111,25 @@ def classify_tool(tool: str, args: dict[str, Any]) -> str:
         :data:`OP_DESTRUCTIVE`, :data:`OP_RISKY`.
 
     .. note::
-        Classification is heuristic: it matches against the **literal command
-        string** after whitespace normalization.  It does NOT parse shell syntax,
-        so shell-escaped executables (``r\\m``, ``r"m"``, ``'rm'``) or aliased
-        commands bypass pattern matching and return :data:`OP_MODIFYING`.  This
-        is defence-in-depth, not a complete security boundary — always combine
-        with ``--approval-mode block`` in fully automated contexts.
+        Classification is heuristic: it matches common literal command patterns
+        after whitespace normalization and first-word unescaping.  Common forms
+        of shell quoting and backslash-escaping on the executable name are
+        stripped (``r\\m`` → ``rm``, ``'rm'`` → ``rm``).  More exotic evasions
+        (aliases, ``eval``, here-strings, brace expansion) are still out of
+        scope — always combine with ``--approval-mode block`` in fully automated
+        contexts for defence-in-depth.
     """
     if tool in ("read", "browser"):
         return OP_SAFE
 
     if tool == "shell":
         cmd = str(args.get("command") or "")
-        # Normalize whitespace so tab/multi-space variants match the same patterns
-        normalized = " ".join(cmd.split())
+        # Normalize whitespace so tab/multi-space variants match the same patterns,
+        # then unescape the first word (executable name) to catch r\m, 'rm', etc.
+        parts = cmd.split()
+        if parts:
+            parts[0] = _unescape_first_word(parts[0])
+        normalized = " ".join(parts)
         for pattern in _DESTRUCTIVE_SHELL_PATTERNS:
             if pattern in normalized:
                 return OP_DESTRUCTIVE

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -90,6 +90,14 @@ def classify_tool(tool: str, args: dict[str, Any]) -> str:
     Returns:
         One of :data:`OP_SAFE`, :data:`OP_MODIFYING`,
         :data:`OP_DESTRUCTIVE`, :data:`OP_RISKY`.
+
+    .. note::
+        Classification is heuristic: it matches against the **literal command
+        string** after whitespace normalization.  It does NOT parse shell syntax,
+        so shell-escaped executables (``r\\m``, ``r"m"``, ``'rm'``) or aliased
+        commands bypass pattern matching and return :data:`OP_MODIFYING`.  This
+        is defence-in-depth, not a complete security boundary — always combine
+        with ``--approval-mode block`` in fully automated contexts.
     """
     if tool in ("read", "browser"):
         return OP_SAFE
@@ -174,15 +182,19 @@ class ApprovalRegistry:
         """Return ``True`` iff an approved record exists for *intent_hash*.
 
         When *workspace* is provided AND the stored record has a workspace, both
-        must resolve to the same path.  This prevents a cross-workspace approval
-        (e.g. ``rm ./data`` approved in workspace A) from silently authorising
-        the same relative command in workspace B.
+        workspace and both must resolve to the same path.  A stored ``NULL``
+        workspace (pre-migration entry or an approval created without workspace
+        context) is rejected when the caller supplies a workspace — preventing
+        NULL-workspace approvals from acting as global pass-through tokens.
         """
         record = self.get(intent_hash)
         if record is None or record["status"] != "approved":
             return False
         stored_ws = record.get("workspace")
-        if workspace is not None and stored_ws is not None:
+        if workspace is not None:
+            # Require an explicit workspace match; NULL stored workspace is rejected.
+            if stored_ws is None:
+                return False
             return str(workspace.resolve()) == stored_ws
         return True
 

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -336,7 +336,15 @@ def register_approval_hooks(
 
         intent = _intent_hash(tool_use.tool, kw)
 
-        if registry.is_approved(intent, workspace=workspace):
+        # Always resolve to a concrete workspace for the scope check.  When the
+        # hook receives workspace=None (e.g. non-workspace CLI path where the
+        # _workspace_cwd ContextVar was never set), fall back to cwd so that
+        # is_approved() always performs a workspace comparison rather than
+        # accepting any stored record regardless of its stored workspace.
+        from pathlib import Path as _Path
+
+        effective_ws = workspace if workspace is not None else _Path.cwd()
+        if registry.is_approved(intent, workspace=effective_ws):
             logger.debug(
                 "Approval gate: pre-approved %s op %s", op_class, tool_use.tool
             )
@@ -359,7 +367,7 @@ def register_approval_hooks(
                     intent_hash=intent,
                     operation_class=op_class,
                     tool=tool_use.tool,
-                    workspace=workspace,
+                    workspace=effective_ws,
                 )
                 return None  # approved — fall through to tool execution
             return ConfirmationResult(

--- a/gptme/hooks/approval.py
+++ b/gptme/hooks/approval.py
@@ -88,6 +88,7 @@ def _unescape_first_word(word: str) -> str:
     - Backslash-escaped characters: ``r\\m`` → ``rm``, ``\\rm`` → ``rm``
     - Surrounding single quotes: ``'rm'`` → ``rm``
     - Surrounding double quotes: ``"rm"`` → ``rm``
+    - Embedded quotes: ``r"m"`` → ``rm``, ``r'm'`` → ``rm``
 
     This is intentionally narrow (first word only, common forms only).  A full
     shell word-expansion is out of scope — see :func:`classify_tool` note.
@@ -96,7 +97,9 @@ def _unescape_first_word(word: str) -> str:
     if len(word) >= 2 and word[0] == word[-1] and word[0] in ('"', "'"):
         word = word[1:-1]
     # Remove backslash escaping inside the word: \X → X
-    return re.sub(r"\\(.)", r"\1", word)
+    word = re.sub(r"\\(.)", r"\1", word)
+    # Strip any remaining embedded quote characters: r"m" → rm, r'm' → rm
+    return word.replace('"', "").replace("'", "")
 
 
 def classify_tool(tool: str, args: dict[str, Any]) -> str:
@@ -114,10 +117,10 @@ def classify_tool(tool: str, args: dict[str, Any]) -> str:
         Classification is heuristic: it matches common literal command patterns
         after whitespace normalization and first-word unescaping.  Common forms
         of shell quoting and backslash-escaping on the executable name are
-        stripped (``r\\m`` → ``rm``, ``'rm'`` → ``rm``).  More exotic evasions
-        (aliases, ``eval``, here-strings, brace expansion) are still out of
-        scope — always combine with ``--approval-mode block`` in fully automated
-        contexts for defence-in-depth.
+        stripped (``r\\m`` → ``rm``, ``'rm'`` → ``rm``, ``r"m"`` → ``rm``).
+        More exotic evasions (aliases, ``eval``, here-strings, brace expansion)
+        are still out of scope — always combine with ``--approval-mode block``
+        in fully automated contexts for defence-in-depth.
     """
     if tool in ("read", "browser"):
         return OP_SAFE

--- a/gptme/hooks/manifest.py
+++ b/gptme/hooks/manifest.py
@@ -112,6 +112,20 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
         }
         if data.tool_use.content:
             record["content_hash"] = _sha256_hex(data.tool_use.content)
+        # Phase 3: annotate with operation class (classifier from approval.py)
+        try:
+            from .approval import classify_tool  # fmt: skip
+
+            kw: dict[str, Any] = dict(data.tool_use.kwargs or {})
+            if (
+                data.tool_use.tool == "shell"
+                and "command" not in kw
+                and data.tool_use.content
+            ):
+                kw["command"] = data.tool_use.content
+            record["approval_class"] = classify_tool(data.tool_use.tool, kw)
+        except ImportError:
+            pass
         fname = f"{session_id}-{seq[0]:04d}-{data.tool_use.tool}-pre.json"
         if _write_record(manifest_dir, fname, record):
             # Only advance the chain tail when the file was actually persisted.

--- a/gptme/hooks/manifest.py
+++ b/gptme/hooks/manifest.py
@@ -112,9 +112,9 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
         }
         if data.tool_use.content:
             record["content_hash"] = _sha256_hex(data.tool_use.content)
-        # Phase 3: annotate with operation class (classifier from approval.py)
+        # Phase 3: annotate with operation class and intent hash (from approval.py)
         try:
-            from .approval import classify_tool  # fmt: skip
+            from .approval import _intent_hash, classify_tool  # fmt: skip
 
             kw: dict[str, Any] = dict(data.tool_use.kwargs or {})
             if (
@@ -124,6 +124,8 @@ def register_manifest_hooks(manifest_dir: Path) -> None:
             ):
                 kw["command"] = data.tool_use.content
             record["approval_class"] = classify_tool(data.tool_use.tool, kw)
+            # intent_hash links this pre-record to the approval registry entry
+            record["intent_hash"] = _intent_hash(data.tool_use.tool, kw)
         except ImportError:
             pass
         fname = f"{session_id}-{seq[0]:04d}-{data.tool_use.tool}-pre.json"

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -101,6 +101,30 @@ class TestClassifyTool:
             classify_tool("shell", {"command": "rm\t/tmp/sensitive"}) == OP_DESTRUCTIVE
         )
 
+    def test_shell_backslash_escaped_rm_is_destructive(self):
+        # r\m is a common shell-escape evasion; first-word unescaping must catch it
+        assert (
+            classify_tool("shell", {"command": r"r\m -rf /tmp/old"}) == OP_DESTRUCTIVE
+        )
+
+    def test_shell_leading_backslash_rm_is_destructive(self):
+        # \rm bypasses shell aliases but is still rm; must be caught
+        assert (
+            classify_tool("shell", {"command": r"\rm -rf /tmp/old"}) == OP_DESTRUCTIVE
+        )
+
+    def test_shell_single_quoted_rm_is_destructive(self):
+        # 'rm' -rf ... is valid shell; classifier must not miss it
+        assert (
+            classify_tool("shell", {"command": "'rm' -rf /tmp/old"}) == OP_DESTRUCTIVE
+        )
+
+    def test_shell_double_quoted_rm_is_destructive(self):
+        # "rm" -rf ... is valid shell; classifier must not miss it
+        assert (
+            classify_tool("shell", {"command": '"rm" -rf /tmp/old'}) == OP_DESTRUCTIVE
+        )
+
     def test_unknown_tool_defaults_to_modifying(self):
         assert classify_tool("ipython", {"code": "print(1)"}) == OP_MODIFYING
 

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -429,3 +429,100 @@ class TestExecuteWithConfirmationWorkspace:
         assert received, "TOOL_CONFIRM hook was never called"
         assert received[0] is not None, "workspace was None — not forwarded"
         assert received[0] == ws, f"expected {ws}, got {received[0]}"
+
+
+class TestApprovalGateCwdFallback:
+    """Verify _approval_gate falls back to cwd when workspace=None."""
+
+    def test_approval_gate_uses_cwd_when_workspace_is_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When workspace=None, the gate must use cwd so is_approved is workspace-scoped."""
+        from gptme.hooks import clear_hooks
+        from gptme.hooks.approval import register_approval_hooks
+
+        db = tmp_path / "approvals.db"
+        # Change cwd to tmp_path so the gate uses tmp_path as effective_ws
+        monkeypatch.chdir(tmp_path)
+
+        clear_hooks()
+        register_approval_hooks(
+            approval_mode="interactive", db_path=db, session_id="test"
+        )
+
+        # Pre-approve the intent for tmp_path (the cwd the gate will use)
+        from gptme.hooks.approval import OP_DESTRUCTIVE, ApprovalRegistry, _intent_hash
+
+        intent = _intent_hash("shell", {"command": "rm /tmp/old"})
+        reg = ApprovalRegistry(db)
+        reg.approve("test", intent, OP_DESTRUCTIVE, "shell", workspace=tmp_path)
+
+        # Now check: the gate should accept this approval when called with workspace=None
+        # because effective_ws falls back to cwd == tmp_path
+        from typing import cast
+        from unittest.mock import MagicMock
+
+        from gptme.hooks import HookType, get_hooks
+        from gptme.hooks.confirm import ToolConfirmHook
+
+        tool_use = MagicMock()
+        tool_use.tool = "shell"
+        tool_use.kwargs = {"command": "rm /tmp/old"}
+        tool_use.content = None
+
+        hooks = [
+            h for h in get_hooks(HookType.TOOL_CONFIRM) if h.name == "approval.gate"
+        ]
+        assert hooks, "approval.gate hook not registered"
+        gate_func = cast(ToolConfirmHook, hooks[0].func)
+
+        result = gate_func(tool_use, workspace=None)
+        assert result is None, (
+            f"Expected gate to pass through (pre-approved for cwd), but got: {result}"
+        )
+
+    def test_approval_gate_rejects_wrong_workspace_even_with_cwd_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A cross-workspace approval must not pass when cwd differs from stored workspace."""
+        from gptme.hooks import clear_hooks
+        from gptme.hooks.approval import register_approval_hooks
+
+        ws_a = tmp_path / "workspace-a"
+        ws_b = tmp_path / "workspace-b"
+        ws_a.mkdir()
+        ws_b.mkdir()
+        db = tmp_path / "approvals.db"
+
+        # Pre-approve for ws_a
+        from gptme.hooks.approval import OP_DESTRUCTIVE, ApprovalRegistry, _intent_hash
+
+        intent = _intent_hash("shell", {"command": "rm /tmp/old"})
+        reg = ApprovalRegistry(db)
+        reg.approve("test", intent, OP_DESTRUCTIVE, "shell", workspace=ws_a)
+
+        clear_hooks()
+        register_approval_hooks(approval_mode="block", db_path=db, session_id="test")
+
+        # Change cwd to ws_b — the gate falls back to ws_b which != ws_a
+        monkeypatch.chdir(ws_b)
+
+        from typing import cast
+        from unittest.mock import MagicMock
+
+        from gptme.hooks import HookType, get_hooks
+        from gptme.hooks.confirm import ConfirmAction, ToolConfirmHook
+
+        tool_use = MagicMock()
+        tool_use.tool = "shell"
+        tool_use.kwargs = {"command": "rm /tmp/old"}
+        tool_use.content = None
+
+        hooks = [
+            h for h in get_hooks(HookType.TOOL_CONFIRM) if h.name == "approval.gate"
+        ]
+        gate_func = cast(ToolConfirmHook, hooks[0].func)
+
+        result = gate_func(tool_use, workspace=None)
+        assert result is not None, "Gate must block when stored workspace != cwd"
+        assert result.action == ConfirmAction.SKIP

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -85,6 +85,22 @@ class TestClassifyTool:
             == OP_RISKY
         )
 
+    def test_shell_curl_request_delete_is_risky(self):
+        # --request DELETE is a valid alternate form of -X DELETE
+        assert (
+            classify_tool(
+                "shell",
+                {"command": "curl --request DELETE https://api.example.com/v1/res"},
+            )
+            == OP_RISKY
+        )
+
+    def test_shell_rm_with_tab_separator_is_destructive(self):
+        # Tabs instead of spaces must not bypass classification
+        assert (
+            classify_tool("shell", {"command": "rm\t/tmp/sensitive"}) == OP_DESTRUCTIVE
+        )
+
     def test_unknown_tool_defaults_to_modifying(self):
         assert classify_tool("ipython", {"code": "print(1)"}) == OP_MODIFYING
 
@@ -189,6 +205,44 @@ class TestApprovalRegistry:
         records_2 = registry.list_session("sess-2")
         assert len(records_2) == 1
 
+    def test_approve_stores_workspace(self, registry: ApprovalRegistry, tmp_path: Path):
+        ws = tmp_path / "my-workspace"
+        ws.mkdir()
+        intent = _intent_hash("shell", {"command": "rm ./stale"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell", workspace=ws)
+        record = registry.get(intent)
+        assert record is not None
+        assert record["workspace"] == str(ws.resolve())
+
+    def test_is_approved_false_for_different_workspace(
+        self, registry: ApprovalRegistry, tmp_path: Path
+    ):
+        ws_a = tmp_path / "workspace-a"
+        ws_b = tmp_path / "workspace-b"
+        ws_a.mkdir()
+        ws_b.mkdir()
+        intent = _intent_hash("shell", {"command": "rm ./data"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell", workspace=ws_a)
+        # Same relative command approved in workspace A must NOT pass for workspace B
+        assert not registry.is_approved(intent, workspace=ws_b)
+
+    def test_is_approved_true_for_same_workspace(
+        self, registry: ApprovalRegistry, tmp_path: Path
+    ):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        intent = _intent_hash("shell", {"command": "rm ./data"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell", workspace=ws)
+        assert registry.is_approved(intent, workspace=ws)
+
+    def test_is_approved_no_workspace_restriction_when_not_stored(
+        self, registry: ApprovalRegistry, tmp_path: Path
+    ):
+        # Approvals without a workspace stored are workspace-unrestricted
+        intent = _intent_hash("shell", {"command": "rm /tmp/old"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")  # no workspace
+        assert registry.is_approved(intent, workspace=tmp_path)
+
     def test_db_created_on_demand(self, tmp_path: Path):
         db_path = tmp_path / "sub" / "dir" / "approvals.db"
         assert not db_path.exists()
@@ -243,6 +297,9 @@ class TestManifestApprovalClass:
 
         record = json.loads(pre_files[0].read_text())
         assert record.get("approval_class") == OP_DESTRUCTIVE
+        # intent_hash must be present so the manifest can be correlated to the
+        # approval registry entry that authorized the operation
+        assert record.get("intent_hash", "").startswith("sha256:")
 
     def test_pre_record_safe_op_class(self, tmp_path: Path):
         from unittest.mock import MagicMock

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -235,13 +235,23 @@ class TestApprovalRegistry:
         registry.approve("s1", intent, OP_DESTRUCTIVE, "shell", workspace=ws)
         assert registry.is_approved(intent, workspace=ws)
 
-    def test_is_approved_no_workspace_restriction_when_not_stored(
+    def test_is_approved_null_workspace_rejected_when_caller_provides_workspace(
         self, registry: ApprovalRegistry, tmp_path: Path
     ):
-        # Approvals without a workspace stored are workspace-unrestricted
+        # An approval stored without workspace must not pass workspace-aware lookups;
+        # NULL-workspace entries would otherwise act as global pass-through tokens.
         intent = _intent_hash("shell", {"command": "rm /tmp/old"})
-        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")  # no workspace
-        assert registry.is_approved(intent, workspace=tmp_path)
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")  # no workspace → NULL
+        assert not registry.is_approved(intent, workspace=tmp_path)
+
+    def test_is_approved_no_workspace_caller_accepts_null_stored(
+        self, registry: ApprovalRegistry
+    ):
+        # When the caller doesn't supply a workspace, NULL-stored approvals still pass
+        # (backward-compat for programmatic / non-gated paths).
+        intent = _intent_hash("shell", {"command": "rm /tmp/old"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")
+        assert registry.is_approved(intent)  # no workspace arg
 
     def test_db_created_on_demand(self, tmp_path: Path):
         db_path = tmp_path / "sub" / "dir" / "approvals.db"

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -1,0 +1,273 @@
+"""Tests for CLODEx Phase 3a: approval gate and registry."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.hooks.approval import (
+    OP_DESTRUCTIVE,
+    OP_MODIFYING,
+    OP_RISKY,
+    OP_SAFE,
+    ApprovalRegistry,
+    _intent_hash,
+    classify_tool,
+)
+
+# ---------------------------------------------------------------------------
+# classify_tool
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTool:
+    def test_read_is_safe(self):
+        assert classify_tool("read", {"path": "/tmp/foo.txt"}) == OP_SAFE
+
+    def test_browser_is_safe(self):
+        assert classify_tool("browser", {"url": "https://example.com"}) == OP_SAFE
+
+    def test_write_is_modifying(self):
+        assert (
+            classify_tool("write", {"path": "foo.py", "content": "x"}) == OP_MODIFYING
+        )
+
+    def test_patch_is_modifying(self):
+        assert classify_tool("patch", {"path": "a.py", "patch": "diff"}) == OP_MODIFYING
+
+    def test_shell_plain_is_modifying(self):
+        assert classify_tool("shell", {"command": "echo hello"}) == OP_MODIFYING
+
+    def test_shell_rm_is_destructive(self):
+        assert classify_tool("shell", {"command": "rm -rf /tmp/old"}) == OP_DESTRUCTIVE
+
+    def test_shell_rmdir_is_destructive(self):
+        assert (
+            classify_tool("shell", {"command": "rmdir /tmp/emptydir"}) == OP_DESTRUCTIVE
+        )
+
+    def test_shell_git_reset_hard_is_destructive(self):
+        assert (
+            classify_tool("shell", {"command": "git reset --hard HEAD~1"})
+            == OP_DESTRUCTIVE
+        )
+
+    def test_shell_git_push_force_is_destructive(self):
+        assert (
+            classify_tool("shell", {"command": "git push --force origin master"})
+            == OP_DESTRUCTIVE
+        )
+
+    def test_shell_git_branch_capital_d_is_destructive(self):
+        assert (
+            classify_tool("shell", {"command": "git branch -D stale-branch"})
+            == OP_DESTRUCTIVE
+        )
+
+    def test_shell_gh_pr_merge_is_risky(self):
+        assert classify_tool("shell", {"command": "gh pr merge 42"}) == OP_RISKY
+
+    def test_shell_gh_pr_close_is_risky(self):
+        assert classify_tool("shell", {"command": "gh pr close 99"}) == OP_RISKY
+
+    def test_shell_git_push_master_is_risky(self):
+        assert classify_tool("shell", {"command": "git push origin master"}) == OP_RISKY
+
+    def test_shell_curl_delete_is_risky(self):
+        assert (
+            classify_tool(
+                "shell", {"command": "curl -X DELETE https://api.example.com/v1/res"}
+            )
+            == OP_RISKY
+        )
+
+    def test_unknown_tool_defaults_to_modifying(self):
+        assert classify_tool("ipython", {"code": "print(1)"}) == OP_MODIFYING
+
+    def test_empty_command_is_modifying(self):
+        assert classify_tool("shell", {"command": ""}) == OP_MODIFYING
+
+    def test_none_command_is_modifying(self):
+        assert classify_tool("shell", {"command": None}) == OP_MODIFYING
+
+
+# ---------------------------------------------------------------------------
+# _intent_hash
+# ---------------------------------------------------------------------------
+
+
+class TestIntentHash:
+    def test_deterministic(self):
+        h1 = _intent_hash("shell", {"command": "rm -rf /tmp/x"})
+        h2 = _intent_hash("shell", {"command": "rm -rf /tmp/x"})
+        assert h1 == h2
+
+    def test_starts_with_sha256(self):
+        h = _intent_hash("read", {"path": "foo.txt"})
+        assert h.startswith("sha256:")
+
+    def test_different_args_produce_different_hash(self):
+        h1 = _intent_hash("shell", {"command": "rm /tmp/a"})
+        h2 = _intent_hash("shell", {"command": "rm /tmp/b"})
+        assert h1 != h2
+
+    def test_different_tool_produces_different_hash(self):
+        h1 = _intent_hash("write", {"path": "a.py"})
+        h2 = _intent_hash("read", {"path": "a.py"})
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# ApprovalRegistry
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def registry(tmp_path: Path) -> ApprovalRegistry:
+    return ApprovalRegistry(tmp_path / "approvals.db")
+
+
+class TestApprovalRegistry:
+    def test_get_returns_none_for_unknown_hash(self, registry: ApprovalRegistry):
+        assert registry.get("sha256:unknown") is None
+
+    def test_is_approved_false_for_unknown(self, registry: ApprovalRegistry):
+        assert not registry.is_approved("sha256:unknown")
+
+    def test_approve_and_retrieve(self, registry: ApprovalRegistry):
+        intent = _intent_hash("shell", {"command": "rm /tmp/old"})
+        approval_id = registry.approve(
+            session_id="sess-abc",
+            intent_hash=intent,
+            operation_class=OP_DESTRUCTIVE,
+            tool="shell",
+        )
+        assert approval_id  # non-empty UUID
+
+        record = registry.get(intent)
+        assert record is not None
+        assert record["status"] == "approved"
+        assert record["intent_hash"] == intent
+        assert record["tool"] == "shell"
+        assert record["session_id"] == "sess-abc"
+
+    def test_is_approved_true_after_approve(self, registry: ApprovalRegistry):
+        intent = _intent_hash("shell", {"command": "git reset --hard HEAD~1"})
+        registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")
+        assert registry.is_approved(intent)
+
+    def test_idempotent_approve(self, registry: ApprovalRegistry):
+        intent = _intent_hash("shell", {"command": "rm /tmp/x"})
+        id1 = registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")
+        id2 = registry.approve("s1", intent, OP_DESTRUCTIVE, "shell")
+        # Second approve replaces the record; both succeed
+        assert id1
+        assert id2
+        assert registry.is_approved(intent)
+
+    def test_list_session_returns_only_session_records(
+        self, registry: ApprovalRegistry
+    ):
+        intent_a = _intent_hash("shell", {"command": "rm /tmp/a"})
+        intent_b = _intent_hash("shell", {"command": "rm /tmp/b"})
+        intent_c = _intent_hash("shell", {"command": "rm /tmp/c"})
+
+        registry.approve("sess-1", intent_a, OP_DESTRUCTIVE, "shell")
+        registry.approve("sess-1", intent_b, OP_DESTRUCTIVE, "shell")
+        registry.approve("sess-2", intent_c, OP_DESTRUCTIVE, "shell")
+
+        records_1 = registry.list_session("sess-1")
+        assert len(records_1) == 2
+        hashes_1 = {r["intent_hash"] for r in records_1}
+        assert intent_a in hashes_1
+        assert intent_b in hashes_1
+
+        records_2 = registry.list_session("sess-2")
+        assert len(records_2) == 1
+
+    def test_db_created_on_demand(self, tmp_path: Path):
+        db_path = tmp_path / "sub" / "dir" / "approvals.db"
+        assert not db_path.exists()
+        ApprovalRegistry(db_path)
+        assert db_path.exists()
+
+    def test_persists_across_instances(self, tmp_path: Path):
+        db_path = tmp_path / "approvals.db"
+        intent = _intent_hash("shell", {"command": "rm /tmp/persist"})
+
+        reg1 = ApprovalRegistry(db_path)
+        reg1.approve("s1", intent, OP_DESTRUCTIVE, "shell")
+
+        reg2 = ApprovalRegistry(db_path)
+        assert reg2.is_approved(intent)
+
+
+# ---------------------------------------------------------------------------
+# Manifest integration: approval_class field
+# ---------------------------------------------------------------------------
+
+
+class TestManifestApprovalClass:
+    """Verify that manifest pre-records include approval_class when approval.py is present."""
+
+    def test_pre_record_includes_approval_class(self, tmp_path: Path):
+        from unittest.mock import MagicMock
+
+        from gptme.hooks import clear_hooks
+        from gptme.hooks.manifest import register_manifest_hooks
+
+        manifest_dir = tmp_path / "manifest"
+        clear_hooks()
+        register_manifest_hooks(manifest_dir)
+
+        # Build a minimal ToolUse mock for a destructive shell command
+        tool_use = MagicMock()
+        tool_use.tool = "shell"
+        tool_use.kwargs = {"command": "rm -rf /tmp/old"}
+        tool_use.content = None
+
+        from gptme.hooks import HookType, trigger_hook
+        from gptme.hooks.types import ToolExecutePreData
+
+        data = ToolExecutePreData(tool_use=tool_use)
+        list(trigger_hook(HookType.TOOL_EXECUTE_PRE, data))
+
+        # Find the written pre-record
+        pre_files = list(manifest_dir.glob("*-pre.json"))
+        assert pre_files, "No pre-record was written"
+        import json
+
+        record = json.loads(pre_files[0].read_text())
+        assert record.get("approval_class") == OP_DESTRUCTIVE
+
+    def test_pre_record_safe_op_class(self, tmp_path: Path):
+        from unittest.mock import MagicMock
+
+        from gptme.hooks import clear_hooks
+        from gptme.hooks.manifest import register_manifest_hooks
+
+        manifest_dir = tmp_path / "manifest2"
+        clear_hooks()
+        register_manifest_hooks(manifest_dir)
+
+        tool_use = MagicMock()
+        tool_use.tool = "read"
+        tool_use.kwargs = {"path": "/tmp/foo.txt"}
+        tool_use.content = None
+
+        from gptme.hooks import HookType, trigger_hook
+        from gptme.hooks.types import ToolExecutePreData
+
+        data = ToolExecutePreData(tool_use=tool_use)
+        list(trigger_hook(HookType.TOOL_EXECUTE_PRE, data))
+
+        import json
+
+        pre_files = list(manifest_dir.glob("*-pre.json"))
+        assert pre_files
+        record = json.loads(pre_files[0].read_text())
+        assert record.get("approval_class") == OP_SAFE

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -368,3 +368,64 @@ class TestManifestApprovalClass:
         assert pre_files
         record = json.loads(pre_files[0].read_text())
         assert record.get("approval_class") == OP_SAFE
+
+
+# ---------------------------------------------------------------------------
+# execute_with_confirmation workspace threading
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWithConfirmationWorkspace:
+    """Verify workspace is forwarded from execute_with_confirmation → get_confirmation."""
+
+    def test_workspace_reaches_tool_confirm_hook(self, tmp_path: Path):
+        """execute_with_confirmation(workspace=ws) must pass ws to TOOL_CONFIRM hooks."""
+        from unittest.mock import MagicMock, patch
+
+        from gptme.hooks import HookType, clear_hooks, register_hook
+        from gptme.hooks.confirm import ConfirmationResult
+        from gptme.util.ask_execute import execute_with_confirmation
+
+        ws = tmp_path / "my-workspace"
+        ws.mkdir()
+
+        received: list[Path | None] = []
+
+        def capture_hook(tool_use, preview=None, workspace=None):
+            received.append(workspace)
+            return ConfirmationResult.confirm()
+
+        clear_hooks()
+        register_hook(
+            name="capture",
+            hook_type=HookType.TOOL_CONFIRM,
+            func=capture_hook,
+            priority=0,
+            enabled=True,
+        )
+
+        # get_confirmation() skips hooks when get_current_tool_use() returns None.
+        # Provide a minimal ToolUse stub so the hook path is exercised.
+        tool_use_stub = MagicMock()
+        tool_use_stub.tool = "shell"
+        tool_use_stub.kwargs = {"command": "rm -rf /tmp/old"}
+        tool_use_stub.content = None
+
+        def execute_fn(cmd: str, path):
+            return iter([])
+
+        with patch("gptme.tools.base.get_current_tool_use", return_value=tool_use_stub):
+            list(
+                execute_with_confirmation(
+                    "rm -rf /tmp/old",
+                    None,
+                    None,
+                    execute_fn=execute_fn,
+                    get_path_fn=lambda code, args, kwargs: None,
+                    workspace=ws,
+                )
+            )
+
+        assert received, "TOOL_CONFIRM hook was never called"
+        assert received[0] is not None, "workspace was None — not forwarded"
+        assert received[0] == ws, f"expected {ws}, got {received[0]}"

--- a/gptme/hooks/tests/test_approval.py
+++ b/gptme/hooks/tests/test_approval.py
@@ -125,6 +125,12 @@ class TestClassifyTool:
             classify_tool("shell", {"command": '"rm" -rf /tmp/old'}) == OP_DESTRUCTIVE
         )
 
+    def test_shell_embedded_quoted_rm_is_destructive(self):
+        # r"m" is a bash word-concat evasion that resolves to rm; must be caught
+        assert (
+            classify_tool("shell", {"command": 'r"m" -rf /tmp/old'}) == OP_DESTRUCTIVE
+        )
+
     def test_unknown_tool_defaults_to_modifying(self):
         assert classify_tool("ipython", {"code": "print(1)"}) == OP_MODIFYING
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -763,6 +763,15 @@ class ToolUse:
                     # Set context var so tools can access current ToolUse
                     # via get_current_tool_use() or implicitly in get_confirmation()
                     token = _current_tool_use.set(self)
+                    # Propagate workspace into the shell ContextVar so execute_shell
+                    # can pass it through to get_confirmation / approval hooks even
+                    # in the CLI path (where session_step.py never calls
+                    # set_workspace_cwd).  Lazy import avoids circular dependency.
+                    ws_token = None
+                    if workspace is not None:
+                        from .shell import _workspace_cwd  # fmt: skip
+
+                        ws_token = _workspace_cwd.set(str(workspace))
                     try:
                         ex = tool.execute(
                             self.content,
@@ -828,6 +837,10 @@ class ToolUse:
                             )
                     finally:
                         _current_tool_use.reset(token)
+                        if ws_token is not None:
+                            from .shell import _workspace_cwd  # fmt: skip
+
+                            _workspace_cwd.reset(ws_token)
 
                     # Calculate duration
                     duration = time.time() - start_time

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1746,12 +1746,15 @@ def execute_shell(
         def execute_fn(cmd: str, path: Path | None) -> Generator[Message, None, None]:
             return execute_shell_impl(cmd, path, timeout=timeout)
 
+        ws_str = get_workspace_cwd()
+        workspace = Path(ws_str) if ws_str else None
         yield from execute_with_confirmation(
             cmd,
             args,
             kwargs,
             execute_fn=execute_fn,
             get_path_fn=get_path_fn,
+            workspace=workspace,
             preview_fn=preview_shell,
             preview_lang="bash",
             confirm_msg="Run command?",

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -326,6 +326,13 @@ class ShellSession:
         # make Python output unbuffered by default for better UX
         self.run("export PYTHONUNBUFFERED=1")
 
+    def cwd(self) -> Path:
+        """Return the persistent shell's current working directory."""
+        returncode, stdout, _ = self._run("pwd -P", output=False)
+        if returncode != 0 or not stdout.strip():
+            raise RuntimeError("Could not determine shell working directory")
+        return Path(stdout.strip()).resolve()
+
     def run(
         self, code: str, output=True, timeout: float | None = None
     ) -> tuple[int | None, str, str]:
@@ -1746,8 +1753,10 @@ def execute_shell(
         def execute_fn(cmd: str, path: Path | None) -> Generator[Message, None, None]:
             return execute_shell_impl(cmd, path, timeout=timeout)
 
-        ws_str = get_workspace_cwd()
-        workspace = Path(ws_str) if ws_str else None
+        # Scope approval reuse to where this persistent shell will execute the
+        # command, not the configured workspace where the shell started.  The
+        # shell may have changed directory in an earlier tool call.
+        workspace = get_shell().cwd()
         yield from execute_with_confirmation(
             cmd,
             args,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -328,7 +328,13 @@ class ShellSession:
 
     def cwd(self) -> Path:
         """Return the persistent shell's current working directory."""
-        returncode, stdout, _ = self._run("pwd -P", output=False)
+        if not _is_windows:
+            # Read the kernel's view of the shell process instead of executing
+            # `pwd` inside the mutable shell, where aliases or functions can
+            # spoof the directory used to scope an approval.
+            return Path(f"/proc/{self.process.pid}/cwd").resolve(strict=True)
+
+        returncode, stdout, _ = self._run("command pwd -P", output=False)
         if returncode != 0 or not stdout.strip():
             raise RuntimeError("Could not determine shell working directory")
         return Path(stdout.strip()).resolve()

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -328,11 +328,40 @@ class ShellSession:
 
     def cwd(self) -> Path:
         """Return the persistent shell's current working directory."""
-        if not _is_windows:
+        if sys.platform.startswith("linux"):
             # Read the kernel's view of the shell process instead of executing
             # `pwd` inside the mutable shell, where aliases or functions can
             # spoof the directory used to scope an approval.
             return Path(f"/proc/{self.process.pid}/cwd").resolve(strict=True)
+
+        if sys.platform == "darwin":
+            try:
+                stdout = subprocess.check_output(
+                    [
+                        "/usr/sbin/lsof",
+                        "-a",
+                        "-p",
+                        str(self.process.pid),
+                        "-d",
+                        "cwd",
+                        "-Fn",
+                    ],
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    timeout=10,
+                )
+            except (
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+                FileNotFoundError,
+            ) as exc:
+                raise RuntimeError(
+                    "Could not determine shell working directory"
+                ) from exc
+            for line in stdout.splitlines():
+                if line.startswith("n"):
+                    return Path(line[1:]).resolve(strict=True)
+            raise RuntimeError("Could not determine shell working directory")
 
         returncode, stdout, _ = self._run("command pwd -P", output=False)
         if returncode != 0 or not stdout.strip():

--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -77,6 +77,7 @@ def execute_with_confirmation(
         [str | None, list[str] | None, dict[str, str] | None], Path | None
     ],
     # Optional parameters
+    workspace: Path | None = None,
     preview_fn: Callable[[str, Path | None], str | None] | None = None,
     preview_header: str | None = None,
     preview_lang: str | None = None,
@@ -94,6 +95,7 @@ def execute_with_confirmation(
         kwargs: Dictionary of keyword arguments
         execute_fn: Function that performs the actual execution
         get_path_fn: Function to get the path from args/kwargs
+        workspace: Workspace directory passed to TOOL_CONFIRM hooks (e.g. approval gate)
         preview_fn: Optional function to prepare preview content
         preview_lang: Language for syntax highlighting
         confirm_msg: Custom confirmation message
@@ -117,6 +119,7 @@ def execute_with_confirmation(
         # The hook will show preview, allow editing, and return result
         result = get_confirmation(
             preview=preview_content or content,
+            workspace=workspace,
             default_confirm=True,
         )
 

--- a/tests/test_hooks_approval.py
+++ b/tests/test_hooks_approval.py
@@ -1,0 +1,189 @@
+"""Tests for CLODEx Phase 3a approval gate and registry.
+
+Covers:
+- ApprovalRegistry CRUD and workspace matching
+- _approval_gate hook: block / interactive-approve / pre-approved
+- Workspace propagation from ToolUse.execute() to the approval gate (CLI path fix)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gptme.hooks.approval import (
+    ApprovalRegistry,
+    classify_tool,
+)
+from gptme.tools.base import ToolUse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from gptme.hooks.confirm import ConfirmationResult
+
+# ---------------------------------------------------------------------------
+# classify_tool
+# ---------------------------------------------------------------------------
+
+
+def test_classify_rm_destructive():
+    assert classify_tool("shell", {"command": "rm -rf /tmp/foo"}) == "DESTRUCTIVE"
+
+
+def test_classify_gh_pr_merge_risky():
+    assert classify_tool("shell", {"command": "gh pr merge 42"}) == "RISKY"
+
+
+def test_classify_write_modifying():
+    assert classify_tool("write", {"path": "foo.py", "content": "x"}) == "MODIFYING"
+
+
+def test_classify_read_safe():
+    assert classify_tool("read", {"path": "README.md"}) == "SAFE"
+
+
+def test_classify_git_push_force_destructive():
+    assert (
+        classify_tool("shell", {"command": "git push --force origin master"})
+        == "DESTRUCTIVE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ApprovalRegistry
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def reg(tmp_path):
+    db = tmp_path / "approvals.db"
+    return ApprovalRegistry(db)
+
+
+def test_registry_approve_and_check(reg, tmp_path):
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    intent = "sha256:aabbcc"
+    reg.approve("sess1", intent, "DESTRUCTIVE", "shell", workspace=ws)
+    assert reg.is_approved(intent, workspace=ws)
+
+
+def test_registry_null_workspace_rejected_when_caller_has_workspace(reg, tmp_path):
+    """A NULL-workspace approval must NOT pass when the caller has a workspace."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    intent = "sha256:aabbcc"
+    reg.approve("sess1", intent, "DESTRUCTIVE", "shell", workspace=None)
+    assert not reg.is_approved(intent, workspace=ws)
+
+
+def test_registry_workspace_mismatch_rejected(reg, tmp_path):
+    ws_a = tmp_path / "ws_a"
+    ws_b = tmp_path / "ws_b"
+    ws_a.mkdir()
+    ws_b.mkdir()
+    intent = "sha256:xxyy"
+    reg.approve("sess1", intent, "RISKY", "shell", workspace=ws_a)
+    assert reg.is_approved(intent, workspace=ws_a)
+    assert not reg.is_approved(intent, workspace=ws_b)
+
+
+def test_registry_no_workspace_caller_accepts_any_approval(reg, tmp_path):
+    """When caller passes workspace=None, no workspace enforcement → accepts."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    intent = "sha256:zzww"
+    reg.approve("sess1", intent, "RISKY", "shell", workspace=ws)
+    assert reg.is_approved(intent, workspace=None)
+
+
+# ---------------------------------------------------------------------------
+# Workspace propagation: ToolUse.execute() → get_workspace_cwd() → approval gate
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_propagated_from_tool_use_execute_to_approval_gate(tmp_path):
+    """ToolUse.execute(workspace=...) must set the shell ContextVar so the
+    approval gate receives the workspace instead of None.
+
+    This is the CLI path fix: in the server path session_step.py calls
+    set_workspace_cwd explicitly; in the CLI path only ToolUse.execute() has
+    the workspace and must propagate it into the ContextVar.
+    """
+    from gptme.hooks import HookType, clear_hooks, register_hook
+    from gptme.hooks.confirm import ConfirmationResult
+
+    captured_workspace: list[Path | None] = []
+
+    def spy_hook(
+        tool_use: ToolUse,
+        preview: str | None = None,
+        workspace: Path | None = None,
+    ) -> ConfirmationResult | None:
+        captured_workspace.append(workspace)
+        # Block execution so the command doesn't actually run
+        return ConfirmationResult.skip("test spy")
+
+    clear_hooks()
+    register_hook(
+        name="test.workspace_spy",
+        hook_type=HookType.TOOL_CONFIRM,
+        func=spy_hook,
+        priority=100,
+        enabled=True,
+    )
+
+    ws = tmp_path / "myproject"
+    ws.mkdir()
+
+    # Use a command that passes the denylist but is not allowlisted, so
+    # execute_with_confirmation() is called and TOOL_CONFIRM hooks fire.
+    # (rm -rf hits the denylist regex rm\s+-rf\s+/ and returns early.)
+    tool_use = ToolUse(
+        tool="shell", args=[], content="touch /tmp/clodex-workspace-propagation-test"
+    )
+    list(tool_use.execute(workspace=ws))  # drain generator; spy hook skips actual exec
+
+    clear_hooks()
+
+    assert len(captured_workspace) == 1, "spy hook should have fired once"
+    assert captured_workspace[0] is not None, (
+        "workspace must not be None when passed via ToolUse.execute()"
+    )
+    assert captured_workspace[0].resolve() == ws.resolve()
+
+
+def test_workspace_contextvar_reset_after_execute(tmp_path):
+    """After ToolUse.execute() completes, the workspace ContextVar is reset."""
+    from gptme.hooks import HookType, clear_hooks, register_hook
+    from gptme.hooks.confirm import ConfirmationResult
+    from gptme.tools.shell import get_workspace_cwd
+
+    clear_hooks()
+
+    def skip_hook(tool_use, preview=None, workspace=None):
+        return ConfirmationResult.skip("test")
+
+    register_hook(
+        name="test.skip",
+        hook_type=HookType.TOOL_CONFIRM,
+        func=skip_hook,
+        priority=100,
+        enabled=True,
+    )
+
+    # Verify ContextVar is None before execution
+    assert get_workspace_cwd() is None
+
+    ws = tmp_path / "project"
+    ws.mkdir()
+    tool_use = ToolUse(tool="shell", args=[], content="ls /tmp")
+    list(tool_use.execute(workspace=ws))
+
+    # ContextVar must be restored after execution
+    assert get_workspace_cwd() is None, (
+        "workspace ContextVar must be reset to None after ToolUse.execute()"
+    )
+    clear_hooks()

--- a/tests/test_hooks_approval.py
+++ b/tests/test_hooks_approval.py
@@ -8,6 +8,7 @@ Covers:
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -230,6 +231,32 @@ def test_workspace_cannot_be_spoofed_by_pwd_function(tmp_path):
         shell.close()
 
     assert captured_workspace == [target.resolve()]
+
+
+def test_workspace_uses_lsof_on_macos(tmp_path):
+    """macOS obtains the shell cwd without relying on Linux procfs."""
+    from unittest.mock import Mock
+
+    from gptme.tools.shell import ShellSession
+
+    shell = ShellSession.__new__(ShellSession)
+    shell.process = Mock(pid=123)
+    lsof_output = f"p123\nfcwd\nn{tmp_path}\n"
+
+    with (
+        patch("gptme.tools.shell.sys.platform", "darwin"),
+        patch(
+            "gptme.tools.shell.subprocess.check_output", return_value=lsof_output
+        ) as check_output,
+    ):
+        assert shell.cwd() == tmp_path.resolve()
+
+    check_output.assert_called_once_with(
+        ["/usr/sbin/lsof", "-a", "-p", "123", "-d", "cwd", "-Fn"],
+        stderr=subprocess.DEVNULL,
+        text=True,
+        timeout=10,
+    )
 
 
 def test_workspace_contextvar_reset_after_execute(tmp_path):

--- a/tests/test_hooks_approval.py
+++ b/tests/test_hooks_approval.py
@@ -194,6 +194,44 @@ def test_workspace_tracks_persistent_shell_after_cd(tmp_path):
     assert captured_workspace == [target.resolve()]
 
 
+def test_workspace_cannot_be_spoofed_by_pwd_function(tmp_path):
+    """Approval scope uses the shell's real cwd even when `pwd` is overridden."""
+    from gptme.hooks import HookType, clear_hooks, register_hook
+    from gptme.hooks.confirm import ConfirmationResult
+    from gptme.tools.shell import ShellSession, set_shell
+
+    approved = tmp_path / "approved"
+    target = tmp_path / "target"
+    approved.mkdir()
+    target.mkdir()
+    shell = ShellSession(cwd=str(approved))
+    shell.run(f"function pwd {{ printf '%s\\n' {approved}; }}; cd {target}")
+    set_shell(shell)
+    captured_workspace: list[Path | None] = []
+
+    def spy_hook(tool_use, preview=None, workspace=None):
+        captured_workspace.append(workspace)
+        return ConfirmationResult.skip("test spy")
+
+    clear_hooks()
+    register_hook(
+        name="test.workspace_spoof",
+        hook_type=HookType.TOOL_CONFIRM,
+        func=spy_hook,
+        priority=100,
+        enabled=True,
+    )
+    try:
+        tool_use = ToolUse(tool="shell", args=[], content="touch relative-file")
+        with patch("gptme.tools.shell.get_shell", return_value=shell):
+            list(tool_use.execute(workspace=approved))
+    finally:
+        clear_hooks()
+        shell.close()
+
+    assert captured_workspace == [target.resolve()]
+
+
 def test_workspace_contextvar_reset_after_execute(tmp_path):
     """After ToolUse.execute() completes, the workspace ContextVar is reset."""
     from gptme.hooks import HookType, clear_hooks, register_hook

--- a/tests/test_hooks_approval.py
+++ b/tests/test_hooks_approval.py
@@ -9,6 +9,7 @@ Covers:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -153,6 +154,44 @@ def test_workspace_propagated_from_tool_use_execute_to_approval_gate(tmp_path):
         "workspace must not be None when passed via ToolUse.execute()"
     )
     assert captured_workspace[0].resolve() == ws.resolve()
+
+
+def test_workspace_tracks_persistent_shell_after_cd(tmp_path):
+    """Approval scope follows the shell's actual cwd after a prior cd."""
+    from gptme.hooks import HookType, clear_hooks, register_hook
+    from gptme.hooks.confirm import ConfirmationResult
+    from gptme.tools.shell import ShellSession, set_shell
+
+    initial = tmp_path / "initial"
+    target = tmp_path / "target"
+    initial.mkdir()
+    target.mkdir()
+    shell = ShellSession(cwd=str(initial))
+    shell.run(f"cd {target}")
+    set_shell(shell)
+    captured_workspace: list[Path | None] = []
+
+    def spy_hook(tool_use, preview=None, workspace=None):
+        captured_workspace.append(workspace)
+        return ConfirmationResult.skip("test spy")
+
+    clear_hooks()
+    register_hook(
+        name="test.workspace_after_cd",
+        hook_type=HookType.TOOL_CONFIRM,
+        func=spy_hook,
+        priority=100,
+        enabled=True,
+    )
+    try:
+        tool_use = ToolUse(tool="shell", args=[], content="touch relative-file")
+        with patch("gptme.tools.shell.get_shell", return_value=shell):
+            list(tool_use.execute(workspace=initial))
+    finally:
+        clear_hooks()
+        shell.close()
+
+    assert captured_workspace == [target.resolve()]
 
 
 def test_workspace_contextvar_reset_after_execute(tmp_path):


### PR DESCRIPTION
## Summary

Adds a four-tier operation classifier and SQLite-backed approval registry that gates destructive/risky tool calls before they execute. This is the Phase 3a milestone of the CLODEx (Claude Local Observability and Deterministic Execution) harness design.

**New files**
- `gptme/hooks/approval.py` — `classify_tool()`, `ApprovalRegistry`, and `register_approval_hooks()` which registers a `TOOL_CONFIRM` hook at priority 5 (fires before `cli_confirm`).
- `gptme/hooks/tests/test_approval.py` — 31 tests: classifier, intent hash, registry CRUD, and manifest integration.

**Modified files**
- `gptme/hooks/manifest.py` — pre-records now carry `approval_class` field (try/except so manifest works without the approval module).
- `gptme/cli/main.py` — `--approval-mode` option (`audit` / `interactive` / `block`) gated on `--manifest-dir`; wires the approval hook at startup.

## Usage

```
gptme --manifest-dir /tmp/manifest --approval-mode interactive …
```

### Modes

| Mode | Behaviour |
|------|-----------|
| `audit` | Classify only — no blocking. Adds `approval_class` to every manifest pre-record. |
| `interactive` | TTY prompt before DESTRUCTIVE/RISKY ops; approved ops persisted to registry so they don't re-prompt. |
| `block` | Always blocks DESTRUCTIVE/RISKY ops without a prior registry entry. Safe for non-interactive agents. |

### Operation classes

| Class | Examples |
|-------|---------|
| `SAFE` | `read`, `browser` |
| `MODIFYING` | `write`, `patch`, plain shell |
| `DESTRUCTIVE` | `rm`, `git reset --hard`, `git push --force`, `git branch -D` |
| `RISKY` | `gh pr merge`, `git push origin master`, `curl -X DELETE` |

### Registry

Approvals are stored in `<gptme-data-dir>/approvals.db` (SQLite), keyed by `intent_hash` (sha256 of tool + args). The same hash appears in the manifest pre-record, creating a tamper-evident link between the authorisation trail and the Phase 2 manifest chain.

## Test plan

- [x] `uv run pytest gptme/hooks/tests/test_approval.py -v` — 31 tests pass
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy` — clean (checked via pre-commit hook)
- [ ] Manual smoke: `gptme --manifest-dir /tmp/m --approval-mode interactive` → shell `rm` should prompt
- [ ] `--approval-mode block` without registry entry → op skipped with log message