### PR TITLE
fix(ci): bundle webui before building Tauri sidecars

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -419,7 +419,7 @@ jobs:
           poetry install --extras server --extras pyinstaller --with dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -418,6 +418,20 @@ jobs:
           make build
           poetry install --extras server --extras pyinstaller --with dev
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Build and bundle webui
+        shell: bash
+        run: |
+          cd webui && npm ci && npm run build
+          cd ..
+          make bundle-webui
+
       - name: Build PyInstaller executable
         shell: bash
         run: make build-server-exe


### PR DESCRIPTION
## Problem

The `v0.32.2.dev20260730` Tauri release failed on all desktop platforms. `scripts/pyinstaller/gptme-server.spec` now requires `gptme/server/webui-dist`, but the Tauri `build-sidecar` job never builds or bundles the web UI. PyInstaller therefore exits before producing any sidecar, and all downstream desktop release jobs fail with missing `tauri/bins/gptme-server-*`.

Failed run: https://github.com/gptme/gptme/actions/runs/30549697049

## Fix

Mirror the existing standalone PyInstaller build workflow in the Tauri sidecar job:

- set up Node.js with the webui npm cache
- build `webui/dist`
- run `make bundle-webui` before `make build-server-exe`

## Verification

- YAML parses successfully
- `git diff --check` passes
- repository pre-commit hooks pass
- PR quality gate: 100/100

## Scope

This only repairs the release pipeline. It does not change runtime code or release assets directly.