### PR TITLE
fix(tauri): avoid duplicating webui in server sidecar

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -418,22 +418,12 @@ jobs:
           make build
           poetry install --extras server --extras pyinstaller --with dev
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: webui/package-lock.json
-
-      - name: Build and bundle webui
-        shell: bash
-        run: |
-          cd webui && npm ci && npm run build
-          cd ..
-          make bundle-webui
-
       - name: Build PyInstaller executable
         shell: bash
+        # Tauri bundles webui/dist itself via frontendDist. Keep the API sidecar
+        # lean instead of embedding a second copy of the same frontend.
+        env:
+          GPTME_PYINSTALLER_EXCLUDE_WEBUI: '1'
         run: make build-server-exe
 
       - name: Place sidecar with Rust target triple

--- a/scripts/pyinstaller/gptme-server.spec
+++ b/scripts/pyinstaller/gptme-server.spec
@@ -7,14 +7,18 @@ from pathlib import Path
 project_root = Path.cwd()
 sys.path.insert(0, str(project_root))
 
-# Define data files to include
+# Define data files to include. Standalone executables serve the modern web UI,
+# while the Tauri host already bundles it via frontendDist.
 datas = [
-    # Include the modern web UI and legacy computer.html fallback.
-    (str(project_root / 'gptme/server/webui-dist'), 'gptme/server/webui-dist'),
     (str(project_root / 'gptme/server/static'), 'gptme/server/static'),
     # Include the logo if needed
     (str(project_root / 'media/logo.png'), 'media'),
 ]
+if os.environ.get('GPTME_PYINSTALLER_EXCLUDE_WEBUI') != '1':
+    datas.insert(
+        0,
+        (str(project_root / 'gptme/server/webui-dist'), 'gptme/server/webui-dist'),
+    )
 
 # Hidden imports - modules that PyInstaller might miss
 hiddenimports = [


### PR DESCRIPTION
## Problem

The Tauri release currently embeds the same compiled web UI twice: once in the Tauri host through `frontendDist`, and once in the PyInstaller `gptme-server` sidecar. The sidecar is only the desktop API backend, so its copy is redundant and adds roughly the compiled frontend size to every desktop artifact.

Follow-up to #3403, requested by @ErikBjare.

## Fix

- add an opt-out flag to the shared PyInstaller spec while preserving the existing standalone executable behavior by default
- set that flag only for the Tauri sidecar build
- remove the now-unnecessary Node setup and webui-to-server copy from the sidecar job

The release job still builds `webui/dist` for Tauri's authoritative `frontendDist` bundle.

## Verification

- exercised the spec in both modes: standalone includes `webui-dist`; Tauri mode excludes it while retaining legacy static files
- workflow YAML parses successfully
- scoped pre-commit hooks pass
- `git diff --check` passes
- PR quality gate: 100/100
