### PR TITLE
fix(server): guard conversation DELETE against concurrent generation

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2349,6 +2349,13 @@ def api_conversation_delete(conversation_id: str):
         )
 
     with SessionManager.conversation_lock(conversation_id):
+        # Another serialized DELETE may have removed it while we waited.
+        if not logdir.exists():
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
         if any(sess.generating for sess in sessions):
             return (

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2340,17 +2340,29 @@ def api_conversation_delete(conversation_id: str):
     if logdir.parent != get_logs_dir():
         logger.warning(f"Path traversal attempt blocked: {conversation_id}")
         return flask.jsonify({"error": "Invalid conversation_id"}), 400
+
+    # Reject missing conversations before acquiring the lock.
     if not logdir.exists():
         return (
             flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
             404,
         )
 
-    try:
-        shutil.rmtree(logdir)
-    except OSError as e:
-        logger.error(f"Error deleting conversation {conversation_id}: {e}")
-        return flask.jsonify({"error": f"Could not delete conversation: {e}"}), 500
+    with SessionManager.conversation_lock(conversation_id):
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify(
+                    {"error": "Cannot delete while generation is in progress"}
+                ),
+                409,
+            )
+
+        try:
+            shutil.rmtree(logdir)
+        except OSError as e:
+            logger.error(f"Error deleting conversation {conversation_id}: {e}")
+            return flask.jsonify({"error": f"Could not delete conversation: {e}"}), 500
 
     SessionManager.remove_all_sessions_for_conversation(conversation_id)
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2308,6 +2308,24 @@ def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     assert "generation is in progress" in response.get_json()["error"]
 
 
+def test_v2_conversation_delete_rejected_during_generation(client: FlaskClient):
+    """Conversation DELETE should return 409 when a session is actively generating."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2.SessionManager.get_sessions_for_conversation"
+    ) as mock_get:
+        mock_session = unittest.mock.MagicMock()
+        mock_session.generating = True
+        mock_get.return_value = [mock_session]
+
+        response = client.delete(f"/api/v2/conversations/{conversation_id}")
+
+    assert response.status_code == 409
+    assert "generation is in progress" in response.get_json()["error"]
+
+
 def test_v2_chat_config_patch_loads_log_under_conversation_lock(
     client: FlaskClient,
 ):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2326,6 +2326,35 @@ def test_v2_conversation_delete_rejected_during_generation(client: FlaskClient):
     assert "generation is in progress" in response.get_json()["error"]
 
 
+def test_v2_conversation_delete_rechecks_existence_under_lock(client: FlaskClient):
+    """A DELETE serialized behind another deletion should return 404, not 500."""
+    from gptme.dirs import get_logs_dir
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    logdir = get_logs_dir() / conversation_id
+
+    class DeleteBeforeLock:
+        def __enter__(self):
+            import shutil
+
+            shutil.rmtree(logdir)
+
+        def __exit__(self, *_args):
+            return None
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2.SessionManager.conversation_lock",
+        return_value=DeleteBeforeLock(),
+    ):
+        response = client.delete(f"/api/v2/conversations/{conversation_id}")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": f"Conversation not found: {conversation_id}"
+    }
+
+
 def test_v2_chat_config_patch_loads_log_under_conversation_lock(
     client: FlaskClient,
 ):


### PR DESCRIPTION
## Problem

`api_conversation_delete` (the whole-conversation `DELETE /api/v2/conversations/{id}` endpoint) was missing the generating guard added to fork, edit, and delete-message in #3401.

Without this guard, a `DELETE` request arriving during an active step call causes `shutil.rmtree` to delete conversation files while the step thread is still writing. The step thread then fails on `manager.write()`, the generated content is silently discarded, and there is no recovery path.

## Fix

Acquire `SessionManager.conversation_lock(conversation_id)` before checking `sess.generating` and before calling `shutil.rmtree`, matching the pattern already applied to the three other mutation endpoints.

The `logdir.exists()` check is moved before the lock acquisition to avoid allocating a lock for a conversation that doesn't exist.

## Test

Added `test_v2_conversation_delete_rejected_during_generation` — patches `SessionManager.get_sessions_for_conversation` to return a mock session with `generating=True` and asserts the DELETE returns 409 with a descriptive error message.

## Related

- Closes the gap left by #3401 (`fix(server): acquire step_lock when checking generating flag in fork/edit/delete/config`)