### PR TITLE
fix(webui): replace CLI server guidance with in-app retry in Tauri desktop app

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -25,6 +25,8 @@ import { withLocalAddressSpace } from '@/utils/addressSpace';
 import { isLikelyChromeCorsPna } from '@/utils/api';
 import { isDemoMode } from '@/utils/connectionConfig';
 import { appRoute, chatRoute } from '@/utils/routes';
+import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
+import { useTauriServerStatus } from '@/hooks/useTauriServerStatus';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
 
@@ -45,10 +47,13 @@ export const WelcomeView = () => {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isRetryingConnection, setIsRetryingConnection] = useState(false);
+  const [isRestartingServer, setIsRestartingServer] = useState(false);
   const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
   const navigate = useNavigate();
   const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
   const demoMode = isDemoMode();
+  const isTauri = isTauriEnvironment();
+  const { managesLocalServer } = useTauriServerStatus();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
   const lastConnectionResult = use$(api.lastConnectionResult$);
@@ -143,6 +148,28 @@ export const WelcomeView = () => {
       toast.success('Start command copied to clipboard');
     } catch {
       toast.error('Failed to copy start command');
+    }
+  };
+
+  const handleTauriRestartServer = async () => {
+    setIsRestartingServer(true);
+    try {
+      await invokeTauri('start_server');
+    } catch (error) {
+      const msg = String(error);
+      if (!msg.includes('already running')) {
+        toast.error('Failed to start the server. Please restart the app.');
+        setIsRestartingServer(false);
+        return;
+      }
+      // Server is already running — just retry the connection below
+    }
+    try {
+      await connect();
+    } catch {
+      // connect() already shows a toast on failure
+    } finally {
+      setIsRestartingServer(false);
     }
   };
 
@@ -256,6 +283,12 @@ export const WelcomeView = () => {
   ]);
 
   const disconnectedDesc = (() => {
+    if (isTauri && managesLocalServer) {
+      // Desktop app: the bundled server is managed by the app — no CLI commands needed.
+      if (errorBucket === 'network' || errorBucket === 'timeout' || errorBucket === 'unknown') {
+        return 'The built-in server failed to start. Click "Restart server" to try again.';
+      }
+    }
     if (errorBucket === 'network') {
       return isDefaultLocalServer
         ? 'The gptme server is not running. Start one with the command below.'
@@ -374,7 +407,8 @@ export const WelcomeView = () => {
                       using the managed gptme.ai option — no copy-pasting required.
                     </p>
                   )}
-                  {isDefaultLocalServer &&
+                  {!isTauri &&
+                    isDefaultLocalServer &&
                     !isFirstVisit &&
                     errorBucket !== 'cors' &&
                     !showHostedLoopbackCorsHint && (
@@ -401,7 +435,7 @@ export const WelcomeView = () => {
                       </div>
                     )}
                   <div className="flex flex-wrap gap-2">
-                    {showGuidedSetup && (
+                    {showGuidedSetup && !isTauri && (
                       <Button
                         type="button"
                         size="sm"
@@ -411,6 +445,17 @@ export const WelcomeView = () => {
                         }}
                       >
                         Get started
+                      </Button>
+                    )}
+                    {isTauri && managesLocalServer && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => void handleTauriRestartServer()}
+                        disabled={isRestartingServer}
+                      >
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        {isRestartingServer ? 'Starting...' : 'Restart server'}
                       </Button>
                     )}
                     <Button
@@ -423,7 +468,7 @@ export const WelcomeView = () => {
                       <RotateCcw className="mr-2 h-4 w-4" />
                       {isRetryingConnection ? 'Retrying...' : 'Retry connection'}
                     </Button>
-                    {isDefaultLocalServer && !isFirstVisit && (
+                    {!isTauri && isDefaultLocalServer && !isFirstVisit && (
                       <Button
                         type="button"
                         size="sm"
@@ -445,7 +490,7 @@ export const WelcomeView = () => {
                       </Button>
                     )}
                   </div>
-                  {isDefaultLocalServer && !isFirstVisit && (
+                  {!isTauri && isDefaultLocalServer && !isFirstVisit && (
                     <p className="text-sm text-muted-foreground">
                       Prefer not to run a local server?{' '}
                       <Button

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -11,6 +11,13 @@ const mockInvalidateQueries = jest.fn();
 const mockConnect = jest.fn();
 const mockFetch = jest.fn();
 const mockIsDemoMode = jest.fn(() => false);
+const mockIsTauriEnvironment = jest.fn(() => false);
+const mockInvokeTauri = jest.fn();
+const mockUseTauriServerStatus = jest.fn(() => ({
+  isLoading: false,
+  managesLocalServer: false,
+  serverStatus: null,
+}));
 const isConnected$ = observable(true);
 const compatibilityWarning$ = observable<null | {
   kind: 'server_older' | 'api_major_mismatch';
@@ -49,6 +56,15 @@ jest.mock('@/utils/api', () => ({
 
 jest.mock('@/utils/connectionConfig', () => ({
   isDemoMode: () => mockIsDemoMode(),
+}));
+
+jest.mock('@/utils/tauri', () => ({
+  isTauriEnvironment: () => mockIsTauriEnvironment(),
+  invokeTauri: (...args: unknown[]) => mockInvokeTauri(...args),
+}));
+
+jest.mock('@/hooks/useTauriServerStatus', () => ({
+  useTauriServerStatus: () => mockUseTauriServerStatus(),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -126,6 +142,13 @@ describe('WelcomeView', () => {
     mockFetch.mockReset();
     mockIsDemoMode.mockReturnValue(false);
     mockIsLikelyChromeCorsPna.mockReturnValue(false);
+    mockIsTauriEnvironment.mockReturnValue(false);
+    mockInvokeTauri.mockReset();
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: null,
+    });
     mockFetch.mockImplementation(() => new Promise(() => {}));
     Object.defineProperty(window, 'fetch', {
       writable: true,
@@ -659,6 +682,100 @@ describe('WelcomeView', () => {
       // jsdom sets window.location.href on assignment, constructing
       // a URL with ?demo=1 appended.
       expect(window.location.href).toContain('demo=1');
+    });
+  });
+
+  describe('Tauri desktop app', () => {
+    beforeEach(() => {
+      mockIsTauriEnvironment.mockReturnValue(true);
+      mockUseTauriServerStatus.mockReturnValue({
+        isLoading: false,
+        managesLocalServer: true,
+        serverStatus: null,
+      });
+      isConnected$.set(false);
+      lastConnectionResult$.set({
+        ok: false,
+        url: 'http://localhost:5700/api/v2',
+        reason: 'network',
+        message: 'Could not reach server (connection refused)',
+      });
+    });
+
+    it('shows desktop-friendly message instead of CLI command when sidecar fails', () => {
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.getByText(/The built-in server failed to start/i)).toBeInTheDocument();
+      // CLI-oriented messages must not appear for desktop users
+      expect(screen.queryByText(/The gptme server is not running/i)).not.toBeInTheDocument();
+      expect(screen.queryByText("pipx install 'gptme[server]'")).not.toBeInTheDocument();
+      expect(screen.queryByText(/gptme-server --cors-origin/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /copy start command/i })).not.toBeInTheDocument();
+    });
+
+    it('shows "Restart server" button in Tauri that invokes start_server then connect', async () => {
+      mockInvokeTauri.mockResolvedValue(5700);
+      mockConnect.mockResolvedValue(undefined);
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      const restartBtn = screen.getByRole('button', { name: /restart server/i });
+      expect(restartBtn).toBeInTheDocument();
+
+      fireEvent.click(restartBtn);
+
+      await waitFor(() => {
+        expect(mockInvokeTauri).toHaveBeenCalledWith('start_server');
+        expect(mockConnect).toHaveBeenCalled();
+      });
+    });
+
+    it('still shows "Retry connection" button alongside "Restart server"', () => {
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.getByRole('button', { name: /restart server/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
+    });
+
+    it('hides "Use gptme.ai" cloud alternative in desktop app', () => {
+      seedReturningUser();
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      expect(screen.queryByRole('button', { name: /use gptme\.ai/i })).not.toBeInTheDocument();
+    });
+
+    it('falls back to connect-only when start_server says already running', async () => {
+      mockInvokeTauri.mockRejectedValue('Server is already running');
+      mockConnect.mockResolvedValue(undefined);
+
+      render(
+        <SettingsProvider>
+          <WelcomeView />
+        </SettingsProvider>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /restart server/i }));
+
+      await waitFor(() => {
+        expect(mockConnect).toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3406.

When the gptme desktop app (Tauri) fails to start the bundled sidecar server, the WelcomeView was showing CLI-oriented content that is confusing and useless for desktop users:
- "The gptme server is not running. Start one with the command below."
- `pipx install 'gptme[server]'` and `gptme-server --cors-origin=...` code blocks
- "Copy start command" button
- "Prefer not to run a local server? Use gptme.ai"

In the desktop app, the user cannot run these CLI commands — the app manages the server sidecar itself.

**Changes:**
- When running in Tauri with `managesLocalServer=true`, show a desktop-friendly message: _"The built-in server failed to start. Click 'Restart server' to try again."_
- Add a **Restart server** button that calls the `start_server` Tauri IPC command and then reconnects; handles the "server already running" edge case by falling through to `connect()` directly
- Hide CLI command blocks, "Copy start command" button, and "Use gptme.ai" cloud link in the desktop context
- Keep **Retry connection** as a lightweight fallback alongside **Restart server**
- Gate the "Get started" setup wizard CTA on non-Tauri (desktop users don't need CLI onboarding)

All existing 24 WelcomeView tests pass; 5 new Tauri-specific tests added covering the message, the restart button flow, the always-running button, the hidden cloud CTA, and the graceful "already running" fallback.

## Test plan

- [ ] In the Tauri desktop app with a failed sidecar start, the banner shows "The built-in server failed to start" and a "Restart server" button, no CLI commands
- [ ] Clicking "Restart server" attempts `start_server` IPC and then connects
- [ ] "Retry connection" still appears alongside "Restart server"
- [ ] In the web UI (non-Tauri), the existing CLI guidance is unchanged
- [ ] All 640 webui unit tests pass (`npx jest --no-coverage` in `webui/`)

<!-- gptme-id:v1:gai_SC44ujRSpu1TLDpKmqicU7m4bJdBaRaoYcUTqjF4RIp -->