### PR TITLE
feat(android): sign APK/AAB and verify signature before release upload

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -834,10 +834,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: tauri-autoupdater-signing
     env:
-      # True only when all four Android signing secrets are provisioned.
-      # PR jobs never reach this job (gated by tag/inputs.tag condition above),
-      # so signing secrets are never exposed to pull-request workflows.
-      HAS_ANDROID_SIGNING: ${{ secrets.ANDROID_KEYSTORE != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
+      # True only when the Android signing key, credentials, and pinned
+      # certificate identity are provisioned. PR jobs never reach this job
+      # (gated by tag/inputs.tag above), so these secrets stay release-only.
+      HAS_ANDROID_SIGNING: ${{ secrets.ANDROID_KEYSTORE != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' && vars.ANDROID_CERT_SHA256 != '' }}
     permissions:
       contents: write
 
@@ -858,27 +858,44 @@ jobs:
           name: android-build
           path: android-dist
 
+      - name: Require Android signing configuration
+        if: env.HAS_ANDROID_SIGNING != 'true'
+        run: |
+          echo "::error::Android release signing is not fully configured."
+          echo "::error::Provision the four ANDROID_* secrets and ANDROID_CERT_SHA256 environment variable."
+          exit 1
+
       - name: Sign Android APK and AAB
-        if: env.HAS_ANDROID_SIGNING == 'true'
         env:
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
         run: |
-          # Decode keystore from base64 secret into a temp file
-          echo "$ANDROID_KEYSTORE" | base64 --decode > /tmp/android-release.jks
+          # Decode the keystore with restrictive permissions and guarantee
+          # removal even when signing fails partway through.
+          KEYSTORE=$(mktemp)
+          trap 'rm -f "$KEYSTORE"' EXIT
+          chmod 600 "$KEYSTORE"
+          printf '%s' "$ANDROID_KEYSTORE" | base64 --decode > "$KEYSTORE"
 
-          # Locate apksigner from the newest installed build-tools version
-          BUILD_TOOLS_DIR=$(ls -d "${ANDROID_HOME}/build-tools"/* 2>/dev/null | sort -V | tail -1)
+          # Locate apksigner from the newest installed build-tools version.
+          BUILD_TOOLS_DIR=$(find "${ANDROID_HOME}/build-tools" -mindepth 1 -maxdepth 1 -type d -print | sort -V | tail -1)
           APKSIGNER="${BUILD_TOOLS_DIR}/apksigner"
-          echo "Using apksigner: $APKSIGNER"
+          test -x "$APKSIGNER"
 
-          # Sign every unsigned APK produced by Gradle (v2/v3 scheme via apksigner)
-          find android-dist -name "*-unsigned.apk" | while read -r apk; do
+          # Sign every unsigned APK produced by Gradle (v2/v3 scheme via apksigner).
+          mapfile -d '' unsigned_apks < <(find android-dist -name "*-unsigned.apk" -print0)
+          mapfile -d '' unsigned_aabs < <(find android-dist -name "*.aab" -print0)
+          if [ "${#unsigned_apks[@]}" -eq 0 ] || [ "${#unsigned_aabs[@]}" -eq 0 ]; then
+            echo "::error::Expected at least one unsigned APK and AAB to sign."
+            exit 1
+          fi
+
+          for apk in "${unsigned_apks[@]}"; do
             signed="${apk/-unsigned/}"
             "$APKSIGNER" sign \
-              --ks /tmp/android-release.jks \
+              --ks "$KEYSTORE" \
               --ks-key-alias "$ANDROID_KEY_ALIAS" \
               --ks-pass "pass:$ANDROID_STORE_PASSWORD" \
               --key-pass "pass:$ANDROID_KEY_PASSWORD" \
@@ -889,10 +906,10 @@ jobs:
           done
 
           # Sign AAB bundles with jarsigner (apksigner does not support AABs;
-          # v1 JAR signing is required for AABs distributed outside the Play Store)
-          find android-dist -name "*.aab" | while read -r aab; do
+          # v1 JAR signing is required for AABs distributed outside the Play Store).
+          for aab in "${unsigned_aabs[@]}"; do
             jarsigner \
-              -keystore /tmp/android-release.jks \
+              -keystore "$KEYSTORE" \
               -storepass "$ANDROID_STORE_PASSWORD" \
               -keypass "$ANDROID_KEY_PASSWORD" \
               -digestalg SHA-256 \
@@ -902,30 +919,39 @@ jobs:
             echo "Signed AAB: $aab"
           done
 
-          # Remove keystore from disk immediately after signing
-          rm -f /tmp/android-release.jks
-
-      - name: Verify APK signatures
-        if: env.HAS_ANDROID_SIGNING == 'true'
+      - name: Verify Android signatures and certificate identity
+        env:
+          EXPECTED_CERT_SHA256: ${{ vars.ANDROID_CERT_SHA256 }}
         run: |
-          BUILD_TOOLS_DIR=$(ls -d "${ANDROID_HOME}/build-tools"/* 2>/dev/null | sort -V | tail -1)
+          BUILD_TOOLS_DIR=$(find "${ANDROID_HOME}/build-tools" -mindepth 1 -maxdepth 1 -type d -print | sort -V | tail -1)
           APKSIGNER="${BUILD_TOOLS_DIR}/apksigner"
+          test -x "$APKSIGNER"
+          EXPECTED_CERT_SHA256=$(printf '%s' "$EXPECTED_CERT_SHA256" | tr '[:lower:]' '[:upper:]' | tr -d ':[:space:]')
 
-          FAILED=0
-          # Verify every APK that is NOT still named -unsigned (i.e. already signed above)
-          while IFS= read -r -d '' apk; do
-            echo "Verifying: $apk"
-            if ! "$APKSIGNER" verify --verbose --print-certs "$apk"; then
-              echo "::error::Signature verification FAILED for $apk"
-              FAILED=1
-            fi
-          done < <(find android-dist -name "*.apk" ! -name "*-unsigned*" -print0)
-
-          if [ "$FAILED" -ne 0 ]; then
-            echo "::error::One or more APKs failed signature verification. Aborting upload."
+          mapfile -d '' apks < <(find android-dist -name "*.apk" ! -name "*-unsigned*" -print0)
+          mapfile -d '' aabs < <(find android-dist -name "*.aab" -print0)
+          if [ "${#apks[@]}" -eq 0 ] || [ "${#aabs[@]}" -eq 0 ]; then
+            echo "::error::Expected at least one signed APK and AAB before upload."
             exit 1
           fi
-          echo "All APKs passed signature verification."
+
+          for apk in "${apks[@]}"; do
+            echo "Verifying APK: $apk"
+            "$APKSIGNER" verify --verbose "$apk"
+            ACTUAL_CERT_SHA256=$("$APKSIGNER" verify --print-certs "$apk" \
+              | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
+              | tr '[:lower:]' '[:upper:]' | tr -d ':[:space:]')
+            if [ "$ACTUAL_CERT_SHA256" != "$EXPECTED_CERT_SHA256" ]; then
+              echo "::error::APK signer certificate does not match ANDROID_CERT_SHA256: $apk"
+              exit 1
+            fi
+          done
+
+          for aab in "${aabs[@]}"; do
+            echo "Verifying AAB: $aab"
+            jarsigner -verify -strict "$aab"
+          done
+          echo "All Android artifacts passed signature and identity verification."
 
       - name: Upload APK/AAB to release
         env:
@@ -933,12 +959,9 @@ jobs:
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           # Rename Gradle's generic output names to match desktop bundle naming:
-          #   app-universal-release[-unsigned].apk  →  gptme-tauri_X.Y.Z_universal[-unsigned].apk
-          # The "-release" build-type marker is always dropped.
-          # The "-unsigned" suffix is NOT stripped here — the sign step above
-          # already renames *-unsigned.apk → *.apk on success, so signed APKs
-          # arrive without the suffix.  Unsigned APKs (no secrets provisioned)
-          # keep the suffix as an explicit signal.
+          #   app-universal-release.apk  →  gptme-tauri_X.Y.Z_universal.apk
+          # The "-release" build-type marker is always dropped. This job fails
+          # before reaching upload unless signing and verification succeeded.
           VERSION="${TAG#v}"
           find android-dist -name "*.apk" -o -name "*.aab" | while read -r f; do
             new="$(basename "$f" | sed -E "s/^app-/gptme-tauri_${VERSION}_/; s/-release//")"

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -847,7 +847,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -865,6 +865,11 @@ jobs:
           echo "::error::Provision the four ANDROID_* secrets and ANDROID_CERT_SHA256 environment variable."
           exit 1
 
+      # Signing strategy is shared with ActivityWatch/aw-android
+      # (scripts/sign_apk.sh + .github/workflows/build.yml there): zipalign,
+      # then apksigner for APKs and jarsigner for AABs, passwords via env.
+      # Keep the two implementations consistent when changing either.
+      # See docs/contributing.rst "Android release signing" for provisioning.
       - name: Sign Android APK and AAB
         env:
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
@@ -879,10 +884,12 @@ jobs:
           chmod 600 "$KEYSTORE"
           printf '%s' "$ANDROID_KEYSTORE" | base64 --decode > "$KEYSTORE"
 
-          # Locate apksigner from the newest installed build-tools version.
+          # Locate apksigner/zipalign from the newest installed build-tools version.
           BUILD_TOOLS_DIR=$(find "${ANDROID_HOME}/build-tools" -mindepth 1 -maxdepth 1 -type d -print | sort -V | tail -1)
           APKSIGNER="${BUILD_TOOLS_DIR}/apksigner"
+          ZIPALIGN="${BUILD_TOOLS_DIR}/zipalign"
           test -x "$APKSIGNER"
+          test -x "$ZIPALIGN"
 
           # Sign every unsigned APK produced by Gradle (v2/v3 scheme via apksigner).
           mapfile -d '' unsigned_apks < <(find android-dist -name "*-unsigned.apk" -print0)
@@ -894,11 +901,15 @@ jobs:
 
           for apk in "${unsigned_apks[@]}"; do
             signed="${apk/-unsigned/}"
+            # zipalign must run before apksigner (which preserves alignment);
+            # Gradle's unsigned output is not guaranteed to be aligned.
+            "$ZIPALIGN" -p 4 "$apk" "$apk.aligned"
+            mv "$apk.aligned" "$apk"
             "$APKSIGNER" sign \
               --ks "$KEYSTORE" \
               --ks-key-alias "$ANDROID_KEY_ALIAS" \
-              --ks-pass "pass:$ANDROID_STORE_PASSWORD" \
-              --key-pass "pass:$ANDROID_KEY_PASSWORD" \
+              --ks-pass env:ANDROID_STORE_PASSWORD \
+              --key-pass env:ANDROID_KEY_PASSWORD \
               --out "$signed" \
               "$apk"
             rm "$apk"
@@ -910,8 +921,8 @@ jobs:
           for aab in "${unsigned_aabs[@]}"; do
             jarsigner \
               -keystore "$KEYSTORE" \
-              -storepass "$ANDROID_STORE_PASSWORD" \
-              -keypass "$ANDROID_KEY_PASSWORD" \
+              -storepass:env ANDROID_STORE_PASSWORD \
+              -keypass:env ANDROID_KEY_PASSWORD \
               -digestalg SHA-256 \
               -sigalg SHA256withRSA \
               "$aab" \

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -832,6 +832,12 @@ jobs:
       (startsWith(github.ref, 'refs/tags/v') || inputs.tag != '')
     needs: [lint, test, build, build-android]
     runs-on: ubuntu-latest
+    environment: tauri-autoupdater-signing
+    env:
+      # True only when all four Android signing secrets are provisioned.
+      # PR jobs never reach this job (gated by tag/inputs.tag condition above),
+      # so signing secrets are never exposed to pull-request workflows.
+      HAS_ANDROID_SIGNING: ${{ secrets.ANDROID_KEYSTORE != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
     permissions:
       contents: write
 
@@ -840,21 +846,99 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Download Android artifacts
         uses: actions/download-artifact@v4
         with:
           name: android-build
           path: android-dist
 
+      - name: Sign Android APK and AAB
+        if: env.HAS_ANDROID_SIGNING == 'true'
+        env:
+          ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          # Decode keystore from base64 secret into a temp file
+          echo "$ANDROID_KEYSTORE" | base64 --decode > /tmp/android-release.jks
+
+          # Locate apksigner from the newest installed build-tools version
+          BUILD_TOOLS_DIR=$(ls -d "${ANDROID_HOME}/build-tools"/* 2>/dev/null | sort -V | tail -1)
+          APKSIGNER="${BUILD_TOOLS_DIR}/apksigner"
+          echo "Using apksigner: $APKSIGNER"
+
+          # Sign every unsigned APK produced by Gradle (v2/v3 scheme via apksigner)
+          find android-dist -name "*-unsigned.apk" | while read -r apk; do
+            signed="${apk/-unsigned/}"
+            "$APKSIGNER" sign \
+              --ks /tmp/android-release.jks \
+              --ks-key-alias "$ANDROID_KEY_ALIAS" \
+              --ks-pass "pass:$ANDROID_STORE_PASSWORD" \
+              --key-pass "pass:$ANDROID_KEY_PASSWORD" \
+              --out "$signed" \
+              "$apk"
+            rm "$apk"
+            echo "Signed APK: $signed"
+          done
+
+          # Sign AAB bundles with jarsigner (apksigner does not support AABs;
+          # v1 JAR signing is required for AABs distributed outside the Play Store)
+          find android-dist -name "*.aab" | while read -r aab; do
+            jarsigner \
+              -keystore /tmp/android-release.jks \
+              -storepass "$ANDROID_STORE_PASSWORD" \
+              -keypass "$ANDROID_KEY_PASSWORD" \
+              -digestalg SHA-256 \
+              -sigalg SHA256withRSA \
+              "$aab" \
+              "$ANDROID_KEY_ALIAS"
+            echo "Signed AAB: $aab"
+          done
+
+          # Remove keystore from disk immediately after signing
+          rm -f /tmp/android-release.jks
+
+      - name: Verify APK signatures
+        if: env.HAS_ANDROID_SIGNING == 'true'
+        run: |
+          BUILD_TOOLS_DIR=$(ls -d "${ANDROID_HOME}/build-tools"/* 2>/dev/null | sort -V | tail -1)
+          APKSIGNER="${BUILD_TOOLS_DIR}/apksigner"
+
+          FAILED=0
+          # Verify every APK that is NOT still named -unsigned (i.e. already signed above)
+          while IFS= read -r -d '' apk; do
+            echo "Verifying: $apk"
+            if ! "$APKSIGNER" verify --verbose --print-certs "$apk"; then
+              echo "::error::Signature verification FAILED for $apk"
+              FAILED=1
+            fi
+          done < <(find android-dist -name "*.apk" ! -name "*-unsigned*" -print0)
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more APKs failed signature verification. Aborting upload."
+            exit 1
+          fi
+          echo "All APKs passed signature verification."
+
       - name: Upload APK/AAB to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          # Rename gradle's generic output names (app-universal-release-unsigned.apk)
-          # to match the desktop bundle naming (gptme-tauri_X.Y.Z_<arch>.<ext>),
-          # e.g. gptme-tauri_0.32.0_universal-unsigned.apk. The "-release" build-type
-          # marker is dropped; "-unsigned" is kept since the APK isn't signed yet.
+          # Rename Gradle's generic output names to match desktop bundle naming:
+          #   app-universal-release[-unsigned].apk  →  gptme-tauri_X.Y.Z_universal[-unsigned].apk
+          # The "-release" build-type marker is always dropped.
+          # The "-unsigned" suffix is NOT stripped here — the sign step above
+          # already renames *-unsigned.apk → *.apk on success, so signed APKs
+          # arrive without the suffix.  Unsigned APKs (no secrets provisioned)
+          # keep the suffix as an explicit signal.
           VERSION="${TAG#v}"
           find android-dist -name "*.apk" -o -name "*.aab" | while read -r f; do
             new="$(basename "$f" | sed -E "s/^app-/gptme-tauri_${VERSION}_/; s/-release//")"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -244,6 +244,13 @@ zipalign before signing, apksigner for APKs, jarsigner for AABs, and passwords
 passed via environment variables. When changing the signing approach in either
 project, apply the same change to the other to keep them consistent.
 
+Note that gptme's Android app is built by Tauri (``tauri android build``, a
+generated Gradle project) while aw-android is a native Android app — this does
+not affect signing, since both sign the standard unsigned Gradle outputs after
+the build. Signing deliberately happens in the tag-gated release job rather
+than via a Gradle ``signingConfig`` or Tauri's keystore hooks in the build job,
+so signing secrets are never exposed to PR-triggered builds.
+
 Issue Labels
 ------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -237,6 +237,13 @@ in one maintenance window, then verify the first release's APK with
 fingerprint in the release notes so downstream metadata consumers can recognize
 the intentional identity transition.
 
+This signing strategy is intentionally shared with
+`ActivityWatch/aw-android <https://github.com/ActivityWatch/aw-android>`_
+(see ``scripts/sign_apk.sh`` and ``.github/workflows/build.yml`` there):
+zipalign before signing, apksigner for APKs, jarsigner for AABs, and passwords
+passed via environment variables. When changing the signing approach in either
+project, apply the same change to the other to keep them consistent.
+
 Issue Labels
 ------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -201,6 +201,42 @@ Release
 
 To make a release, simply run ``make release`` and follow the instructions.
 
+Android release signing
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Android releases are signed with a long-lived upload key in the
+``tauri-autoupdater-signing`` GitHub environment. Configure these secrets before
+running a tagged release:
+
+- ``ANDROID_KEYSTORE``: base64-encoded JKS or PKCS12 keystore
+- ``ANDROID_KEY_ALIAS``: alias of the signing key
+- ``ANDROID_KEY_PASSWORD``: password for the key entry
+- ``ANDROID_STORE_PASSWORD``: password for the keystore
+
+Also set the non-secret environment variable ``ANDROID_CERT_SHA256`` to the
+signing certificate's SHA-256 fingerprint. Generate a key and obtain that value
+with:
+
+.. code-block:: bash
+
+   keytool -genkeypair -keystore release.jks -alias gptme-release \
+     -keyalg RSA -keysize 4096 -validity 10000 \
+     -dname "CN=gptme, OU=release, O=gptme, C=SE"
+   keytool -list -v -keystore release.jks -alias gptme-release
+
+Store the keystore and passwords in the project's offline recovery vault before
+provisioning GitHub. Losing this key prevents future releases from retaining the
+same Android signing identity.
+
+The release workflow refuses to upload Android artifacts when any signing value
+is missing, signature verification fails, or the APK certificate does not match
+``ANDROID_CERT_SHA256``. To rotate the key, first archive the old keystore,
+create and back up the replacement, update all four secrets and the fingerprint
+in one maintenance window, then verify the first release's APK with
+``apksigner verify --verbose --print-certs``. Keep the previous public
+fingerprint in the release notes so downstream metadata consumers can recognize
+the intentional identity transition.
+
 Issue Labels
 ------------
 


### PR DESCRIPTION
Closes #3408

## What this does

Adds fail-closed Android APK/AAB signing and verification to the `release-android` job in `.github/workflows/tauri.yml`.

- Requires all four signing secrets and the pinned `ANDROID_CERT_SHA256` environment variable before a tagged Android release can upload anything.
- Signs APKs with `apksigner` (v2/v3) and AABs with `jarsigner`.
- Verifies every APK signature and its exact SHA-256 signer fingerprint, plus every AAB signature, before upload.
- Uses a mode-600 temporary keystore with trap-based cleanup on success or failure.
- Documents key provisioning, offline recovery, fingerprint verification, and rotation in `docs/contributing.rst`.
- Pins the added `actions/setup-java` action to a full commit SHA.

### Environment configuration

In the `tauri-autoupdater-signing` environment, provision:

| Kind | Name | Content |
|---|---|---|
| Secret | `ANDROID_KEYSTORE` | Base64-encoded JKS/PKCS12 keystore |
| Secret | `ANDROID_KEY_ALIAS` | Signing key alias |
| Secret | `ANDROID_KEY_PASSWORD` | Key-entry password |
| Secret | `ANDROID_STORE_PASSWORD` | Keystore password |
| Variable | `ANDROID_CERT_SHA256` | Expected signing certificate SHA-256 fingerprint |

The workflow intentionally fails until these are configured; it no longer publishes an unsigned fallback from a release job.

## Verification

- [x] Workflow YAML and RST pre-commit checks pass.
- [x] Embedded bash steps pass `bash -n` and ShellCheck.
- [x] PR CI exercises the Android build path without exposing release secrets.
- [ ] Erik provisions the environment values and reviews this sensitive release-workflow change.
- [ ] First tagged release proves the published APK fingerprint and downstream cryptographic classification end to end.
