### PR TITLE
fix(server): reject message append during generation

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1833,7 +1833,9 @@ def api_conversation_post(conversation_id: str):
             )
 
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify(
                     {"error": "Cannot add message while generation is in progress"}
@@ -1884,8 +1886,14 @@ def api_conversation_post(conversation_id: str):
                     {"error": f"Command /{cmd_name} is not available in server mode"}
                 ), 400
 
-            # Append command message first (handle_cmd may undo it via auto_undo)
+            # Reserve the conversation before releasing the lock. Command execution
+            # may call an LLM or tools, so keeping the lock held would block rather
+            # than promptly reject concurrent mutations and /step requests.
+            SessionManager.start_command(conversation_id)
+        else:
             log.append(msg)
+
+            # Notify all sessions that a new message was added
             SessionManager.add_event(
                 conversation_id,
                 {
@@ -1894,39 +1902,16 @@ def api_conversation_post(conversation_id: str):
                 },
             )
 
-            # Execute the command and collect response messages
-            responses: list[Message] = []
-            try:
-                for resp in handle_cmd(msg.content, log):
-                    log.append(resp)
-                    responses.append(resp)
-                    SessionManager.add_event(
-                        conversation_id,
-                        {
-                            "type": "message_added",
-                            "message": msg2dict(resp, log.workspace, log.logdir),
-                        },
-                    )
-            except Exception as e:
-                logger.exception("Error executing command: %s", msg.content)
-                error_msg = Message("system", f"Command error: {e}")
-                log.append(error_msg)
-                responses.append(error_msg)
-                SessionManager.add_event(
-                    conversation_id,
-                    {
-                        "type": "message_added",
-                        "message": msg2dict(error_msg, log.workspace, log.logdir),
-                    },
-                )
+            # Partial cache update: only refresh this conversation's entry so the
+            # conversations-list endpoint can keep serving from cache during streaming.
+            _update_conversation_in_cache(conversation_id)
+            return flask.jsonify({"status": "ok"})
 
-            return flask.jsonify(
-                {"status": "ok", "command": True, "responses": len(responses)}
-            )
-
+    # Append and execute a command under its reservation, not the conversation lock.
+    # The reservation is always cleared, including when handle_cmd raises.
+    responses: list[Message] = []
+    try:
         log.append(msg)
-
-        # Notify all sessions that a new message was added
         SessionManager.add_event(
             conversation_id,
             {
@@ -1934,11 +1919,34 @@ def api_conversation_post(conversation_id: str):
                 "message": msg2dict(msg, log.workspace, log.logdir),
             },
         )
-
-        # Partial cache update: only refresh this conversation's entry so the
-        # conversations-list endpoint can keep serving from cache during streaming.
-        _update_conversation_in_cache(conversation_id)
-        return flask.jsonify({"status": "ok"})
+        try:
+            for resp in handle_cmd(msg.content, log):
+                log.append(resp)
+                responses.append(resp)
+                SessionManager.add_event(
+                    conversation_id,
+                    {
+                        "type": "message_added",
+                        "message": msg2dict(resp, log.workspace, log.logdir),
+                    },
+                )
+        except Exception as e:
+            logger.exception("Error executing command: %s", msg.content)
+            error_msg = Message("system", f"Command error: {e}")
+            log.append(error_msg)
+            responses.append(error_msg)
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "message_added",
+                    "message": msg2dict(error_msg, log.workspace, log.logdir),
+                },
+            )
+        return flask.jsonify(
+            {"status": "ok", "command": True, "responses": len(responses)}
+        )
+    finally:
+        SessionManager.finish_command(conversation_id)
 
 
 @v2_api.route(

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1816,13 +1816,6 @@ def api_conversation_post(conversation_id: str):
     if isinstance(tool_allowlist, tuple):
         return tool_allowlist
 
-    try:
-        init_tools(tool_allowlist)
-    except ValueError as exc:
-        return flask.jsonify({"error": str(exc)}), 400
-    except Exception as exc:
-        return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
-
     # Check conversation existence before branch to return accurate error messages.
     logdir = get_logs_dir() / conversation_id
     if not logdir.exists():
@@ -1830,42 +1823,110 @@ def api_conversation_post(conversation_id: str):
             flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
             404,
         )
-    try:
-        log = LogManager.load(logdir, branch=branch)
-    except FileNotFoundError:
-        return (
-            flask.jsonify({"error": f"Branch not found: {branch}"}),
-            404,
+
+    with SessionManager.conversation_lock(conversation_id):
+        # Another serialized DELETE may have removed it while we waited.
+        if not logdir.exists():
+            return (
+                flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+                404,
+            )
+
+        sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(sess.generating for sess in sessions):
+            return (
+                flask.jsonify(
+                    {"error": "Cannot add message while generation is in progress"}
+                ),
+                409,
+            )
+
+        try:
+            log = LogManager.load(logdir, branch=branch)
+        except FileNotFoundError:
+            return (
+                flask.jsonify({"error": f"Branch not found: {branch}"}),
+                404,
+            )
+
+        try:
+            init_tools(tool_allowlist)
+        except ValueError as exc:
+            return flask.jsonify({"error": str(exc)}), 400
+        except Exception as exc:
+            return flask.jsonify({"error": f"Failed to load tool: {exc}"}), 400
+
+        # Validate and convert file paths from JSON strings to Path objects
+        files_result = _get_optional_string_list_field(req_json, "files")
+        if isinstance(files_result, tuple):
+            return files_result
+        file_paths: list[FilePath] = []
+        if files_result is not None:
+            validated_files = _validate_message_file_references(
+                files_result, log.workspace
+            )
+            if isinstance(validated_files, tuple):
+                return validated_files
+            file_paths = validated_files
+        msg = Message(
+            req_json["role"],
+            req_json["content"],
+            files=file_paths,
         )
 
-    # Validate and convert file paths from JSON strings to Path objects
-    files_result = _get_optional_string_list_field(req_json, "files")
-    if isinstance(files_result, tuple):
-        return files_result
-    file_paths: list[FilePath] = []
-    if files_result is not None:
-        validated_files = _validate_message_file_references(files_result, log.workspace)
-        if isinstance(validated_files, tuple):
-            return validated_files
-        file_paths = validated_files
-    msg = Message(
-        req_json["role"],
-        req_json["content"],
-        files=file_paths,
-    )
+        # Check if the message is a slash command (e.g. /help, /model, /tools)
+        if msg.role == "user" and is_message_command(msg.content):
+            # Block commands that are unsafe in server context (see _SERVER_BLOCKED_COMMANDS)
+            parts = msg.content.lstrip("/").split()
+            cmd_name = parts[0] if parts else ""
+            if cmd_name in _SERVER_BLOCKED_COMMANDS:
+                return flask.jsonify(
+                    {"error": f"Command /{cmd_name} is not available in server mode"}
+                ), 400
 
-    # Check if the message is a slash command (e.g. /help, /model, /tools)
-    if msg.role == "user" and is_message_command(msg.content):
-        # Block commands that are unsafe in server context (see _SERVER_BLOCKED_COMMANDS)
-        parts = msg.content.lstrip("/").split()
-        cmd_name = parts[0] if parts else ""
-        if cmd_name in _SERVER_BLOCKED_COMMANDS:
+            # Append command message first (handle_cmd may undo it via auto_undo)
+            log.append(msg)
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "message_added",
+                    "message": msg2dict(msg, log.workspace, log.logdir),
+                },
+            )
+
+            # Execute the command and collect response messages
+            responses: list[Message] = []
+            try:
+                for resp in handle_cmd(msg.content, log):
+                    log.append(resp)
+                    responses.append(resp)
+                    SessionManager.add_event(
+                        conversation_id,
+                        {
+                            "type": "message_added",
+                            "message": msg2dict(resp, log.workspace, log.logdir),
+                        },
+                    )
+            except Exception as e:
+                logger.exception("Error executing command: %s", msg.content)
+                error_msg = Message("system", f"Command error: {e}")
+                log.append(error_msg)
+                responses.append(error_msg)
+                SessionManager.add_event(
+                    conversation_id,
+                    {
+                        "type": "message_added",
+                        "message": msg2dict(error_msg, log.workspace, log.logdir),
+                    },
+                )
+
             return flask.jsonify(
-                {"error": f"Command /{cmd_name} is not available in server mode"}
-            ), 400
+                {"status": "ok", "command": True, "responses": len(responses)}
+            )
 
-        # Append command message first (handle_cmd may undo it via auto_undo)
         log.append(msg)
+
+        # Notify all sessions that a new message was added
         SessionManager.add_event(
             conversation_id,
             {
@@ -1874,51 +1935,10 @@ def api_conversation_post(conversation_id: str):
             },
         )
 
-        # Execute the command and collect response messages
-        responses: list[Message] = []
-        try:
-            for resp in handle_cmd(msg.content, log):
-                log.append(resp)
-                responses.append(resp)
-                SessionManager.add_event(
-                    conversation_id,
-                    {
-                        "type": "message_added",
-                        "message": msg2dict(resp, log.workspace, log.logdir),
-                    },
-                )
-        except Exception as e:
-            logger.exception("Error executing command: %s", msg.content)
-            error_msg = Message("system", f"Command error: {e}")
-            log.append(error_msg)
-            responses.append(error_msg)
-            SessionManager.add_event(
-                conversation_id,
-                {
-                    "type": "message_added",
-                    "message": msg2dict(error_msg, log.workspace, log.logdir),
-                },
-            )
-
-        return flask.jsonify(
-            {"status": "ok", "command": True, "responses": len(responses)}
-        )
-
-    log.append(msg)
-
-    # Notify all sessions that a new message was added
-    SessionManager.add_event(
-        conversation_id,
-        {
-            "type": "message_added",
-            "message": msg2dict(msg, log.workspace, log.logdir),
-        },
-    )
-
-    # Partial cache update: only refresh this conversation's entry so the
-    # conversations-list endpoint can keep serving from cache during streaming.
-    _update_conversation_in_cache(conversation_id)
-    return flask.jsonify({"status": "ok"})
+        # Partial cache update: only refresh this conversation's entry so the
+        # conversations-list endpoint can keep serving from cache during streaming.
+        _update_conversation_in_cache(conversation_id)
+        return flask.jsonify({"status": "ok"})
 
 
 @v2_api.route(

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2030,7 +2030,9 @@ def api_conversation_edit_message(conversation_id: str, index: int):
     # lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify({"error": "Cannot edit while generation is in progress"}),
                 409,
@@ -2153,7 +2155,9 @@ def api_conversation_delete_message(conversation_id: str, index: int):
     # lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify(
                     {"error": "Cannot delete while generation is in progress"}
@@ -2275,7 +2279,9 @@ def api_conversation_fork(conversation_id: str):
     # the lock so deletion between the existence check and lock acquisition is safe.
     with SessionManager.conversation_lock(conversation_id):
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify({"error": "Cannot fork while generation is in progress"}),
                 409,
@@ -2385,7 +2391,9 @@ def api_conversation_delete(conversation_id: str):
             )
 
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify(
                     {"error": "Cannot delete while generation is in progress"}
@@ -2764,7 +2772,9 @@ def api_conversation_config_patch(conversation_id: str):
             )
 
         sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(sess.generating for sess in sessions):
+        if any(
+            sess.generating for sess in sessions
+        ) or SessionManager.command_is_active(conversation_id):
             return (
                 flask.jsonify(
                     {"error": "Cannot update config while generation is in progress"}

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -383,7 +383,7 @@ def api_conversation_step(conversation_id: str):
     # config PATCH. A PATCH completed before this acquisition must affect the
     # worker; one arriving afterward sees generating=True and returns 409.
     with SessionManager.conversation_lock(conversation_id), session.step_lock:
-        if session.generating:
+        if session.generating or SessionManager.command_is_active(conversation_id):
             return flask.jsonify({"error": "Generation already in progress"}), 409
         chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
         if stream is None:

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -135,6 +135,9 @@ class SessionManager:
     # per-ID locks are tiny; retaining them avoids replacing a lock while a
     # request still holds it after the final session is removed.
     _conversation_locks: dict[str, threading.RLock] = {}
+    # Slash commands may perform slow LLM/tool work outside the conversation lock.
+    # This reservation keeps generation and mutations from racing that work.
+    _active_commands: set[str] = set()
     _lock = threading.Lock()
 
     @classmethod
@@ -146,6 +149,24 @@ class SessionManager:
                 lock = threading.RLock()
                 cls._conversation_locks[conversation_id] = lock
             return lock
+
+    @classmethod
+    def command_is_active(cls, conversation_id: str) -> bool:
+        """Return whether a synchronous command owns the conversation."""
+        with cls._lock:
+            return conversation_id in cls._active_commands
+
+    @classmethod
+    def start_command(cls, conversation_id: str) -> None:
+        """Reserve a conversation for synchronous command execution."""
+        with cls._lock:
+            cls._active_commands.add(conversation_id)
+
+    @classmethod
+    def finish_command(cls, conversation_id: str) -> None:
+        """Release a synchronous command reservation."""
+        with cls._lock:
+            cls._active_commands.discard(conversation_id)
 
     @classmethod
     def create_session(cls, conversation_id: str) -> ConversationSession:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -511,10 +511,10 @@ def _start_acp_step_thread(
     *,
     reserved: bool = False,
 ) -> bool:
-    """Start an ACP-backed step unless another generation has reserved it."""
+    """Start an ACP-backed step unless another operation has reserved it."""
     if not reserved:
         with SessionManager.conversation_lock(conversation_id), session.step_lock:
-            if session.generating:
+            if session.generating or SessionManager.command_is_active(conversation_id):
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
@@ -1040,14 +1040,14 @@ def _start_step_thread(
     *,
     reserved: bool = False,
 ) -> bool:
-    """Start a step unless another generation has already reserved it."""
+    """Start a step unless another operation has already reserved it."""
 
     # Direct callers (tool continuations and A2A) share /step's atomic
     # check-and-reserve protocol. The /step route reserves before setup and
     # identifies that reservation explicitly to avoid rejecting itself.
     if not reserved:
         with SessionManager.conversation_lock(conversation_id), session.step_lock:
-            if session.generating:
+            if session.generating or SessionManager.command_is_active(conversation_id):
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2402,6 +2402,35 @@ def test_v2_step_rejected_while_conversation_command_is_active(client: FlaskClie
     assert response.get_json()["error"] == "Generation already in progress"
 
 
+@pytest.mark.parametrize(
+    ("method", "path", "json"),
+    [
+        ("PATCH", "/messages/0", {"content": "updated"}),
+        ("DELETE", "/messages/0", None),
+        ("POST", "/fork?after_message=0", None),
+        ("DELETE", "", None),
+        ("PATCH", "/config", {"model": "openai/gpt-4o"}),
+    ],
+)
+def test_v2_mutations_rejected_while_conversation_command_is_active(
+    client: FlaskClient, method: str, path: str, json: dict | None
+):
+    """Mutations cannot race a synchronous command's log snapshot."""
+    from gptme.server.session_models import SessionManager
+
+    conversation_id = create_conversation(client)["conversation_id"]
+    SessionManager.start_command(conversation_id)
+    try:
+        response = client.open(
+            f"/api/v2/conversations/{conversation_id}{path}", method=method, json=json
+        )
+    finally:
+        SessionManager.finish_command(conversation_id)
+
+    assert response.status_code == 409
+    assert "generation is in progress" in response.get_json()["error"]
+
+
 def test_v2_conversation_delete_rechecks_existence_under_lock(client: FlaskClient):
     """A DELETE serialized behind another deletion should return 404, not 500."""
     from gptme.dirs import get_logs_dir

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2326,6 +2326,31 @@ def test_v2_conversation_delete_rejected_during_generation(client: FlaskClient):
     assert "generation is in progress" in response.get_json()["error"]
 
 
+def test_v2_conversation_post_rejected_during_generation(client: FlaskClient):
+    """Appending a message while generation is active should not race the worker."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2.SessionManager.get_sessions_for_conversation"
+    ) as mock_get:
+        mock_session = unittest.mock.MagicMock()
+        mock_session.generating = True
+        mock_get.return_value = [mock_session]
+
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}",
+            json={"role": "user", "content": "This should wait"},
+        )
+
+    assert response.status_code == 409
+    assert "generation is in progress" in response.get_json()["error"]
+
+    conversation = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    assert conversation is not None
+    assert all(msg["content"] != "This should wait" for msg in conversation["log"])
+
+
 def test_v2_conversation_delete_rechecks_existence_under_lock(client: FlaskClient):
     """A DELETE serialized behind another deletion should return 404, not 500."""
     from gptme.dirs import get_logs_dir

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2351,6 +2351,57 @@ def test_v2_conversation_post_rejected_during_generation(client: FlaskClient):
     assert all(msg["content"] != "This should wait" for msg in conversation["log"])
 
 
+def test_v2_conversation_command_releases_lock_while_reserved(client: FlaskClient):
+    """Slow commands reserve the conversation without retaining its lock."""
+    from gptme.server.session_models import SessionManager
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    lock_was_available = False
+
+    def handle_cmd_while_probing_lock(*_args):
+        nonlocal lock_was_available
+        lock = SessionManager.conversation_lock(conversation_id)
+        acquired = lock.acquire(blocking=False)
+        lock_was_available = acquired
+        if acquired:
+            lock.release()
+        assert SessionManager.command_is_active(conversation_id)
+        return iter(())
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2.handle_cmd", side_effect=handle_cmd_while_probing_lock
+    ):
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}",
+            json={"role": "user", "content": "/help"},
+        )
+
+    assert response.status_code == 200
+    assert lock_was_available
+    assert not SessionManager.command_is_active(conversation_id)
+
+
+def test_v2_step_rejected_while_conversation_command_is_active(client: FlaskClient):
+    """Generation cannot start while a synchronous command owns the log."""
+    from gptme.server.session_models import SessionManager
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+    SessionManager.start_command(conversation_id)
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}/step",
+            json={"session_id": session_id},
+        )
+    finally:
+        SessionManager.finish_command(conversation_id)
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == "Generation already in progress"
+
+
 def test_v2_conversation_delete_rechecks_existence_under_lock(client: FlaskClient):
     """A DELETE serialized behind another deletion should return 404, not 500."""
     from gptme.dirs import get_logs_dir


### PR DESCRIPTION
## What

Reject `POST /api/v2/conversations/<id>` with `409` while any session for that conversation is actively generating.

## Why

The other conversation mutation endpoints already guard active generation, but message append did not. That let the server return `200 OK` and mutate the log while the generation worker was running from an older `LogManager` snapshot, which can drop or reorder the user message when the worker writes its response.

## Verification

- RED first: `uv run python3 -m pytest tests/test_server_v2.py::test_v2_conversation_post_rejected_during_generation -q` failed with `assert 200 == 409`
- `uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py`
- `uv run python3 -m pytest tests/test_server_v2.py -q` → `209 passed, 5 skipped`
- pre-commit via `git commit` passed
