### PR TITLE
feat(webui): add Tool Activity Panel to right sidebar

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -125,6 +125,7 @@ class MessageMetadata(TypedDict, total=False):
     usage: UsageData
     voice_call: dict[str, Any]  # Voice call metadata (call_sid, source, etc.)
     artifacts: list[ArtifactDescriptor]  # tool/plugin-emitted artifact descriptors
+    tool: str  # tool that produced this result message
     # Identifies one generated startup-prompt generation. A newer generation
     # supersedes older ones in provider context while all remain on disk.
     prompt_generation: str

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -99,6 +99,7 @@ class MessageDict(TypedDict):
     timestamp: str
     files: NotRequired[list[str] | None]
     hide: NotRequired[bool]
+    call_id: NotRequired[str]
     metadata: NotRequired[dict]
 
 
@@ -294,6 +295,8 @@ def msg2dict(msg: Message, workspace: Path, logdir: Path | None = None) -> Messa
         ]
     if msg.hide:
         result["hide"] = True
+    if msg.call_id:
+        result["call_id"] = msg.call_id
     if msg.metadata:
         result["metadata"] = dict(msg.metadata)
     return result

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -78,6 +78,9 @@ class Message(BaseModel):
     content: str = Field(..., description="Message content")
     timestamp: str = Field(..., description="Message timestamp")
     files: list[str] | None = Field(None, description="Associated files")
+    call_id: str | None = Field(
+        None, description="Tool call identifier for result messages"
+    )
 
 
 class Conversation(BaseModel):

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -778,11 +778,12 @@ class ToolUse:
                         if generator_result is not None:
                             if self.call_id:
                                 # Buffer the generator so we can identify the last
-                                # message and stamp call_id on it. The Responses API
-                                # expects exactly one function_call_output per call_id;
-                                # stamping only the last message ensures the actual
-                                # tool result (not an earlier warning such as a
-                                # shellcheck notice) becomes the function_call_output.
+                                # message and stamp call_id plus tool provenance on it.
+                                # The Responses API expects exactly one
+                                # function_call_output per call_id; stamping only the
+                                # last message ensures the actual tool result (not an
+                                # earlier warning such as a shellcheck notice) becomes
+                                # the function_call_output.
                                 # Earlier messages pass through without call_id and
                                 # become system context instead.
                                 #
@@ -801,11 +802,17 @@ class ToolUse:
                                     result_msgs.append(msg)
                                     if on_result_message:
                                         on_result_message(msg)
-                                    yield (
-                                        msg.replace(call_id=self.call_id)
-                                        if idx == last_idx and _ki is None
-                                        else msg
-                                    )
+                                    if idx == last_idx and _ki is None:
+                                        metadata = (
+                                            dict(msg.metadata) if msg.metadata else {}
+                                        )
+                                        metadata["tool"] = self.tool
+                                        yield msg.replace(
+                                            call_id=self.call_id,
+                                            metadata=metadata,
+                                        )
+                                    else:
+                                        yield msg
                                 if _ki is not None:
                                     raise _ki
                             else:
@@ -821,11 +828,19 @@ class ToolUse:
                             result_msgs = [single_result]
                             if on_result_message:
                                 on_result_message(single_result)
-                            yield (
-                                single_result.replace(call_id=self.call_id)
-                                if self.call_id
-                                else single_result
-                            )
+                            if self.call_id:
+                                metadata = (
+                                    dict(single_result.metadata)
+                                    if single_result.metadata
+                                    else {}
+                                )
+                                metadata["tool"] = self.tool
+                                yield single_result.replace(
+                                    call_id=self.call_id,
+                                    metadata=metadata,
+                                )
+                            else:
+                                yield single_result
                     finally:
                         _current_tool_use.reset(token)
 

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -897,6 +897,7 @@ class ToolUse:
                         "system",
                         f"Error executing tool '{self.tool}': {e}",
                         call_id=self.call_id if not result_msgs else None,
+                        metadata={"tool": self.tool},
                     )
             else:
                 logger.warning(f"Tool '{self.tool}' is not available for execution.")

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -267,6 +267,7 @@ def test_message_metadata():
     meta: MessageMetadata = {
         "model": "claude-sonnet",
         "cost": 0.005,
+        "tool": "shell",
         "usage": {
             "input_tokens": 100,
             "output_tokens": 50,
@@ -280,6 +281,7 @@ def test_message_metadata():
     assert msg.metadata is not None
     assert msg.metadata["model"] == "claude-sonnet"
     assert msg.metadata["cost"] == 0.005
+    assert msg.metadata["tool"] == "shell"
     usage = msg.metadata["usage"]
     assert usage["input_tokens"] == 100
     assert usage["output_tokens"] == 50

--- a/tests/test_server_api_v2_common.py
+++ b/tests/test_server_api_v2_common.py
@@ -220,6 +220,18 @@ class TestMsg2Dict:
         result = msg2dict(msg, tmp_path)
         assert "hide" not in result
 
+    def test_call_id_included_for_tool_result(self, tmp_path):
+        """Tool result identity is exposed to API clients."""
+        msg = Message(role="system", content="result", call_id="call-1")
+        result = msg2dict(msg, tmp_path)
+        assert result["call_id"] == "call-1"
+
+    def test_call_id_omitted_when_absent(self, tmp_path):
+        """Ordinary messages omit the optional call_id key."""
+        msg = Message(role="system", content="context")
+        result = msg2dict(msg, tmp_path)
+        assert "call_id" not in result
+
     def test_timestamp_is_iso_format(self, tmp_path):
         """Timestamp is a valid ISO 8601 string."""
         from datetime import datetime, timezone

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -984,6 +984,29 @@ class TestToolUseFormatting:
         assert yielded[0].metadata == {"artifacts": [], "tool": "test_tool"}
         assert actual_output.metadata == {"artifacts": []}
 
+    def test_execute_adds_tool_provenance_to_error_result(self, monkeypatch):
+        def execute(code, args, kwargs):
+            raise RuntimeError("boom")
+
+        fake_tool = ToolSpec(name="test_tool", desc="test", execute=execute)
+        monkeypatch.setattr("gptme.tools.get_tool", lambda name: fake_tool)
+        monkeypatch.setattr("gptme.hooks.trigger_hook", lambda hook_type, data: [])
+
+        yielded = list(
+            ToolUse(
+                "test_tool",
+                [],
+                None,
+                call_id="call-1",
+                start=0,
+                _format="tool",
+            ).execute()
+        )
+
+        assert yielded[0].call_id == "call-1"
+        assert yielded[0].metadata == {"tool": "test_tool"}
+        assert "boom" in yielded[0].content
+
     def test_execute_on_result_message_streams_generator_progressively(
         self, monkeypatch
     ):

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -955,6 +955,35 @@ class TestToolUseFormatting:
         ]
         assert streamed == [actual_output]
 
+    def test_execute_adds_tool_provenance_to_identified_result(self, monkeypatch):
+        actual_output = Message(
+            "system",
+            "actual output",
+            metadata={"artifacts": []},
+        )
+
+        def execute(code, args, kwargs):
+            yield actual_output
+
+        fake_tool = ToolSpec(name="test_tool", desc="test", execute=execute)
+        monkeypatch.setattr("gptme.tools.get_tool", lambda name: fake_tool)
+        monkeypatch.setattr("gptme.hooks.trigger_hook", lambda hook_type, data: [])
+
+        yielded = list(
+            ToolUse(
+                "test_tool",
+                [],
+                None,
+                call_id="call-1",
+                start=0,
+                _format="tool",
+            ).execute()
+        )
+
+        assert yielded[0].call_id == "call-1"
+        assert yielded[0].metadata == {"artifacts": [], "tool": "test_tool"}
+        assert actual_output.metadata == {"artifacts": []}
+
     def test_execute_on_result_message_streams_generator_progressively(
         self, monkeypatch
     ):

--- a/webui/src/components/ToolActivityPanel.tsx
+++ b/webui/src/components/ToolActivityPanel.tsx
@@ -1,0 +1,141 @@
+import { type FC, useMemo } from 'react';
+import { use$ } from '@legendapp/state/react';
+import { Terminal, FileText, Code, Globe, Monitor, Wrench, ChevronDown } from 'lucide-react';
+import { conversations$ } from '@/stores/conversations';
+import { buildToolActivity, type ToolActivityEntry } from '@/utils/toolActivity';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+
+interface Props {
+  conversationId: string;
+}
+
+function toolIcon(tool: string) {
+  switch (tool) {
+    case 'bash':
+    case 'shell':
+    case 'tmux':
+      return <Terminal className="h-4 w-4 shrink-0" />;
+    case 'python':
+    case 'ipython':
+      return <Code className="h-4 w-4 shrink-0" />;
+    case 'save':
+    case 'append':
+    case 'read':
+    case 'patch':
+      return <FileText className="h-4 w-4 shrink-0" />;
+    case 'browser':
+      return <Globe className="h-4 w-4 shrink-0" />;
+    case 'computer':
+    case 'screenshot':
+      return <Monitor className="h-4 w-4 shrink-0" />;
+    default:
+      return <Wrench className="h-4 w-4 shrink-0" />;
+  }
+}
+
+function formatTimestamp(ts?: string): string {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen) + '…';
+}
+
+const ToolEntryRow: FC<{ entry: ToolActivityEntry }> = ({ entry }) => {
+  const previewLine = entry.lastCall.content.split('\n')[0].trim();
+  const args = entry.lastCall.args.join(' ');
+  const subtitle = args || previewLine;
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="group flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-muted/50">
+        {toolIcon(entry.tool)}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-1">
+            <span className="font-mono text-sm font-medium">{entry.tool}</span>
+            <div className="flex shrink-0 items-center gap-1">
+              <Badge variant="secondary" className="h-4 px-1 text-xs">
+                {entry.callCount}
+              </Badge>
+              <ChevronDown className="h-3 w-3 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+            </div>
+          </div>
+          {subtitle && (
+            <p className="truncate text-xs text-muted-foreground">{truncate(subtitle, 48)}</p>
+          )}
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mx-2 mb-1 rounded-md bg-muted px-2 py-1.5 text-xs">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-muted-foreground">Last call</span>
+            <span className="text-muted-foreground">
+              {formatTimestamp(entry.lastCall.timestamp)}
+            </span>
+          </div>
+          {entry.lastCall.args.length > 0 && (
+            <div className="mb-1">
+              <span className="text-muted-foreground">Args: </span>
+              <code className="text-foreground">{entry.lastCall.args.join(' ')}</code>
+            </div>
+          )}
+          {entry.lastCall.content && (
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-foreground">
+              {truncate(entry.lastCall.content.trim(), 200)}
+            </pre>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export const ToolActivityPanel: FC<Props> = ({ conversationId }) => {
+  const log = use$(conversations$.get(conversationId)?.data.log);
+  const activity = useMemo(() => buildToolActivity(log ?? []), [log]);
+
+  if (!log || log.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center text-muted-foreground">
+        <Wrench className="h-8 w-8 opacity-40" />
+        <p className="text-sm">No messages yet</p>
+      </div>
+    );
+  }
+
+  if (activity.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center text-muted-foreground">
+        <Wrench className="h-8 w-8 opacity-40" />
+        <p className="text-sm">No tool calls in this session</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <h3 className="text-sm font-medium">Tool Activity</h3>
+        <Badge variant="outline" className="text-xs">
+          {activity.reduce((s, e) => s + e.callCount, 0)} calls
+        </Badge>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-1">
+          {activity.map((entry) => (
+            <ToolEntryRow key={entry.tool} entry={entry} />
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+};

--- a/webui/src/components/ToolActivityPanel.tsx
+++ b/webui/src/components/ToolActivityPanel.tsx
@@ -100,7 +100,9 @@ const ToolEntryRow: FC<{ entry: ToolActivityEntry }> = ({ entry }) => {
 };
 
 export const ToolActivityPanel: FC<Props> = ({ conversationId }) => {
-  const log = use$(conversations$.get(conversationId)?.data.log);
+  const conversation = conversations$.get(conversationId);
+  const log = use$(conversation?.data.log);
+  const hasMoreBefore = use$(conversation?.hasMoreBefore) ?? false;
   const activity = useMemo(() => buildToolActivity(log ?? []), [log]);
 
   if (!log || log.length === 0) {
@@ -116,18 +118,28 @@ export const ToolActivityPanel: FC<Props> = ({ conversationId }) => {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center text-muted-foreground">
         <Wrench className="h-8 w-8 opacity-40" />
-        <p className="text-sm">No tool calls in this session</p>
+        <p className="text-sm">
+          {hasMoreBefore ? 'No tool calls in loaded messages' : 'No tool calls in this session'}
+        </p>
+        {hasMoreBefore && (
+          <p className="text-xs">Load older messages in the conversation to include them.</p>
+        )}
       </div>
     );
   }
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <h3 className="text-sm font-medium">Tool Activity</h3>
-        <Badge variant="outline" className="text-xs">
-          {activity.reduce((s, e) => s + e.callCount, 0)} calls
-        </Badge>
+      <div className="border-b px-3 py-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Tool Activity</h3>
+          <Badge variant="outline" className="text-xs">
+            {activity.reduce((s, e) => s + e.callCount, 0)} calls
+          </Badge>
+        </div>
+        {hasMoreBefore && (
+          <p className="mt-1 text-xs text-muted-foreground">Loaded messages only</p>
+        )}
       </div>
       <ScrollArea className="flex-1">
         <div className="p-1">

--- a/webui/src/components/rightSidebarPanels.tsx
+++ b/webui/src/components/rightSidebarPanels.tsx
@@ -8,6 +8,7 @@ import {
   Monitor,
   Package,
   SlidersHorizontal,
+  Wrench,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { RightSidebarPanelId } from '@/types/sidebar';
@@ -18,6 +19,7 @@ import { ComputerPreview } from './ComputerPreview';
 import { ConversationSettings } from './ConversationSettings';
 import { FunctionBrowserPanel } from './FunctionBrowserPanel';
 import { PanelsPanel } from './PanelsPanel';
+import { ToolActivityPanel } from './ToolActivityPanel';
 import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
 
 interface RightSidebarPanelRenderProps {
@@ -67,6 +69,12 @@ export const rightSidebarPanels: RightSidebarPanelDefinition[] = [
     label: 'Functions',
     icon: Cpu,
     render: () => <FunctionBrowserPanel />,
+  },
+  {
+    id: 'tools',
+    label: 'Tool Activity',
+    icon: Wrench,
+    render: ({ conversationId }) => <ToolActivityPanel conversationId={conversationId} />,
   },
   {
     id: 'browser',

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -19,6 +19,7 @@ export interface Message {
   timestamp?: string;
   files?: string[];
   hide?: boolean;
+  call_id?: string;
   metadata?: MessageMetadata;
   /** Client-only: tracks send status for optimistic messages */
   _status?: 'pending' | 'sent' | 'failed';

--- a/webui/src/types/conversation.ts
+++ b/webui/src/types/conversation.ts
@@ -11,6 +11,7 @@ export interface MessageMetadata {
   model?: string;
   cost?: number;
   usage?: MessageUsage;
+  tool?: string;
 }
 
 export interface Message {

--- a/webui/src/types/sidebar.ts
+++ b/webui/src/types/sidebar.ts
@@ -5,5 +5,6 @@ export type RightSidebarPanelId =
   | 'branches'
   | 'panels'
   | 'functions'
+  | 'tools'
   | 'browser'
   | 'computer';

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -5,6 +5,8 @@ function msg(content: string, role: Message['role'] = 'assistant', ts?: string):
   return { role, content, timestamp: ts };
 }
 
+const toolResult = (content = 'Tool completed') => msg(content, 'system');
+
 describe('buildToolActivity', () => {
   it('returns empty for no messages', () => {
     expect(buildToolActivity([])).toEqual([]);
@@ -18,98 +20,129 @@ describe('buildToolActivity', () => {
   it('ignores non-gptme code blocks', () => {
     const messages = [
       msg('```typescript\nconst x = 1;\n```', 'assistant'),
+      toolResult(),
       msg('```json\n{"a": 1}\n```', 'assistant'),
+      toolResult(),
     ];
     expect(buildToolActivity(messages)).toEqual([]);
   });
 
-  it('detects a bash tool call', () => {
-    const messages = [msg('```bash\nls -la\n```', 'assistant', '2026-08-01T00:00:00Z')];
-    const result = buildToolActivity(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0].tool).toBe('bash');
-    expect(result[0].callCount).toBe(1);
-    expect(result[0].lastCall.content).toBe('ls -la\n');
+  it('detects a shell tool call followed by an execution result', () => {
+    const messages = [
+      msg('```shell\nls -la\n```', 'assistant', '2026-08-01T00:00:00Z'),
+      toolResult(),
+    ];
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('shell');
+    expect(activity[0].callCount).toBe(1);
+    expect(activity[0].lastCall.content).toBe('ls -la');
   });
 
   it('detects save tool call with filename arg', () => {
-    const messages = [msg('```save myfile.py\nprint("hello")\n```', 'assistant')];
-    const result = buildToolActivity(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0].tool).toBe('save');
-    expect(result[0].lastCall.args).toEqual(['myfile.py']);
+    const messages = [msg('```save myfile.py\nprint("hello")\n```'), toolResult()];
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('save');
+    expect(activity[0].lastCall.args).toEqual(['myfile.py']);
   });
 
   it('counts multiple calls to the same tool', () => {
     const messages = [
-      msg('```bash\nls\n```', 'assistant'),
-      msg('```bash\npwd\n```', 'assistant'),
-      msg('```bash\necho hi\n```', 'assistant'),
+      msg('```shell\nls\n```'),
+      toolResult(),
+      msg('```shell\npwd\n```'),
+      toolResult(),
+      msg('```shell\necho hi\n```'),
+      toolResult(),
     ];
-    const result = buildToolActivity(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0].tool).toBe('bash');
-    expect(result[0].callCount).toBe(3);
-    expect(result[0].lastCall.content).toBe('echo hi\n');
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('shell');
+    expect(activity[0].callCount).toBe(3);
+    expect(activity[0].lastCall.content).toBe('echo hi');
   });
 
   it('tracks multiple distinct tools', () => {
     const messages = [
-      msg('```bash\nls\n```', 'assistant'),
-      msg('```python\nprint("hi")\n```', 'assistant'),
-      msg('```save out.txt\nhello\n```', 'assistant'),
+      msg('```shell\nls\n```'),
+      toolResult(),
+      msg('```ipython\nprint("hi")\n```'),
+      toolResult(),
+      msg('```save out.txt\nhello\n```'),
+      toolResult(),
     ];
-    const result = buildToolActivity(messages);
-    expect(result).toHaveLength(3);
-    const tools = result.map((e) => e.tool);
-    expect(tools).toContain('bash');
-    expect(tools).toContain('python');
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(3);
+    const tools = activity.map((entry) => entry.tool);
+    expect(tools).toContain('shell');
+    expect(tools).toContain('ipython');
     expect(tools).toContain('save');
   });
 
   it('sorts by call count descending', () => {
     const messages = [
-      msg('```python\nprint(1)\n```', 'assistant'),
-      msg('```bash\nls\n```', 'assistant'),
-      msg('```bash\npwd\n```', 'assistant'),
+      msg('```ipython\nprint(1)\n```'),
+      toolResult(),
+      msg('```shell\nls\n```'),
+      toolResult(),
+      msg('```shell\npwd\n```'),
+      toolResult(),
     ];
-    const result = buildToolActivity(messages);
-    expect(result[0].tool).toBe('bash');
-    expect(result[0].callCount).toBe(2);
-    expect(result[1].tool).toBe('python');
-    expect(result[1].callCount).toBe(1);
+    const activity = buildToolActivity(messages);
+    expect(activity[0].tool).toBe('shell');
+    expect(activity[0].callCount).toBe(2);
+    expect(activity[1].tool).toBe('ipython');
+    expect(activity[1].callCount).toBe(1);
   });
 
   it('ignores tool calls in non-assistant messages', () => {
     const messages = [
-      msg('```bash\nls\n```', 'user'),
-      msg('```bash\npwd\n```', 'system'),
-      msg('```bash\necho ok\n```', 'tool'),
+      msg('```shell\nls\n```', 'user'),
+      msg('```shell\npwd\n```', 'system'),
+      msg('```shell\necho ok\n```', 'tool'),
     ];
     expect(buildToolActivity(messages)).toHaveLength(0);
   });
 
-  it('handles ipython/shell aliases', () => {
+  it('uses the canonical tool allowlist', () => {
     const messages = [
-      msg('```ipython\nimport os\n```', 'assistant'),
-      msg('```shell\necho hi\n```', 'assistant'),
+      msg('```mcp\nlist servers\n```'),
+      toolResult(),
+      msg('```gh\npr view 1\n```'),
+      toolResult(),
     ];
-    const result = buildToolActivity(messages);
-    expect(result).toHaveLength(2);
-    const tools = result.map((e) => e.tool);
-    expect(tools).toContain('ipython');
-    expect(tools).toContain('shell');
+    const tools = buildToolActivity(messages).map((entry) => entry.tool);
+    expect(tools).toContain('mcp');
+    expect(tools).toContain('gh');
   });
 
   it('preserves firstSeen timestamp from first call', () => {
     const ts1 = '2026-08-01T00:00:00Z';
     const ts2 = '2026-08-01T01:00:00Z';
     const messages = [
-      msg('```bash\nls\n```', 'assistant', ts1),
-      msg('```bash\npwd\n```', 'assistant', ts2),
+      msg('```shell\nls\n```', 'assistant', ts1),
+      toolResult(),
+      msg('```shell\npwd\n```', 'assistant', ts2),
+      toolResult(),
     ];
-    const result = buildToolActivity(messages);
-    expect(result[0].firstSeen).toBe(ts1);
-    expect(result[0].lastCall.timestamp).toBe(ts2);
+    const activity = buildToolActivity(messages);
+    expect(activity[0].firstSeen).toBe(ts1);
+    expect(activity[0].lastCall.timestamp).toBe(ts2);
+  });
+
+  it('does not count a recognized code example without a tool result', () => {
+    const messages = [msg('For example:\n```ipython\nprint("hello")\n```'), msg('Thanks', 'user')];
+    expect(buildToolActivity(messages)).toEqual([]);
+  });
+
+  it('counts only calls with corresponding result messages', () => {
+    const messages = [
+      msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
+      toolResult('Ran command'),
+    ];
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('shell');
   });
 });

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -1,0 +1,115 @@
+import { buildToolActivity } from '../toolActivity';
+import type { Message } from '@/types/conversation';
+
+function msg(content: string, role: Message['role'] = 'assistant', ts?: string): Message {
+  return { role, content, timestamp: ts };
+}
+
+describe('buildToolActivity', () => {
+  it('returns empty for no messages', () => {
+    expect(buildToolActivity([])).toEqual([]);
+  });
+
+  it('returns empty when no tool calls exist', () => {
+    const messages = [msg('Hello world', 'user'), msg('Sure, I can help.', 'assistant')];
+    expect(buildToolActivity(messages)).toEqual([]);
+  });
+
+  it('ignores non-gptme code blocks', () => {
+    const messages = [
+      msg('```typescript\nconst x = 1;\n```', 'assistant'),
+      msg('```json\n{"a": 1}\n```', 'assistant'),
+    ];
+    expect(buildToolActivity(messages)).toEqual([]);
+  });
+
+  it('detects a bash tool call', () => {
+    const messages = [msg('```bash\nls -la\n```', 'assistant', '2026-08-01T00:00:00Z')];
+    const result = buildToolActivity(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].tool).toBe('bash');
+    expect(result[0].callCount).toBe(1);
+    expect(result[0].lastCall.content).toBe('ls -la\n');
+  });
+
+  it('detects save tool call with filename arg', () => {
+    const messages = [msg('```save myfile.py\nprint("hello")\n```', 'assistant')];
+    const result = buildToolActivity(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].tool).toBe('save');
+    expect(result[0].lastCall.args).toEqual(['myfile.py']);
+  });
+
+  it('counts multiple calls to the same tool', () => {
+    const messages = [
+      msg('```bash\nls\n```', 'assistant'),
+      msg('```bash\npwd\n```', 'assistant'),
+      msg('```bash\necho hi\n```', 'assistant'),
+    ];
+    const result = buildToolActivity(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].tool).toBe('bash');
+    expect(result[0].callCount).toBe(3);
+    expect(result[0].lastCall.content).toBe('echo hi\n');
+  });
+
+  it('tracks multiple distinct tools', () => {
+    const messages = [
+      msg('```bash\nls\n```', 'assistant'),
+      msg('```python\nprint("hi")\n```', 'assistant'),
+      msg('```save out.txt\nhello\n```', 'assistant'),
+    ];
+    const result = buildToolActivity(messages);
+    expect(result).toHaveLength(3);
+    const tools = result.map((e) => e.tool);
+    expect(tools).toContain('bash');
+    expect(tools).toContain('python');
+    expect(tools).toContain('save');
+  });
+
+  it('sorts by call count descending', () => {
+    const messages = [
+      msg('```python\nprint(1)\n```', 'assistant'),
+      msg('```bash\nls\n```', 'assistant'),
+      msg('```bash\npwd\n```', 'assistant'),
+    ];
+    const result = buildToolActivity(messages);
+    expect(result[0].tool).toBe('bash');
+    expect(result[0].callCount).toBe(2);
+    expect(result[1].tool).toBe('python');
+    expect(result[1].callCount).toBe(1);
+  });
+
+  it('ignores tool calls in non-assistant messages', () => {
+    const messages = [
+      msg('```bash\nls\n```', 'user'),
+      msg('```bash\npwd\n```', 'system'),
+      msg('```bash\necho ok\n```', 'tool'),
+    ];
+    expect(buildToolActivity(messages)).toHaveLength(0);
+  });
+
+  it('handles ipython/shell aliases', () => {
+    const messages = [
+      msg('```ipython\nimport os\n```', 'assistant'),
+      msg('```shell\necho hi\n```', 'assistant'),
+    ];
+    const result = buildToolActivity(messages);
+    expect(result).toHaveLength(2);
+    const tools = result.map((e) => e.tool);
+    expect(tools).toContain('ipython');
+    expect(tools).toContain('shell');
+  });
+
+  it('preserves firstSeen timestamp from first call', () => {
+    const ts1 = '2026-08-01T00:00:00Z';
+    const ts2 = '2026-08-01T01:00:00Z';
+    const messages = [
+      msg('```bash\nls\n```', 'assistant', ts1),
+      msg('```bash\npwd\n```', 'assistant', ts2),
+    ];
+    const result = buildToolActivity(messages);
+    expect(result[0].firstSeen).toBe(ts1);
+    expect(result[0].lastCall.timestamp).toBe(ts2);
+  });
+});

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -5,7 +5,10 @@ function msg(content: string, role: Message['role'] = 'assistant', ts?: string):
   return { role, content, timestamp: ts };
 }
 
-const toolResult = (content = 'Tool completed') => msg(content, 'system');
+const toolResult = (content = 'Tool completed'): Message => ({
+  ...msg(content, 'system'),
+  call_id: 'call-1',
+});
 
 describe('buildToolActivity', () => {
   it('returns empty for no messages', () => {
@@ -142,13 +145,37 @@ describe('buildToolActivity', () => {
     expect(buildToolActivity(messages)).toEqual([]);
   });
 
-  it('does not treat a TURN_POST system message as execution evidence', () => {
+  it('does not treat a hook message after an identified result as another result', () => {
     const messages = [
-      msg('For example:\n```ipython\nprint("hello")\n```'),
+      msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
+      toolResult(),
       msg('# Relevant Lessons', 'system'),
-      msg('Thanks', 'user'),
+      msg('Done'),
     ];
-    expect(buildToolActivity(messages)).toEqual([]);
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('shell');
+  });
+
+  it('keeps the legacy continuation heuristic when no result has an ID', () => {
+    const messages = [msg('```shell\nls\n```'), msg('legacy tool output', 'system'), msg('Done')];
+    expect(buildToolActivity(messages)).toHaveLength(1);
+  });
+
+  it('counts an identified result even when no assistant continuation follows', () => {
+    const messages = [msg('```shell\nls\n```'), toolResult()];
+    expect(buildToolActivity(messages)).toHaveLength(1);
+  });
+
+  it('ignores hook output interleaved with a real tool result', () => {
+    const messages = [
+      msg('```shell\nls\n```'),
+      msg('# Tool pre-hook context', 'system'),
+      toolResult(),
+      msg('# Tool post-hook context', 'system'),
+      msg('Done'),
+    ];
+    expect(buildToolActivity(messages)).toHaveLength(1);
   });
 
   it('counts only calls with corresponding result messages', () => {

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -27,10 +27,11 @@ describe('buildToolActivity', () => {
     expect(buildToolActivity(messages)).toEqual([]);
   });
 
-  it('detects a shell tool call followed by an execution result', () => {
+  it('detects a shell tool call followed by an execution result and continuation', () => {
     const messages = [
       msg('```shell\nls -la\n```', 'assistant', '2026-08-01T00:00:00Z'),
       toolResult(),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(1);
@@ -40,7 +41,7 @@ describe('buildToolActivity', () => {
   });
 
   it('detects save tool call with filename arg', () => {
-    const messages = [msg('```save myfile.py\nprint("hello")\n```'), toolResult()];
+    const messages = [msg('```save myfile.py\nprint("hello")\n```'), toolResult(), msg('Done')];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(1);
     expect(activity[0].tool).toBe('save');
@@ -55,6 +56,7 @@ describe('buildToolActivity', () => {
       toolResult(),
       msg('```shell\necho hi\n```'),
       toolResult(),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(1);
@@ -71,6 +73,7 @@ describe('buildToolActivity', () => {
       toolResult(),
       msg('```save out.txt\nhello\n```'),
       toolResult(),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(3);
@@ -88,6 +91,7 @@ describe('buildToolActivity', () => {
       toolResult(),
       msg('```shell\npwd\n```'),
       toolResult(),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity[0].tool).toBe('shell');
@@ -111,6 +115,7 @@ describe('buildToolActivity', () => {
       toolResult(),
       msg('```gh\npr view 1\n```'),
       toolResult(),
+      msg('Done'),
     ];
     const tools = buildToolActivity(messages).map((entry) => entry.tool);
     expect(tools).toContain('mcp');
@@ -125,6 +130,7 @@ describe('buildToolActivity', () => {
       toolResult(),
       msg('```shell\npwd\n```', 'assistant', ts2),
       toolResult(),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity[0].firstSeen).toBe(ts1);
@@ -136,10 +142,20 @@ describe('buildToolActivity', () => {
     expect(buildToolActivity(messages)).toEqual([]);
   });
 
+  it('does not treat a TURN_POST system message as execution evidence', () => {
+    const messages = [
+      msg('For example:\n```ipython\nprint("hello")\n```'),
+      msg('# Relevant Lessons', 'system'),
+      msg('Thanks', 'user'),
+    ];
+    expect(buildToolActivity(messages)).toEqual([]);
+  });
+
   it('counts only calls with corresponding result messages', () => {
     const messages = [
       msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
       toolResult('Ran command'),
+      msg('Done'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(1);

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -5,9 +5,10 @@ function msg(content: string, role: Message['role'] = 'assistant', ts?: string):
   return { role, content, timestamp: ts };
 }
 
-const toolResult = (content = 'Tool completed'): Message => ({
+const toolResult = (content = 'Tool completed', tool?: string): Message => ({
   ...msg(content, 'system'),
   call_id: 'call-1',
+  metadata: tool ? { tool } : undefined,
 });
 
 describe('buildToolActivity', () => {
@@ -183,6 +184,27 @@ describe('buildToolActivity', () => {
       msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
       toolResult('Ran command'),
       msg('Done'),
+    ];
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('shell');
+  });
+
+  it('matches mixed native and markdown-format results by tool provenance', () => {
+    const messages = [
+      msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
+      toolResult('Saved file', 'save'),
+    ];
+    const activity = buildToolActivity(messages);
+    expect(activity).toHaveLength(1);
+    expect(activity[0].tool).toBe('save');
+  });
+
+  it('does not count untagged hook output in a mixed result batch', () => {
+    const messages = [
+      msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
+      msg('# Relevant Lessons', 'system'),
+      toolResult('Ran command', 'shell'),
     ];
     const activity = buildToolActivity(messages);
     expect(activity).toHaveLength(1);

--- a/webui/src/utils/__tests__/toolActivity.test.ts
+++ b/webui/src/utils/__tests__/toolActivity.test.ts
@@ -210,4 +210,14 @@ describe('buildToolActivity', () => {
     expect(activity).toHaveLength(1);
     expect(activity[0].tool).toBe('shell');
   });
+
+  it('counts both successful and failed identified tools in one batch', () => {
+    const messages = [
+      msg('```shell\nls\n```\n```save out.txt\nhello\n```'),
+      toolResult('Ran command', 'shell'),
+      toolResult('Error executing save', 'save'),
+    ];
+    const activity = buildToolActivity(messages);
+    expect(activity.map((entry) => entry.tool)).toEqual(['shell', 'save']);
+  });
 });

--- a/webui/src/utils/toolActivity.ts
+++ b/webui/src/utils/toolActivity.ts
@@ -25,23 +25,38 @@ function parseExecutedToolCalls(messages: Message[]): ToolCall[] {
     const parsedCalls = parseToolCalls(message.content);
     if (parsedCalls.length === 0) continue;
 
-    // Native tool results carry call_id while hook/context system messages do
-    // not. Legacy markdown logs predate call IDs, so retain the conservative
-    // system-result + assistant-continuation fallback for those logs only.
+    // New result messages carry explicit tool provenance. Fall back to call_id
+    // counts for older native-tool logs, then to the conservative continuation
+    // heuristic for legacy markdown logs. A mixed batch can therefore match
+    // identified and untagged results without treating hook output as execution.
     let next = index + 1;
     const resultMessages: Message[] = [];
     while (next < messages.length && messages[next].role === 'system') {
       resultMessages.push(messages[next]);
       next++;
     }
-    const hasIdentifiedResults = resultMessages.some((result) => result.call_id);
-    const resultCount = hasIdentifiedResults
-      ? resultMessages.filter((result) => result.call_id).length
-      : next < messages.length && messages[next].role === 'assistant'
-        ? resultMessages.length
-        : 0;
+    const remainingByTool = new Map<string, number>();
+    for (const result of resultMessages) {
+      const tool = result.metadata?.tool?.toLowerCase();
+      if (tool) remainingByTool.set(tool, (remainingByTool.get(tool) ?? 0) + 1);
+    }
+    const identifiedResultCount = resultMessages.filter((result) => result.call_id).length;
+    let fallbackCount = remainingByTool.size > 0 ? 0 : identifiedResultCount;
+    if (fallbackCount === 0 && remainingByTool.size === 0) {
+      fallbackCount =
+        next < messages.length && messages[next].role === 'assistant' ? resultMessages.length : 0;
+    }
 
-    for (const call of parsedCalls.slice(0, resultCount)) {
+    for (const call of parsedCalls) {
+      const tool = call.tool.toLowerCase();
+      const matchingResults = remainingByTool.get(tool) ?? 0;
+      if (matchingResults > 0) {
+        remainingByTool.set(tool, matchingResults - 1);
+      } else if (fallbackCount > 0) {
+        fallbackCount--;
+      } else {
+        continue;
+      }
       const args = call.args;
       const content = call.content || args[0] || '';
       calls.push({

--- a/webui/src/utils/toolActivity.ts
+++ b/webui/src/utils/toolActivity.ts
@@ -1,20 +1,5 @@
 import type { Message } from '@/types/conversation';
-
-// Known gptme tool names that appear as code block language identifiers
-const GPTME_TOOLS = new Set([
-  'bash',
-  'shell',
-  'python',
-  'ipython',
-  'save',
-  'append',
-  'patch',
-  'read',
-  'computer',
-  'browser',
-  'screenshot',
-  'tmux',
-]);
+import { parseToolCalls } from './toolCallParser';
 
 export interface ToolCall {
   tool: string;
@@ -30,42 +15,54 @@ export interface ToolActivityEntry {
   firstSeen?: string;
 }
 
-const TOOL_CALL_RE = /```(\w+)(?:[ \t]+([^\n]*))?\n([\s\S]*?)```/g;
-
-function parseToolCallsFromMessage(message: Message): ToolCall[] {
-  if (message.role !== 'assistant') return [];
+function parseExecutedToolCalls(messages: Message[]): ToolCall[] {
   const calls: ToolCall[] = [];
-  let match: RegExpExecArray | null;
-  TOOL_CALL_RE.lastIndex = 0;
-  while ((match = TOOL_CALL_RE.exec(message.content)) !== null) {
-    const toolName = match[1].toLowerCase();
-    if (!GPTME_TOOLS.has(toolName)) continue;
-    const rawArgs = match[2]?.trim() || '';
-    const args = rawArgs ? rawArgs.split(/\s+/) : [];
-    const content = match[3] || '';
-    calls.push({ tool: toolName, args, content, timestamp: message.timestamp });
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.role !== 'assistant') continue;
+
+    const parsedCalls = parseToolCalls(message.content);
+    if (parsedCalls.length === 0) continue;
+
+    // Markdown tool calls have no persisted call ID. A call is only known to have
+    // executed when its assistant message is followed by one or more system
+    // result messages. Plain examples in a final response have no such result.
+    let resultCount = 0;
+    for (let next = index + 1; next < messages.length && messages[next].role === 'system'; next++) {
+      resultCount++;
+    }
+
+    for (const call of parsedCalls.slice(0, resultCount)) {
+      const args = call.args;
+      const content = call.content || args[0] || '';
+      calls.push({
+        tool: call.tool.toLowerCase(),
+        args,
+        content,
+        timestamp: message.timestamp,
+      });
+    }
   }
+
   return calls;
 }
 
 export function buildToolActivity(messages: Message[]): ToolActivityEntry[] {
   const byTool = new Map<string, ToolActivityEntry>();
 
-  for (const message of messages) {
-    const calls = parseToolCallsFromMessage(message);
-    for (const call of calls) {
-      const existing = byTool.get(call.tool);
-      if (existing) {
-        existing.callCount++;
-        existing.lastCall = call;
-      } else {
-        byTool.set(call.tool, {
-          tool: call.tool,
-          callCount: 1,
-          lastCall: call,
-          firstSeen: call.timestamp,
-        });
-      }
+  for (const call of parseExecutedToolCalls(messages)) {
+    const existing = byTool.get(call.tool);
+    if (existing) {
+      existing.callCount++;
+      existing.lastCall = call;
+    } else {
+      byTool.set(call.tool, {
+        tool: call.tool,
+        callCount: 1,
+        lastCall: call,
+        firstSeen: call.timestamp,
+      });
     }
   }
 

--- a/webui/src/utils/toolActivity.ts
+++ b/webui/src/utils/toolActivity.ts
@@ -1,0 +1,73 @@
+import type { Message } from '@/types/conversation';
+
+// Known gptme tool names that appear as code block language identifiers
+const GPTME_TOOLS = new Set([
+  'bash',
+  'shell',
+  'python',
+  'ipython',
+  'save',
+  'append',
+  'patch',
+  'read',
+  'computer',
+  'browser',
+  'screenshot',
+  'tmux',
+]);
+
+export interface ToolCall {
+  tool: string;
+  args: string[];
+  content: string;
+  timestamp?: string;
+}
+
+export interface ToolActivityEntry {
+  tool: string;
+  callCount: number;
+  lastCall: ToolCall;
+  firstSeen?: string;
+}
+
+const TOOL_CALL_RE = /```(\w+)(?:[ \t]+([^\n]*))?\n([\s\S]*?)```/g;
+
+function parseToolCallsFromMessage(message: Message): ToolCall[] {
+  if (message.role !== 'assistant') return [];
+  const calls: ToolCall[] = [];
+  let match: RegExpExecArray | null;
+  TOOL_CALL_RE.lastIndex = 0;
+  while ((match = TOOL_CALL_RE.exec(message.content)) !== null) {
+    const toolName = match[1].toLowerCase();
+    if (!GPTME_TOOLS.has(toolName)) continue;
+    const rawArgs = match[2]?.trim() || '';
+    const args = rawArgs ? rawArgs.split(/\s+/) : [];
+    const content = match[3] || '';
+    calls.push({ tool: toolName, args, content, timestamp: message.timestamp });
+  }
+  return calls;
+}
+
+export function buildToolActivity(messages: Message[]): ToolActivityEntry[] {
+  const byTool = new Map<string, ToolActivityEntry>();
+
+  for (const message of messages) {
+    const calls = parseToolCallsFromMessage(message);
+    for (const call of calls) {
+      const existing = byTool.get(call.tool);
+      if (existing) {
+        existing.callCount++;
+        existing.lastCall = call;
+      } else {
+        byTool.set(call.tool, {
+          tool: call.tool,
+          callCount: 1,
+          lastCall: call,
+          firstSeen: call.timestamp,
+        });
+      }
+    }
+  }
+
+  return Array.from(byTool.values()).sort((a, b) => b.callCount - a.callCount);
+}

--- a/webui/src/utils/toolActivity.ts
+++ b/webui/src/utils/toolActivity.ts
@@ -25,14 +25,17 @@ function parseExecutedToolCalls(messages: Message[]): ToolCall[] {
     const parsedCalls = parseToolCalls(message.content);
     if (parsedCalls.length === 0) continue;
 
-    // Markdown tool calls have no persisted call ID. A call is only known to have
-    // executed when its assistant message is followed by one or more system
-    // result messages. Plain examples in a final response have no such result.
-    let resultCount = 0;
-    for (let next = index + 1; next < messages.length && messages[next].role === 'system'; next++) {
-      resultCount++;
+    // Markdown tool calls have no persisted call ID. A completed tool step has
+    // system output followed by the assistant's continuation. TURN_POST hooks
+    // can also emit system messages immediately after a final response, so a
+    // system message alone is not evidence that a fenced example executed.
+    let next = index + 1;
+    while (next < messages.length && messages[next].role === 'system') {
+      next++;
     }
+    if (next >= messages.length || messages[next].role !== 'assistant') continue;
 
+    const resultCount = next - index - 1;
     for (const call of parsedCalls.slice(0, resultCount)) {
       const args = call.args;
       const content = call.content || args[0] || '';

--- a/webui/src/utils/toolActivity.ts
+++ b/webui/src/utils/toolActivity.ts
@@ -25,17 +25,22 @@ function parseExecutedToolCalls(messages: Message[]): ToolCall[] {
     const parsedCalls = parseToolCalls(message.content);
     if (parsedCalls.length === 0) continue;
 
-    // Markdown tool calls have no persisted call ID. A completed tool step has
-    // system output followed by the assistant's continuation. TURN_POST hooks
-    // can also emit system messages immediately after a final response, so a
-    // system message alone is not evidence that a fenced example executed.
+    // Native tool results carry call_id while hook/context system messages do
+    // not. Legacy markdown logs predate call IDs, so retain the conservative
+    // system-result + assistant-continuation fallback for those logs only.
     let next = index + 1;
+    const resultMessages: Message[] = [];
     while (next < messages.length && messages[next].role === 'system') {
+      resultMessages.push(messages[next]);
       next++;
     }
-    if (next >= messages.length || messages[next].role !== 'assistant') continue;
+    const hasIdentifiedResults = resultMessages.some((result) => result.call_id);
+    const resultCount = hasIdentifiedResults
+      ? resultMessages.filter((result) => result.call_id).length
+      : next < messages.length && messages[next].role === 'assistant'
+        ? resultMessages.length
+        : 0;
 
-    const resultCount = next - index - 1;
     for (const call of parsedCalls.slice(0, resultCount)) {
       const args = call.args;
       const content = call.content || args[0] || '';


### PR DESCRIPTION
## Summary

- Adds a **Tool Activity** panel (Wrench icon) to the webui right sidebar showing which gptme tools were used in the current session — name, call count, last args/content preview, and timestamp
- Parses assistant messages for markdown code blocks with known gptme tool names (bash, python, save, append, patch, browser, tmux, etc.) and maintains a per-session inventory sorted by call count
- Each tool row is collapsible to show the last call's args and content digest

## Motivation

Tool calls appear inline in the chat stream but vanish into scroll history. When a session runs many tool calls, it's hard to answer "what has the agent actually done?" without scrolling back. This panel surfaces that information persistently, reducing the cognitive load of understanding agent state — a key usability gap highlighted in the [HN GUI for AI agents](https://news.ycombinator.com/item?id=49119274) discussion.

## Implementation

- `webui/src/utils/toolActivity.ts`: `buildToolActivity(messages)` parses code fences from assistant messages, filtering to known gptme tool names, and returns `ToolActivityEntry[]` sorted by call count
- `webui/src/components/ToolActivityPanel.tsx`: collapsible sidebar panel with per-tool icons and content preview
- `webui/src/utils/__tests__/toolActivity.test.ts`: 11 unit tests covering parsing, deduplication, sorting, and edge cases
- `webui/src/components/rightSidebarPanels.tsx` + `webui/src/types/sidebar.ts`: register panel in existing sidebar plugin architecture

## Test plan

- [ ] Unit tests: `cd webui && npx jest src/utils/__tests__/toolActivity.test.ts` (11 tests, all passing)
- [ ] TypeScript: `cd webui && npx tsc --noEmit` (clean)
- [ ] ESLint: `cd webui && npx eslint src/utils/toolActivity.ts src/components/ToolActivityPanel.tsx` (clean)
- [ ] Manual: open a gptme session that runs bash/python/save tool calls, click Wrench icon in right sidebar, verify tool inventory updates live