### PR TITLE
fix(server): acquire step_lock in interrupt endpoint to prevent race

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -1090,18 +1090,19 @@ def api_conversation_interrupt(conversation_id: str):
             }
         ), 403
 
-    if not session.generating and not session.pending_tools:
-        # Idempotent: if nothing is generating, treat as already interrupted
-        return flask.jsonify(
-            {"status": "ok", "message": "Already interrupted or not generating"}
-        )
+    with session.step_lock:
+        if not session.generating and not session.pending_tools:
+            # Idempotent: if nothing is generating, treat as already interrupted
+            return flask.jsonify(
+                {"status": "ok", "message": "Already interrupted or not generating"}
+            )
 
-    # Mark session as not generating
-    session.generating = False
-    session.generating_since = None
+        # Mark session as not generating
+        session.generating = False
+        session.generating_since = None
 
-    # Clear pending tools
-    session.pending_tools.clear()
+        # Clear pending tools
+        session.pending_tools.clear()
 
     # Notify about interruption
     SessionManager.add_event(conversation_id, {"type": "interrupted"})


### PR DESCRIPTION
## Summary
Fixed a race condition in the interrupt endpoint that could cause concurrent generation issues.

The interrupt endpoint was checking and modifying `session.generating` and `session.pending_tools` without holding `step_lock`, creating a TOCTOU (Time-Of-Check-Time-Of-Use) window:

1. Interrupt thread reads `generating=False`
2. Step thread acquires `step_lock`, sets `generating=True`
3. Interrupt thread proceeds to modify session state while Step thread is writing

## Changes
- Wrapped the check-and-set logic in the interrupt endpoint with `step_lock` to serialize access
- Consistent with PR #3401 which fixed similar issues in fork/edit/delete/config endpoints

## Testing
- Existing interrupt endpoint tests still pass
- The fix mirrors the pattern established in PR #3401