### PR TITLE
feat(k-best): add k_best_guess decorator for K-candidate validation

### DIFF
--- a/gptme/__init__.py
+++ b/gptme/__init__.py
@@ -10,7 +10,15 @@ warnings.filterwarnings(
     message=r"urllib3 .* or chardet.*charset_normalizer .* doesn't match a supported version",
 )
 
-__all__ = ["Codeblock", "LogManager", "Message", "__version__", "chat", "get_prompt"]
+__all__ = [
+    "Codeblock",
+    "LogManager",
+    "Message",
+    "__version__",
+    "chat",
+    "get_prompt",
+    "k_best_guess",
+]
 
 _lazy: dict[str, tuple[str, str]] = {
     "chat": (".chat", "chat"),
@@ -18,6 +26,7 @@ _lazy: dict[str, tuple[str, str]] = {
     "LogManager": (".logmanager", "LogManager"),
     "Message": (".message", "Message"),
     "get_prompt": (".prompts", "get_prompt"),
+    "k_best_guess": (".k_best", "k_best_guess"),
 }
 
 

--- a/gptme/k_best.py
+++ b/gptme/k_best.py
@@ -28,6 +28,7 @@ exception is re-raised.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -187,7 +188,10 @@ def _score(
         return 0.0, None
     try:
         raw = check(result)
-        return float(raw), None
+        score = float(raw)
+        if not math.isfinite(score):
+            raise ValueError(f"check returned a non-finite score: {score!r}")
+        return score, None
     except Exception as e:
         logger.debug(
             "k_best_guess check function raised for candidate %d: %s", index, e

--- a/gptme/k_best.py
+++ b/gptme/k_best.py
@@ -20,8 +20,9 @@ The ``check`` callable receives the return value and must return a numeric
 score; higher is better. If ``check`` is omitted, the first non-exception
 result is returned. Candidates are run in parallel by default.
 
-Exceptions from individual candidates are caught and logged; if **all** K
-candidates raise, the last exception is re-raised.
+Exceptions from individual candidates and validation checks are caught and
+logged; if **all** K candidates fail generation or validation, the last
+exception is re-raised.
 """
 
 from __future__ import annotations
@@ -88,7 +89,8 @@ def k_best_guess(
 
     Raises:
         ValueError: If ``k < 1``.
-        Exception: Re-raises the last candidate exception if all K fail.
+        Exception: Re-raises the last generation or validation exception if all
+                   K candidates fail.
     """
     if k < 1:
         raise ValueError(f"k must be >= 1, got {k!r}")
@@ -123,17 +125,22 @@ def k_best_guess(
                             )
                         else:
                             result = future.result()
-                            score = _score(result, check, idx)
+                            score, error = _score(result, check, idx)
                             candidates.append(
-                                Candidate(result=result, score=score, index=idx)
+                                Candidate(
+                                    result=result,
+                                    score=score,
+                                    index=idx,
+                                    error=error,
+                                )
                             )
             else:
                 for i in range(k):
                     try:
                         result = fn(*args, **kwargs)
-                        score = _score(result, check, i)
+                        score, error = _score(result, check, i)
                         candidates.append(
-                            Candidate(result=result, score=score, index=i)
+                            Candidate(result=result, score=score, index=i, error=error)
                         )
                     except Exception as e:
                         logger.debug("k_best_guess candidate %d raised: %s", i, e)
@@ -170,17 +177,19 @@ def k_best_guess(
     return decorator
 
 
-def _score(result: object, check: CheckFn | None, index: int) -> float:
-    """Return the numeric score for a candidate result."""
+def _score(
+    result: object, check: CheckFn | None, index: int
+) -> tuple[float, BaseException | None]:
+    """Return the numeric score and any validation error for a candidate."""
     if check is None:
         # First successful result gets score 0; parallel order is non-deterministic
         # so we do not award bonus points for first-arrival here.
-        return 0.0
+        return 0.0, None
     try:
         raw = check(result)
-        return float(raw)
+        return float(raw), None
     except Exception as e:
         logger.debug(
             "k_best_guess check function raised for candidate %d: %s", index, e
         )
-        return float("-inf")
+        return float("-inf"), e

--- a/gptme/k_best.py
+++ b/gptme/k_best.py
@@ -1,0 +1,186 @@
+"""
+K-Best Guess validation framework.
+
+Reduces agent hallucination at decision points by generating K candidate
+outputs, scoring each, and returning the winner. Instead of committing to
+a single model output, this explores the solution space and keeps the best.
+
+Usage::
+
+    from gptme.k_best import k_best_guess
+
+    @k_best_guess(k=3, check=lambda result: run_tests(result))
+    def generate_code(prompt: str) -> str:
+        # This function is called K times; the highest-scoring result wins
+        return call_llm(prompt)
+
+    best_code = generate_code("implement a binary search")
+
+The ``check`` callable receives the return value and must return a numeric
+score; higher is better. If ``check`` is omitted, the first non-exception
+result is returned. Candidates are run in parallel by default.
+
+Exceptions from individual candidates are caught and logged; if **all** K
+candidates raise, the last exception is re-raised.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+CheckFn = Callable[[T], float | int]
+
+
+@dataclass
+class Candidate:
+    """A single evaluated candidate from a K-best run."""
+
+    result: object
+    score: float
+    index: int
+    error: BaseException | None = None
+
+
+@dataclass
+class KBestResult:
+    """Full result from a K-best run, including all candidates."""
+
+    winner: object
+    winner_score: float
+    winner_index: int
+    candidates: list[Candidate] = field(default_factory=list)
+
+    @property
+    def k(self) -> int:
+        return len(self.candidates)
+
+
+def k_best_guess(
+    k: int = 3,
+    check: CheckFn | None = None,
+    *,
+    parallel: bool = True,
+    max_workers: int | None = None,
+    return_metadata: bool = False,
+) -> Callable:
+    """Decorator factory: run the wrapped function K times and return the best result.
+
+    Args:
+        k: Number of candidates to generate. Must be >= 1.
+        check: Callable ``(result) -> float`` scoring each candidate.
+               Higher scores win. If omitted, returns the first successful result.
+        parallel: Run candidates in parallel threads (default True).
+        max_workers: Thread pool size. Defaults to ``k``.
+        return_metadata: If True, return a :class:`KBestResult` with all
+                         candidates instead of just the winning value.
+
+    Returns:
+        A decorator that wraps any function to explore K candidates.
+
+    Raises:
+        ValueError: If ``k < 1``.
+        Exception: Re-raises the last candidate exception if all K fail.
+    """
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k!r}")
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T | KBestResult]:
+        @wraps(fn)
+        def wrapper(*args, **kwargs) -> T | KBestResult:
+            candidates: list[Candidate] = []
+
+            if parallel and k > 1:
+                workers = max_workers or k
+                futures: dict[Future, int] = {}
+                with ThreadPoolExecutor(max_workers=workers) as pool:
+                    for i in range(k):
+                        f = pool.submit(fn, *args, **kwargs)
+                        futures[f] = i
+
+                    for future in as_completed(futures):
+                        idx = futures[future]
+                        exc = future.exception()
+                        if exc is not None:
+                            logger.debug(
+                                "k_best_guess candidate %d raised: %s", idx, exc
+                            )
+                            candidates.append(
+                                Candidate(
+                                    result=None,
+                                    score=float("-inf"),
+                                    index=idx,
+                                    error=exc,
+                                )
+                            )
+                        else:
+                            result = future.result()
+                            score = _score(result, check, idx)
+                            candidates.append(
+                                Candidate(result=result, score=score, index=idx)
+                            )
+            else:
+                for i in range(k):
+                    try:
+                        result = fn(*args, **kwargs)
+                        score = _score(result, check, i)
+                        candidates.append(
+                            Candidate(result=result, score=score, index=i)
+                        )
+                    except Exception as e:
+                        logger.debug("k_best_guess candidate %d raised: %s", i, e)
+                        candidates.append(
+                            Candidate(
+                                result=None, score=float("-inf"), index=i, error=e
+                            )
+                        )
+
+            successful = [c for c in candidates if c.error is None]
+            if not successful:
+                last_err = max(candidates, key=lambda c: c.index).error
+                raise last_err  # type: ignore[misc]
+
+            winner = max(successful, key=lambda c: c.score)
+            logger.debug(
+                "k_best_guess winner: candidate %d (score=%.4f) out of %d",
+                winner.index,
+                winner.score,
+                len(successful),
+            )
+
+            if return_metadata:
+                return KBestResult(
+                    winner=winner.result,
+                    winner_score=winner.score,
+                    winner_index=winner.index,
+                    candidates=candidates,
+                )
+            return winner.result  # type: ignore[return-value]
+
+        return wrapper
+
+    return decorator
+
+
+def _score(result: object, check: CheckFn | None, index: int) -> float:
+    """Return the numeric score for a candidate result."""
+    if check is None:
+        # First successful result gets score 0; parallel order is non-deterministic
+        # so we do not award bonus points for first-arrival here.
+        return 0.0
+    try:
+        raw = check(result)
+        return float(raw)
+    except Exception as e:
+        logger.debug(
+            "k_best_guess check function raised for candidate %d: %s", index, e
+        )
+        return float("-inf")

--- a/tests/test_k_best.py
+++ b/tests/test_k_best.py
@@ -1,0 +1,250 @@
+"""Tests for gptme.k_best — K-Best Guess validation framework."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from gptme.k_best import Candidate, KBestResult, k_best_guess
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def always_returns(value: Any):
+    """Return a function that always returns *value*."""
+
+    def fn(*_args, **_kwargs):
+        return value
+
+    return fn
+
+
+def counter_fn(counter: list[int]):
+    """Increment counter[0] and return its current value."""
+
+    def fn(*_args, **_kwargs):
+        counter[0] += 1
+        return counter[0]
+
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Basic behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestKBestGuessBasic:
+    def test_k1_returns_single_result(self):
+        @k_best_guess(k=1)
+        def fn():
+            return 42
+
+        assert fn() == 42
+
+    def test_default_no_check_returns_first_successful(self):
+        """Without a check function, any successful candidate is fine."""
+        calls: list[int] = []
+
+        @k_best_guess(k=3)
+        def fn():
+            calls.append(1)
+            return "ok"
+
+        result = fn()
+        assert result == "ok"
+        assert len(calls) == 3  # all K candidates ran
+
+    def test_check_fn_selects_best(self):
+        """check= should pick the highest-scoring candidate."""
+        outcomes = iter([1, 5, 3])
+
+        @k_best_guess(k=3, check=lambda x: x, parallel=False)
+        def fn():
+            return next(outcomes)
+
+        result = fn()
+        assert result == 5
+
+    def test_check_fn_float_scores(self):
+        outcomes = iter([0.1, 0.9, 0.5])
+
+        @k_best_guess(k=3, check=lambda x: x, parallel=False)
+        def fn():
+            return next(outcomes)
+
+        assert fn() == pytest.approx(0.9)
+
+    def test_pass_through_args(self):
+        @k_best_guess(k=2, check=lambda x: x)
+        def fn(a: int, b: int) -> int:
+            return a + b
+
+        assert fn(3, 4) == 7
+
+    def test_pass_through_kwargs(self):
+        @k_best_guess(k=2)
+        def fn(*, msg: str) -> str:
+            return msg.upper()
+
+        assert fn(msg="hello") == "HELLO"
+
+    def test_wraps_preserves_name(self):
+        @k_best_guess(k=2)
+        def my_special_function():
+            return None
+
+        assert my_special_function.__name__ == "my_special_function"
+
+    def test_k_must_be_positive(self):
+        with pytest.raises(ValueError, match="k must be >= 1"):
+            k_best_guess(k=0)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestKBestGuessErrors:
+    def test_all_fail_reraises_last(self):
+        @k_best_guess(k=3, parallel=False)
+        def always_explodes():
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            always_explodes()
+
+    def test_partial_failure_still_returns_winner(self):
+        call_count = [0]
+
+        @k_best_guess(k=3, check=lambda x: x, parallel=False)
+        def flaky():
+            call_count[0] += 1
+            n = call_count[0]
+            if n == 1:
+                raise ValueError("first fails")
+            return n  # 2 or 3; 3 wins
+
+        result = flaky()
+        assert result == 3
+
+    def test_check_raises_treated_as_minus_inf(self):
+        """If check() itself raises, that candidate should still lose."""
+        outcomes = iter([10, 20])
+
+        def bad_check(x):
+            if x == 10:
+                raise TypeError("bad!")
+            return x
+
+        @k_best_guess(k=2, check=bad_check, parallel=False)
+        def fn():
+            return next(outcomes)
+
+        assert fn() == 20
+
+
+# ---------------------------------------------------------------------------
+# Parallel execution
+# ---------------------------------------------------------------------------
+
+
+class TestKBestGuessParallel:
+    def test_parallel_all_called(self):
+        lock = threading.Lock()
+        calls: list[int] = []
+
+        @k_best_guess(k=4, parallel=True)
+        def fn():
+            with lock:
+                calls.append(1)
+            return "x"
+
+        fn()
+        assert len(calls) == 4
+
+    def test_parallel_check_fn_selects_best(self):
+        # All threads return the same value; score it by identity
+        @k_best_guess(k=5, check=lambda x: x, parallel=True)
+        def fn():
+            return 7
+
+        assert fn() == 7
+
+    def test_parallel_partial_failure(self):
+        """Some threads raise; winner should still be returned."""
+        call_count = [0]
+        lock = threading.Lock()
+
+        @k_best_guess(k=4, check=lambda x: x, parallel=True)
+        def fn():
+            with lock:
+                call_count[0] += 1
+                n = call_count[0]
+            if n % 2 == 0:
+                raise RuntimeError("even fails")
+            return n  # 1 or 3
+
+        result = fn()
+        assert result in (1, 3)
+
+
+# ---------------------------------------------------------------------------
+# return_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestKBestGuessMetadata:
+    def test_returns_kbest_result(self):
+        @k_best_guess(k=3, return_metadata=True)
+        def fn():
+            return 42
+
+        out = fn()
+        assert isinstance(out, KBestResult)
+        assert out.winner == 42
+        assert out.k == 3
+
+    def test_metadata_winner_matches_best(self):
+        outcomes = iter([1, 9, 4])
+
+        @k_best_guess(k=3, check=lambda x: x, parallel=False, return_metadata=True)
+        def fn():
+            return next(outcomes)
+
+        out = fn()
+        assert isinstance(out, KBestResult)
+        assert out.winner == 9
+        assert out.winner_score == pytest.approx(9.0)
+
+    def test_metadata_includes_all_candidates(self):
+        @k_best_guess(k=3, return_metadata=True)
+        def fn():
+            return "x"
+
+        out = fn()
+        assert isinstance(out, KBestResult)
+        assert len(out.candidates) == 3
+        for c in out.candidates:
+            assert isinstance(c, Candidate)
+
+    def test_metadata_records_errors(self):
+        call_count = [0]
+
+        @k_best_guess(k=3, parallel=False, return_metadata=True)
+        def fn():
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise ValueError("second fails")
+            return "ok"
+
+        out = fn()
+        assert isinstance(out, KBestResult)
+        errors = [c for c in out.candidates if c.error is not None]
+        assert len(errors) == 1
+        assert isinstance(errors[0].error, ValueError)

--- a/tests/test_k_best.py
+++ b/tests/test_k_best.py
@@ -148,6 +148,17 @@ class TestKBestGuessErrors:
 
         assert fn() == 20
 
+    def test_all_checks_fail_reraises_last_validation_error(self):
+        def invalid_check(_result):
+            raise ValueError("invalid")
+
+        @k_best_guess(k=3, check=invalid_check, parallel=False)
+        def fn():
+            return "unvalidated"
+
+        with pytest.raises(ValueError, match="invalid"):
+            fn()
+
 
 # ---------------------------------------------------------------------------
 # Parallel execution

--- a/tests/test_k_best.py
+++ b/tests/test_k_best.py
@@ -159,6 +159,26 @@ class TestKBestGuessErrors:
         with pytest.raises(ValueError, match="invalid"):
             fn()
 
+    @pytest.mark.parametrize(
+        "non_finite_score", [float("nan"), float("inf"), float("-inf")]
+    )
+    def test_non_finite_score_is_rejected(self, non_finite_score):
+        outcomes = iter(["invalid", "valid"])
+
+        @k_best_guess(
+            k=2,
+            check=lambda result: non_finite_score if result == "invalid" else 1.0,
+            parallel=False,
+            return_metadata=True,
+        )
+        def fn():
+            return next(outcomes)
+
+        result = fn()
+        assert isinstance(result, KBestResult)
+        assert result.winner == "valid"
+        assert isinstance(result.candidates[0].error, ValueError)
+
 
 # ---------------------------------------------------------------------------
 # Parallel execution


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the K-Best Guess Validation Framework: a general-purpose `@k_best_guess` decorator that reduces agent hallucination at decision points by exploring K candidate outputs and returning the winner.

## Motivation

Agent decision points produce single outputs that often fail downstream. The K-best pattern: generate K candidate implementations, validate all K in parallel, commit the winner based on a metric.

## What ships

### `gptme/k_best.py` — new module
- `@k_best_guess(k=3, check=score_fn)` — decorator factory
- Parallel execution via `ThreadPoolExecutor` (default `parallel=True`)
- Partial-failure tolerance: any successful candidate wins; all-fail re-raises
- `check()` exceptions → `score=-inf` (candidate tracked in metadata but loses)
- `return_metadata=True` → returns `KBestResult` with all candidates + scores

### `tests/test_k_best.py` — 18 tests
Basic selection, float scores, args/kwargs passthrough, `functools.wraps`, `k<1` validation, all-fail reraise, partial failure, check-raises, parallel execution, metadata shape and content.

## Usage

```python
from gptme.k_best import k_best_guess

@k_best_guess(k=3, check=lambda code: run_tests(code))
def generate_code(prompt: str) -> str:
    return call_llm(prompt)

best_code = generate_code('implement binary search')
```

## What's next (Phase 2+)

- Auto-scoring calibration
- Integration into gptme's default session workflow
- Connects to visualization for K-path exploration UI