### PR TITLE
feat(attestation): add ModelSelectionTrace for durable model provenance (Phase 0)

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -21,6 +21,7 @@ from ..dirs import get_logs_dir
 from ..init import init
 from ..llm.models import get_default_model, set_default_model
 from ..logmanager import LogManager, list_conversations
+from ..model_attestation import record_runtime_selection
 from ..prompts import get_prompt
 from ..session import SessionRegistry
 from ..tools import ToolUse, get_tools, set_tools
@@ -1042,8 +1043,7 @@ class GptmeAgent:
         effective_model = self._session_models.get(session_id, self._model)
         if effective_model:
             set_default_model(effective_model)
-        elif self._model:
-            set_default_model(self._model)
+            record_runtime_selection(effective_model, "acp_runtime")
         if self._tools is not None:
             set_tools(self._tools)
 

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -113,6 +113,9 @@ def init_model(
 ):
     config = get_config()
 
+    # Save original input for provenance tracking before precedence resolution.
+    _requested_model = model
+
     # get from config
     # Precedence: explicit CLI --model > per-chat saved model > [models].default > MODEL env var.
     if not model:
@@ -241,7 +244,48 @@ def init_model(
             model_meta = replace(model_meta, context=context_length)
             logger.info(f"Context length overridden to {context_length} tokens")
 
+    # Record model selection provenance trace (Phase 0).
+    _record_selection_trace(config, _requested_model, model_full, provider, model_meta)
+
     set_default_model(model_meta)
+
+
+def _record_selection_trace(
+    config: Config,
+    requested_model: str | None,
+    model_full: str,
+    provider: Provider,
+    model_meta: ModelMeta,
+) -> None:
+    """Create and store a ModelSelectionTrace for this session."""
+    from .model_attestation import create_selection_trace, set_selection_trace
+
+    # Infer source kind from the precedence chain.
+    if requested_model is not None:
+        source_kind = "cli"
+        source_value = requested_model
+    elif config.chat and config.chat.model:
+        source_kind = "chat_config"
+        source_value = config.chat.model
+    elif config.user.models.default:
+        source_kind = "models.default"
+        source_value = config.user.models.default
+    elif config.get_env("MODEL"):
+        source_kind = "MODEL"
+        source_value = config.get_env("MODEL") or model_full
+    else:
+        source_kind = "cli"
+        source_value = model_full
+
+    trace = create_selection_trace(
+        requested_model=requested_model or model_full,
+        resolved_model=model_full,
+        source_kind=source_kind,  # type: ignore[arg-type]
+        source_value=source_value,
+        transport_provider=str(provider),
+        backend_provider=str(model_meta.provider),
+    )
+    set_selection_trace(trace)
 
 
 def _maybe_authenticate_gptme_interactively(

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -290,6 +290,10 @@ def _record_selection_trace(
     transport_provider = str(provider)
     backend_provider = _backend_provider(transport_provider, resolved_model)
     alias_name = model_full.split("/", 1)[1]
+    # Mirror get_model()'s metadata lookup normalization. The reasoning suffix
+    # remains part of the selected wire model, but it is not part of the alias key.
+    if transport_provider == "openai-subscription" and ":" in alias_name:
+        alias_name = alias_name.rsplit(":", 1)[0]
     alias_model = MODEL_ALIASES.get(transport_provider, {}).get(alias_name)
     alias_target = (
         f"{transport_provider}/{alias_model}" if alias_model is not None else None

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -231,6 +231,13 @@ def init_model(
 
     model_meta = _resolved_meta or get_model(model_full)
 
+    # Preserve the transport-qualified resolved model before any metadata-only
+    # alias expansion. Routed providers can encode the real backend in ModelMeta.
+    if str(provider) == "gptme" and "/" in model_meta.model:
+        resolved_model = f"gptme/{model_meta.model}"
+    else:
+        resolved_model = model_full
+
     # Apply GPTME_CONTEXT_LENGTH override (useful for local models with non-standard context)
     context_length_str = os.environ.get("GPTME_CONTEXT_LENGTH")
     if context_length_str:
@@ -245,7 +252,9 @@ def init_model(
             logger.info(f"Context length overridden to {context_length} tokens")
 
     # Record model selection provenance trace (Phase 0).
-    _record_selection_trace(config, _requested_model, model_full, provider, model_meta)
+    _record_selection_trace(
+        config, _requested_model, model_full, resolved_model, provider, model_meta
+    )
 
     set_default_model(model_meta)
 
@@ -254,6 +263,7 @@ def _record_selection_trace(
     config: Config,
     requested_model: str | None,
     model_full: str,
+    resolved_model: str,
     provider: Provider,
     model_meta: ModelMeta,
 ) -> None:
@@ -277,15 +287,43 @@ def _record_selection_trace(
         source_kind = "cli"
         source_value = model_full
 
+    transport_provider = str(provider)
+    backend_provider = _backend_provider(transport_provider, resolved_model)
+    alias_name = model_full.split("/", 1)[1]
+    alias_model = MODEL_ALIASES.get(transport_provider, {}).get(alias_name)
+    alias_target = (
+        f"{transport_provider}/{alias_model}" if alias_model is not None else None
+    )
+    resolved_model = alias_target or resolved_model
+    resolution_notes = []
+    if alias_target is not None:
+        resolution_notes.append("resolved model alias for metadata lookup")
+    if resolved_model != model_full and alias_target is None:
+        resolution_notes.append("resolved backend model from provider catalog")
+
     trace = create_selection_trace(
-        requested_model=requested_model or model_full,
-        resolved_model=model_full,
+        requested_model=source_value,
+        resolved_model=resolved_model,
         source_kind=source_kind,  # type: ignore[arg-type]
         source_value=source_value,
-        transport_provider=str(provider),
-        backend_provider=str(model_meta.provider),
+        transport_provider=transport_provider,
+        backend_provider=backend_provider,
+        alias_target=alias_target,
+        resolution_notes=resolution_notes,
     )
     set_selection_trace(trace)
+
+
+def _backend_provider(transport_provider: str, resolved_model: str) -> str:
+    """Return the provider serving the model weights when it is knowable."""
+    parts = resolved_model.split("/")
+    if transport_provider == "gptme" and len(parts) >= 3:
+        if parts[1] == "openrouter" and len(parts) >= 4:
+            return parts[2]
+        return parts[1]
+    if transport_provider == "openrouter" and len(parts) >= 3:
+        return parts[1]
+    return transport_provider
 
 
 def _maybe_authenticate_gptme_interactively(

--- a/gptme/model_attestation.py
+++ b/gptme/model_attestation.py
@@ -253,3 +253,18 @@ def create_selection_trace(
             registry_record=registry_record,
         ),
     )
+
+
+# Module-level storage for the current session's trace.
+_current_trace: ModelSelectionTrace | None = None
+
+
+def get_selection_trace() -> ModelSelectionTrace | None:
+    """Return the model selection trace captured during this session's init."""
+    return _current_trace
+
+
+def set_selection_trace(trace: ModelSelectionTrace) -> None:
+    """Store the model selection trace for this session."""
+    global _current_trace
+    _current_trace = trace

--- a/gptme/model_attestation.py
+++ b/gptme/model_attestation.py
@@ -10,6 +10,7 @@ This module provides durable, auditable records of:
 from __future__ import annotations
 
 import json
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal
@@ -255,16 +256,18 @@ def create_selection_trace(
     )
 
 
-# Module-level storage for the current session's trace.
-_current_trace: ModelSelectionTrace | None = None
+# Context-local storage mirrors the default model's ownership. This keeps
+# concurrent ACP/server sessions from seeing each other's provenance.
+_current_trace_var: ContextVar[ModelSelectionTrace | None] = ContextVar(
+    "model_selection_trace", default=None
+)
 
 
 def get_selection_trace() -> ModelSelectionTrace | None:
-    """Return the model selection trace captured during this session's init."""
-    return _current_trace
+    """Return the model selection trace captured in the current context."""
+    return _current_trace_var.get()
 
 
-def set_selection_trace(trace: ModelSelectionTrace) -> None:
-    """Store the model selection trace for this session."""
-    global _current_trace
-    _current_trace = trace
+def set_selection_trace(trace: ModelSelectionTrace | None) -> None:
+    """Store the model selection trace in the current context."""
+    _current_trace_var.set(trace)

--- a/gptme/model_attestation.py
+++ b/gptme/model_attestation.py
@@ -271,3 +271,43 @@ def get_selection_trace() -> ModelSelectionTrace | None:
 def set_selection_trace(trace: ModelSelectionTrace | None) -> None:
     """Store the model selection trace in the current context."""
     _current_trace_var.set(trace)
+
+
+def record_runtime_selection(
+    model: str, source_kind: Literal["api_request", "acp_runtime"]
+) -> ModelSelectionTrace:
+    """Resolve and record a model selected outside CLI initialization.
+
+    This is intentionally explicit rather than part of ``set_default_model``:
+    internal temporary model switches are not user/session selections.
+    """
+    from .llm.models import get_model
+
+    model_meta = get_model(model)
+    transport_provider = model.split("/", 1)[0]
+    resolved_model = model
+    if transport_provider == "gptme" and "/" in model_meta.model:
+        resolved_model = f"gptme/{model_meta.model}"
+
+    parts = resolved_model.split("/")
+    backend_provider = transport_provider
+    if transport_provider == "gptme" and len(parts) >= 3:
+        backend_provider = parts[2] if parts[1] == "openrouter" else parts[1]
+    elif transport_provider == "openrouter" and len(parts) >= 3:
+        backend_provider = parts[1]
+
+    trace = create_selection_trace(
+        requested_model=model,
+        resolved_model=resolved_model,
+        source_kind=source_kind,
+        source_value=model,
+        transport_provider=transport_provider,
+        backend_provider=backend_provider,
+        resolution_notes=(
+            ["resolved backend model from provider catalog"]
+            if resolved_model != model
+            else []
+        ),
+    )
+    set_selection_trace(trace)
+    return trace

--- a/gptme/model_attestation.py
+++ b/gptme/model_attestation.py
@@ -281,13 +281,23 @@ def record_runtime_selection(
     This is intentionally explicit rather than part of ``set_default_model``:
     internal temporary model switches are not user/session selections.
     """
-    from .llm.models import get_model
+    from .llm.models import MODEL_ALIASES, get_model
 
     model_meta = get_model(model)
-    transport_provider = model.split("/", 1)[0]
+    transport_provider, model_name = model.split("/", 1)
     resolved_model = model
     if transport_provider == "gptme" and "/" in model_meta.model:
         resolved_model = f"gptme/{model_meta.model}"
+
+    alias_name = model_name
+    if transport_provider == "openai-subscription" and ":" in alias_name:
+        alias_name = alias_name.rsplit(":", 1)[0]
+    alias_model = MODEL_ALIASES.get(transport_provider, {}).get(alias_name)
+    alias_target = (
+        f"{transport_provider}/{alias_model}" if alias_model is not None else None
+    )
+    if alias_target is not None:
+        resolved_model = alias_target
 
     parts = resolved_model.split("/")
     backend_provider = transport_provider
@@ -303,8 +313,11 @@ def record_runtime_selection(
         source_value=model,
         transport_provider=transport_provider,
         backend_provider=backend_provider,
+        alias_target=alias_target,
         resolution_notes=(
-            ["resolved backend model from provider catalog"]
+            ["resolved model alias for metadata lookup"]
+            if alias_target is not None
+            else ["resolved backend model from provider catalog"]
             if resolved_model != model
             else []
         ),

--- a/gptme/model_attestation.py
+++ b/gptme/model_attestation.py
@@ -1,0 +1,255 @@
+"""Model selection attestation and provenance tracking for gptme sessions.
+
+This module provides durable, auditable records of:
+- Which model a session requested
+- How that request resolved through aliases and catalogs
+- Which provider actually served it
+- What evidence exists about the underlying checkpoint or backend revision
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+
+@dataclass
+class ModelSelectionSource:
+    """Describes where the model selection came from."""
+
+    kind: Literal[
+        "cli", "api_request", "chat_config", "models.default", "MODEL", "acp_runtime"
+    ]
+    """Source of the model selection."""
+
+    value: str
+    """The value selected from this source."""
+
+
+@dataclass
+class ModelSelectionResolution:
+    """Describes how a model request was resolved."""
+
+    source: ModelSelectionSource
+    """Where the selection came from."""
+
+    requested_model: str
+    """The model string as requested by the user/API."""
+
+    resolved_model: str
+    """The final backend-facing model after aliasing and catalog resolution."""
+
+    transport_provider: str
+    """Provider handling the transport (e.g., 'gptme', 'openrouter', 'anthropic')."""
+
+    backend_provider: str
+    """Provider of the actual model weights (e.g., 'anthropic', 'openai')."""
+
+    alias_target: str | None = None
+    """If this was an alias, what it resolved to."""
+
+    catalog_source: str | None = None
+    """Where the catalog lookup came from (e.g., 'dynamic_fetch:gptme', 'local_config')."""
+
+    resolution_notes: list[str] = field(default_factory=list)
+    """Human-readable notes about resolution decisions."""
+
+
+@dataclass
+class ModelIdentityClaim:
+    """Describes what we know about a model's identity and provenance."""
+
+    attestation_level: Literal["selection_only", "provider_claim", "provider_signed"]
+    """Honesty bit about what evidence supports this claim.
+
+    - 'selection_only': we know what was requested and resolved to
+    - 'provider_claim': provider exposed a revision/build identifier
+    - 'provider_signed': provider exposed a cryptographically signed statement
+    """
+
+    provider_revision: str | None = None
+    """Provider-specific revision, build ID, or date qualifier."""
+
+    checkpoint_digest: str | None = None
+    """Cryptographic digest of the actual model weights (not available for closed-weight models)."""
+
+    registry_record: str | None = None
+    """Reference to a model record in packages/model-capability-registry."""
+
+    catalog_observed_at: datetime | None = None
+    """Timestamp when this model was observed in a catalog."""
+
+    signature: dict[str, Any] | None = None
+    """Optional vendor-signed model identity envelope (Phase 3+).
+
+    Contains:
+    - algorithm: signing algorithm used
+    - key_id: vendor's key identifier
+    - payload_hash: hash of the signed payload
+    - signed_at: ISO timestamp of the signature
+    - value: the raw signed statement
+    """
+
+
+@dataclass
+class ModelSelectionTrace:
+    """Complete durable record of model selection for a session.
+
+    This record travels with a session and can be embedded into output
+    attestations, session metadata, and conversation summaries.
+    """
+
+    schema: str = "gptme.model-attestation/v0"
+    """Schema version for forward compatibility."""
+
+    selected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    """When this selection was made."""
+
+    selection: ModelSelectionResolution | None = None
+    """How the model was resolved."""
+
+    identity: ModelIdentityClaim | None = None
+    """What we know about the model's identity."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return asdict(self, dict_factory=self._dict_factory)
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @staticmethod
+    def _dict_factory(
+        fields: list[tuple[str, Any]],
+    ) -> dict[str, Any]:
+        """Custom dict factory to handle datetime serialization."""
+        result: dict[str, Any] = {}
+        for key, value in fields:
+            if isinstance(value, datetime):
+                result[key] = value.isoformat()
+            elif isinstance(value, dict):
+                result[key] = value
+            elif hasattr(value, "__dataclass_fields__"):
+                # Recursively handle nested dataclasses
+                result[key] = ModelSelectionTrace._dict_factory(
+                    [
+                        (f.name, getattr(value, f.name))
+                        for f in value.__dataclass_fields__.values()
+                    ]
+                )
+            else:
+                result[key] = value
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelSelectionTrace:
+        """Reconstruct from a dictionary."""
+        if data.get("schema") != cls.schema:
+            raise ValueError(f"Unsupported schema: {data.get('schema')}")
+
+        # Parse selected_at timestamp
+        selected_at_raw = data.get("selected_at")
+        selected_at: datetime = datetime.now(timezone.utc)
+        if isinstance(selected_at_raw, str):
+            selected_at = datetime.fromisoformat(selected_at_raw.replace("Z", "+00:00"))
+
+        # Reconstruct nested objects
+        selection_data = data.get("selection")
+        selection: ModelSelectionResolution | None = None
+        if selection_data:
+            source_data = selection_data.get("source", {})
+            source = ModelSelectionSource(**source_data)
+            selection = ModelSelectionResolution(
+                source=source,
+                requested_model=selection_data.get("requested_model"),
+                resolved_model=selection_data.get("resolved_model"),
+                transport_provider=selection_data.get("transport_provider"),
+                backend_provider=selection_data.get("backend_provider"),
+                alias_target=selection_data.get("alias_target"),
+                catalog_source=selection_data.get("catalog_source"),
+                resolution_notes=selection_data.get("resolution_notes", []),
+            )
+
+        identity_data = data.get("identity")
+        identity: ModelIdentityClaim | None = None
+        if identity_data:
+            # Parse catalog_observed_at if present
+            catalog_observed_at_raw = identity_data.get("catalog_observed_at")
+            catalog_observed_at: datetime | None = None
+            if isinstance(catalog_observed_at_raw, str):
+                catalog_observed_at = datetime.fromisoformat(
+                    catalog_observed_at_raw.replace("Z", "+00:00")
+                )
+
+            identity = ModelIdentityClaim(
+                attestation_level=identity_data.get(
+                    "attestation_level", "selection_only"
+                ),
+                provider_revision=identity_data.get("provider_revision"),
+                checkpoint_digest=identity_data.get("checkpoint_digest"),
+                registry_record=identity_data.get("registry_record"),
+                catalog_observed_at=catalog_observed_at,
+                signature=identity_data.get("signature"),
+            )
+
+        return cls(
+            schema=data.get("schema", cls.schema),
+            selected_at=selected_at,
+            selection=selection,
+            identity=identity,
+        )
+
+
+def create_selection_trace(
+    requested_model: str,
+    resolved_model: str,
+    source_kind: Literal[
+        "cli", "api_request", "chat_config", "models.default", "MODEL", "acp_runtime"
+    ],
+    source_value: str,
+    transport_provider: str,
+    backend_provider: str,
+    alias_target: str | None = None,
+    catalog_source: str | None = None,
+    resolution_notes: list[str] | None = None,
+    provider_revision: str | None = None,
+    registry_record: str | None = None,
+) -> ModelSelectionTrace:
+    """Convenience constructor for creating a selection trace.
+
+    Args:
+        requested_model: The model string as requested
+        resolved_model: The final backend-facing model
+        source_kind: Where the selection came from
+        source_value: The value selected from the source
+        transport_provider: Provider handling transport
+        backend_provider: Provider of the model weights
+        alias_target: If this was an alias, what it resolved to
+        catalog_source: Where the catalog lookup came from
+        resolution_notes: Human-readable notes about resolution
+        provider_revision: Provider-specific revision identifier
+        registry_record: Reference to model-capability-registry record
+
+    Returns:
+        A ModelSelectionTrace with selection_only attestation level.
+    """
+    return ModelSelectionTrace(
+        selection=ModelSelectionResolution(
+            source=ModelSelectionSource(kind=source_kind, value=source_value),
+            requested_model=requested_model,
+            resolved_model=resolved_model,
+            transport_provider=transport_provider,
+            backend_provider=backend_provider,
+            alias_target=alias_target,
+            catalog_source=catalog_source,
+            resolution_notes=resolution_notes or [],
+        ),
+        identity=ModelIdentityClaim(
+            attestation_level="selection_only",
+            provider_revision=provider_revision,
+            registry_record=registry_record,
+        ),
+    )

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -605,8 +605,10 @@ def step(
     # Set the model as default before triggering hooks
     # This ensures hooks like token_awareness can access the model
     from ..llm.models import set_default_model
+    from ..model_attestation import record_runtime_selection
 
     set_default_model(model)
+    record_runtime_selection(model, "api_request")
 
     # Trigger SESSION_START hook for new conversations
     assistant_messages = [m for m in manager.log.messages if m.role == "assistant"]

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -1,6 +1,8 @@
 """Tests for the model selection attestation module (Phase 0)."""
 
 import json
+from contextvars import Context, copy_context
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -112,8 +114,22 @@ def test_session_trace_storage():
     assert retrieved is trace
 
     # Reset
-    set_selection_trace(None)  # type: ignore[arg-type]
+    set_selection_trace(None)
     assert get_selection_trace() is None
+
+
+def test_session_trace_storage_is_context_local():
+    parent_trace = make_trace(requested="anthropic/parent")
+    child_trace = make_trace(requested="anthropic/child")
+    set_selection_trace(parent_trace)
+
+    child_context = copy_context()
+    child_context.run(set_selection_trace, child_trace)
+    empty_context = Context()
+
+    assert get_selection_trace() is parent_trace
+    assert child_context.run(get_selection_trace) is child_trace
+    assert empty_context.run(get_selection_trace) is None
 
 
 def test_session_trace_distinguishes_providers():
@@ -145,3 +161,117 @@ def test_source_kinds():
         trace = make_trace(source_kind=kind)
         assert trace.selection is not None
         assert trace.selection.source.kind == kind
+
+
+def _config() -> MagicMock:
+    config = MagicMock()
+    config.chat = MagicMock(model=None)
+    config.user.models.default = None
+    config.get_env.return_value = None
+    return config
+
+
+def test_record_selection_trace_resolves_gptme_backend():
+    from gptme.init import _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    _record_selection_trace(
+        _config(),
+        "gptme/claude-sonnet-4-6",
+        "gptme/claude-sonnet-4-6",
+        "gptme/anthropic/claude-sonnet-4-6",
+        "gptme",
+        ModelMeta(
+            provider="gptme",
+            model="anthropic/claude-sonnet-4-6",
+            context=200_000,
+        ),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.requested_model == "gptme/claude-sonnet-4-6"
+    assert trace.selection.resolved_model == "gptme/anthropic/claude-sonnet-4-6"
+    assert trace.selection.transport_provider == "gptme"
+    assert trace.selection.backend_provider == "anthropic"
+    assert trace.selection.resolution_notes == [
+        "resolved backend model from provider catalog"
+    ]
+
+
+def test_record_selection_trace_resolves_openrouter_backend():
+    from gptme.init import _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    model = "openrouter/anthropic/claude-sonnet-4-6"
+    _record_selection_trace(
+        _config(),
+        model,
+        model,
+        model,
+        "openrouter",
+        ModelMeta(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4-6",
+            context=200_000,
+        ),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.resolved_model == model
+    assert trace.selection.transport_provider == "openrouter"
+    assert trace.selection.backend_provider == "anthropic"
+
+
+def test_record_selection_trace_resolves_openrouter_backed_gptme_backend():
+    from gptme.init import _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    requested = "gptme/gpt-5.4"
+    resolved = "gptme/openrouter/openai/gpt-5.4"
+    _record_selection_trace(
+        _config(),
+        requested,
+        requested,
+        resolved,
+        "gptme",
+        ModelMeta(
+            provider="gptme",
+            model="openrouter/openai/gpt-5.4",
+            context=400_000,
+        ),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.resolved_model == resolved
+    assert trace.selection.transport_provider == "gptme"
+    assert trace.selection.backend_provider == "openai"
+
+
+def test_record_selection_trace_preserves_alias_resolution(monkeypatch):
+    from gptme.init import MODEL_ALIASES, _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    monkeypatch.setitem(
+        MODEL_ALIASES,
+        "anthropic",
+        {"claude-haiku-4-5": "claude-haiku-4-5-20251001"},
+    )
+    _record_selection_trace(
+        _config(),
+        "anthropic/claude-haiku-4-5",
+        "anthropic/claude-haiku-4-5",
+        "anthropic/claude-haiku-4-5",
+        "anthropic",
+        ModelMeta(provider="anthropic", model="claude-haiku-4-5", context=200_000),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.alias_target == "anthropic/claude-haiku-4-5-20251001"
+    assert trace.selection.resolved_model == "anthropic/claude-haiku-4-5-20251001"
+    assert trace.selection.resolution_notes == [
+        "resolved model alias for metadata lookup"
+    ]

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -1,0 +1,147 @@
+"""Tests for the model selection attestation module (Phase 0)."""
+
+import json
+
+import pytest
+
+from gptme.model_attestation import (
+    ModelSelectionTrace,
+    create_selection_trace,
+    get_selection_trace,
+    set_selection_trace,
+)
+
+
+def make_trace(
+    requested="anthropic/claude-sonnet-4-6",
+    resolved="anthropic/claude-sonnet-4-6",
+    source_kind="cli",
+    transport="anthropic",
+    backend="anthropic",
+) -> ModelSelectionTrace:
+    return create_selection_trace(
+        requested_model=requested,
+        resolved_model=resolved,
+        source_kind=source_kind,
+        source_value=requested,
+        transport_provider=transport,
+        backend_provider=backend,
+    )
+
+
+def test_create_selection_trace_basic():
+    trace = make_trace()
+    assert trace.selection is not None
+    assert trace.selection.requested_model == "anthropic/claude-sonnet-4-6"
+    assert trace.selection.resolved_model == "anthropic/claude-sonnet-4-6"
+    assert trace.selection.transport_provider == "anthropic"
+    assert trace.selection.backend_provider == "anthropic"
+    assert trace.identity is not None
+    assert trace.identity.attestation_level == "selection_only"
+
+
+def test_create_selection_trace_alias_resolution():
+    trace = create_selection_trace(
+        requested_model="gptme/claude-sonnet-4-6",
+        resolved_model="anthropic/claude-sonnet-4-6",
+        source_kind="cli",
+        source_value="gptme/claude-sonnet-4-6",
+        transport_provider="gptme",
+        backend_provider="anthropic",
+        alias_target="anthropic/claude-sonnet-4-6",
+        resolution_notes=["gptme suffix match", "anthropic-first tie-break"],
+    )
+    assert trace.selection is not None
+    assert trace.selection.transport_provider == "gptme"
+    assert trace.selection.backend_provider == "anthropic"
+    assert trace.selection.alias_target == "anthropic/claude-sonnet-4-6"
+    assert len(trace.selection.resolution_notes) == 2
+
+
+def test_schema_field():
+    trace = make_trace()
+    assert trace.schema == "gptme.model-attestation/v0"
+
+
+def test_to_dict_roundtrip():
+    trace = make_trace(
+        requested="openrouter/anthropic/claude-sonnet-4-6",
+        resolved="anthropic/claude-sonnet-4-6",
+        source_kind="api_request",
+        transport="openrouter",
+        backend="anthropic",
+    )
+    d = trace.to_dict()
+    assert d["schema"] == "gptme.model-attestation/v0"
+    assert d["selection"]["requested_model"] == "openrouter/anthropic/claude-sonnet-4-6"
+    assert d["selection"]["transport_provider"] == "openrouter"
+    assert d["selection"]["backend_provider"] == "anthropic"
+    assert d["identity"]["attestation_level"] == "selection_only"
+
+    # Round-trip through from_dict
+    trace2 = ModelSelectionTrace.from_dict(d)
+    assert trace2.selection is not None
+    assert trace2.identity is not None
+    assert trace2.selection.requested_model == trace.selection.requested_model  # type: ignore[union-attr]
+    assert trace2.selection.resolved_model == trace.selection.resolved_model  # type: ignore[union-attr]
+    assert trace2.selection.transport_provider == trace.selection.transport_provider  # type: ignore[union-attr]
+    assert trace2.selection.backend_provider == trace.selection.backend_provider  # type: ignore[union-attr]
+    assert trace2.identity.attestation_level == trace.identity.attestation_level  # type: ignore[union-attr]
+
+
+def test_to_json_roundtrip():
+    trace = make_trace()
+    json_str = trace.to_json()
+    d = json.loads(json_str)
+    assert d["schema"] == "gptme.model-attestation/v0"
+    trace2 = ModelSelectionTrace.from_dict(d)
+    assert trace2.selection is not None
+    assert trace2.selection.requested_model == trace.selection.requested_model  # type: ignore[union-attr]
+
+
+def test_from_dict_wrong_schema():
+    d = {"schema": "wrong/v0", "selected_at": "2026-08-01T00:00:00Z"}
+    with pytest.raises(ValueError, match="Unsupported schema"):
+        ModelSelectionTrace.from_dict(d)
+
+
+def test_session_trace_storage():
+    trace = make_trace()
+    set_selection_trace(trace)
+    retrieved = get_selection_trace()
+    assert retrieved is trace
+
+    # Reset
+    set_selection_trace(None)  # type: ignore[arg-type]
+    assert get_selection_trace() is None
+
+
+def test_session_trace_distinguishes_providers():
+    """Phase 0 acceptance: trace distinguishes transport vs backend provider."""
+    trace = create_selection_trace(
+        requested_model="gptme/claude-sonnet-4-6",
+        resolved_model="anthropic/claude-sonnet-4-6",
+        source_kind="cli",
+        source_value="gptme/claude-sonnet-4-6",
+        transport_provider="gptme",
+        backend_provider="anthropic",
+    )
+    assert trace.selection is not None
+    assert trace.identity is not None
+    assert trace.selection.transport_provider != trace.selection.backend_provider
+    assert trace.selection.requested_model != trace.selection.resolved_model
+    assert trace.identity.attestation_level == "selection_only"
+
+
+def test_source_kinds():
+    for kind in (
+        "cli",
+        "api_request",
+        "chat_config",
+        "models.default",
+        "MODEL",
+        "acp_runtime",
+    ):
+        trace = make_trace(source_kind=kind)
+        assert trace.selection is not None
+        assert trace.selection.source.kind == kind

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -250,6 +250,27 @@ def test_record_selection_trace_resolves_openrouter_backed_gptme_backend():
     assert trace.selection.backend_provider == "openai"
 
 
+def test_record_runtime_selection_resolves_server_model(monkeypatch):
+    from gptme.llm.models import ModelMeta
+    from gptme.model_attestation import record_runtime_selection
+
+    monkeypatch.setattr(
+        "gptme.llm.models.get_model",
+        lambda _model: ModelMeta(
+            provider="gptme",
+            model="anthropic/claude-sonnet-4-6",
+            context=200_000,
+        ),
+    )
+
+    trace = record_runtime_selection("gptme/claude-sonnet-4-6", "api_request")
+    assert trace.selection is not None
+    assert trace.selection.source.kind == "api_request"
+    assert trace.selection.resolved_model == "gptme/anthropic/claude-sonnet-4-6"
+    assert trace.selection.backend_provider == "anthropic"
+    assert get_selection_trace() is trace
+
+
 def test_record_selection_trace_preserves_alias_resolution(monkeypatch):
     from gptme.init import MODEL_ALIASES, _record_selection_trace
     from gptme.llm.models import ModelMeta

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -296,3 +296,36 @@ def test_record_selection_trace_preserves_alias_resolution(monkeypatch):
     assert trace.selection.resolution_notes == [
         "resolved model alias for metadata lookup"
     ]
+
+
+def test_record_selection_trace_preserves_reasoning_suffixed_alias(monkeypatch):
+    from gptme.init import MODEL_ALIASES, _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    monkeypatch.setitem(
+        MODEL_ALIASES,
+        "openai-subscription",
+        {"gpt-5.6": "gpt-5.6-sol"},
+    )
+    model = "openai-subscription/gpt-5.6:high"
+    _record_selection_trace(
+        _config(),
+        model,
+        model,
+        model,
+        "openai-subscription",
+        ModelMeta(
+            provider="openai-subscription",
+            model="gpt-5.6:high",
+            context=400_000,
+        ),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.requested_model == model
+    assert trace.selection.alias_target == "openai-subscription/gpt-5.6-sol"
+    assert trace.selection.resolved_model == "openai-subscription/gpt-5.6-sol"
+    assert trace.selection.resolution_notes == [
+        "resolved model alias for metadata lookup"
+    ]

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -271,6 +271,37 @@ def test_record_runtime_selection_resolves_server_model(monkeypatch):
     assert get_selection_trace() is trace
 
 
+def test_record_runtime_selection_preserves_alias_resolution(monkeypatch):
+    from gptme.llm.models import MODEL_ALIASES, ModelMeta
+    from gptme.model_attestation import record_runtime_selection
+
+    monkeypatch.setitem(
+        MODEL_ALIASES,
+        "openai-subscription",
+        {"gpt-5.6": "gpt-5.6-sol"},
+    )
+    monkeypatch.setattr(
+        "gptme.llm.models.get_model",
+        lambda _model: ModelMeta(
+            provider="openai-subscription",
+            model="gpt-5.6:high",
+            context=400_000,
+        ),
+    )
+
+    model = "openai-subscription/gpt-5.6:high"
+    trace = record_runtime_selection(model, "api_request")
+
+    assert trace.selection is not None
+    assert trace.selection.requested_model == model
+    assert trace.selection.alias_target == "openai-subscription/gpt-5.6-sol"
+    assert trace.selection.resolved_model == "openai-subscription/gpt-5.6-sol"
+    assert trace.selection.backend_provider == "openai-subscription"
+    assert trace.selection.resolution_notes == [
+        "resolved model alias for metadata lookup"
+    ]
+
+
 def test_record_selection_trace_preserves_alias_resolution(monkeypatch):
     from gptme.init import MODEL_ALIASES, _record_selection_trace
     from gptme.llm.models import ModelMeta


### PR DESCRIPTION
## Summary

Adds a durable model selection provenance layer to gptme sessions (Phase 0).

**What's in this PR:**
- `gptme/model_attestation.py`: `ModelSelectionTrace` dataclass with serialization — records requested model, resolved model, transport/backend provider distinction, alias resolution path, and attestation level
- Integration into `init_model()`: trace is created at the end of model resolution and stored via `set_selection_trace()` / retrievable via `get_selection_trace()`
- 9 tests covering creation, alias resolution, serialization, round-trip, provider distinction, and session storage

**Phase 0 acceptance criterion met:** A session can distinguish:
- `requested_model` vs `resolved_model` (after alias/catalog resolution)
- `transport_provider` vs `backend_provider` (e.g. `gptme` vs `anthropic`)
- `attestation_level: selection_only` (honest about what evidence exists)

**What's deferred to later phases:**
- Phase 1: Registry bridge to `packages/model-capability-registry`
- Phase 2: Provider live evidence (revision IDs, build metadata)
- Phase 3: Provider-signed identity (cryptographic signatures)

Related: knowledge/technical-designs/2026-08-01-model-weight-governance-attestation.md (design doc), idea #924

## Test plan

- [x] `uv run pytest tests/test_model_attestation.py -v` → 9 passed
- [x] `mypy gptme/model_attestation.py gptme/init.py` → no issues
- [x] Pre-commit hooks pass (ruff + mypy)