### PR TITLE
fix(shell): fold workspace hint into tool response

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1495,24 +1495,21 @@ def execute_shell_impl(
         logdir=logdir,
     )
     # Workspace-awareness: notify when cd enters a directory with gptme.toml.
-    # Yield BEFORE the command output so that the command output is the last
-    # message from this generator.  base.py stamps call_id on the last yielded
-    # message (the actual tool result); earlier messages become plain system
-    # context with no call_id.  If the workspace hint were last, it — not the
-    # command output — would receive the call_id, making it the nominal tool
-    # response.  Strict providers (e.g. Moonshot AI / kimi-k2.6) then reject
-    # the conversation because the actual command output arrives as a bare
-    # system message between the assistant tool_calls and the tool response.
-    workspace_hint: Message | None = None
+    # Append hint text directly to the command output (single yield) so no
+    # separate message is interleaved between the assistant tool_calls entry
+    # and the tool response.  The serializer converts system messages without
+    # a call_id to user-role messages; any message interleaved between
+    # tool_calls and the tool result causes strict providers (e.g. Moonshot AI
+    # / kimi-k2.6) to reject the conversation with a 400 error.
+    workspace_hint_content = ""
     if returncode == 0 and not interrupted:
         cmd_stripped = cmd.strip()
         if cmd_stripped.startswith("cd ") or cmd_stripped == "cd":
-            workspace_hint = _check_workspace_config()
+            hint = _check_workspace_config()
+            if hint:
+                workspace_hint_content = "\n\n" + hint.content
 
-    if workspace_hint:
-        yield workspace_hint  # first: no call_id → becomes system context
-
-    yield Message("system", msg)  # last: receives call_id stamp → correct tool response
+    yield Message("system", msg + workspace_hint_content)
 
     if interrupted:
         raise KeyboardInterrupt from None

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1494,18 +1494,28 @@ def execute_shell_impl(
         timeout_value=timeout,
         logdir=logdir,
     )
-    yield Message("system", msg)
-
-    if interrupted:
-        raise KeyboardInterrupt from None
-
-    # Workspace-awareness: notify when cd enters a directory with gptme.toml
-    if returncode == 0:
+    # Workspace-awareness: notify when cd enters a directory with gptme.toml.
+    # Yield BEFORE the command output so that the command output is the last
+    # message from this generator.  base.py stamps call_id on the last yielded
+    # message (the actual tool result); earlier messages become plain system
+    # context with no call_id.  If the workspace hint were last, it — not the
+    # command output — would receive the call_id, making it the nominal tool
+    # response.  Strict providers (e.g. Moonshot AI / kimi-k2.6) then reject
+    # the conversation because the actual command output arrives as a bare
+    # system message between the assistant tool_calls and the tool response.
+    workspace_hint: Message | None = None
+    if returncode == 0 and not interrupted:
         cmd_stripped = cmd.strip()
         if cmd_stripped.startswith("cd ") or cmd_stripped == "cd":
             workspace_hint = _check_workspace_config()
-            if workspace_hint:
-                yield workspace_hint
+
+    if workspace_hint:
+        yield workspace_hint  # first: no call_id → becomes system context
+
+    yield Message("system", msg)  # last: receives call_id stamp → correct tool response
+
+    if interrupted:
+        raise KeyboardInterrupt from None
 
 
 # Workspace paths already hinted this session, so we don't spam the

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1973,6 +1973,57 @@ def test_workspace_hint_in_command_output(tmp_path):
     )
 
 
+def test_workspace_hint_serializes_as_one_tool_response(tmp_path):
+    """No message may sit between a structured call and its tool result."""
+    from gptme.llm.llm_openai import _prepare_messages_for_api
+    from gptme.message import Message
+    from gptme.tools import get_tool, init_tools
+    from gptme.tools.base import ToolUse
+    from gptme.tools.shell import _hinted_workspaces
+
+    (tmp_path / "gptme.toml").write_text("[gptme]\n")
+    _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+    original_cwd = os.getcwd()
+    try:
+        result_messages = list(
+            ToolUse(
+                tool="shell",
+                args=None,
+                content=None,
+                kwargs={"command": f"cd {tmp_path}"},
+                call_id="call_workspace",
+                _format="tool",
+            ).execute()
+        )
+    finally:
+        os.chdir(original_cwd)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+    init_tools(allowlist=["shell"])
+    messages = [
+        Message(role="user", content="Enter the workspace."),
+        Message(
+            role="assistant",
+            content=(f'@shell(call_workspace): {{"command": "cd {tmp_path}"}}'),
+        ),
+        *result_messages,
+    ]
+    shell_tool = get_tool("shell")
+    assert shell_tool is not None
+    serialized, _ = _prepare_messages_for_api(
+        messages, "moonshot/kimi-k2.6", [shell_tool]
+    )
+
+    assistant_idx = next(
+        idx for idx, message in enumerate(serialized) if message["role"] == "assistant"
+    )
+    tool_result = serialized[assistant_idx + 1]
+    assert tool_result["role"] == "tool"
+    assert tool_result["tool_call_id"] == "call_workspace"
+    assert "gptme.toml" in str(tool_result["content"])
+
+
 def test_shell_bare_cd_updates_working_directory(tmp_path):
     """A bare ``cd`` should update cwd to HOME, not leave stale state behind."""
     original_cwd = os.getcwd()

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1938,6 +1938,42 @@ def test_check_workspace_config_hint_includes_workdir_param(tmp_path):
         _hinted_workspaces.discard(str(tmp_path.resolve()))
 
 
+def test_workspace_hint_yielded_before_command_output(tmp_path):
+    """Workspace hint is the FIRST yielded message, command output is LAST.
+
+    base.py stamps call_id only on the last message from a tool generator so
+    that the actual tool result becomes the function_call_output, not earlier
+    context/warning messages.  If the workspace hint were last, it would
+    receive the call_id instead of the command output, and strict providers
+    (e.g. Moonshot AI) would reject the conversation because the actual shell
+    output then arrives as a bare ``system`` role message between the assistant
+    ``tool_calls`` entry and its expected ``tool`` response.
+    """
+    from gptme.tools.shell import _hinted_workspaces, execute_shell
+
+    (tmp_path / "gptme.toml").write_text("[gptme]\n")
+    _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+    original_cwd = os.getcwd()
+    try:
+        messages = list(execute_shell(None, None, {"command": f"cd {tmp_path}"}))
+    finally:
+        os.chdir(original_cwd)
+        _hinted_workspaces.discard(str(tmp_path.resolve()))
+
+    assert len(messages) == 2, (
+        f"Expected 2 messages (hint + output), got {len(messages)}"
+    )
+
+    hint_msg, output_msg = messages
+    assert "gptme.toml" in hint_msg.content, (
+        "First message should be the workspace hint"
+    )
+    assert output_msg.content.startswith("Ran"), (
+        "Second message should be the command output"
+    )
+
+
 def test_shell_bare_cd_updates_working_directory(tmp_path):
     """A bare ``cd`` should update cwd to HOME, not leave stale state behind."""
     original_cwd = os.getcwd()

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1938,16 +1938,17 @@ def test_check_workspace_config_hint_includes_workdir_param(tmp_path):
         _hinted_workspaces.discard(str(tmp_path.resolve()))
 
 
-def test_workspace_hint_yielded_before_command_output(tmp_path):
-    """Workspace hint is the FIRST yielded message, command output is LAST.
+def test_workspace_hint_in_command_output(tmp_path):
+    """Workspace hint is appended to the command output in a single message.
 
-    base.py stamps call_id only on the last message from a tool generator so
-    that the actual tool result becomes the function_call_output, not earlier
-    context/warning messages.  If the workspace hint were last, it would
-    receive the call_id instead of the command output, and strict providers
-    (e.g. Moonshot AI) would reject the conversation because the actual shell
-    output then arrives as a bare ``system`` role message between the assistant
-    ``tool_calls`` entry and its expected ``tool`` response.
+    Strict providers (e.g. Moonshot AI / kimi-k2.6) require that an assistant
+    ``tool_calls`` entry is immediately followed by ``tool`` role responses —
+    any interleaved message causes a 400 error.  The serializer converts system
+    messages without a call_id to user-role messages, so a separate hint yield
+    would appear as a user message between the tool_call and its result.
+    The fix: append the hint directly to the output so the generator yields a
+    single message that receives the call_id stamp and becomes a clean tool
+    response with no interleaved content.
     """
     from gptme.tools.shell import _hinted_workspaces, execute_shell
 
@@ -1961,16 +1962,14 @@ def test_workspace_hint_yielded_before_command_output(tmp_path):
         os.chdir(original_cwd)
         _hinted_workspaces.discard(str(tmp_path.resolve()))
 
-    assert len(messages) == 2, (
-        f"Expected 2 messages (hint + output), got {len(messages)}"
+    assert len(messages) == 1, (
+        f"Expected 1 message (output + appended hint), got {len(messages)}"
     )
 
-    hint_msg, output_msg = messages
-    assert "gptme.toml" in hint_msg.content, (
-        "First message should be the workspace hint"
-    )
-    assert output_msg.content.startswith("Ran"), (
-        "Second message should be the command output"
+    msg = messages[0]
+    assert msg.content.startswith("Ran"), "Message should start with the command output"
+    assert "gptme.toml" in msg.content, (
+        "Workspace hint should be appended to the output"
     )
 
 


### PR DESCRIPTION
## Summary

- **Bug**: When a shell \`cd\` enters a gptme workspace, \`_check_workspace_config\` previously yielded the workspace hint as a **separate** system message without a \`call_id\`. The serializer (\`_prep_o1\`) converts system messages without a \`call_id\` to user-role messages, which then appeared **between** the assistant \`tool_calls\` entry and the expected \`tool\` response.
- **Impact**: Providers with strict tool_call sequencing (e.g. Moonshot AI / kimi-k2.6) return a 400 error (\`an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'\`), causing 100% failure rate for kimi sessions that run any \`cd\` into a workspace.
- **Fix**: Fold the workspace hint into the single command-output message. The generator now yields **exactly one message** that receives the \`call_id\` stamp and becomes a clean \`tool\` response — no interleaving, no separate user/system message between tool_call and tool result.

## Test plan

- [x] \`test_workspace_hint_in_command_output\` — verifies a single message is yielded with hint appended to command output
- [x] \`test_workspace_hint_serializes_as_one_tool_response\` — end-to-end: runs \`cd\` through \`_prepare_messages_for_api\` with \`moonshot/kimi-k2.6\` and asserts the message immediately after \`assistant\` is \`role=tool\` with the correct \`tool_call_id\` and hint content
- [x] All 117 \`tests/test_tools_shell.py\` tests pass