### PR TITLE
fix(llm): buffer non-tool system msgs between tool_calls and tool responses

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1394,6 +1394,12 @@ def stream(
 
 
 def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
+    # Non-tool system messages between an assistant tool_calls message and the
+    # corresponding tool responses break strict APIs like DeepSeek. Buffer them
+    # and re-emit after the tool responses are flushed.
+    pending_system: list[dict] = []
+    after_tool_calls = False
+
     for message in message_dicts:
         # Format tool result as expected by the model
         if message["role"] == "system" and "call_id" in message:
@@ -1402,8 +1408,18 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
             modified_message["role"] = "tool"
             modified_message["tool_call_id"] = modified_message.pop("call_id")
             yield modified_message
+            # Flush system messages buffered while waiting for this tool response
+            for buffered in pending_system:
+                yield buffered
+            pending_system = []
+            after_tool_calls = False
         # Find tool_use occurrences and format them as expected
         elif message["role"] == "assistant":
+            # Flush any orphaned buffered system messages before next assistant turn
+            for buffered in pending_system:
+                yield buffered
+            pending_system = []
+
             modified_message = dict(message)
 
             content, tool_uses = extract_tool_uses_from_assistant_message(
@@ -1438,9 +1454,19 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     del modified_message["content"]
                 modified_message["tool_calls"] = tool_calls
 
+            after_tool_calls = bool(tool_calls)
             yield modified_message
         else:
-            yield message
+            if after_tool_calls:
+                # Buffer: a non-tool system message between tool_calls and tool
+                # responses is an invalid sequence for strict APIs (e.g. DeepSeek)
+                pending_system.append(message)
+            else:
+                yield message
+
+    # Flush any remaining buffered messages at end of conversation
+    for buffered in pending_system:
+        yield buffered
 
 
 def _merge_tool_results_with_same_call_id(

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1398,6 +1398,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
     # corresponding tool responses break strict APIs like DeepSeek. Buffer them
     # and re-emit after the tool responses are flushed.
     pending_system: list[dict] = []
+    pending_tool_call_ids: set[str] = set()
     after_tool_calls = False
 
     for message in message_dicts:
@@ -1406,13 +1407,11 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
             # Convert system+call_id to tool message (conforms to MessageDict)
             modified_message = dict(message)
             modified_message["role"] = "tool"
-            modified_message["tool_call_id"] = modified_message.pop("call_id")
+            tool_call_id = modified_message.pop("call_id")
+            modified_message["tool_call_id"] = tool_call_id
             yield modified_message
-            # Flush system messages buffered while waiting for this tool response
-            for buffered in pending_system:
-                yield buffered
-            pending_system = []
-            after_tool_calls = False
+            pending_tool_call_ids.discard(tool_call_id)
+            after_tool_calls = bool(pending_tool_call_ids)
         # Find tool_use occurrences and format them as expected
         elif message["role"] == "assistant":
             # Flush any orphaned buffered system messages before next assistant turn
@@ -1454,6 +1453,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     del modified_message["content"]
                 modified_message["tool_calls"] = tool_calls
 
+            pending_tool_call_ids = {call["id"] for call in tool_calls if call["id"]}
             after_tool_calls = bool(tool_calls)
             yield modified_message
         else:
@@ -1462,6 +1462,12 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                 # responses is an invalid sequence for strict APIs (e.g. DeepSeek)
                 pending_system.append(message)
             else:
+                # Delay flushing until the tool-response run actually ends. A tool
+                # can emit multiple messages with one call ID, and those must stay
+                # adjacent so _merge_tool_results_with_same_call_id can merge them.
+                for buffered in pending_system:
+                    yield buffered
+                pending_system = []
                 yield message
 
     # Flush any remaining buffered messages at end of conversation

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -356,6 +356,41 @@ def test_handle_tools_buffers_non_tool_system_between_tool_calls_and_response():
     assert first_part["text"] == "Shellcheck found potential issues: SC2086"
 
 
+def test_handle_tools_buffers_system_until_all_parallel_tool_responses():
+    """Buffered messages must not interrupt parallel tool responses."""
+    init_tools(allowlist=["shell"])
+
+    messages = [
+        Message(role="user", content="Run two shell commands"),
+        Message(
+            role="assistant",
+            content=(
+                '@shell(call_001): {"command": "echo one"}\n'
+                '@shell(call_002): {"command": "echo two"}'
+            ),
+        ),
+        Message(role="system", content="Shellcheck warning"),
+        Message(role="system", content="Output: one", call_id="call_001"),
+        Message(role="system", content="Output: two", call_id="call_002"),
+    ]
+
+    tool_shell = get_tool("shell")
+    assert tool_shell
+
+    model = get_model("openai/gpt-4o")
+    messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
+
+    assert [message["role"] for message in messages_dicts] == [
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "system",
+    ]
+    assert messages_dicts[2]["tool_call_id"] == "call_001"
+    assert messages_dicts[3]["tool_call_id"] == "call_002"
+
+
 def test_message_conversion_tool_response_with_image():
     """Tool responses with image files should use follow-up user messages for images.
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -310,6 +310,52 @@ def test_message_conversion_with_tool_and_non_tool():
     ]
 
 
+def test_handle_tools_buffers_non_tool_system_between_tool_calls_and_response():
+    """Non-tool system messages between tool_calls and tool responses are buffered.
+
+    DeepSeek and other strict APIs require that an assistant message with tool_calls
+    be immediately followed by tool messages. A plain system message (no call_id)
+    in between — e.g. a shellcheck warning emitted before the actual tool result —
+    causes a 400 error. The fix buffers such messages and re-emits them after the
+    tool responses.
+    """
+    init_tools(allowlist=["shell"])
+
+    messages = [
+        Message(role="user", content="Run a shell command"),
+        Message(
+            role="assistant",
+            content='@shell(call_001): {"command": "echo hello"}',
+        ),
+        # Non-tool system message (e.g. shellcheck warning) — no call_id
+        Message(role="system", content="Shellcheck found potential issues: SC2086"),
+        # Actual tool result — has call_id
+        Message(role="system", content="Output: hello", call_id="call_001"),
+    ]
+
+    tool_shell = get_tool("shell")
+    assert tool_shell
+
+    model = get_model("openai/gpt-4o")
+    messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
+
+    # The tool response must immediately follow the assistant tool_calls message.
+    # The non-tool system message must appear AFTER the tool response.
+    assert messages_dicts[0]["role"] == "user"
+    assert messages_dicts[1]["role"] == "assistant"
+    assert "tool_calls" in messages_dicts[1]
+    # Index 2 must be the tool response, not the shellcheck warning
+    assert messages_dicts[2]["role"] == "tool"
+    assert messages_dicts[2]["tool_call_id"] == "call_001"
+    # The buffered system message must appear after the tool response
+    assert messages_dicts[3]["role"] == "system"
+    content = messages_dicts[3]["content"]
+    assert isinstance(content, list)
+    first_part = content[0]
+    assert isinstance(first_part, dict)
+    assert first_part["text"] == "Shellcheck found potential issues: SC2086"
+
+
 def test_message_conversion_tool_response_with_image():
     """Tool responses with image files should use follow-up user messages for images.
 


### PR DESCRIPTION
## Summary

Fixes #3421.

DeepSeek and other strict OpenAI-compatible APIs require that an assistant message with `tool_calls` be immediately followed by `role: tool` messages for each `tool_call_id`. A plain system message without `call_id` appearing between them (e.g. a shellcheck warning emitted before the actual tool result) causes a 400 error:

> "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'."

## Root Cause

In `_handle_tools()`, messages without `call_id` were passed through unchanged regardless of position. This produced an invalid sequence for strict APIs:

```
[assistant: tool_calls=[{id: "call_001"}]]
[system: "Shellcheck found potential issues: SC2086"]  ← breaks DeepSeek
[tool: tool_call_id="call_001", content: "..."]
```

## Fix

`_handle_tools()` now buffers non-tool system messages that appear after an assistant `tool_calls` turn and flushes them after the corresponding tool responses:

```
[assistant: tool_calls=[{id: "call_001"}]]
[tool: tool_call_id="call_001", content: "..."]  ← tool response first
[system: "Shellcheck found potential issues: SC2086"]  ← buffered, now after
```

Orphaned buffered messages (no matching tool response follows) are flushed before the next assistant turn or at end-of-conversation, preserving all content.

## Test plan

- [x] New test `test_handle_tools_buffers_non_tool_system_between_tool_calls_and_response` verifies the reordering
- [x] All existing `test_llm_openai.py` tests pass (114/114)
- [x] mypy and ruff checks pass

<!-- gptme-id:v1:gai_3GqlED6AfvqvPgAO4x2d7erAc1qzCYuo4d0EcvdB2V2 -->