### PR TITLE
feat(cost): add session budget warnings

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -345,6 +345,9 @@ Besides the configuration files, gptme supports several environment variables to
 - ``GPTME_CHECK`` - Enable ``pre-commit`` checks (default: true if ``.pre-commit-config.yaml`` present, see :ref:`pre-commit`)
 - ``GPTME_CHAT_HISTORY`` - Enable cross-conversation context (default: false)
 - ``GPTME_COSTS`` - Enable cost reporting for API calls (default: false)
+- ``GPTME_SESSION_BUDGET_USD`` - Optional per-session cost budget in USD. When set, gptme warns once the current session crosses ``GPTME_BUDGET_WARN_PCT`` of the budget.
+- ``GPTME_SESSION_BUDGET_TOKENS`` - Optional per-session token budget. Counts input, output, cache-read, and cache-creation tokens.
+- ``GPTME_BUDGET_WARN_PCT`` - Percentage of the configured session budget that triggers the warning (default: 80).
 - ``GPTME_FRESH`` - Enable fresh context mode (default: false)
 - ``GPTME_BREAK_ON_TOOLUSE`` - Interrupt generation when tool use occurs in stream. Default is model-dependent: ``false`` for capable models that support parallel tool calls (e.g. claude-sonnet-4-6, gpt-4o), ``true`` for others. Set to ``0`` to force parallel tool calls, ``1`` to force single tool call per response (equivalent to ``--multi-tool`` flag).
 - ``GPTME_PATCH_RECOVERY`` - Return file content in error for non-matching patches (default: false)

--- a/gptme/hooks/cost_awareness.py
+++ b/gptme/hooks/cost_awareness.py
@@ -10,6 +10,7 @@ See Issue #935 for design context, #2320 for cache-cold warning.
 """
 
 import logging
+import math
 import os
 import time
 from collections.abc import Generator
@@ -74,7 +75,7 @@ def _positive_float_from_env(name: str) -> float | None:
     except ValueError:
         logger.warning("Ignoring invalid %s=%r; expected positive number", name, value)
         return None
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         logger.warning("Ignoring invalid %s=%r; expected positive number", name, value)
         return None
     return parsed
@@ -121,6 +122,8 @@ def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
     warn_pct = _budget_warn_pct()
     warn_fraction = warn_pct / 100
     last_entry = costs.entries[-1]
+    warning_parts: list[str] = []
+    log_parts: list[str] = []
 
     cost_budget = _positive_float_from_env("GPTME_SESSION_BUDGET_USD")
     if cost_budget is not None:
@@ -129,17 +132,15 @@ def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
         warn_at = cost_budget * warn_fraction
         if prev_cost < warn_at <= total_cost:
             cache_hit_pct = costs.cache_hit_rate * 100
-            return (
-                (
-                    f"<system_warning>Session cost reached ${total_cost:.2f} "
-                    f"({warn_pct:.0f}% of ${cost_budget:.2f} budget; "
-                    f"tokens: {costs.total_input_tokens:,}/{costs.total_output_tokens:,} in/out, "
-                    f"cache hit: {cache_hit_pct:.1f}%)</system_warning>"
-                ),
-                (
-                    f"Session cost reached ${total_cost:.2f} "
-                    f"({warn_pct:.0f}% of ${cost_budget:.2f} budget)"
-                ),
+            warning_parts.append(
+                f"Session cost reached ${total_cost:.2f} "
+                f"({warn_pct:.0f}% of ${cost_budget:.2f} budget; "
+                f"tokens: {costs.total_input_tokens:,}/{costs.total_output_tokens:,} in/out, "
+                f"cache hit: {cache_hit_pct:.1f}%)"
+            )
+            log_parts.append(
+                f"Session cost reached ${total_cost:.2f} "
+                f"({warn_pct:.0f}% of ${cost_budget:.2f} budget)"
             )
 
     token_budget = _positive_int_from_env("GPTME_SESSION_BUDGET_TOKENS")
@@ -154,18 +155,18 @@ def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
         prev_tokens = total_tokens - last_tokens
         warn_at_tokens = token_budget * warn_fraction
         if prev_tokens < warn_at_tokens <= total_tokens:
-            return (
-                (
-                    f"<system_warning>Session token usage reached {total_tokens:,} "
-                    f"({warn_pct:.0f}% of {token_budget:,} token budget)</system_warning>"
-                ),
-                (
-                    f"Session token usage reached {total_tokens:,} "
-                    f"({warn_pct:.0f}% of {token_budget:,} token budget)"
-                ),
+            warning_parts.append(
+                f"Session token usage reached {total_tokens:,} "
+                f"({warn_pct:.0f}% of {token_budget:,} token budget)"
             )
+            log_parts.append(warning_parts[-1])
 
-    return None
+    if not warning_parts:
+        return None
+    return (
+        f"<system_warning>{' '.join(warning_parts)}</system_warning>",
+        " ".join(log_parts),
+    )
 
 
 def anthropic_cache_cold_warning(

--- a/gptme/hooks/cost_awareness.py
+++ b/gptme/hooks/cost_awareness.py
@@ -10,6 +10,7 @@ See Issue #935 for design context, #2320 for cache-cold warning.
 """
 
 import logging
+import os
 import time
 from collections.abc import Generator
 from contextvars import ContextVar
@@ -56,10 +57,115 @@ COST_WARNING_THRESHOLDS = [
     1000.00,  # Large session warnings
 ]
 
+DEFAULT_BUDGET_WARN_PCT = 80.0
+
 
 def _is_direct_anthropic_model(model: str | None) -> bool:
     """Return True for direct Anthropic model IDs recorded by gptme."""
     return bool(model and model.startswith(("anthropic/", "claude-")))
+
+
+def _positive_float_from_env(name: str) -> float | None:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; expected positive number", name, value)
+        return None
+    if parsed <= 0:
+        logger.warning("Ignoring invalid %s=%r; expected positive number", name, value)
+        return None
+    return parsed
+
+
+def _positive_int_from_env(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; expected positive integer", name, value)
+        return None
+    if parsed <= 0:
+        logger.warning("Ignoring invalid %s=%r; expected positive integer", name, value)
+        return None
+    return parsed
+
+
+def _budget_warn_pct() -> float:
+    pct = _positive_float_from_env("GPTME_BUDGET_WARN_PCT")
+    if pct is None:
+        return DEFAULT_BUDGET_WARN_PCT
+    if pct > 100:
+        logger.warning(
+            "Ignoring invalid GPTME_BUDGET_WARN_PCT=%r; expected 0-100",
+            os.environ.get("GPTME_BUDGET_WARN_PCT"),
+        )
+        return DEFAULT_BUDGET_WARN_PCT
+    return pct
+
+
+def _total_tokens(costs: SessionCosts) -> int:
+    return (
+        costs.total_input_tokens
+        + costs.total_output_tokens
+        + costs.total_cache_read_tokens
+        + costs.total_cache_creation_tokens
+    )
+
+
+def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
+    warn_pct = _budget_warn_pct()
+    warn_fraction = warn_pct / 100
+    last_entry = costs.entries[-1]
+
+    cost_budget = _positive_float_from_env("GPTME_SESSION_BUDGET_USD")
+    if cost_budget is not None:
+        total_cost = costs.total_cost
+        prev_cost = total_cost - last_entry.cost
+        warn_at = cost_budget * warn_fraction
+        if prev_cost < warn_at <= total_cost:
+            cache_hit_pct = costs.cache_hit_rate * 100
+            return (
+                (
+                    f"<system_warning>Session cost reached ${total_cost:.2f} "
+                    f"({warn_pct:.0f}% of ${cost_budget:.2f} budget; "
+                    f"tokens: {costs.total_input_tokens:,}/{costs.total_output_tokens:,} in/out, "
+                    f"cache hit: {cache_hit_pct:.1f}%)</system_warning>"
+                ),
+                (
+                    f"Session cost reached ${total_cost:.2f} "
+                    f"({warn_pct:.0f}% of ${cost_budget:.2f} budget)"
+                ),
+            )
+
+    token_budget = _positive_int_from_env("GPTME_SESSION_BUDGET_TOKENS")
+    if token_budget is not None:
+        total_tokens = _total_tokens(costs)
+        last_tokens = (
+            last_entry.input_tokens
+            + last_entry.output_tokens
+            + last_entry.cache_read_tokens
+            + last_entry.cache_creation_tokens
+        )
+        prev_tokens = total_tokens - last_tokens
+        warn_at_tokens = token_budget * warn_fraction
+        if prev_tokens < warn_at_tokens <= total_tokens:
+            return (
+                (
+                    f"<system_warning>Session token usage reached {total_tokens:,} "
+                    f"({warn_pct:.0f}% of {token_budget:,} token budget)</system_warning>"
+                ),
+                (
+                    f"Session token usage reached {total_tokens:,} "
+                    f"({warn_pct:.0f}% of {token_budget:,} token budget)"
+                ),
+            )
+
+    return None
 
 
 def anthropic_cache_cold_warning(
@@ -186,6 +292,13 @@ def cost_warning_hook(
     # Find if we crossed any threshold with the last request
     last_entry = costs.entries[-1]
     prev_cost = total - last_entry.cost
+
+    if budget_warning := _budget_warning(costs):
+        warning_text, log_text = budget_warning
+        _pending_warning_var.set(warning_text)
+        logger.info(log_text)
+        yield from ()
+        return
 
     for threshold in COST_WARNING_THRESHOLDS:
         if prev_cost < threshold <= total:

--- a/gptme/hooks/cost_awareness.py
+++ b/gptme/hooks/cost_awareness.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..hooks import HookType, StopPropagation, register_hook
 from ..message import Message
-from ..util.cost_tracker import CostTracker, SessionCosts
+from ..util.cost_tracker import CostEntry, CostTracker, SessionCosts
 
 if TYPE_CHECKING:
     from ..logmanager import LogManager
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 # Thread-safe storage for pending warning to inject on next user message
 _pending_warning_var: ContextVar[str | None] = ContextVar(
     "pending_warning", default=None
+)
+_turn_start_entry_count_var: ContextVar[int | None] = ContextVar(
+    "turn_start_entry_count", default=None
 )
 
 # Anthropic prompt cache TTL (5 minutes)
@@ -118,17 +121,26 @@ def _total_tokens(costs: SessionCosts) -> int:
     )
 
 
-def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
+def _budget_warning(
+    costs: SessionCosts, turn_entries: list[CostEntry]
+) -> tuple[str, str] | None:
     warn_pct = _budget_warn_pct()
     warn_fraction = warn_pct / 100
-    last_entry = costs.entries[-1]
+    turn_cost = sum(entry.cost for entry in turn_entries)
+    turn_tokens = sum(
+        entry.input_tokens
+        + entry.output_tokens
+        + entry.cache_read_tokens
+        + entry.cache_creation_tokens
+        for entry in turn_entries
+    )
     warning_parts: list[str] = []
     log_parts: list[str] = []
 
     cost_budget = _positive_float_from_env("GPTME_SESSION_BUDGET_USD")
     if cost_budget is not None:
         total_cost = costs.total_cost
-        prev_cost = total_cost - last_entry.cost
+        prev_cost = total_cost - turn_cost
         warn_at = cost_budget * warn_fraction
         if prev_cost < warn_at <= total_cost:
             cache_hit_pct = costs.cache_hit_rate * 100
@@ -146,13 +158,7 @@ def _budget_warning(costs: SessionCosts) -> tuple[str, str] | None:
     token_budget = _positive_int_from_env("GPTME_SESSION_BUDGET_TOKENS")
     if token_budget is not None:
         total_tokens = _total_tokens(costs)
-        last_tokens = (
-            last_entry.input_tokens
-            + last_entry.output_tokens
-            + last_entry.cache_read_tokens
-            + last_entry.cache_creation_tokens
-        )
-        prev_tokens = total_tokens - last_tokens
+        prev_tokens = total_tokens - turn_tokens
         warn_at_tokens = token_budget * warn_fraction
         if prev_tokens < warn_at_tokens <= total_tokens:
             warning_parts.append(
@@ -268,6 +274,15 @@ def session_start_cost_tracking(
     yield from ()
 
 
+def record_turn_start_costs(
+    manager: "LogManager",
+) -> Generator[Message | StopPropagation, None, None]:
+    """Remember how many cost entries existed before the current turn."""
+    costs = CostTracker.get_session_costs()
+    _turn_start_entry_count_var.set(len(costs.entries) if costs else 0)
+    yield from ()
+
+
 def cost_warning_hook(
     manager: "LogManager",
 ) -> Generator[Message | StopPropagation, None, None]:
@@ -289,12 +304,20 @@ def cost_warning_hook(
         return
 
     total = costs.total_cost
+    turn_start = _turn_start_entry_count_var.get()
+    if turn_start is None:
+        turn_start = len(costs.entries) - 1
+    turn_start = min(turn_start, len(costs.entries))
+    turn_entries = costs.entries[turn_start:]
+    if not turn_entries:
+        return
 
-    # Find if we crossed any threshold with the last request
-    last_entry = costs.entries[-1]
-    prev_cost = total - last_entry.cost
+    # Find whether the completed turn crossed any threshold. A turn may contain
+    # multiple LLM requests when the assistant uses tools.
+    turn_cost = sum(entry.cost for entry in turn_entries)
+    prev_cost = total - turn_cost
 
-    if budget_warning := _budget_warning(costs):
+    if budget_warning := _budget_warning(costs, turn_entries):
         warning_text, log_text = budget_warning
         _pending_warning_var.set(warning_text)
         logger.info(log_text)
@@ -435,6 +458,12 @@ def register() -> None:
         HookType.GENERATION_PRE,
         cache_cold_warning_hook,
         priority=7,  # Must run before inject_pending_warning (priority=5) so warning is set before injection
+    )
+    register_hook(
+        "cost_awareness.turn_start",
+        HookType.TURN_PRE,
+        record_turn_start_costs,
+        priority=0,
     )
     register_hook(
         "cost_awareness.cost_warning",

--- a/gptme/hooks/tests/test_cost_awareness.py
+++ b/gptme/hooks/tests/test_cost_awareness.py
@@ -184,6 +184,67 @@ class TestCostWarningHook:
         for i in range(len(COST_WARNING_THRESHOLDS) - 1):
             assert COST_WARNING_THRESHOLDS[i] < COST_WARNING_THRESHOLDS[i + 1]
 
+    def test_budget_cost_warning_uses_env_budget(self, monkeypatch: pytest.MonkeyPatch):
+        """Cost budget warning fires at GPTME_BUDGET_WARN_PCT of budget."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", "1.00")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "80")
+        CostTracker.start_session("test")
+        self._record_cost(0.79)
+        list(cost_warning_hook(self._make_manager()))
+        assert _pending_warning_var.get() is not None  # fixed $0.10 threshold
+
+        _pending_warning_var.set(None)
+        self._record_cost(0.02)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "80% of $1.00 budget" in warning
+        assert "Session cost reached $0.81" in warning
+
+    def test_budget_token_warning_uses_env_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Token budget warning fires when total tokens cross the configured pct."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_TOKENS", "1000")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "80")
+        CostTracker.start_session("test")
+        self._record_cost(0.0, input_tokens=500, output_tokens=299)
+        list(cost_warning_hook(self._make_manager()))
+        assert _pending_warning_var.get() is None
+
+        self._record_cost(0.0, input_tokens=1, output_tokens=0)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "Session token usage reached 800" in warning
+        assert "80% of 1,000 token budget" in warning
+
+    def test_invalid_budget_warn_pct_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Invalid GPTME_BUDGET_WARN_PCT falls back to the 80% default."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", "1.00")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "150")
+        CostTracker.start_session("test")
+        self._record_cost(0.81)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "80% of $1.00 budget" in warning
+
+    def test_budget_warning_precedes_fixed_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Configured budget warning is more actionable than fixed milestones."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", "0.50")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "50")
+        CostTracker.start_session("test")
+        self._record_cost(0.60)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "50% of $0.50 budget" in warning
+
 
 class TestInjectPendingWarning:
     """Tests for inject_pending_warning hook."""

--- a/gptme/hooks/tests/test_cost_awareness.py
+++ b/gptme/hooks/tests/test_cost_awareness.py
@@ -11,9 +11,11 @@ from gptme.hooks.cost_awareness import (
     ANTHROPIC_CACHE_TTL_SECS,
     COST_WARNING_THRESHOLDS,
     _pending_warning_var,
+    _turn_start_entry_count_var,
     anthropic_cache_cold_warning,
     cost_warning_hook,
     inject_pending_warning,
+    record_turn_start_costs,
     session_end_cost_summary,
     session_start_cost_tracking,
 )
@@ -26,9 +28,11 @@ def reset_cost_state():
     """Reset cost tracker and pending warning before each test."""
     CostTracker.reset()
     _pending_warning_var.set(None)
+    _turn_start_entry_count_var.set(None)
     yield
     CostTracker.reset()
     _pending_warning_var.set(None)
+    _turn_start_entry_count_var.set(None)
 
 
 class TestSessionStartCostTracking:
@@ -244,6 +248,26 @@ class TestCostWarningHook:
         warning = _pending_warning_var.get()
         assert warning is not None
         assert "50% of $0.50 budget" in warning
+
+    def test_budget_crossing_in_earlier_request_of_turn_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Budget crossings in multi-request turns are not lost."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", "1.00")
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_TOKENS", "1000")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "80")
+        CostTracker.start_session("test")
+        self._record_cost(0.70, input_tokens=600, output_tokens=100)
+        list(record_turn_start_costs(self._make_manager()))
+        self._record_cost(0.11, input_tokens=100, output_tokens=0)
+        self._record_cost(0.01, input_tokens=1, output_tokens=0)
+
+        list(cost_warning_hook(self._make_manager()))
+
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "80% of $1.00 budget" in warning
+        assert "80% of 1,000 token budget" in warning
 
     def test_cost_and_token_budget_crossing_combines_warnings(
         self, monkeypatch: pytest.MonkeyPatch

--- a/gptme/hooks/tests/test_cost_awareness.py
+++ b/gptme/hooks/tests/test_cost_awareness.py
@@ -245,6 +245,35 @@ class TestCostWarningHook:
         assert warning is not None
         assert "50% of $0.50 budget" in warning
 
+    def test_cost_and_token_budget_crossing_combines_warnings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A single turn can cross both configured budgets without losing either."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", "1.00")
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_TOKENS", "1000")
+        monkeypatch.setenv("GPTME_BUDGET_WARN_PCT", "80")
+        CostTracker.start_session("test")
+        self._record_cost(0.81, input_tokens=700, output_tokens=100)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "80% of $1.00 budget" in warning
+        assert "80% of 1,000 token budget" in warning
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_non_finite_budget_float_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        """Non-finite float env values must not disable sane warnings silently."""
+        monkeypatch.setenv("GPTME_SESSION_BUDGET_USD", value)
+        CostTracker.start_session("test")
+        self._record_cost(0.15)
+        list(cost_warning_hook(self._make_manager()))
+        warning = _pending_warning_var.get()
+        assert warning is not None
+        assert "Session cost reached $0.15" in warning
+        assert "budget" not in warning
+
 
 class TestInjectPendingWarning:
     """Tests for inject_pending_warning hook."""


### PR DESCRIPTION
## Summary
- add optional `GPTME_SESSION_BUDGET_USD` and `GPTME_SESSION_BUDGET_TOKENS` session budgets
- warn at `GPTME_BUDGET_WARN_PCT` of the configured budget, defaulting to 80%
- document the new environment variables in the config reference

## Why
Existing cost awareness warns at fixed dollar milestones. This adds a user-defined budget threshold on top of the existing `CostTracker`, so long sessions can proactively surface budget pressure before the user gets a post-hoc surprise.

## Tests
- `uv run python3 -m pytest gptme/hooks/tests/test_cost_awareness.py tests/test_cost_awareness_delayed_warning.py tests/test_hooks_cost_awareness.py tests/test_cost_cache_cold_warning.py -q`
- `uv run ruff check gptme/hooks/cost_awareness.py gptme/hooks/tests/test_cost_awareness.py`
- `uv run ruff format --check gptme/hooks/cost_awareness.py gptme/hooks/tests/test_cost_awareness.py`
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme`
