### PR TITLE
feat(attestation): persist ModelSelectionTrace to logdir and embed in attestations

### DIFF
--- a/gptme/attestation.py
+++ b/gptme/attestation.py
@@ -140,6 +140,8 @@ def _build_payload(
     output_path: str | None,
     url: str | None,
 ) -> dict[str, Any]:
+    from .model_attestation import get_selection_trace
+
     model_id, model_provider = get_model_identity()
     output: dict[str, Any] = {
         "type": output_type,
@@ -150,6 +152,14 @@ def _build_payload(
     if url is not None:
         output["url"] = url
 
+    model_block: dict[str, Any] = {
+        "id": model_id,
+        "provider": model_provider,
+    }
+    trace = get_selection_trace()
+    if trace is not None:
+        model_block["selection_trace"] = trace.to_dict()
+
     return {
         "gptme_id": "v1",
         "issued_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
@@ -159,10 +169,7 @@ def _build_payload(
             "gptme_version": __version__,
             "session_id": get_session_id(),
         },
-        "model": {
-            "id": model_id,
-            "provider": model_provider,
-        },
+        "model": model_block,
         "output": output,
     }
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -496,17 +496,21 @@ class LogManager:
                     log.write_jsonl(view_path)
 
         # Persist model selection trace alongside the conversation
-        self.write_model_trace()
+        trace_path = self.write_model_trace()
 
         # Force sync to disk if requested
         if sync:
-            with open(self.logfile, "rb") as f:
-                os.fsync(f.fileno())
+            paths = [Path(self.logfile)]
+            if trace_path is not None:
+                paths.append(trace_path)
+            for path in paths:
+                with path.open("rb") as f:
+                    os.fsync(f.fileno())
 
     _TRACE_FILENAME = "model_selection_trace.json"
 
-    def write_model_trace(self) -> None:
-        """Persist the active ModelSelectionTrace to logdir/model_selection_trace.json.
+    def write_model_trace(self) -> Path | None:
+        """Persist the active ModelSelectionTrace and return its path.
 
         Called automatically by write(). No-op when no trace is active in the
         current context (e.g. tests or sessions that pre-date Phase 0).
@@ -515,9 +519,10 @@ class LogManager:
 
         trace = get_selection_trace()
         if trace is None:
-            return
+            return None
         trace_path = self.logdir / self._TRACE_FILENAME
         trace_path.write_text(trace.to_json() + "\n")
+        return trace_path
 
     def read_model_trace(self):
         """Read the persisted ModelSelectionTrace from logdir, or None if absent.

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -495,10 +495,49 @@ class LogManager:
                     view_path = views_dir / f"{view_name}.jsonl"
                     log.write_jsonl(view_path)
 
+        # Persist model selection trace alongside the conversation
+        self.write_model_trace()
+
         # Force sync to disk if requested
         if sync:
             with open(self.logfile, "rb") as f:
                 os.fsync(f.fileno())
+
+    _TRACE_FILENAME = "model_selection_trace.json"
+
+    def write_model_trace(self) -> None:
+        """Persist the active ModelSelectionTrace to logdir/model_selection_trace.json.
+
+        Called automatically by write(). No-op when no trace is active in the
+        current context (e.g. tests or sessions that pre-date Phase 0).
+        """
+        from ..model_attestation import get_selection_trace
+
+        trace = get_selection_trace()
+        if trace is None:
+            return
+        trace_path = self.logdir / self._TRACE_FILENAME
+        trace_path.write_text(trace.to_json() + "\n")
+
+    def read_model_trace(self):
+        """Read the persisted ModelSelectionTrace from logdir, or None if absent.
+
+        Returns:
+            ModelSelectionTrace if model_selection_trace.json exists, else None.
+        """
+        from ..model_attestation import ModelSelectionTrace
+
+        trace_path = self.logdir / self._TRACE_FILENAME
+        if not trace_path.exists():
+            return None
+        try:
+            data = json.loads(trace_path.read_text())
+            return ModelSelectionTrace.from_dict(data)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "Failed to parse model_selection_trace.json in %s", self.logdir
+            )
+            return None
 
     def _save_backup_branch(self, type="edit") -> None:
         """backup the current log to a new branch, usually before editing/undoing"""

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -506,6 +506,19 @@ class LogManager:
             for path in paths:
                 with path.open("rb") as f:
                     os.fsync(f.fileno())
+            if trace_path is not None:
+                self._fsync_directory(trace_path.parent)
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        """Make directory-entry changes durable where the platform supports it."""
+        if os.name == "nt":
+            return
+        directory_fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
 
     _TRACE_FILENAME = "model_selection_trace.json"
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 from itertools import islice, zip_longest
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import (
     Literal,
     TextIO,
@@ -521,7 +521,19 @@ class LogManager:
         if trace is None:
             return None
         trace_path = self.logdir / self._TRACE_FILENAME
-        trace_path.write_text(trace.to_json() + "\n")
+        with NamedTemporaryFile(
+            mode="w",
+            dir=self.logdir,
+            prefix=f".{self._TRACE_FILENAME}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_file.write(trace.to_json() + "\n")
+            temp_path = Path(temp_file.name)
+        try:
+            temp_path.replace(trace_path)
+        finally:
+            temp_path.unlink(missing_ok=True)
         return trace_path
 
     def read_model_trace(self):

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -511,14 +511,18 @@ class LogManager:
 
     @staticmethod
     def _fsync_directory(path: Path) -> None:
-        """Make directory-entry changes durable where the platform supports it."""
+        """Best-effort sync of directory-entry changes on POSIX filesystems."""
         if os.name == "nt":
             return
-        directory_fd = os.open(path, os.O_RDONLY)
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
         try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+            directory_fd = os.open(path, flags)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError as error:
+            logger.warning("Could not fsync log directory %s: %s", path, error)
 
     _TRACE_FILENAME = "model_selection_trace.json"
 

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -1414,6 +1414,46 @@ class TestCwdSessionId:
 class TestPromptTurnLoop:
     """Regression tests for complete ACP prompt-turn execution."""
 
+    def test_prompt_records_trace_before_first_persisted_message(self, monkeypatch):
+        """ACP task contexts must record their model before LogManager.append()."""
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        import gptme.acp.agent as agent_mod
+
+        agent = GptmeAgent()
+        agent._conn = MagicMock()
+        agent._conn.session_update = AsyncMock()
+        agent._session_commands_advertised.add("s1")
+        agent._session_models["s1"] = "openai/gpt-4o-mini"
+
+        log = _make_mock_log()
+        log.log = []
+        log.workspace = None
+        agent._registry.create("s1", log=log)
+
+        trace = MagicMock()
+        record = MagicMock(return_value=trace)
+        monkeypatch.setattr(agent_mod, "record_runtime_selection", record)
+
+        def append(message):
+            assert record.call_count == 1
+
+        log.append.side_effect = append
+        monkeypatch.setattr(
+            "gptme.util.content.is_message_command", lambda content: True
+        )
+        monkeypatch.setattr(agent, "_handle_slash_command", AsyncMock())
+
+        _run(
+            agent.prompt(
+                prompt=[{"type": "text", "text": "/help"}],
+                session_id="s1",
+            )
+        )
+
+        record.assert_called_once_with("openai/gpt-4o-mini", "acp_runtime")
+
     def test_prompt_continues_after_tool_result(self, monkeypatch):
         """A tool call must be followed by another model step in the same turn."""
         if not _import_acp():

--- a/tests/test_model_selection_trace_export.py
+++ b/tests/test_model_selection_trace_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -150,6 +151,26 @@ class TestLogManagerTracePersistence:
 
         expected_calls = 2 if os.name == "nt" else 3
         assert fsync.call_count == expected_calls
+
+    def test_unsupported_directory_fsync_does_not_fail_save(
+        self, tmp_path: Path
+    ) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        set_selection_trace(make_trace())
+        lm = LogManager(logdir=tmp_path, lock=False)
+        real_fsync = os.fsync
+
+        def reject_directory(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError("directory fsync unsupported")
+            real_fsync(fd)
+
+        with patch.object(os, "fsync", side_effect=reject_directory):
+            lm.write(sync=True)
+
+        assert lm.logfile.exists()
+        assert (tmp_path / "model_selection_trace.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_selection_trace_export.py
+++ b/tests/test_model_selection_trace_export.py
@@ -139,7 +139,7 @@ class TestLogManagerTracePersistence:
         assert trace_path.read_text() == "old trace\n"
         assert not temp_path.exists()
 
-    def test_sync_fsyncs_conversation_and_trace(self, tmp_path: Path) -> None:
+    def test_sync_fsyncs_conversation_trace_and_directory(self, tmp_path: Path) -> None:
         from gptme.logmanager.manager import LogManager
 
         set_selection_trace(make_trace())
@@ -148,7 +148,8 @@ class TestLogManagerTracePersistence:
         with patch.object(os, "fsync") as fsync:
             lm.write(sync=True)
 
-        assert fsync.call_count == 2
+        expected_calls = 2 if os.name == "nt" else 3
+        assert fsync.call_count == expected_calls
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_selection_trace_export.py
+++ b/tests/test_model_selection_trace_export.py
@@ -1,0 +1,184 @@
+"""Tests for ModelSelectionTrace durability: LogManager persistence and attestation embedding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gptme.model_attestation import (
+    ModelSelectionTrace,
+    create_selection_trace,
+    set_selection_trace,
+)
+
+
+def make_trace(
+    requested: str = "anthropic/claude-sonnet-4-6",
+    resolved: str = "anthropic/claude-sonnet-4-6",
+    source_kind: str = "cli",
+    transport: str = "anthropic",
+    backend: str = "anthropic",
+) -> ModelSelectionTrace:
+    return create_selection_trace(
+        requested_model=requested,
+        resolved_model=resolved,
+        source_kind=source_kind,  # type: ignore[arg-type]
+        source_value=requested,
+        transport_provider=transport,
+        backend_provider=backend,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LogManager trace persistence
+# ---------------------------------------------------------------------------
+
+
+class TestLogManagerTracePersistence:
+    """Round-trip: LogManager.write() persists trace, read_model_trace() restores it."""
+
+    def test_write_model_trace_creates_file(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        trace = make_trace()
+        set_selection_trace(trace)
+
+        lm = LogManager(logdir=tmp_path, lock=False)
+        lm.write()
+
+        trace_file = tmp_path / "model_selection_trace.json"
+        assert trace_file.exists(), "model_selection_trace.json must be written"
+
+    def test_write_model_trace_no_file_when_no_trace(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        set_selection_trace(None)
+
+        lm = LogManager(logdir=tmp_path, lock=False)
+        lm.write()
+
+        trace_file = tmp_path / "model_selection_trace.json"
+        assert not trace_file.exists(), "no trace file when context has no trace"
+
+    def test_read_model_trace_round_trips_fields(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        original = make_trace(
+            requested="openrouter/anthropic/claude-sonnet-4-6",
+            resolved="openrouter/anthropic/claude-sonnet-4-6",
+            source_kind="api_request",
+            transport="openrouter",
+            backend="anthropic",
+        )
+        set_selection_trace(original)
+
+        lm = LogManager(logdir=tmp_path, lock=False)
+        lm.write()
+
+        # Re-read from a fresh manager instance (no active ContextVar)
+        set_selection_trace(None)
+        lm2 = LogManager(logdir=tmp_path, lock=False)
+        restored = lm2.read_model_trace()
+
+        assert restored is not None
+        assert restored.schema == original.schema
+        # Narrow both selection fields for mypy
+        assert original.selection is not None
+        assert restored.selection is not None
+        orig_sel = original.selection
+        rest_sel = restored.selection
+        assert rest_sel.requested_model == orig_sel.requested_model
+        assert rest_sel.resolved_model == orig_sel.resolved_model
+        assert rest_sel.transport_provider == orig_sel.transport_provider
+        assert rest_sel.backend_provider == orig_sel.backend_provider
+        assert rest_sel.source.kind == orig_sel.source.kind
+        assert restored.identity is not None
+        assert restored.identity.attestation_level == "selection_only"
+
+    def test_read_model_trace_returns_none_when_file_absent(
+        self, tmp_path: Path
+    ) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        lm = LogManager(logdir=tmp_path, lock=False)
+        assert lm.read_model_trace() is None
+
+    def test_trace_file_is_valid_json(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        set_selection_trace(make_trace())
+        lm = LogManager(logdir=tmp_path, lock=False)
+        lm.write()
+
+        trace_path = tmp_path / "model_selection_trace.json"
+        data = json.loads(trace_path.read_text())
+        assert data["schema"] == "gptme.model-attestation/v0"
+        assert "selection" in data
+        assert "identity" in data
+
+
+# ---------------------------------------------------------------------------
+# Attestation embedding
+# ---------------------------------------------------------------------------
+
+
+FAKE_COMMIT = "a" * 40
+
+
+def _build_payload(trace: ModelSelectionTrace | None) -> dict:
+    """Build an attestation payload with git calls mocked out."""
+    from unittest.mock import patch
+
+    import gptme.attestation as att_mod
+
+    set_selection_trace(trace)
+    with (
+        patch.object(att_mod, "get_workspace_commit", return_value=FAKE_COMMIT),
+        patch.object(att_mod, "resolve_workspace_root", return_value=Path("/fake")),
+        patch.object(
+            att_mod, "get_model_identity", return_value=("test/model", "test")
+        ),
+        patch.object(att_mod, "get_agent_id", return_value="bob@host"),
+        patch.object(att_mod, "get_session_id", return_value="sess-123"),
+    ):
+        payload = att_mod._build_payload(
+            workspace_commit=FAKE_COMMIT,
+            output_type="text",
+            content_hash="sha256:abc",
+            output_path=None,
+            url=None,
+        )
+    return payload
+
+
+class TestAttestationTraceEmbedding:
+    """attestation.py embeds ModelSelectionTrace when active, omits it gracefully when absent."""
+
+    def test_attestation_includes_selection_trace_when_active(self) -> None:
+        trace = make_trace()
+        payload = _build_payload(trace)
+
+        assert "selection_trace" in payload["model"], (
+            "model.selection_trace must be present when trace is active"
+        )
+        st = payload["model"]["selection_trace"]
+        assert st["schema"] == "gptme.model-attestation/v0"
+        assert st["selection"]["requested_model"] == "anthropic/claude-sonnet-4-6"
+        assert st["selection"]["transport_provider"] == "anthropic"
+        assert st["identity"]["attestation_level"] == "selection_only"
+
+    def test_attestation_omits_selection_trace_when_none(self) -> None:
+        payload = _build_payload(None)
+
+        assert "selection_trace" not in payload["model"], (
+            "model.selection_trace must be absent when no trace is active"
+        )
+        assert "id" in payload["model"]
+        assert "provider" in payload["model"]
+
+    def test_attestation_model_block_backward_compat(self) -> None:
+        """Legacy fields (id, provider) are always present regardless of trace."""
+        for trace in [make_trace(), None]:
+            payload = _build_payload(trace)
+            assert "id" in payload["model"]
+            assert "provider" in payload["model"]

--- a/tests/test_model_selection_trace_export.py
+++ b/tests/test_model_selection_trace_export.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 from gptme.model_attestation import (
     ModelSelectionTrace,
@@ -115,6 +117,17 @@ class TestLogManagerTracePersistence:
         assert data["schema"] == "gptme.model-attestation/v0"
         assert "selection" in data
         assert "identity" in data
+
+    def test_sync_fsyncs_conversation_and_trace(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        set_selection_trace(make_trace())
+        lm = LogManager(logdir=tmp_path, lock=False)
+
+        with patch.object(os, "fsync") as fsync:
+            lm.write(sync=True)
+
+        assert fsync.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_selection_trace_export.py
+++ b/tests/test_model_selection_trace_export.py
@@ -118,6 +118,27 @@ class TestLogManagerTracePersistence:
         assert "selection" in data
         assert "identity" in data
 
+    def test_trace_write_replaces_file_atomically(self, tmp_path: Path) -> None:
+        from gptme.logmanager.manager import LogManager
+
+        trace_path = tmp_path / "model_selection_trace.json"
+        trace_path.write_text("old trace\n")
+        set_selection_trace(make_trace())
+        lm = LogManager(logdir=tmp_path, lock=False)
+
+        with patch.object(Path, "replace", autospec=True) as replace:
+            result = lm.write_model_trace()
+
+        replace.assert_called_once()
+        temp_path, destination = replace.call_args.args
+        assert temp_path.parent == tmp_path
+        assert temp_path.name.startswith(".model_selection_trace.json.")
+        assert temp_path.suffix == ".tmp"
+        assert destination == trace_path
+        assert result == trace_path
+        assert trace_path.read_text() == "old trace\n"
+        assert not temp_path.exists()
+
     def test_sync_fsyncs_conversation_and_trace(self, tmp_path: Path) -> None:
         from gptme.logmanager.manager import LogManager
 


### PR DESCRIPTION
## Summary

Durability slice for Phase 0 of model weight governance attestation.

Phase 0 (#3416) captured `ModelSelectionTrace` in a context-local `ContextVar` at model init time, but nothing persisted it — the trace existed only in memory for the process lifetime. This PR makes the trace durable in the two places where provenance evidence is most useful.

**Changes:**

- **`LogManager.write_model_trace()`**: called automatically by `write()` on every conversation save; serializes the active trace to `{logdir}/model_selection_trace.json`. No-op when no trace is active (pre-Phase-0 sessions, tests, CLI helpers).
- **`LogManager.read_model_trace()`**: reads it back as a `ModelSelectionTrace`, returning `None` for log dirs without the file (backward-compatible).
- **`attestation._build_payload()`**: embeds `trace.to_dict()` under `model.selection_trace` when a trace is active. Legacy `model.{id, provider}` fields remain unconditionally present.
- **8 focused tests** in `tests/test_model_selection_trace_export.py` covering file creation, no-op when absent, field round-trip, backward compat, and attestation embedding.

## Test plan

- [x] All 8 new tests pass: `pytest tests/test_model_selection_trace_export.py`
- [x] All 28 existing attestation/model tests pass: `pytest tests/test_model_attestation.py tests/test_util_cli_attest.py`
- [x] Mypy clean on modified files
- [x] Pre-commit hooks pass

## Relation to phase plan

- Phase 0 (schema + ContextVar wiring): merged in #3416
- **This PR (durability slice)**: `logdir/model_selection_trace.json` + attestation embedding
- Phase 1 (capability-registry enrichment): separate task, depends on this