### PR TITLE
fix(android): print actual cert fingerprint on verification mismatch

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -949,10 +949,17 @@ jobs:
           for apk in "${apks[@]}"; do
             echo "Verifying APK: $apk"
             "$APKSIGNER" verify --verbose "$apk"
+            # Label format varies across build-tools versions:
+            #   <=36: "Signer #1 certificate SHA-256 digest: <hex>"
+            #   37+:  "V3.0 Signer: certificate SHA-256 digest: <hex>"
+            # Match only *certificate* digests (not public-key digests) and
+            # dedupe: with one signing key every line carries the same value;
+            # multiple distinct certs concatenate and fail the comparison.
             PRINT_CERTS_OUT=$("$APKSIGNER" verify --print-certs "$apk")
-            ACTUAL_CERT_SHA256=$(printf '%s' "$PRINT_CERTS_OUT" \
-              | sed -n 's/.*SHA-256 digest: *//p' \
-              | tr '[:lower:]' '[:upper:]' | tr -d ':[:space:]')
+            ACTUAL_CERT_SHA256=$(printf '%s\n' "$PRINT_CERTS_OUT" \
+              | sed -n 's/.*certificate SHA-256 digest: *//p' \
+              | tr '[:lower:]' '[:upper:]' | tr -d ':' \
+              | sort -u | tr -d '[:space:]')
             if [ -z "$ACTUAL_CERT_SHA256" ]; then
               echo "::error::Could not extract certificate SHA-256 fingerprint from: $apk"
               printf '%s\n' "$PRINT_CERTS_OUT" | sed 's/^/  /'

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -949,11 +949,19 @@ jobs:
           for apk in "${apks[@]}"; do
             echo "Verifying APK: $apk"
             "$APKSIGNER" verify --verbose "$apk"
-            ACTUAL_CERT_SHA256=$("$APKSIGNER" verify --print-certs "$apk" \
-              | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
+            PRINT_CERTS_OUT=$("$APKSIGNER" verify --print-certs "$apk")
+            ACTUAL_CERT_SHA256=$(printf '%s' "$PRINT_CERTS_OUT" \
+              | sed -n 's/.*SHA-256 digest: *//p' \
               | tr '[:lower:]' '[:upper:]' | tr -d ':[:space:]')
+            if [ -z "$ACTUAL_CERT_SHA256" ]; then
+              echo "::error::Could not extract certificate SHA-256 fingerprint from: $apk"
+              printf '%s\n' "$PRINT_CERTS_OUT" | sed 's/^/  /'
+              exit 1
+            fi
             if [ "$ACTUAL_CERT_SHA256" != "$EXPECTED_CERT_SHA256" ]; then
               echo "::error::APK signer certificate does not match ANDROID_CERT_SHA256: $apk"
+              echo "::error::  expected: $EXPECTED_CERT_SHA256"
+              echo "::error::  actual:   $ACTUAL_CERT_SHA256"
               exit 1
             fi
           done


### PR DESCRIPTION
## Summary

- Capture `apksigner --print-certs` output to a variable before piping, so it can be reused for diagnostics
- Broaden sed pattern from exact `^Signer #1 certificate SHA-256 digest: ` prefix to `.*SHA-256 digest: *` — tolerates format variation across SDK/build-tools versions
- Fail with a dump of the full `--print-certs` output if fingerprint extraction yields empty string (parse failure is now its own error, not silent)
- Print **both** expected and actual fingerprints on mismatch so the operator can immediately read the real value and update `ANDROID_CERT_SHA256`

## Context

End-to-end validation run (30808558736, triggered to test #3408 signing) showed:

- APK signs successfully (v2/v3 schemes) ✅
- `apksigner verify --verbose` → "Verifies" ✅  
- Certificate fingerprint check → ❌ silent "does not match" with no actual value printed

The prior error message only named the file, making it impossible to distinguish two failure modes:

1. `sed` parse failure → `ACTUAL_CERT_SHA256=""` → always fails comparison
2. Genuine keystore/variable mismatch → correct value, wrong config

With this fix, the next CI run will print the actual fingerprint, and Erik can either confirm a sed format issue was the cause (unlikely but possible) or update `ANDROID_CERT_SHA256` in the `tauri-autoupdater-signing` environment with the real value.

Closes #3408 (pending fingerprint config confirmed correct after next run).

## Test plan

- [ ] Trigger `workflow_dispatch` with any `inputs.tag` after merging — the `Release Android` job will now print both expected and actual fingerprints on mismatch, or pass outright if the fingerprint was a sed parse issue all along
- [ ] If mismatch: copy the printed `actual:` value and update `ANDROID_CERT_SHA256` in the `tauri-autoupdater-signing` GitHub environment; re-trigger