### PR TITLE
fix(android): pin AAB signer fingerprint instead of -strict chain check

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -975,7 +975,25 @@ jobs:
 
           for aab in "${aabs[@]}"; do
             echo "Verifying AAB: $aab"
-            jarsigner -verify -strict "$aab"
+            # No -strict: Android upload keys are self-signed, so PKIX chain
+            # validation can never pass (exit 4). Identity is enforced by
+            # pinning the signer certificate fingerprint below, like the APK.
+            VERIFY_OUT=$(jarsigner -verify "$aab")
+            printf '%s\n' "$VERIFY_OUT"
+            if ! printf '%s' "$VERIFY_OUT" | grep -q "jar verified"; then
+              echo "::error::AAB signature verification failed: $aab"
+              exit 1
+            fi
+            ACTUAL_CERT_SHA256=$(keytool -printcert -jarfile "$aab" \
+              | sed -n 's/^[[:space:]]*SHA256: //p' \
+              | tr '[:lower:]' '[:upper:]' | tr -d ':' \
+              | sort -u | tr -d '[:space:]')
+            if [ "$ACTUAL_CERT_SHA256" != "$EXPECTED_CERT_SHA256" ]; then
+              echo "::error::AAB signer certificate does not match ANDROID_CERT_SHA256: $aab"
+              echo "::error::  expected: $EXPECTED_CERT_SHA256"
+              echo "::error::  actual:   $ACTUAL_CERT_SHA256"
+              exit 1
+            fi
           done
           echo "All Android artifacts passed signature and identity verification."
 


### PR DESCRIPTION
Third and final fix in the Android signing E2E validation chain (#3409 → #3426 → this).

## Problem

Validation run [30810636935](https://github.com/gptme/gptme/actions/runs/30810636935) (workflow_dispatch on tag `v0.32.2.dev20260730`) got further than before: **the APK path now fully passes** — signing, `apksigner verify`, and the pinned SHA-256 fingerprint check all succeeded with the #3426 fix. The remaining failure was the AAB step:

```
jar verified, with signer errors.
Error: This jar contains entries whose certificate chain is invalid. Reason: PKIX path building failed ...
##[error]Process completed with exit code 4.
```

`jarsigner -verify -strict` validates the certificate chain against the JDK truststore. Android upload keys are always self-signed, so this check can never pass — it was wrong since #3409 (aw-android doesn't verify AABs at all, so there was no battle-tested reference here).

## Fix

- Integrity: `jarsigner -verify` without `-strict`, requiring `jar verified` in the output (plain `-verify` exits 0 even for unsigned jars, so the output check is load-bearing).
- Identity: extract the signer certificate SHA-256 via `keytool -printcert -jarfile` and compare against the pinned `ANDROID_CERT_SHA256`, exactly like the APK path (with the same sort -u dedupe hardening from #3426).

## Verification

- [x] Positive case: locally signed the real AAB artifact from run 30810636935 with the release keystore — `jar verified` + fingerprint matches `FFF9...3240`.
- [x] Negative case: unsigned artifact correctly rejected (`no manifest.` → no `jar verified` → fail).
- [ ] Re-run workflow_dispatch validation after merge — should now pass end-to-end and upload signed APK/AAB.