### PR TITLE
fix(server): check all sessions when guarding concurrent generation in /step

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -383,7 +383,10 @@ def api_conversation_step(conversation_id: str):
     # config PATCH. A PATCH completed before this acquisition must affect the
     # worker; one arriving afterward sees generating=True and returns 409.
     with SessionManager.conversation_lock(conversation_id), session.step_lock:
-        if session.generating or SessionManager.command_is_active(conversation_id):
+        conv_sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+        if any(s.generating for s in conv_sessions) or SessionManager.command_is_active(
+            conversation_id
+        ):
             return flask.jsonify({"error": "Generation already in progress"}), 409
         chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
         if stream is None:

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2402,6 +2402,28 @@ def test_v2_step_rejected_while_conversation_command_is_active(client: FlaskClie
     assert response.get_json()["error"] == "Generation already in progress"
 
 
+def test_v2_step_rejected_while_other_session_generating(client: FlaskClient):
+    """Step is rejected when a *different* session for the same conversation is generating."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2_sessions.SessionManager.get_sessions_for_conversation"
+    ) as mock_get:
+        other_session = unittest.mock.MagicMock()
+        other_session.generating = True
+        mock_get.return_value = [other_session]
+
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}/step",
+            json={"session_id": session_id},
+        )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == "Generation already in progress"
+
+
 @pytest.mark.parametrize(
     ("method", "path", "json"),
     [


### PR DESCRIPTION
## Summary

- **Bug**: `POST /step` only checked the requesting session's own `.generating` flag. Two clients holding different `ConversationSession` objects for the same `conversation_id` could both pass the guard and generate concurrently, writing conflicting messages to the same JSONL file.
- **Fix**: Align `/step` with every other write endpoint — use `any(s.generating for s in get_sessions_for_conversation(...))` to block if *any* session for the conversation is already generating.
- **Test**: Added `test_v2_step_rejected_while_other_session_generating` that patches `get_sessions_for_conversation` on the `api_v2_sessions` module to return a mock session with `generating=True`, then asserts that `/step` returns 409.

## Root cause detail

All of `POST /conversations/<id>`, `PATCH/DELETE /messages/<n>`, `PATCH /config`, and `DELETE /conversations/<id>` guard with:
```python
sessions = SessionManager.get_sessions_for_conversation(conversation_id)
if any(sess.generating for sess in sessions) or ...:
    return 409
```

But `/step` used:
```python
if session.generating or ...:
    return 409
```

where `session` is the single session associated with the requester. A second client with its own session would see `session.generating = False` and start a competing generation thread.

## Test plan
- [x] `test_v2_step_rejected_while_other_session_generating` passes
- [x] All 7 generating/command_is_active related tests pass
- [x] Pre-commit hooks pass (ruff format auto-corrected one file)