### PR TITLE
fix(server): complete cross-session generation guarding for conversations

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -805,10 +805,13 @@ def api_conversation_rerun(conversation_id: str):
             }
         ), 403
 
-    # Check under the conversation lock so the check is atomic against
-    # reservation sites (/step, skip continuation), and check all sessions for
-    # the conversation — another client's session generating into the same log
-    # must also block a rerun (same class of bug as the /step guard).
+    # Hold the conversation lock from the guard through pending-tool
+    # registration and execution scheduling, so a concurrent /step (or another
+    # reservation site) cannot reserve generation between the check and the
+    # rerun's shared-state work. The check is conversation-wide — another
+    # client's session generating into the same log must also block a rerun
+    # (same class of bug as the /step guard). All work inside the lock is fast
+    # and local (log read, parsing, thread spawn) — no LLM or tool execution.
     with SessionManager.conversation_lock(conversation_id), session.step_lock:
         if SessionManager.conversation_generating(
             conversation_id
@@ -817,86 +820,88 @@ def api_conversation_rerun(conversation_id: str):
                 {"error": "Cannot rerun while generation is in progress"}
             ), 409
 
-    # Load conversation and find the last assistant message
-    try:
-        manager = LogManager.load(conversation_id, lock=False)
-    except FileNotFoundError:
-        return flask.jsonify(
-            {"error": f"Conversation not found: {conversation_id}"}
-        ), 404
+        # Load conversation and find the last assistant message
+        try:
+            manager = LogManager.load(conversation_id, lock=False)
+        except FileNotFoundError:
+            return flask.jsonify(
+                {"error": f"Conversation not found: {conversation_id}"}
+            ), 404
 
-    # Find the last assistant message
-    last_assistant = None
-    for msg in reversed(list(manager.log.messages)):
-        if msg.role == "assistant":
-            last_assistant = msg
-            break
+        # Find the last assistant message
+        last_assistant = None
+        for msg in reversed(list(manager.log.messages)):
+            if msg.role == "assistant":
+                last_assistant = msg
+                break
 
-    if not last_assistant:
-        return flask.jsonify({"error": "No assistant message found"}), 400
+        if not last_assistant:
+            return flask.jsonify({"error": "No assistant message found"}), 400
 
-    # Parse tool uses from the message content
-    tooluses = list(ToolUse.iter_from_content(last_assistant.content))
-    if not tooluses:
-        return flask.jsonify(
-            {"error": "No tool uses found in the last assistant message"}
-        ), 400
+        # Parse tool uses from the message content
+        tooluses = list(ToolUse.iter_from_content(last_assistant.content))
+        if not tooluses:
+            return flask.jsonify(
+                {"error": "No tool uses found in the last assistant message"}
+            ), 400
 
-    # Set them as pending (same flow as step() tool detection)
-    first_auto_id: str | None = None
-    logdir = get_logs_dir() / conversation_id
-    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
-    default_model = get_default_model()
-    model = chat_config.model or (default_model.full if default_model else "anthropic")
-
-    for tooluse in tooluses:
-        tool_id = str(uuid.uuid4())
-        tool_exec = ToolExecution(
-            tool_id=tool_id,
-            tooluse=tooluse,
-            auto_confirm=session.auto_confirm_count > 0,
+        # Set them as pending (same flow as step() tool detection)
+        first_auto_id: str | None = None
+        logdir = get_logs_dir() / conversation_id
+        chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+        default_model = get_default_model()
+        model = chat_config.model or (
+            default_model.full if default_model else "anthropic"
         )
-        session.pending_tools[tool_id] = tool_exec
 
-        SessionManager.add_event(
-            conversation_id,
-            {
-                "type": "tool_pending",
-                "tool_id": tool_id,
-                "tooluse": {
-                    "tool": tooluse.tool,
-                    "args": tooluse.args,
-                    "content": tooluse.content,
+        for tooluse in tooluses:
+            tool_id = str(uuid.uuid4())
+            tool_exec = ToolExecution(
+                tool_id=tool_id,
+                tooluse=tooluse,
+                auto_confirm=session.auto_confirm_count > 0,
+            )
+            session.pending_tools[tool_id] = tool_exec
+
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "tool_pending",
+                    "tool_id": tool_id,
+                    "tooluse": {
+                        "tool": tooluse.tool,
+                        "args": tooluse.args,
+                        "content": tooluse.content,
+                    },
+                    "auto_confirm": tool_exec.auto_confirm,
                 },
-                "auto_confirm": tool_exec.auto_confirm,
-            },
+            )
+
+            if tool_exec.auto_confirm:
+                if session.auto_confirm_count > 0:
+                    session.auto_confirm_count -= 1
+                if first_auto_id is None:
+                    first_auto_id = tool_id
+
+        # Start execution for only the first auto-confirm tool.
+        # execute_tool_thread will chain the remaining tools serially (same as step()).
+        if first_auto_id is not None:
+            start_tool_execution(
+                conversation_id,
+                session,
+                first_auto_id,
+                session.pending_tools[first_auto_id].tooluse,
+                model,
+                chat_config,
+            )
+
+        return flask.jsonify(
+            {
+                "status": "ok",
+                "message": f"Re-running {len(tooluses)} tool(s)",
+                "tool_ids": list(session.pending_tools),
+            }
         )
-
-        if tool_exec.auto_confirm:
-            if session.auto_confirm_count > 0:
-                session.auto_confirm_count -= 1
-            if first_auto_id is None:
-                first_auto_id = tool_id
-
-    # Start execution for only the first auto-confirm tool.
-    # execute_tool_thread will chain the remaining tools serially (same as step()).
-    if first_auto_id is not None:
-        start_tool_execution(
-            conversation_id,
-            session,
-            first_auto_id,
-            session.pending_tools[first_auto_id].tooluse,
-            model,
-            chat_config,
-        )
-
-    return flask.jsonify(
-        {
-            "status": "ok",
-            "message": f"Re-running {len(tooluses)} tool(s)",
-            "tool_ids": list(session.pending_tools),
-        }
-    )
 
 
 @sessions_api.route(

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -383,10 +383,9 @@ def api_conversation_step(conversation_id: str):
     # config PATCH. A PATCH completed before this acquisition must affect the
     # worker; one arriving afterward sees generating=True and returns 409.
     with SessionManager.conversation_lock(conversation_id), session.step_lock:
-        conv_sessions = SessionManager.get_sessions_for_conversation(conversation_id)
-        if any(s.generating for s in conv_sessions) or SessionManager.command_is_active(
+        if SessionManager.conversation_generating(
             conversation_id
-        ):
+        ) or SessionManager.command_is_active(conversation_id):
             return flask.jsonify({"error": "Generation already in progress"}), 409
         chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
         if stream is None:
@@ -692,7 +691,9 @@ def api_conversation_tool_confirm(conversation_id: str):
             current_tool = session.pending_tools.get(tool_id)
             if current_tool is None:
                 return flask.jsonify({"error": f"Tool not found: {tool_id}"}), 404
-            if session.generating:
+            # Check all sessions for the conversation (not just this one) —
+            # another client's session may be generating into the same log.
+            if SessionManager.conversation_generating(conversation_id):
                 return (
                     flask.jsonify({"error": "Generation already in progress"}),
                     409,
@@ -804,10 +805,17 @@ def api_conversation_rerun(conversation_id: str):
             }
         ), 403
 
-    if session.generating:
-        return flask.jsonify(
-            {"error": "Cannot rerun while generation is in progress"}
-        ), 409
+    # Check under the conversation lock so the check is atomic against
+    # reservation sites (/step, skip continuation), and check all sessions for
+    # the conversation — another client's session generating into the same log
+    # must also block a rerun (same class of bug as the /step guard).
+    with SessionManager.conversation_lock(conversation_id), session.step_lock:
+        if SessionManager.conversation_generating(
+            conversation_id
+        ) or SessionManager.command_is_active(conversation_id):
+            return flask.jsonify(
+                {"error": "Cannot rerun while generation is in progress"}
+            ), 409
 
     # Load conversation and find the last assistant message
     try:
@@ -1093,19 +1101,28 @@ def api_conversation_interrupt(conversation_id: str):
             }
         ), 403
 
-    with session.step_lock:
-        if not session.generating and not session.pending_tools:
-            # Idempotent: if nothing is generating, treat as already interrupted
-            return flask.jsonify(
-                {"status": "ok", "message": "Already interrupted or not generating"}
-            )
+    # Interrupt conversation-wide: generation may have been started by a
+    # *different* session for the same conversation (e.g. another connected
+    # client). Only clearing the requesting session's flag would leave that
+    # sibling generation running and report "Already interrupted".
+    # Hold the conversation lock so a concurrent reservation can't slip in
+    # between clearing one session and the next.
+    interrupted = False
+    with SessionManager.conversation_lock(conversation_id):
+        for sess in SessionManager.get_sessions_for_conversation(conversation_id):
+            with sess.step_lock:
+                if sess.generating or sess.pending_tools:
+                    interrupted = True
+                # Mark session as not generating and clear pending tools
+                sess.generating = False
+                sess.generating_since = None
+                sess.pending_tools.clear()
 
-        # Mark session as not generating
-        session.generating = False
-        session.generating_since = None
-
-        # Clear pending tools
-        session.pending_tools.clear()
+    if not interrupted:
+        # Idempotent: if nothing is generating, treat as already interrupted
+        return flask.jsonify(
+            {"status": "ok", "message": "Already interrupted or not generating"}
+        )
 
     # Notify about interruption
     SessionManager.add_event(conversation_id, {"type": "interrupted"})

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -885,7 +885,14 @@ def api_conversation_rerun(conversation_id: str):
 
         # Start execution for only the first auto-confirm tool.
         # execute_tool_thread will chain the remaining tools serially (same as step()).
+        # Pre-reserve generation inside the lock so no concurrent /step can slip
+        # in between the guard check above and the tool worker's own call to
+        # _start_step_thread.  The worker transfers the reservation to
+        # _start_step_thread (reserved=True) when it starts the continuation, or
+        # releases it itself if the continuation is not needed.
         if first_auto_id is not None:
+            session.generating = True
+            session.generating_since = datetime.now(tz=timezone.utc)
             start_tool_execution(
                 conversation_id,
                 session,
@@ -893,6 +900,7 @@ def api_conversation_rerun(conversation_id: str):
                 session.pending_tools[first_auto_id].tooluse,
                 model,
                 chat_config,
+                reserved=True,
             )
 
         return flask.jsonify(

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -203,6 +203,19 @@ class SessionManager:
             ]
 
     @classmethod
+    def conversation_generating(cls, conversation_id: str) -> bool:
+        """Return whether any session for the conversation is generating.
+
+        The ``generating`` flag is session-scoped, but generation writes to the
+        conversation's shared log — so reservation checks must consider all
+        sessions for the conversation, not just the requesting one.
+        """
+        return any(
+            session.generating
+            for session in cls.get_sessions_for_conversation(conversation_id)
+        )
+
+    @classmethod
     def add_event(cls, conversation_id: str, event: EventType) -> None:
         """Add an event to all sessions for a conversation."""
         sessions = cls.get_sessions_for_conversation(conversation_id)

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -514,7 +514,9 @@ def _start_acp_step_thread(
     """Start an ACP-backed step unless another operation has reserved it."""
     if not reserved:
         with SessionManager.conversation_lock(conversation_id), session.step_lock:
-            if session.generating or SessionManager.command_is_active(conversation_id):
+            if SessionManager.conversation_generating(
+                conversation_id
+            ) or SessionManager.command_is_active(conversation_id):
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
@@ -920,8 +922,10 @@ def start_tool_execution(
             # Reload the conversation to pick up outputs from prior tools
             manager = LogManager.load(conversation_id, lock=False)
 
-            # Use .get() to atomically retrieve and handle concurrent removal
-            tool_exec = session.pending_tools.get(current_tool_id)
+            # Atomically claim the tool with pop(): a get-then-pop sequence
+            # leaves a window where two threads (e.g. two concurrent confirm
+            # requests) both see the tool and both execute it.
+            tool_exec = session.pending_tools.pop(current_tool_id, None)
             if tool_exec is None:
                 logger.warning(
                     f"Tool {current_tool_id} not found in pending tools "
@@ -932,9 +936,6 @@ def start_tool_execution(
 
             # use explicit tooluse if set (may be modified), else from pending
             tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
-
-            # Remove the tool from pending
-            session.pending_tools.pop(current_tool_id, None)
 
             # Record start time and notify about tool execution
             tool_exec.started_at = time.monotonic()
@@ -1049,7 +1050,9 @@ def _start_step_thread(
     # identifies that reservation explicitly to avoid rejecting itself.
     if not reserved:
         with SessionManager.conversation_lock(conversation_id), session.step_lock:
-            if session.generating or SessionManager.command_is_active(conversation_id):
+            if SessionManager.conversation_generating(
+                conversation_id
+            ) or SessionManager.command_is_active(conversation_id):
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -913,142 +913,156 @@ def start_tool_execution(
         current_conversation_id.set(conversation_id)
         current_session_id.set(session.id)
 
-        # Prepare execution environment (config, tools, hooks, .env)
-        prepare_execution_environment(
-            workspace=chat_config.workspace,
-            tools=None,
-            chat_config=chat_config,
-        )
-
-        # Execute tools serially. When break_on_tooluse=False, a single
-        # assistant message may contain multiple tool uses. After completing
-        # each tool we chain to the next pending auto-confirm tool (if any)
-        # to guarantee serial execution order.
-        current_tool_id: str = tool_id
-        current_edited_tooluse: ToolUse | None = edited_tooluse
-
-        while True:
-            # Reload the conversation to pick up outputs from prior tools
-            manager = LogManager.load(conversation_id, lock=False)
-
-            # Atomically claim the tool with pop(): a get-then-pop sequence
-            # leaves a window where two threads (e.g. two concurrent confirm
-            # requests) both see the tool and both execute it.
-            tool_exec = session.pending_tools.pop(current_tool_id, None)
-            if tool_exec is None:
-                logger.warning(
-                    f"Tool {current_tool_id} not found in pending tools "
-                    "(may have been handled by another thread)"
-                )
-                # Release any pre-reserved generation slot so the conversation
-                # is not permanently blocked.
-                if reserved:
-                    session.generating = False
-                    session.generating_since = None
-                return  # another thread claimed this tool; don't trigger auto-step
-            tool_exec.status = ToolStatus.EXECUTING
-
-            # use explicit tooluse if set (may be modified), else from pending
-            tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
-
-            # Record start time and notify about tool execution
-            tool_exec.started_at = time.monotonic()
-            SessionManager.add_event(
-                conversation_id,
-                {"type": "tool_executing", "tool_id": current_tool_id},
+        try:
+            # Prepare execution environment (config, tools, hooks, .env)
+            prepare_execution_environment(
+                workspace=chat_config.workspace,
+                tools=None,
+                chat_config=chat_config,
             )
-            logger.info(f"Tool {current_tool_id} executing")
 
-            # Execute the tool
-            try:
-                logger.info(f"Executing tool: {tooluse.tool}")
-                stream_tool_id = current_tool_id
+            # Execute tools serially. When break_on_tooluse=False, a single
+            # assistant message may contain multiple tool uses. After completing
+            # each tool we chain to the next pending auto-confirm tool (if any)
+            # to guarantee serial execution order.
+            current_tool_id: str = tool_id
+            current_edited_tooluse: ToolUse | None = edited_tooluse
 
-                def stream_tool_output(
-                    tool_output: Message, tool_id: str = stream_tool_id
-                ) -> None:
-                    if (
-                        tool_output.role == "system"
-                        and not tool_output.hide
-                        and not tool_output.quiet
-                    ):
-                        SessionManager.add_event(
-                            conversation_id,
-                            {
-                                "type": "tool_output",
-                                "tool_id": tool_id,
-                                "output": tool_output.content,
-                            },
-                        )
+            while True:
+                # Reload the conversation to pick up outputs from prior tools
+                manager = LogManager.load(conversation_id, lock=False)
 
-                tool_outputs = list(
-                    tooluse.execute(
-                        log=manager.log,
-                        workspace=manager.workspace,
-                        on_result_message=stream_tool_output,
+                # Atomically claim the tool with pop(): a get-then-pop sequence
+                # leaves a window where two threads (e.g. two concurrent confirm
+                # requests) both see the tool and both execute it.
+                tool_exec = session.pending_tools.pop(current_tool_id, None)
+                if tool_exec is None:
+                    logger.warning(
+                        f"Tool {current_tool_id} not found in pending tools "
+                        "(may have been handled by another thread)"
                     )
-                )
-                logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
+                    # Release any pre-reserved generation slot so the conversation
+                    # is not permanently blocked.
+                    if reserved:
+                        session.generating = False
+                        session.generating_since = None
+                    return  # another thread claimed this tool; don't trigger auto-step
+                tool_exec.status = ToolStatus.EXECUTING
 
-                # Store the tool outputs. call_id is already assigned in
-                # ToolUse.execute() for real results; hook messages intentionally
-                # have no call_id — don't re-stamp here or hook messages become
-                # duplicate function_call_output entries (Responses API 400).
-                for tool_output in tool_outputs:
-                    _append_and_notify(manager, session, tool_output)
-            except Exception as e:
-                logger.exception(f"Error executing tool {tooluse.tool}: {e}")
-                tool_exec.status = ToolStatus.FAILED
+                # use explicit tooluse if set (may be modified), else from pending
+                tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
 
-                msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
-                _append_and_notify(manager, session, msg)
-
-            # Emit tool_complete with duration
-            if tool_exec.started_at is not None:
-                duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
+                # Record start time and notify about tool execution
+                tool_exec.started_at = time.monotonic()
                 SessionManager.add_event(
                     conversation_id,
-                    {
-                        "type": "tool_complete",
-                        "tool_id": current_tool_id,
-                        "duration_ms": duration_ms,
-                        "success": tool_exec.status != ToolStatus.FAILED,
-                    },
+                    {"type": "tool_executing", "tool_id": current_tool_id},
                 )
+                logger.info(f"Tool {current_tool_id} executing")
 
-            # Persist tool outputs to disk
-            manager.write()
+                # Execute the tool
+                try:
+                    logger.info(f"Executing tool: {tooluse.tool}")
+                    stream_tool_id = current_tool_id
 
-            # Chain to next pending auto-confirm tool (serial execution)
-            next_auto_id: str | None = None
-            for tid, texec in list(session.pending_tools.items()):
-                if texec.auto_confirm:
-                    next_auto_id = tid
+                    def stream_tool_output(
+                        tool_output: Message, tool_id: str = stream_tool_id
+                    ) -> None:
+                        if (
+                            tool_output.role == "system"
+                            and not tool_output.hide
+                            and not tool_output.quiet
+                        ):
+                            SessionManager.add_event(
+                                conversation_id,
+                                {
+                                    "type": "tool_output",
+                                    "tool_id": tool_id,
+                                    "output": tool_output.content,
+                                },
+                            )
+
+                    tool_outputs = list(
+                        tooluse.execute(
+                            log=manager.log,
+                            workspace=manager.workspace,
+                            on_result_message=stream_tool_output,
+                        )
+                    )
+                    logger.info(
+                        f"Tool execution complete, outputs: {len(tool_outputs)}"
+                    )
+
+                    # Store the tool outputs. call_id is already assigned in
+                    # ToolUse.execute() for real results; hook messages intentionally
+                    # have no call_id — don't re-stamp here or hook messages become
+                    # duplicate function_call_output entries (Responses API 400).
+                    for tool_output in tool_outputs:
+                        _append_and_notify(manager, session, tool_output)
+                except Exception as e:
+                    logger.exception(f"Error executing tool {tooluse.tool}: {e}")
+                    tool_exec.status = ToolStatus.FAILED
+
+                    msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
+                    _append_and_notify(manager, session, msg)
+
+                # Emit tool_complete with duration
+                if tool_exec.started_at is not None:
+                    duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
+                    SessionManager.add_event(
+                        conversation_id,
+                        {
+                            "type": "tool_complete",
+                            "tool_id": current_tool_id,
+                            "duration_ms": duration_ms,
+                            "success": tool_exec.status != ToolStatus.FAILED,
+                        },
+                    )
+
+                # Persist tool outputs to disk
+                manager.write()
+
+                # Chain to next pending auto-confirm tool (serial execution)
+                next_auto_id: str | None = None
+                for tid, texec in list(session.pending_tools.items()):
+                    if texec.auto_confirm:
+                        next_auto_id = tid
+                        break
+
+                if next_auto_id is not None:
+                    current_tool_id = next_auto_id
+                    current_edited_tooluse = None
+                else:
                     break
 
-            if next_auto_id is not None:
-                current_tool_id = next_auto_id
-                current_edited_tooluse = None
-            else:
-                break
-
-        # Only auto-step when all pending tools have been executed.
-        # With multiple tools per message, we must wait until every tool
-        # has run before asking the model for a continuation.
-        if not session.pending_tools:
-            _start_step_thread(
-                conversation_id,
-                session,
-                model,
-                chat_config.workspace,
-                reserved=reserved,
+            # Only auto-step when all pending tools have been executed.
+            # With multiple tools per message, we must wait until every tool
+            # has run before asking the model for a continuation.
+            if not session.pending_tools:
+                _start_step_thread(
+                    conversation_id,
+                    session,
+                    model,
+                    chat_config.workspace,
+                    reserved=reserved,
+                )
+            elif reserved:
+                # Pending non-auto-confirm tools remain; those need explicit client
+                # confirmation.  Release the pre-reserved generation slot so the
+                # conversation is not permanently blocked.
+                session.generating = False
+                session.generating_since = None
+        except Exception:
+            logger.exception(
+                f"Unhandled error in tool execution thread for {conversation_id}"
             )
-        elif reserved:
-            # Pending non-auto-confirm tools remain; those need explicit client
-            # confirmation.  Release the pre-reserved generation slot so the
-            # conversation is not permanently blocked.
-            session.generating = False
-            session.generating_since = None
+            if reserved:
+                # A crash anywhere before the reservation is transferred to
+                # _start_step_thread (or explicitly released above) must not
+                # permanently strand the conversation in a generating state.
+                session.generating = False
+                session.generating_since = None
+            raise
 
     # Propagate ContextVars from the request context into the execution thread.
     ctx = contextvars.copy_context()

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -891,8 +891,17 @@ def start_tool_execution(
     edited_tooluse: ToolUse | None,
     model: str,
     chat_config: ChatConfig,
+    *,
+    reserved: bool = False,
 ) -> threading.Thread:
-    """Execute a tool and handle its output."""
+    """Execute a tool and handle its output.
+
+    If ``reserved`` is True, the caller has already set ``session.generating``
+    inside the conversation lock.  The generation reservation is transferred to
+    ``_start_step_thread`` (via ``reserved=True``) when a continuation is
+    started; if the thread exits without starting a continuation, it clears the
+    reservation so subsequent requests are not permanently blocked.
+    """
 
     # This function would ideally run asynchronously to not block the request
     # For simplicity, we'll run it in a thread
@@ -931,6 +940,11 @@ def start_tool_execution(
                     f"Tool {current_tool_id} not found in pending tools "
                     "(may have been handled by another thread)"
                 )
+                # Release any pre-reserved generation slot so the conversation
+                # is not permanently blocked.
+                if reserved:
+                    session.generating = False
+                    session.generating_since = None
                 return  # another thread claimed this tool; don't trigger auto-step
             tool_exec.status = ToolStatus.EXECUTING
 
@@ -1022,7 +1036,19 @@ def start_tool_execution(
         # With multiple tools per message, we must wait until every tool
         # has run before asking the model for a continuation.
         if not session.pending_tools:
-            _start_step_thread(conversation_id, session, model, chat_config.workspace)
+            _start_step_thread(
+                conversation_id,
+                session,
+                model,
+                chat_config.workspace,
+                reserved=reserved,
+            )
+        elif reserved:
+            # Pending non-auto-confirm tools remain; those need explicit client
+            # confirmation.  Release the pre-reserved generation slot so the
+            # conversation is not permanently blocked.
+            session.generating = False
+            session.generating_since = None
 
     # Propagate ContextVars from the request context into the execution thread.
     ctx = contextvars.copy_context()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2424,6 +2424,141 @@ def test_v2_step_rejected_while_other_session_generating(client: FlaskClient):
     assert response.get_json()["error"] == "Generation already in progress"
 
 
+def test_v2_rerun_rejected_while_other_session_generating(client: FlaskClient):
+    """Rerun is rejected when a *different* session for the same conversation is generating."""
+    from gptme.server.session_models import SessionManager
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+
+    other_session = SessionManager.create_session(conversation_id)
+    other_session.generating = True
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}/rerun",
+            json={"session_id": session_id},
+        )
+        assert response.status_code == 409
+        assert (
+            response.get_json()["error"]
+            == "Cannot rerun while generation is in progress"
+        )
+    finally:
+        other_session.generating = False
+        SessionManager.remove_session(other_session.id)
+
+
+def test_v2_tool_skip_rejected_while_other_session_generating(client: FlaskClient):
+    """Skip is rejected when a *different* session for the same conversation is generating."""
+    from gptme.server.session_models import SessionManager, ToolExecution
+    from gptme.tools import ToolUse
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+    session = SessionManager.get_session(session_id)
+    assert session is not None
+
+    tool_id = "tool-skip-cross-session"
+    session.pending_tools[tool_id] = ToolExecution(
+        tool_id=tool_id,
+        tooluse=ToolUse("shell", [], "echo hello", call_id="call-skip-1"),
+    )
+
+    other_session = SessionManager.create_session(conversation_id)
+    other_session.generating = True
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}/tool/confirm",
+            json={"session_id": session_id, "tool_id": tool_id, "action": "skip"},
+        )
+        assert response.status_code == 409
+        assert response.get_json()["error"] == "Generation already in progress"
+        # The pending tool must remain untouched so the client can retry
+        assert tool_id in session.pending_tools
+    finally:
+        other_session.generating = False
+        SessionManager.remove_session(other_session.id)
+        session.pending_tools.pop(tool_id, None)
+
+
+def test_v2_interrupt_stops_other_sessions_generation(client: FlaskClient):
+    """Interrupt clears generation started by a *different* session for the conversation."""
+    from gptme.server.session_models import SessionManager
+
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+
+    other_session = SessionManager.create_session(conversation_id)
+    other_session.generating = True
+    other_session.generating_since = datetime.now(tz=timezone.utc)
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{conversation_id}/interrupt",
+            json={"session_id": session_id},
+        )
+        assert response.status_code == 200
+        assert response.get_json()["message"] == "Interrupted"
+        assert other_session.generating is False
+        assert other_session.generating_since is None
+    finally:
+        other_session.generating = False
+        SessionManager.remove_session(other_session.id)
+
+
+def test_start_step_thread_rejected_while_other_session_generating(v2_conv):
+    """Tool-continuation steps must not start while a sibling session is generating."""
+    from gptme.server.session_models import SessionManager
+    from gptme.server.session_step import _start_step_thread
+
+    conversation_id = v2_conv["conversation_id"]
+    session = SessionManager.get_session(v2_conv["session_id"])
+    assert session is not None
+
+    other_session = SessionManager.create_session(conversation_id)
+    other_session.generating = True
+    try:
+        started = _start_step_thread(
+            conversation_id,
+            session,
+            "openai/mock-model",
+            Path("/tmp"),
+            reserved=False,
+        )
+        assert started is False
+        assert session.generating is False
+    finally:
+        other_session.generating = False
+        SessionManager.remove_session(other_session.id)
+
+
+def test_start_acp_step_thread_rejected_while_other_session_generating(v2_conv):
+    """ACP steps must not start while a sibling session is generating."""
+    from gptme.server.session_models import SessionManager
+    from gptme.server.session_step import _start_acp_step_thread
+
+    conversation_id = v2_conv["conversation_id"]
+    session = SessionManager.get_session(v2_conv["session_id"])
+    assert session is not None
+
+    other_session = SessionManager.create_session(conversation_id)
+    other_session.generating = True
+    try:
+        started = _start_acp_step_thread(
+            conversation_id=conversation_id,
+            session=session,
+            workspace=Path("/tmp"),
+            reserved=False,
+        )
+        assert started is False
+        assert session.generating is False
+    finally:
+        other_session.generating = False
+        SessionManager.remove_session(other_session.id)
+
+
 @pytest.mark.parametrize(
     ("method", "path", "json"),
     [


### PR DESCRIPTION
## What

#3428 fixed the `/step` route to check **all** sessions for a conversation before reserving generation. This PR completes that fix: the same single-session `.generating` check survived at four other reservation/guard sites, and `/interrupt` had the inverse bug.

Two different `ConversationSession` objects for the same `conversation_id` (two connected clients) generate into the same conversation log, so all of these could produce concurrent generations writing conflicting messages to the same JSONL:

- **`_start_step_thread` (non-reserved path)** — used by every tool-continuation step and A2A: checked only its own session's flag
- **`_start_acp_step_thread` (non-reserved path)** — same for ACP steps
- **`tool/confirm` `skip` action** — the skip continuation reserved against the requesting session only
- **`/rerun`** — checked only its own session, with no lock at all

And the inverse:

- **`/interrupt`** only cleared the *requesting* session's flag — a client could not stop generation started by another client's session for the same conversation. It returned "Already interrupted or not generating" while the sibling generation kept running.

## How

- New `SessionManager.conversation_generating(conversation_id)` — single source of truth for "is anything generating into this conversation", used at every guard site (including `/step`, replacing its inline check)
- `/rerun` now checks under `conversation_lock` + `step_lock`, matching the other sites' lock ordering
- `/interrupt` clears `generating`/`generating_since`/`pending_tools` across **all** sessions for the conversation, holding the conversation lock so a concurrent reservation can't slip in between sessions; the idempotent "already interrupted" response is now conversation-wide
- **Bonus race fix**: `execute_tool_thread` claimed tools with a get-then-pop sequence, so two concurrent confirm requests could both observe and both execute the same pending tool (double execution of destructive tools). The claim is now a single atomic `pop()`.

## Tests

Five new regression tests mirroring the #3428 test:
- `/rerun` 409 while a sibling session generates
- `skip` 409 while a sibling session generates (pending tool left intact for retry)
- `/interrupt` stops a *sibling* session's generation (200 + flag cleared)
- `_start_step_thread` / `_start_acp_step_thread` refuse to start while a sibling generates

`tests/test_server_v2.py`: 221 passed, 5 skipped locally (one pre-existing env-only timeout in `test_v2_conversations_list_keeps_messages_in_fast_mode` on a machine with 25k conversation dirs — unrelated to this diff). Adjacent suites (`test_server_session_models`, `test_hooks_server_confirm`, `test_server_elicitation`, `test_server_a2a`, `test_acp_agent`, `test_acp_session_runtime`): 218 passed. mypy clean on the three changed modules.

Follow-up to #3428.