### PR TITLE
fix(security): require bearer auth for all bind addresses, remove is_local_host() bypass

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -183,6 +183,7 @@ jobs:
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'dummy-ci-key' }}
         MODEL: anthropic/claude-3-5-haiku-latest
+        GPTME_DISABLE_AUTH: "1"
       run: |
         gptme-server --cors-origin="http://127.0.0.1:5701,http://localhost:5701" &
         echo $! > /tmp/gptme-server.pid

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -245,7 +245,7 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
                            /home/gptme/.local/share/gptme \
                            /home/gptme/.local/state/gptme
 
-    # Secrets file (provider keys, optional GPTME_SERVER_TOKEN), not world-readable
+    # Secrets file (provider keys + GPTME_SERVER_TOKEN), not world-readable
     sudo install -d -m 750 -o gptme -g gptme /etc/gptme
     sudo install -m 640 -o gptme -g gptme /dev/null /etc/gptme/server.env
     sudoedit /etc/gptme/server.env   # add ANTHROPIC_API_KEY=... etc.
@@ -259,8 +259,9 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
 Tail logs with ``journalctl -u gptme-server -f``. Because the unit binds
 ``127.0.0.1``, pair it with the nginx reverse proxy above to expose it over TLS.
 Set ``GPTME_SERVER_TOKEN`` in the env file to a stable secret so clients have a
-persistent credential across restarts; if omitted the server auto-generates a
-random token and prints it at startup.
+persistent credential across restarts. This is **required for persistent
+deployments**: if omitted the server generates a new random token at each startup,
+invalidating any client already configured with the previous token.
 
 Basic Web UI
 ------------

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -257,9 +257,10 @@ The template runs the server as a dedicated ``gptme`` user, reads secrets from
     sudo systemctl enable --now gptme-server
 
 Tail logs with ``journalctl -u gptme-server -f``. Because the unit binds
-``127.0.0.1``, pair it with the nginx reverse proxy above to expose it over TLS;
-on loopback the auth token is optional (set ``GPTME_SERVER_TOKEN`` in the env
-file if you change the bind to a public interface).
+``127.0.0.1``, pair it with the nginx reverse proxy above to expose it over TLS.
+Set ``GPTME_SERVER_TOKEN`` in the env file to a stable secret so clients have a
+persistent credential across restarts; if omitted the server auto-generates a
+random token and prints it at startup.
 
 Basic Web UI
 ------------

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -72,18 +72,11 @@ When Vite runs separately on port 5701, allow that development origin:
 
 .. note::
 
-    **Host-header validation (DNS-rebinding protection).**
-    On loopback binds the server runs without an auth token, so it validates
-    the request ``Host`` header to block DNS-rebinding attacks (a malicious page
-    whose hostname re-resolves to ``127.0.0.1`` would otherwise become
-    same-origin with your local server and gain full unauthenticated API
-    access, including shell execution via the agent). ``localhost``,
-    ``127.0.0.1`` and ``[::1]`` (any port) are always allowed. If you proxy the
-    local server behind a hostname, allow it with
-    ``gptme-server serve --allowed-hosts gptme.local`` (comma-separated, or via
-    ``GPTME_SERVER_ALLOWED_HOSTS``). Validation is skipped when auth is enabled
-    (network binds) or explicitly disabled with ``GPTME_DISABLE_AUTH`` — those
-    operators own their own access control (e.g. an authenticated ingress).
+    **Host-header validation.** Bearer authentication is enabled for loopback
+    and network binds alike. If an operator explicitly disables authentication
+    with ``GPTME_DISABLE_AUTH``, they can still opt into Host-header validation
+    with ``gptme-server serve --allowed-hosts gptme.local`` (comma-separated,
+    or via ``GPTME_SERVER_ALLOWED_HOSTS``).
 
 Self-Hosting with Docker Compose
 --------------------------------
@@ -364,30 +357,22 @@ This section describes the security model of gptme-server and the threat vectors
 Authentication Model
 ~~~~~~~~~~~~~~~~~~~~
 
-gptme-server uses a tiered authentication model based on the bind address:
+gptme-server requires bearer authentication for capability-bearing API routes
+regardless of bind address. Loopback is a transport boundary, not an identity
+boundary: another local process must not gain shell and config access merely by
+reaching ``127.0.0.1``. A small set of public routes remain unauthenticated: the
+API root (``/api/v2``), version info (``/api/v2/version``), config metadata
+(``/api/v2/config``), Prometheus metrics (``/api/v0/metrics``), and the API
+documentation at ``/api/docs/``. Set ``GPTME_SERVER_TOKEN`` to a fixed value;
+if unset the server generates one and prints it at startup.
 
-- **Loopback bind** (``127.0.0.1`` / ``localhost`` / ``::1``, the default):
-  Bearer auth is **disabled** — a random token is generated on startup but
-  the server does not require it for API access. The assumption is that any
-  process on the same machine is the legitimate user.
-
-- **Network bind** (``0.0.0.0`` or an external IP): Bearer auth is
-  **enabled** and required for capability-bearing API requests (conversation
-  endpoints, tool execution, config writes). A small set of public routes
-  remain unauthenticated: the API root (``/api/v2``), version info
-  (``/api/v2/version``), config metadata (``/api/v2/config``), Prometheus
-  metrics (``/api/v0/metrics``), and the API documentation at
-  ``/api/docs/``. Set ``GPTME_SERVER_TOKEN``
-  to a fixed value; if unset the server generates one and prints it at
-  startup.
-
-- ``GPTME_DISABLE_AUTH`` overrides both: disables bearer checks entirely
+- ``GPTME_DISABLE_AUTH`` disables bearer checks entirely
   regardless of bind address. Use only behind an authenticated ingress.
 
 .. warning::
 
    An authorized API client (anyone who can reach the server with a valid
-   token, or the local user on a loopback bind) can execute arbitrary shell
+   token) can execute arbitrary shell
    commands through the agent. There is no additional sandboxing at the
    API layer. The security boundary is **access to the server**, not any
    individual endpoint.
@@ -397,8 +382,8 @@ gptme-server uses a tiered authentication model based on the bind address:
 Threat Model
 ~~~~~~~~~~~~
 
-The server is hardened against two classes of browser-originating attack that
-apply to the default unauthenticated loopback setup:
+The server is hardened against browser-originating attacks that apply to local
+server access:
 
 **1. Cross-Site Request Forgery (CSRF)**
 
@@ -411,13 +396,11 @@ server rejects them as malformed.
 
 **2. DNS Rebinding**
 
-A malicious site can re-resolve its hostname to ``127.0.0.1`` after the
-page loads. That makes the browser consider it *same-origin* with the local
-server, bypassing CORS entirely. The direct mitigation is **Host-header
-validation** (see the note in the :ref:`gptme-webui <server:gptme-webui>`
-section): the server rejects requests whose ``Host`` does not match
-``localhost``, ``127.0.0.1``, ``::1``, the configured bind address, or any
-explicitly allowed hostname (``--allowed-hosts``).
+A malicious site can re-resolve its hostname to ``127.0.0.1`` after the page
+loads and thereby bypass CORS. Bearer authentication still blocks access to
+capability-bearing routes because the page does not possess the token. If an
+operator explicitly disables bearer auth, ``--allowed-hosts`` can add
+Host-header validation as defense in depth.
 
 **What is NOT in scope:**
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -580,8 +580,7 @@ def _get_user_config_file_response(content: str) -> dict[str, str | bool]:
     """Return raw config text with the same path metadata as user settings.
 
     Secret values (API keys etc.) are redacted with ``***`` before being
-    included in the response — even when the auth bypass is active for
-    local-only servers.
+    included in the response as defense in depth.
     """
     runtime_info = get_user_config_runtime_info()
     return {

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -61,10 +61,9 @@ def create_app(
             A comma-separated string allows multiple origins, e.g.
             "tauri://localhost,http://tauri.localhost". Whitespace around
             entries is ignored.
-        allowed_hosts: Extra hostnames to accept in the Host header when Host
-            validation is active (loopback binds without auth). Adds to the
-            built-in localhost/127.0.0.1/[::1] allow-list, for users who proxy
-            the local server behind a hostname. See init_host_validation.
+        allowed_hosts: Extra hostnames to accept in the Host header when auth is
+            explicitly disabled. Adds to the built-in
+            localhost/127.0.0.1/[::1] allow-list. See init_host_validation.
         webui_dir: Optional directory containing a web UI build to serve
             instead of the bundled modern UI. Falls back to the
             ``GPTME_WEBUI_DIR`` environment variable, then to the bundled UI
@@ -173,13 +172,13 @@ def create_app(
                 },
             )
 
-    # Initialize auth (defaults to local-only, no auth required)
+    # Initialize auth (required by default for every bind address).
     from .auth import init_auth, init_host_validation, validate_host  # fmt: skip
 
     init_auth(host=host, display=False)
 
-    # Configure and register Host-header validation (DNS-rebinding hardening).
-    # Enforced only for unauthenticated loopback binds; see init_host_validation.
+    # Configure and register optional Host-header validation for deployments that
+    # explicitly disable bearer auth; see init_host_validation.
     # Registered as a before_request hook so it runs ahead of any route/auth.
     init_host_validation(host=host, allowed_hosts=allowed_hosts)
     app.before_request(validate_host)

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -1,8 +1,8 @@
 """
 Authentication middleware for gptme-server.
 
-Provides bearer token authentication for API access.
-Authentication is only required when binding to network interfaces.
+Provides bearer token authentication for API access. Authentication is required
+for every bind address unless explicitly disabled with ``GPTME_DISABLE_AUTH``.
 
 Supports three authentication methods (checked in order):
 1. Authorization header (preferred for normal API calls)
@@ -23,15 +23,12 @@ logger = logging.getLogger(__name__)
 # Token storage (in-memory, generated on startup)
 _server_token: str | None = None
 
-# Auth state (disabled for local-only binding)
+# Auth state (enabled by default for every bind address)
 _auth_enabled: bool = True
 
-# Host-header validation state (DNS-rebinding hardening).
-# Only enforced when auth is disabled for a loopback bind: a malicious page
-# whose hostname re-resolves to 127.0.0.1 becomes same-origin with the local
-# server and bypasses CORS entirely, gaining full unauthenticated API access
-# (which includes shell execution via the agent). Validating the Host header
-# blocks that vector without affecting legitimate localhost/127.0.0.1 clients.
+# Host-header validation state. This is normally redundant with bearer auth, but
+# remains available when an operator explicitly disables auth and supplies an
+# allow-list.
 _host_validation_enabled: bool = False
 _allowed_hosts: set[str] = set()
 
@@ -53,18 +50,6 @@ def generate_token() -> str:
         A URL-safe random string of 32+ characters.
     """
     return secrets.token_urlsafe(32)
-
-
-def is_local_host(host: str) -> bool:
-    """Check if host is a local-only address.
-
-    Args:
-        host: The host address to check.
-
-    Returns:
-        True if host is localhost or 127.0.0.1, False otherwise.
-    """
-    return host in ("127.0.0.1", "localhost", "::1")
 
 
 def _extract_hostname(host_header: str) -> str:
@@ -113,16 +98,10 @@ def init_host_validation(
 
     Must be called after :func:`init_auth` (it reads ``_auth_enabled``).
 
-    Validation is only enabled when auth is disabled for a loopback bind — the
-    one case where a DNS-rebinding page can reach the API without credentials.
-    It is skipped when:
-
-    - Auth is enabled (network bind): the bearer token already gates access.
-    - ``GPTME_DISABLE_AUTH`` is explicitly set and no ``--allowed-hosts`` was
-      given: the operator owns security here (e.g. gptme-cloud pods bind
-      ``0.0.0.0`` behind an authenticated ingress). We must not break those
-      setups. If the operator *does* pass ``--allowed-hosts``, we honor it and
-      enforce the check against the given hosts.
+    Validation is skipped while bearer auth is enabled. When
+    ``GPTME_DISABLE_AUTH`` is explicitly set, the operator owns security (for
+    example, gptme-cloud pods bind ``0.0.0.0`` behind an authenticated ingress),
+    so validation remains disabled unless ``--allowed-hosts`` is also supplied.
 
     Args:
         host: The host the server is binding to. A concrete (non-wildcard)
@@ -152,7 +131,6 @@ def init_host_validation(
         _allowed_hosts = set()
         return
 
-    # Auth disabled for a loopback bind (the DNS-rebinding vector), or
     # GPTME_DISABLE_AUTH with an explicit allow-list. Enforce Host validation.
     allowed = set(_DEFAULT_ALLOWED_HOSTS)
     if host and host not in ("0.0.0.0", "::"):
@@ -243,9 +221,8 @@ def set_server_token(token: str) -> None:
 def require_auth(f):
     """Decorator to require bearer token authentication.
 
-    Authentication is only required when binding to network interfaces.
-    When binding to localhost (127.0.0.1), authentication is disabled
-    for seamless local development.
+    Authentication is required for every bind address unless explicitly
+    disabled with ``GPTME_DISABLE_AUTH``.
 
     Checks authentication in order of preference:
     1. Authorization header (most secure, use for normal API calls)
@@ -256,17 +233,15 @@ def require_auth(f):
         Decorated function that validates bearer token before execution.
 
     Raises:
-        401 Unauthorized: Missing or invalid authentication credentials
-            (only when auth is enabled for network binding).
+        401 Unauthorized: Missing or invalid authentication credentials.
     """
 
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        # Skip authentication for local-only binding
+        # Skip authentication only after an explicit operator override.
         if not _auth_enabled:
             return f(*args, **kwargs)
 
-        # Authentication is required for network binding
         server_token = get_server_token()
         if not server_token:
             logger.error("Server token not available but auth is enabled")
@@ -321,8 +296,7 @@ def init_auth(host: str = "127.0.0.1", display: bool = True) -> str | None:
         display: Whether to display the token in logs (default: True).
 
     Returns:
-        The server token (only generated when binding to network,
-        None for local-only binding).
+        The server token, or ``None`` when auth is explicitly disabled.
     """
     global _auth_enabled
 
@@ -343,22 +317,8 @@ def init_auth(host: str = "127.0.0.1", display: bool = True) -> str | None:
             logger.info("=" * 60)
         return None
 
-    # Disable auth for local-only binding
-    if is_local_host(host):
-        _auth_enabled = False
-        if display:
-            logger.info("=" * 60)
-            logger.info("gptme-server (Local Mode)")
-            logger.info("=" * 60)
-            logger.info(f"Binding to: {host} (local-only)")
-            logger.info("Authentication: DISABLED")
-            logger.info("")
-            logger.info("This is safe for local development.")
-            logger.info("For network access, use --host 0.0.0.0 (enables auth)")
-            logger.info("=" * 60)
-        return None
-
-    # Enable auth for network binding
+    # Require authentication for every bind address, including loopback. A local
+    # process is not inherently trusted and must prove possession of the token.
     _auth_enabled = True
     token = get_server_token()
 

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -185,11 +185,9 @@ def main():
     envvar="GPTME_SERVER_ALLOWED_HOSTS",
     help=(
         "Comma-separated hostnames to accept in the Host header, in addition "
-        "to the built-in localhost/127.0.0.1/[::1] allow-list. Only relevant "
-        "for unauthenticated loopback binds, where the server validates the "
-        "Host header to block DNS-rebinding attacks. Set this if you proxy the "
-        "local server behind a hostname (e.g. 'gptme.local'). Can also be set "
-        "via the GPTME_SERVER_ALLOWED_HOSTS environment variable."
+        "to the built-in localhost/127.0.0.1/[::1] allow-list. Relevant when "
+        "bearer auth is explicitly disabled with GPTME_DISABLE_AUTH. Can also "
+        "be set via the GPTME_SERVER_ALLOWED_HOSTS environment variable."
     ),
 )
 @click.option(

--- a/scripts/gptme-server.service
+++ b/scripts/gptme-server.service
@@ -24,8 +24,10 @@
 #
 # The server binds to loopback (127.0.0.1) by design: terminate TLS and expose
 # it with a reverse proxy (see the "Production Deployment" section of
-# docs/server.rst). On loopback, gptme-server does not require an auth token;
-# set GPTME_SERVER_TOKEN in the EnvironmentFile if you bind a public interface.
+# docs/server.rst). gptme-server requires bearer authentication on every bind
+# address. Set GPTME_SERVER_TOKEN to a stable secret in the EnvironmentFile so
+# clients keep a persistent credential across restarts — omitting it generates
+# a new random token at each startup, which invalidates existing client configs.
 #
 # Inspect logs with:  journalctl -u gptme-server -f
 
@@ -40,9 +42,11 @@ Type=simple
 User=gptme
 Group=gptme
 
-# Provider keys (OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY) and an
-# optional GPTME_SERVER_TOKEN live here, one KEY=value per line. Keep it 0640
-# and owned by the service user so secrets are not world-readable.
+# Provider keys (OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY) and
+# GPTME_SERVER_TOKEN live here, one KEY=value per line. Set GPTME_SERVER_TOKEN
+# to a stable secret; omitting it generates a fresh random token at each startup
+# which breaks any client already configured with the previous token. Keep the
+# file 0640 and owned by the service user so secrets are not world-readable.
 EnvironmentFile=-/etc/gptme/server.env
 
 # Adjust the path to wherever pipx installed the entrypoint for User= above.

--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
 name = "gptme-tauri"
 version = "0.31.0"
 dependencies = [
+ "getrandom 0.3.4",
  "log",
  "serde",
  "serde_json",

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-deep-link = "2"
 url = "2"
 log = "0.4"
 tauri-plugin-log = "2"
+getrandom = "0.3"
 tokio = { version = "1", features = ["net", "time", "io-util", "sync"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use tauri_plugin_shell::ShellExt;
 use tauri_plugin_updater::UpdaterExt;
 
 const GPTME_SERVER_PORT: u16 = 5700;
+const SERVER_TOKEN_ENV: &str = "GPTME_SERVER_TOKEN";
 
 /// Returns the port gptme-server should bind to.
 /// Override at run time with `GPTME_SERVER_PORT=<port>` for development or
@@ -29,6 +30,13 @@ fn server_port() -> u16 {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(GPTME_SERVER_PORT)
+}
+
+#[cfg(desktop)]
+fn generate_server_token() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("OS randomness unavailable");
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 #[cfg(not(desktop))]
 const LOCAL_SERVER_UNSUPPORTED: &str =
@@ -129,6 +137,8 @@ struct ServerProcess {
     // (port occupied by an unresponsive foreign process).  Used in cleanup to
     // avoid killing a process that we never owned.
     owns_port: Arc<AtomicBool>,
+    // Bearer token shared only with the sidecar and the Tauri webview.
+    token: String,
     // Held at app setup so #[tauri::command] functions that need the handle
     // can fetch it from state instead of taking AppHandle as a command
     // parameter — the latter would break tests because AppHandle does not
@@ -143,6 +153,7 @@ struct ServerStatus {
     port_available: bool,
     manages_local_server: bool,
     existing_server_detected: bool,
+    auth_token: Option<String>,
 }
 
 #[cfg(desktop)]
@@ -164,6 +175,7 @@ async fn get_server_status(state: tauri::State<'_, ServerProcess>) -> Result<Ser
         port_available,
         manages_local_server: true,
         existing_server_detected,
+        auth_token: Some(state.token.clone()),
     })
 }
 
@@ -176,6 +188,7 @@ fn get_server_status() -> ServerStatus {
         port_available: false,
         manages_local_server: false,
         existing_server_detected: false,
+        auth_token: None,
     }
 }
 
@@ -227,7 +240,13 @@ async fn start_server(state: tauri::State<'_, ServerProcess>) -> Result<u16, Str
         .map_err(|e| format!("Lock error: {}", e))?
         .clone()
         .ok_or_else(|| "ServerProcess.app_handle not set".to_string())?;
-    spawn_server_sidecar(&app, state.child.clone(), state.owns_port.clone()).await?;
+    spawn_server_sidecar(
+        &app,
+        state.child.clone(),
+        state.owns_port.clone(),
+        &state.token,
+    )
+    .await?;
     Ok(server_port())
 }
 
@@ -258,6 +277,7 @@ async fn spawn_server_sidecar(
     app: &tauri::AppHandle,
     state_arc: Arc<Mutex<Option<CommandChild>>>,
     owns_port: Arc<AtomicBool>,
+    token: &str,
 ) -> Result<(), String> {
     if !is_port_available(server_port()) {
         // Port is occupied — probe whether we can actually use the server there.
@@ -330,7 +350,8 @@ async fn spawn_server_sidecar(
             port_str.as_str(),
             "--watch-pid",
             tauri_pid.as_str(),
-        ]);
+        ])
+        .env(SERVER_TOKEN_ENV, token);
 
     let (mut rx, child) = sidecar_command
         .spawn()
@@ -612,16 +633,18 @@ pub fn run() {
             {
                 let child_handle: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
                 let owns_port: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+                let token = generate_server_token();
                 app.manage(ServerProcess {
                     child: child_handle.clone(),
                     owns_port: owns_port.clone(),
+                    token: token.clone(),
                     app_handle: Arc::new(Mutex::new(Some(app.handle().clone()))),
                 });
 
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     if let Err(err) =
-                        spawn_server_sidecar(&app_handle, child_handle, owns_port).await
+                        spawn_server_sidecar(&app_handle, child_handle, owns_port, &token).await
                     {
                         log::error!("Failed to start gptme-server: {}", err);
                         if err.contains("already in use") {
@@ -881,6 +904,7 @@ mod tests {
             .manage(ServerProcess {
                 child: Arc::new(Mutex::new(None)),
                 owns_port: Arc::new(AtomicBool::new(false)),
+                token: "test-tauri-server-token".to_string(),
                 // app_handle left as None: no test calls start_server
                 // in a way that reads it (all tests seed first, causing
                 // start_server to return early).  A future test that
@@ -1104,6 +1128,7 @@ mod tests {
             port_available: true,
             manages_local_server: true,
             existing_server_detected: false,
+            auth_token: Some("test-token".to_string()),
         };
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("\"running\":false"));
@@ -1111,6 +1136,7 @@ mod tests {
         assert!(json.contains("\"port_available\":true"));
         assert!(json.contains("\"manages_local_server\":true"));
         assert!(json.contains("\"existing_server_detected\":false"));
+        assert!(json.contains("\"auth_token\":\"test-token\""));
     }
 
     #[test]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -531,12 +531,15 @@ def server_thread():
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
     from gptme.server.app import create_app  # fmt: skip
+
+    # Disable auth for the generic test client so existing tests don't need tokens.
+    # Auth-specific coverage lives in test_server_auth.py.
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
 
     app = create_app()
 
-    # Create a test client without authentication by default
     with app.test_client() as test_client:
         yield test_client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -494,14 +494,22 @@ def cleanup_tmux_sessions():
 
 
 @pytest.fixture
-def server_thread():
+def server_thread(monkeypatch):
     """Start a server in a thread for testing."""
     # Skip if flask not installed
     pytest.importorskip(
         "flask", reason="flask not installed, install server extras (-E server)"
     )
 
+    from gptme.server import auth as _auth_mod  # fmt: skip
     from gptme.server.app import create_app  # fmt: skip
+
+    # Set a known token so setup_conversation/event_listener can authenticate.
+    monkeypatch.setenv("GPTME_SERVER_TOKEN", "test-token-for-server-thread")
+    # Reset the cached token so get_server_token() picks up the env var above
+    # (it's a module-level singleton that persists between tests).
+    monkeypatch.setattr(_auth_mod, "_server_token", None)
+    monkeypatch.setattr(_auth_mod, "_auth_enabled", True)
 
     app = create_app()
 

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -101,7 +101,8 @@ def _minimal_png_bytes() -> bytes:
 
 
 @pytest.fixture()
-def client():
+def client(monkeypatch):
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
     app = create_app(cors_origin=None)
     app.config["TESTING"] = True
     with app.test_client() as c:

--- a/tests/test_llm_auth.py
+++ b/tests/test_llm_auth.py
@@ -1,7 +1,7 @@
 """Comprehensive tests for LLM authentication helpers.
 
 Covers pure-function auth logic that doesn't require API calls:
-- Server auth helpers (is_local_host, generate_token, get_server_token, init_auth)
+- Server auth helpers (generate_token, get_server_token, init_auth)
 - Server auth middleware edge cases (invalid scheme, cookie auth, query param)
 - OpenAI subscription auth (PKCE, JWT decode, token I/O, port check)
 - gptme provider edge cases (near-expiry boundary, malformed JSON, URL normalization)
@@ -23,45 +23,6 @@ import pytest
 pytest.importorskip(
     "flask", reason="flask not installed, install server extras (-E server)"
 )
-
-
-class TestIsLocalHost:
-    """Tests for is_local_host() hostname detection."""
-
-    def test_localhost(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("localhost") is True
-
-    def test_ipv4_loopback(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("127.0.0.1") is True
-
-    def test_ipv6_loopback(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("::1") is True
-
-    def test_all_interfaces(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("0.0.0.0") is False
-
-    def test_external_host(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("192.168.1.1") is False
-
-    def test_hostname(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("myserver.example.com") is False
-
-    def test_empty_string(self):
-        from gptme.server.auth import is_local_host
-
-        assert is_local_host("") is False
 
 
 class TestGenerateToken:
@@ -143,17 +104,21 @@ class TestGetServerToken:
 class TestInitAuth:
     """Tests for init_auth() state management."""
 
-    def test_local_host_disables_auth(self):
+    def test_local_host_enables_auth(self):
         import gptme.server.auth
 
-        original = gptme.server.auth._auth_enabled
+        original_enabled = gptme.server.auth._auth_enabled
+        original_token = gptme.server.auth._server_token
         try:
-            gptme.server.auth._auth_enabled = True
-            result = gptme.server.auth.init_auth("127.0.0.1", display=False)
-            assert gptme.server.auth._auth_enabled is False
-            assert result is None
+            gptme.server.auth._auth_enabled = False
+            gptme.server.auth._server_token = None
+            with patch.dict(os.environ, {"GPTME_SERVER_TOKEN": "local-token"}):
+                result = gptme.server.auth.init_auth("127.0.0.1", display=False)
+                assert gptme.server.auth._auth_enabled is True
+                assert result == "local-token"
         finally:
-            gptme.server.auth._auth_enabled = original
+            gptme.server.auth._auth_enabled = original_enabled
+            gptme.server.auth._server_token = original_token
 
     def test_network_host_enables_auth(self):
         import gptme.server.auth

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -788,12 +788,14 @@ def test_debug_errors_enabled(monkeypatch):
         )
 
 
-def test_default_model_propagation():
+def test_default_model_propagation(monkeypatch):
     """Test that the server's default model is propagated to request contexts.
 
     This tests the before_request hook that propagates the default model
     from the startup context to each request context (ContextVar fix).
     """
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+
     # Set a default model before creating the app (simulates server startup with --model)
     # Use a mock model object that matches what get_default_model returns
     from gptme.llm.models import ModelMeta, set_default_model
@@ -1150,7 +1152,7 @@ def test_api_v2_conversation_post_tools_validation(conv, client: FlaskClient):
 
 @pytest.fixture
 def auth_app():
-    """Create an app with auth enabled (network binding)."""
+    """Create an app with bearer auth enabled."""
     from gptme.server.app import create_app
     from gptme.server.auth import (
         AUTH_COOKIE_NAME,

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -26,7 +26,7 @@ def auth_token():
     os.environ["GPTME_SERVER_TOKEN"] = token
     gptme.server.auth._server_token = None  # Force regeneration
 
-    # Enable auth for tests (simulate network binding)
+    # Enable auth for tests.
     gptme.server.auth.init_auth("0.0.0.0")
 
     yield token
@@ -116,7 +116,7 @@ def test_auth_disabled_via_env():
         # Set environment variable to disable auth
         os.environ["GPTME_DISABLE_AUTH"] = "true"
 
-        # Re-initialize auth with network binding (would normally enable auth)
+        # Re-initialize auth with an explicit disable override.
         gptme.server.auth._auth_enabled = True  # Reset state
         gptme.server.auth.init_auth("0.0.0.0", display=False)
 

--- a/tests/test_server_bad_input.py
+++ b/tests/test_server_bad_input.py
@@ -40,6 +40,7 @@ def _start_server():
 
     from gptme.server.app import create_app  # fmt: skip
 
+    os.environ["GPTME_DISABLE_AUTH"] = "true"
     app = create_app()
     app.config["TESTING"] = True
 

--- a/tests/test_server_default_profile.py
+++ b/tests/test_server_default_profile.py
@@ -17,6 +17,16 @@ pytest.importorskip(
 from flask.testing import FlaskClient  # fmt: skip
 
 # ---------------------------------------------------------------------------
+# Auth disable (all tests in this module use raw create_app() helpers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth(monkeypatch):
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_elicitation.py
+++ b/tests/test_server_elicitation.py
@@ -147,7 +147,7 @@ class TestResolveHookElicitation:
 
 @pytest.mark.skipif(not _has_flask, reason="flask not installed (server extra)")
 @pytest.mark.timeout(10)
-def test_elicit_respond_endpoint_validation(init_, setup_conversation):
+def test_elicit_respond_endpoint_validation(init_, setup_conversation, auth_headers):
     """Test that the elicit respond endpoint validates required fields."""
     port, conversation_id, _ = setup_conversation
 
@@ -155,6 +155,7 @@ def test_elicit_respond_endpoint_validation(init_, setup_conversation):
     resp = requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}/elicit/respond",
         json={"action": "accept", "value": "hello"},
+        headers=auth_headers,
     )
     assert resp.status_code == 400
 
@@ -162,6 +163,7 @@ def test_elicit_respond_endpoint_validation(init_, setup_conversation):
     resp = requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}/elicit/respond",
         json={"elicit_id": "test-123", "value": "hello"},
+        headers=auth_headers,
     )
     assert resp.status_code == 400
 
@@ -169,13 +171,14 @@ def test_elicit_respond_endpoint_validation(init_, setup_conversation):
     resp = requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}/elicit/respond",
         json={"elicit_id": "test-123", "action": "invalid"},
+        headers=auth_headers,
     )
     assert resp.status_code == 400
 
 
 @pytest.mark.skipif(not _has_flask, reason="flask not installed (server extra)")
 @pytest.mark.timeout(10)
-def test_elicit_respond_endpoint_accept(init_, setup_conversation):
+def test_elicit_respond_endpoint_accept(init_, setup_conversation, auth_headers):
     """Test that the elicit respond endpoint resolves a pending elicitation."""
     port, conversation_id, _ = setup_conversation
 
@@ -191,6 +194,7 @@ def test_elicit_respond_endpoint_accept(init_, setup_conversation):
             "action": "accept",
             "value": "test-value",
         },
+        headers=auth_headers,
     )
     assert resp.status_code == 200
 

--- a/tests/test_server_etag.py
+++ b/tests/test_server_etag.py
@@ -14,9 +14,9 @@ def app(tmp_path, monkeypatch):
     from gptme.server.app import create_app
 
     monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
     app = create_app()
     app.config["TESTING"] = True
-    app.config["AUTH_DISABLED"] = True
     return app
 
 

--- a/tests/test_server_host_validation.py
+++ b/tests/test_server_host_validation.py
@@ -1,10 +1,7 @@
-"""Tests for Host-header validation (DNS-rebinding hardening) in gptme-server.
+"""Tests for optional Host-header validation in gptme-server.
 
-gptme-server disables bearer auth for loopback binds. CORS preflight blocks
-plain cross-origin JSON, but DNS rebinding defeats CORS: a malicious page whose
-hostname re-resolves to 127.0.0.1 becomes same-origin with the local server and
-gains full unauthenticated API access (which includes shell execution via the
-agent). Validating the Host header blocks that vector.
+Bearer auth now protects every bind address. Host validation remains available
+for operators that explicitly disable auth and supply ``--allowed-hosts``.
 
 See issue #3320.
 """
@@ -38,7 +35,11 @@ def _get(client: FlaskClient, host_header: str):
 
 
 class TestLoopbackAllowed:
-    """Loopback binds enforce validation but allow the standard local hosts."""
+    """Explicitly unauthenticated loopback binds allow standard local hosts."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_auth(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
 
     def test_localhost_with_port_allowed(self):
         resp = _get(_client(), "localhost:5700")
@@ -68,10 +69,14 @@ class TestLoopbackAllowed:
 
 
 class TestRebindingRejected:
-    """A Host that isn't on the allow-list is rejected with a clear 403."""
+    """A Host outside an explicit allow-list is rejected with a clear 403."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_auth(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
 
     def test_evil_host_rejected(self):
-        resp = _get(_client(), "attacker.example.com")
+        resp = _get(_client(allowed_hosts=["localhost"]), "attacker.example.com")
         assert resp.status_code == 403
         error = resp.get_json()["error"]
         # Error must name the offending host and how to allow it.
@@ -79,12 +84,16 @@ class TestRebindingRejected:
         assert "--allowed-hosts" in error
 
     def test_evil_host_with_port_rejected(self):
-        resp = _get(_client(), "attacker.example.com:5700")
+        resp = _get(_client(allowed_hosts=["localhost"]), "attacker.example.com:5700")
         assert resp.status_code == 403
 
 
 class TestAllowedHostsExtension:
     """--allowed-hosts / allowed_hosts extends the allow-list for proxied setups."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_auth(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
 
     def test_configured_host_allowed(self):
         client = _client(allowed_hosts=["gptme.local"])
@@ -111,9 +120,8 @@ class TestAllowedHostsExtension:
 class TestConfiguredBindHost:
     """A concrete (non-wildcard) bind host is added to the allow-list."""
 
-    def test_bind_host_allowed(self):
-        # Binding to a concrete host enables auth (non-loopback), so validation
-        # is skipped there; but a loopback bind with a custom host stays enforced.
+    def test_bind_host_allowed(self, monkeypatch):
+        monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
         client = _client(host="127.0.0.1", allowed_hosts=["myhost.internal"])
         assert _get(client, "myhost.internal").status_code == 200
 

--- a/tests/test_server_panels.py
+++ b/tests/test_server_panels.py
@@ -592,8 +592,9 @@ class TestLiveAppPanels:
 
 
 @pytest.fixture()
-def app():
+def app(monkeypatch):
     pytest.importorskip("flask")
+    monkeypatch.setenv("GPTME_DISABLE_AUTH", "true")
     from gptme.server.app import create_app
 
     application = create_app()

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -14,7 +14,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.timeout(30)
 def test_auto_stepping(
-    init_, setup_conversation, event_listener, mock_generation, wait_for_event
+    init_,
+    setup_conversation,
+    event_listener,
+    mock_generation,
+    wait_for_event,
+    auth_headers,
 ):
     """Test auto-stepping and auto-confirm functionality with multiple tools in sequence."""
     port, conversation_id, session_id = setup_conversation
@@ -28,6 +33,7 @@ def test_auto_stepping(
             "role": "user",
             "content": f"Create a directory named {test_dir} and list its contents",
         },
+        headers=auth_headers,
     )
 
     # Define tools that will be used
@@ -64,6 +70,7 @@ def test_auto_stepping(
                 "model": "openai/mock-model",
                 "auto_confirm": 2,
             },
+            headers=auth_headers,
         )
 
         # Wait for first tool execution and verify directory creation
@@ -87,6 +94,7 @@ def test_auto_stepping(
     # Verify conversation state
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
 
@@ -131,7 +139,7 @@ def test_auto_stepping(
 
 @pytest.mark.timeout(30)
 def test_generation_error_persists_system_message(
-    setup_conversation, event_listener, wait_for_event
+    setup_conversation, event_listener, wait_for_event, auth_headers
 ):
     """Generation failures should be visible in the conversation log, not SSE-only."""
     port, conversation_id, session_id = setup_conversation
@@ -139,6 +147,7 @@ def test_generation_error_persists_system_message(
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
         json={"role": "user", "content": "Say hello"},
+        headers=auth_headers,
     )
 
     with unittest.mock.patch(
@@ -151,6 +160,7 @@ def test_generation_error_persists_system_message(
                 "session_id": session_id,
                 "model": "openai/mock-model",
             },
+            headers=auth_headers,
         )
 
         # Step now returns 500 when it detects the LLM error (instead of
@@ -162,6 +172,7 @@ def test_generation_error_persists_system_message(
 
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
 
@@ -175,7 +186,7 @@ def test_generation_error_persists_system_message(
 
 @pytest.mark.timeout(30)
 def test_append_write_failure_blocks_generation_complete_and_persists_error(
-    setup_conversation, event_listener, mock_generation, wait_for_event
+    setup_conversation, event_listener, mock_generation, wait_for_event, auth_headers
 ):
     """A failed assistant append must not emit generation_complete."""
     from gptme.logmanager.manager import LogManager
@@ -186,6 +197,7 @@ def test_append_write_failure_blocks_generation_complete_and_persists_error(
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
         json={"role": "user", "content": "Say hello"},
+        headers=auth_headers,
     )
 
     original_write = LogManager.write
@@ -217,6 +229,7 @@ def test_append_write_failure_blocks_generation_complete_and_persists_error(
                 "session_id": session_id,
                 "model": "openai/mock-model",
             },
+            headers=auth_headers,
         )
 
         assert wait_for_event(event_listener, "generation_started")
@@ -228,6 +241,7 @@ def test_append_write_failure_blocks_generation_complete_and_persists_error(
 
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
 
@@ -243,7 +257,13 @@ def test_append_write_failure_blocks_generation_complete_and_persists_error(
 @pytest.mark.timeout(60)
 @pytest.mark.no_retry
 def test_multi_tool_per_message(
-    init_, setup_conversation, event_listener, mock_generation, wait_for_event, tmp_path
+    init_,
+    setup_conversation,
+    event_listener,
+    mock_generation,
+    wait_for_event,
+    tmp_path,
+    auth_headers,
 ):
     """Test multiple tool uses in a single assistant message.
 
@@ -298,6 +318,7 @@ def test_multi_tool_per_message(
                 "role": "user",
                 "content": "Run two commands",
             },
+            headers=auth_headers,
         )
 
         requests.post(
@@ -307,6 +328,7 @@ def test_multi_tool_per_message(
                 "model": "openai/mock-model",
                 "auto_confirm": 2,
             },
+            headers=auth_headers,
         )
 
         # Generation produces a single message with two tools.
@@ -344,6 +366,7 @@ def test_multi_tool_per_message(
     # Verify conversation has the expected messages
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
     messages = resp.json()["log"]

--- a/tests/test_server_v2_sse.py
+++ b/tests/test_server_v2_sse.py
@@ -13,7 +13,7 @@ pytest.importorskip(
 
 
 @pytest.mark.timeout(20)
-def test_event_stream(event_listener, wait_for_event):
+def test_event_stream(event_listener, wait_for_event, auth_headers):
     """Test the event stream endpoint."""
     port = event_listener["port"]
     conversation_id = event_listener["conversation_id"]
@@ -22,6 +22,7 @@ def test_event_stream(event_listener, wait_for_event):
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
         json={"role": "user", "content": "Test message"},
+        headers=auth_headers,
     )
 
     # Wait for events
@@ -31,6 +32,7 @@ def test_event_stream(event_listener, wait_for_event):
     # Verify message content
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
     messages = resp.json()["log"]
@@ -45,7 +47,7 @@ def test_event_stream(event_listener, wait_for_event):
 @pytest.mark.timeout(20)
 @pytest.mark.slow
 @pytest.mark.requires_api
-def test_event_stream_with_generation(event_listener, wait_for_event):
+def test_event_stream_with_generation(event_listener, wait_for_event, auth_headers):
     """Test that the event stream receives generation events."""
     port = event_listener["port"]
     conversation_id = event_listener["conversation_id"]
@@ -55,12 +57,14 @@ def test_event_stream_with_generation(event_listener, wait_for_event):
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
         json={"role": "user", "content": "Say hello"},
+        headers=auth_headers,
     )
 
     # Use a real model
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
         json={"session_id": session_id},
+        headers=auth_headers,
     )
 
     # Wait for events
@@ -71,6 +75,7 @@ def test_event_stream_with_generation(event_listener, wait_for_event):
     # Verify the response
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
     messages = resp.json()["log"]
@@ -83,7 +88,7 @@ def test_event_stream_with_generation(event_listener, wait_for_event):
 
 @pytest.mark.timeout(10)
 def test_generation_complete_before_auto_naming(
-    setup_conversation, event_listener, mock_generation, wait_for_event
+    setup_conversation, event_listener, mock_generation, wait_for_event, auth_headers
 ):
     """generation_complete must be emitted before _try_auto_name_and_notify runs.
 
@@ -100,6 +105,7 @@ def test_generation_complete_before_auto_naming(
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
         json={"role": "user", "content": "Hello"},
+        headers=auth_headers,
     )
 
     mock_stream = mock_generation(["Hello!"])
@@ -126,6 +132,7 @@ def test_generation_complete_before_auto_naming(
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
             json={"session_id": session_id, "model": "openai/mock-model"},
+            headers=auth_headers,
         )
 
         assert wait_for_event(event_listener, "generation_complete", timeout=5), (

--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -13,7 +13,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.timeout(60)
 def test_tool_confirmation_flow(
-    init_, setup_conversation, event_listener, mock_generation, wait_for_event
+    init_,
+    setup_conversation,
+    event_listener,
+    mock_generation,
+    wait_for_event,
+    auth_headers,
 ):
     """Test the tool confirmation flow."""
     port, conversation_id, session_id = setup_conversation
@@ -21,6 +26,7 @@ def test_tool_confirmation_flow(
     # Add a user message requesting a command
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
         json={"role": "user", "content": "List files in the current directory"},
     )
 
@@ -50,6 +56,7 @@ def test_tool_confirmation_flow(
         # Request a step
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+            headers=auth_headers,
             json={"session_id": session_id, "model": "openai/mock-model"},
         )
 
@@ -62,6 +69,7 @@ def test_tool_confirmation_flow(
         # Confirm the tool execution
         resp = requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/tool/confirm",
+            headers=auth_headers,
             json={"session_id": session_id, "tool_id": tool_id, "action": "confirm"},
         )
         assert resp.status_code == 200
@@ -80,6 +88,7 @@ def test_tool_confirmation_flow(
     # Verify conversation state
     resp = requests.get(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
     )
     assert resp.status_code == 200
 
@@ -125,7 +134,12 @@ def test_tool_confirmation_flow(
 
 @pytest.mark.timeout(60)
 def test_tool_confirmation_without_session_id(
-    init_, setup_conversation, event_listener, mock_generation, wait_for_event
+    init_,
+    setup_conversation,
+    event_listener,
+    mock_generation,
+    wait_for_event,
+    auth_headers,
 ):
     """Test that tool confirmation works without session_id (server finds tool across sessions)."""
     port, conversation_id, session_id = setup_conversation
@@ -133,6 +147,7 @@ def test_tool_confirmation_without_session_id(
     # Add a user message requesting a command
     requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+        headers=auth_headers,
         json={"role": "user", "content": "Echo hello world"},
     )
 
@@ -161,6 +176,7 @@ def test_tool_confirmation_without_session_id(
         # Request a step
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+            headers=auth_headers,
             json={"session_id": session_id, "model": "openai/mock-model"},
         )
 
@@ -173,6 +189,7 @@ def test_tool_confirmation_without_session_id(
         # Confirm the tool WITHOUT session_id - server should find it
         resp = requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}/tool/confirm",
+            headers=auth_headers,
             json={"tool_id": tool_id, "action": "confirm"},  # No session_id!
         )
         assert resp.status_code == 200, (
@@ -188,13 +205,16 @@ def test_tool_confirmation_without_session_id(
 
 
 @pytest.mark.timeout(10)
-def test_tool_confirmation_without_session_id_tool_not_found(init_, setup_conversation):
+def test_tool_confirmation_without_session_id_tool_not_found(
+    init_, setup_conversation, auth_headers
+):
     """Test that confirming a non-existent tool without session_id returns 404."""
     port, conversation_id, session_id = setup_conversation
 
     # Try to confirm a non-existent tool without session_id
     resp = requests.post(
         f"http://localhost:{port}/api/v2/conversations/{conversation_id}/tool/confirm",
+        headers=auth_headers,
         json={"tool_id": "non-existent-tool-id", "action": "confirm"},  # No session_id
     )
     assert resp.status_code == 404

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -389,15 +389,17 @@ export function ApiProvider({
   );
 
   useEffect(() => {
-    if (!activeServer || !tauriServerBaseUrl || !tauriServerStatus?.auth_token) return;
+    if (!activeServer || !tauriServerBaseUrl) return;
     if (!isDefaultLoopbackTarget(connectionConfig.baseUrl)) return;
+    if (!needsTauriServerUrlSync && !tauriServerStatus?.auth_token) return;
 
-    const updates: Partial<ServerConfig> = {
-      authToken: tauriServerStatus.auth_token,
-      useAuthToken: true,
-    };
+    const updates: Partial<ServerConfig> = {};
     if (needsTauriServerUrlSync) {
       updates.baseUrl = tauriServerBaseUrl;
+    }
+    if (tauriServerStatus?.auth_token) {
+      updates.authToken = tauriServerStatus.auth_token;
+      updates.useAuthToken = true;
     }
     updateServer(activeServer.id, updates);
   }, [

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -389,9 +389,24 @@ export function ApiProvider({
   );
 
   useEffect(() => {
-    if (!needsTauriServerUrlSync || !activeServer || !tauriServerBaseUrl) return;
-    updateServer(activeServer.id, { baseUrl: tauriServerBaseUrl });
-  }, [activeServer, needsTauriServerUrlSync, tauriServerBaseUrl]);
+    if (!activeServer || !tauriServerBaseUrl || !tauriServerStatus?.auth_token) return;
+    if (!isDefaultLoopbackTarget(connectionConfig.baseUrl)) return;
+
+    const updates: Partial<ServerConfig> = {
+      authToken: tauriServerStatus.auth_token,
+      useAuthToken: true,
+    };
+    if (needsTauriServerUrlSync) {
+      updates.baseUrl = tauriServerBaseUrl;
+    }
+    updateServer(activeServer.id, updates);
+  }, [
+    activeServer,
+    connectionConfig.baseUrl,
+    needsTauriServerUrlSync,
+    tauriServerBaseUrl,
+    tauriServerStatus?.auth_token,
+  ]);
 
   const shouldSkipInitialMobileAutoConnect =
     isTauri && managesLocalServer === false && isDefaultLoopbackTarget(connectionConfig.baseUrl);

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -398,9 +398,17 @@ export function ApiProvider({
       updates.baseUrl = tauriServerBaseUrl;
     }
     if (tauriServerStatus?.auth_token) {
-      updates.authToken = tauriServerStatus.auth_token;
-      updates.useAuthToken = true;
+      // Only inject the sidecar token when Tauri manages the server.  If an
+      // independently-running server was detected on the same port, its own
+      // credential is already configured and must not be overwritten.
+      const tokenAlreadySet =
+        activeServer.authToken === tauriServerStatus.auth_token && activeServer.useAuthToken;
+      if (!tokenAlreadySet && !tauriServerStatus.existing_server_detected) {
+        updates.authToken = tauriServerStatus.auth_token;
+        updates.useAuthToken = true;
+      }
     }
+    if (Object.keys(updates).length === 0) return;
     updateServer(activeServer.id, updates);
   }, [
     activeServer,
@@ -408,6 +416,7 @@ export function ApiProvider({
     needsTauriServerUrlSync,
     tauriServerBaseUrl,
     tauriServerStatus?.auth_token,
+    tauriServerStatus?.existing_server_detected,
   ]);
 
   const shouldSkipInitialMobileAutoConnect =

--- a/webui/src/hooks/useTauriServerStatus.ts
+++ b/webui/src/hooks/useTauriServerStatus.ts
@@ -8,6 +8,7 @@ interface TauriServerStatus {
   port_available: boolean;
   manages_local_server: boolean;
   existing_server_detected: boolean;
+  auth_token: string | null;
 }
 
 let cachedServerStatus: TauriServerStatus | null = null;
@@ -69,6 +70,7 @@ export function useTauriServerStatus() {
           port_available: false,
           manages_local_server: false,
           existing_server_detected: false,
+          auth_token: null,
         });
       })
       .finally(() => {

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -4,6 +4,7 @@ import App from './App.tsx';
 import './index.css';
 import { isDemoMode } from './utils/connectionConfig';
 import { setupLogging } from './utils/logging';
+import { isTauriEnvironment } from './utils/tauri';
 
 // Initialize logging as early as possible
 setupLogging()
@@ -19,7 +20,7 @@ setupLogging()
 // See: gptme/gptme#2236
 (function probeLocalhost() {
   // Only probe in Tauri desktop app; skip in regular browsers
-  if (typeof window === 'undefined' || !window.__TAURI__ || isDemoMode()) {
+  if (typeof window === 'undefined' || !isTauriEnvironment() || isDemoMode()) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Removes the `is_local_host()` auth bypass in `gptme/server/auth.py`, completing the fix for GHSA-vjp6-7cm5-m8h6 (the redaction half shipped in #3246 on 2026-07-14).

**The problem**: gptme-server disabled bearer authentication for loopback binds (127.0.0.1/localhost/::1). Any process on the local machine — or a DNS-rebinding page whose hostname resolves to 127.0.0.1 — gained full unauthenticated API access, including shell execution via the agent.

**The fix**: `init_auth()` no longer checks the bind address. Auth is now always required; `GPTME_DISABLE_AUTH=1` remains the explicit operator escape hatch.

## Changes

- **`gptme/server/auth.py`**: Remove `is_local_host()` and the loopback-disable branch in `init_auth()`; warn clearly at startup when `GPTME_SERVER_TOKEN` is unset; update docstrings throughout
- **`tauri/src-tauri/src/lib.rs`**: Generate a per-session random token at app setup; pass to the sidecar via `GPTME_SERVER_TOKEN` env; expose via `get_server_status().auth_token` so the webview injects it; add `getrandom` dep
- **`webui/src/hooks/useTauriServerStatus.ts`**: Add `auth_token` field to status type
- **`webui/src/contexts/ApiContext.tsx`**: Inject `auth_token` from Tauri server status into the active server config on startup (no manual token entry for the desktop app)
- **`tests/conftest.py`**: Set `GPTME_DISABLE_AUTH=true` in the generic `client` fixture so ~100 pre-existing server tests need no token plumbing; auth-specific coverage stays in `test_server_auth.py`
- **`tests/test_server.py`**: Add `monkeypatch` to `test_default_model_propagation` for `GPTME_DISABLE_AUTH`
- **`tests/test_llm_auth.py`**: Remove `TestIsLocalHost` class (function removed)
- **`tests/test_server_host_validation.py`**: All classes opt into `GPTME_DISABLE_AUTH`; host-validation still meaningfully tested for the operator opt-in case
- **`docs/server.rst`**: Rewrite authentication model section for the new single-tier model

**Not broken**: gptme-cloud pods (0.0.0.0 + GPTME_DISABLE_AUTH path), docker-compose (already token-based).

**BREAKING (security)**: gptme-server now requires a bearer token on 127.0.0.1 just as it does on 0.0.0.0. Clients relying on unauthenticated local access must set `GPTME_SERVER_TOKEN` or `GPTME_DISABLE_AUTH=1`.

Ops note: `bob-gptme-server.service` needs `GPTME_SERVER_TOKEN` or `GPTME_DISABLE_AUTH` before upgrading.

## Test plan

- [x] 143 Python tests pass locally (`test_server.py`, `test_server_auth.py`, `test_server_host_validation.py`, `test_llm_auth.py`)
- [ ] CI Python test suite
- [ ] CI Tauri build (sidecar binary required; environment-dependent)
- [ ] CI webui typecheck

Relates to: #3246, GHSA-vjp6-7cm5-m8h6