### PR TITLE
fix(webui/a11y): raise green text to green-700 for WCAG AA compliance

### DIFF
--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -220,7 +220,7 @@ export const ComputerPreview: FC = () => {
           title={isPolling ? 'Pause live view' : 'Resume live view'}
         >
           {isPolling ? (
-            <Wifi className="h-4 w-4 text-green-500" />
+            <Wifi className="h-4 w-4 text-green-700 dark:text-green-400" />
           ) : (
             <WifiOff className="h-4 w-4 text-muted-foreground" />
           )}

--- a/webui/src/components/ExtensionChat.tsx
+++ b/webui/src/components/ExtensionChat.tsx
@@ -430,7 +430,9 @@ export default function ExtensionChat() {
     <div className="flex h-dvh flex-col bg-background text-foreground">
       {/* Status bar */}
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5 text-xs">
-        <span className={state.online ? 'text-green-500' : 'text-muted-foreground'}>
+        <span
+          className={state.online ? 'text-green-700 dark:text-green-400' : 'text-muted-foreground'}
+        >
           {state.status}
         </span>
         <div className="ml-auto flex min-w-0 items-center gap-1">

--- a/webui/src/components/PanelsPanel.tsx
+++ b/webui/src/components/PanelsPanel.tsx
@@ -27,7 +27,7 @@ interface PanelsPanelProps {
 function statusTextColor(status: LiveAppStatus): string {
   switch (status) {
     case 'running':
-      return 'text-green-500';
+      return 'text-green-700 dark:text-green-400';
     case 'error':
       return 'text-destructive';
     case 'stopped':

--- a/webui/src/components/RichToolCall.tsx
+++ b/webui/src/components/RichToolCall.tsx
@@ -94,7 +94,7 @@ export const RichToolCall: FC<RichToolCallProps> = ({
   const statusBadge = isExecuting ? (
     <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-500" />
   ) : completed === true ? (
-    <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+    <CheckCircle className="h-3.5 w-3.5 text-green-700 dark:text-green-400" />
   ) : completed === false ? (
     <XCircle className="h-3.5 w-3.5 text-red-500" />
   ) : null;

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -658,7 +658,7 @@ export function SetupWizard() {
                 </div>
               ) : managesLocalServer ? (
                 <div className="flex items-start gap-3 rounded-lg bg-muted p-4">
-                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-500" />
+                  <Check className="mt-0.5 h-5 w-5 shrink-0 text-green-700 dark:text-green-400" />
                   <div className="text-sm">
                     <p className="font-medium">Server starts automatically</p>
                     <p className="mt-1 text-muted-foreground">
@@ -704,7 +704,7 @@ export function SetupWizard() {
                 </div>
               )}
               {isConnected && (
-                <div className="flex items-center gap-2 text-sm text-green-500">
+                <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-400">
                   <Check className="h-4 w-4" />
                   Connected to server
                 </div>

--- a/webui/src/components/TaskDetails.tsx
+++ b/webui/src/components/TaskDetails.tsx
@@ -36,7 +36,7 @@ const TaskDetails: FC<Props> = ({ task }) => {
       case 'active':
         return <RefreshCw className="h-5 w-5 animate-spin text-blue-500" />;
       case 'completed':
-        return <CheckCircle className="h-5 w-5 text-green-500" />;
+        return <CheckCircle className="h-5 w-5 text-green-700 dark:text-green-400" />;
       case 'failed':
         return <XCircle className="h-5 w-5 text-red-500" />;
     }
@@ -49,7 +49,7 @@ const TaskDetails: FC<Props> = ({ task }) => {
       case 'active':
         return 'text-blue-600';
       case 'completed':
-        return 'text-green-600';
+        return 'text-green-700 dark:text-green-400';
       case 'failed':
         return 'text-red-600';
     }
@@ -349,7 +349,7 @@ const TaskDetails: FC<Props> = ({ task }) => {
                             <div className="text-muted-foreground">Files</div>
                           </div>
                           <div className="text-center">
-                            <div className="font-bold text-green-600">
+                            <div className="font-bold text-green-700 dark:text-green-400">
                               +{task.git.diff_stats.lines_added}
                             </div>
                             <div className="text-muted-foreground">Added</div>
@@ -384,10 +384,14 @@ const TaskDetails: FC<Props> = ({ task }) => {
                   {task.git && (
                     <div className="flex items-center gap-2 text-sm">
                       <CheckCircle
-                        className={`h-4 w-4 ${task.git.clean ? 'text-green-500' : 'text-yellow-500'}`}
+                        className={`h-4 w-4 ${task.git.clean ? 'text-green-700 dark:text-green-400' : 'text-yellow-500'}`}
                       />
                       <span className="text-muted-foreground">Status:</span>
-                      <span className={task.git.clean ? 'text-green-600' : 'text-yellow-600'}>
+                      <span
+                        className={
+                          task.git.clean ? 'text-green-700 dark:text-green-400' : 'text-yellow-600'
+                        }
+                      >
                         {task.git.clean ? 'Clean' : `${task.git.files?.length || 0} modified files`}
                       </span>
                     </div>

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -42,7 +42,7 @@ const TaskListItem: FC<{ task: Task; isSelected: boolean; onClick: () => void }>
       case 'active':
         return <RefreshCw className="h-3 w-3 animate-spin text-blue-500" />;
       case 'completed':
-        return <CheckCircle className="h-3 w-3 text-green-500" />;
+        return <CheckCircle className="h-3 w-3 text-green-700 dark:text-green-400" />;
       case 'failed':
         return <XCircle className="h-3 w-3 text-red-500" />;
     }


### PR DESCRIPTION
## Problem

The webui uses Tailwind's `green-500` and `green-600` as foreground text/icon colors on white backgrounds:

| Color | Hex | Contrast on white | WCAG |
|-------|-----|------------------|------|
| green-500 (primary) | `#22c55e` | **2.28:1** | ❌ fails all |
| green-600 | `#16a34a` | **3.30:1** | ❌ fails text AA (4.5:1 required) |
| green-700 | `#15803d` | **5.02:1** | ✅ passes AA text, AAA large |

Source: `scripts/audit-color-palette-wcag.py` in ErikBjare/bob (output committed to `knowledge/research/2026-08-05-inclusive-color-space-audit-verdict.md`).

## Fix

Replace all light-mode `text-green-500`/`text-green-600` (on white) with `text-green-700 dark:text-green-400`.

This pattern already exists in the codebase (`ArtifactsPanel.tsx`, `InlineToolExecution.tsx` already use `text-green-600 dark:text-green-400`) — this PR extends it consistently to the remaining occurrences.

**Changes per file:**
- **ComputerPreview**: online Wifi icon
- **ExtensionChat**: online/status text span
- **PanelsPanel**: running app status color function
- **RichToolCall**: success CheckCircle icon
- **SetupWizard**: auto-managed server check icon + 'Connected to server' confirmation text
- **TaskDetails**: completed-status icon, status color function, +lines stat, git-clean indicator/text
- **UnifiedSidebar**: completed task sidebar icon

## Why green-700, not green-600?

green-600 = 3.30:1: passes non-text contrast (icons ≥ 3:1) but fails text AA (4.5:1). Since several of these usages are text spans, and the fix should be consistent, green-700 (5.02:1) is the right choice for both icons and text.

## Dark mode

`dark:text-green-400` (#4ade80) on the dark background (#141414) yields ~11:1 contrast — AAA. Same approach as existing occurrences in the codebase.