### PR TITLE
feat(timings): persist per-step timing breakdown in session records

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -638,6 +638,12 @@ def step(
             tool_timings: dict[str, float] = {}
             # Buffer tool outputs so we can attach per-step timing to the
             # assistant message *before* it is yielded (and written to the log).
+            # Trade-off: the assistant message (and any tool output) isn't
+            # exposed or persisted until all tools in this step complete, so a
+            # crash or interrupt mid-tool-execution can lose the step record.
+            # Accepted for the CLI path since most tools finish quickly; the
+            # server path instead persists immediately and patches timings in
+            # after the fact via _attach_tool_timings().
             # list() exhausts execute_msg which populates tool_timings in-place.
             tool_outputs = list(
                 execute_msg(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -23,6 +23,7 @@ from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
     Message,
+    MessageTimings,
     get_output_format,
     is_output_json,
     is_output_quiet,
@@ -634,8 +635,45 @@ def step(
 
         # log response and run tools
         if msg_response:
+            tool_timings: dict[str, float] = {}
+            # Buffer tool outputs so we can attach per-step timing to the
+            # assistant message *before* it is yielded (and written to the log).
+            # list() exhausts execute_msg which populates tool_timings in-place.
+            tool_outputs = list(
+                execute_msg(
+                    msg_response,
+                    log=log,
+                    workspace=workspace,
+                    tool_timings=tool_timings,
+                )
+            )
+            if tool_timings:
+                # Attach aggregated tool timing to the assistant message metadata
+                # so it is persisted in the session record alongside LLM timings.
+                from typing import cast
+
+                from .message import (
+                    MessageMetadata,
+                )
+
+                existing_meta = (
+                    dict(msg_response.metadata) if msg_response.metadata else {}
+                )
+                _raw_timings = existing_meta.get("timings")
+                existing_timings = cast(
+                    MessageTimings,
+                    dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
+                )
+                existing_timings["tool_ms"] = round(sum(tool_timings.values()), 1)
+                existing_timings["tool_ms_by_name"] = {
+                    k: round(v, 1) for k, v in tool_timings.items()
+                }
+                existing_meta["timings"] = existing_timings
+                msg_response = msg_response.replace(
+                    metadata=cast(MessageMetadata, existing_meta)
+                )
             yield msg_response.replace(quiet=True)
-            yield from execute_msg(msg_response, log=log, workspace=workspace)
+            yield from tool_outputs
 
     finally:
         clear_interruptible()

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -969,6 +969,19 @@ def _reply_stream(
             # Emit as one chunk; ACP batching callback handles downstream chunking.
             # Display/ACP only — not a chunk hook event (don't speak the suffix).
             on_token(suffix)
+        # Attach partial LLM timings to stream.metadata *before* constructing
+        # the Message — the finally block runs after this return but too late
+        # to affect a Message that has already been built from stream.metadata.
+        if first_token_time:
+            _end = time.time()
+            _gen = max(_end - first_token_time, 0.001)
+            _timings: MessageTimings = {
+                "ttft_ms": round((first_token_time - start_time) * 1000, 1),
+                "gen_ms": round(_gen * 1000, 1),
+            }
+            _meta = dict(stream.metadata) if stream.metadata else {}
+            _meta["timings"] = _timings
+            stream.metadata = cast(MessageMetadata, _meta)
         return Message("assistant", output + suffix, metadata=stream.metadata)
     finally:
         # Explicitly close the underlying generator to release resources
@@ -989,13 +1002,16 @@ def _reply_stream(
             # Attach timing breakdown to message metadata so it is persisted in
             # conversation.jsonl and available for bottleneck analysis.
             # Reuse end_time / gen_time already computed above for the debug log.
-            timings: MessageTimings = {
-                "ttft_ms": round((first_token_time - start_time) * 1000, 1),
-                "gen_ms": round(gen_time * 1000, 1),
-            }
-            meta = dict(stream.metadata) if stream.metadata else {}
-            meta["timings"] = timings
-            stream.metadata = cast(MessageMetadata, meta)
+            # Skip if already set by the KeyboardInterrupt handler above.
+            _existing_meta = dict(stream.metadata) if stream.metadata else {}
+            if "timings" not in _existing_meta:
+                timings: MessageTimings = {
+                    "ttft_ms": round((first_token_time - start_time) * 1000, 1),
+                    "gen_ms": round(gen_time * 1000, 1),
+                }
+                meta = dict(stream.metadata) if stream.metadata else {}
+                meta["timings"] = timings
+                stream.metadata = cast(MessageMetadata, meta)
 
     return Message("assistant", output, metadata=stream.metadata)
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -15,6 +15,7 @@ from ..constants import prompt_assistant
 from ..message import (
     Message,
     MessageMetadata,
+    MessageTimings,
     format_msgs,
     is_output_json,
     is_output_quiet,
@@ -985,6 +986,16 @@ def _reply_stream(
                 f"gen: {gen_time:.2f}s, "
                 f"tok/s: {len_tokens(output, model) / gen_time:.1f})"
             )
+            # Attach timing breakdown to message metadata so it is persisted in
+            # conversation.jsonl and available for bottleneck analysis.
+            # Reuse end_time / gen_time already computed above for the debug log.
+            timings: MessageTimings = {
+                "ttft_ms": round((first_token_time - start_time) * 1000, 1),
+                "gen_ms": round(gen_time * 1000, 1),
+            }
+            meta = dict(stream.metadata) if stream.metadata else {}
+            meta["timings"] = timings
+            stream.metadata = cast(MessageMetadata, meta)
 
     return Message("assistant", output, metadata=stream.metadata)
 

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -98,6 +98,46 @@ class ArtifactDescriptor(TypedDict, total=False):
     tool: str  # producing tool name (provenance)
 
 
+class MessageTimings(TypedDict, total=False):
+    """Per-step timing breakdown for an assistant message.
+
+    All fields are in milliseconds (wall-clock).  All are optional — only the
+    phases that were instrumented for a given step will be present.
+
+    Persisted under ``timings`` in :class:`MessageMetadata` so that session
+    records can be used for bottleneck analysis (model latency vs. tool
+    execution time) without any overhead on the hot path — values are summed
+    during streaming and written once at message completion.
+
+    Example session record entry::
+
+        {
+          "role": "assistant",
+          "content": "...",
+          "metadata": {
+            "model": "anthropic/claude-sonnet-4-6",
+            "cost": 0.0018,
+            "usage": {"input_tokens": 2100, "output_tokens": 340},
+            "timings": {
+              "ttft_ms": 820,
+              "gen_ms": 4200,
+              "tool_ms": 1850,
+              "tool_ms_by_name": {"shell": 1600, "read": 250}
+            }
+          }
+        }
+    """
+
+    ttft_ms: float
+    """Wall-clock from prompt send to first token (model dispatch latency)."""
+    gen_ms: float
+    """Time from first token to last token (generation time only, not TTFT)."""
+    tool_ms: float
+    """Total wall-clock time spent in tool execution for this turn."""
+    tool_ms_by_name: dict[str, float]
+    """Per-tool breakdown, e.g. ``{"shell": 1200, "browser": 450}``."""
+
+
 class MessageMetadata(TypedDict, total=False):
     """
     Metadata stored with each message.
@@ -123,6 +163,7 @@ class MessageMetadata(TypedDict, total=False):
     model: str
     cost: float  # Cost in USD
     usage: UsageData
+    timings: MessageTimings  # Per-step timing breakdown (ttft_ms, gen_ms, tool_ms, …)
     voice_call: dict[str, Any]  # Voice call metadata (call_sid, source, etc.)
     artifacts: list[ArtifactDescriptor]  # tool/plugin-emitted artifact descriptors
     tool: str  # tool that produced this result message

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -876,6 +876,7 @@ def api_conversation_rerun(conversation_id: str):
                 tool_id=tool_id,
                 tooluse=tooluse,
                 auto_confirm=session.auto_confirm_count > 0,
+                assistant_msg_timestamp=last_assistant.timestamp,
             )
             session.pending_tools[tool_id] = tool_exec
 

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -44,6 +44,11 @@ class ToolExecution:
     auto_confirm: bool = False
     started_at: float | None = None
     branch: str = "main"
+    # Timestamp of the assistant message that requested this tool. Used to
+    # target the correct message when persisting timing data, since by the
+    # time execution completes a later assistant message may already exist
+    # (see _attach_tool_timings in session_step.py).
+    assistant_msg_timestamp: datetime | None = None
 
 
 @dataclass

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -230,7 +230,7 @@ def _append_and_notify(manager: LogManager, session: ConversationSession, msg: M
 
 
 def _attach_tool_timings(
-    manager: LogManager, tool_ms_by_name: dict[str, float]
+    conversation_id: str, tool_ms_by_name: dict[str, float]
 ) -> None:
     """Attach aggregated tool-execution timing to the last assistant message.
 
@@ -238,41 +238,53 @@ def _attach_tool_timings(
     the per-tool timing data into its ``metadata.timings`` dict, and rewrites
     the JSONL file.  This is a best-effort operation — failures are logged but
     do not interrupt tool execution or step continuation.
+
+    Multiple confirmation threads for the same assistant message can call this
+    concurrently, each with only its own local tool durations. Merging alone
+    isn't enough to avoid a lost update: two threads can each read the
+    caller's (possibly stale) in-memory log before either has written, merge
+    against that same stale state, and the later write silently discards the
+    earlier thread's contribution. Serialize the whole read-merge-write under
+    the conversation lock and reload fresh from disk inside it so each thread
+    merges against the latest state, not a snapshot taken before the lock.
     """
     from typing import cast
 
-    messages = manager.log.messages
-    for i in range(len(messages) - 1, -1, -1):
-        if messages[i].role == "assistant":
-            msg = messages[i]
-            existing_meta = dict(msg.metadata) if msg.metadata else {}
-            _raw_timings = existing_meta.get("timings")
-            existing_timings = cast(
-                MessageTimings,
-                dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
-            )
-            # Merge with any tool timings already recorded by prior confirmation
-            # threads — each thread only has its own local measurements, so we
-            # must accumulate rather than replace to avoid losing earlier tools.
-            prior = {
-                k: round(v, 1)
-                for k, v in (existing_timings.get("tool_ms_by_name") or {}).items()
-            }
-            for k, v in tool_ms_by_name.items():
-                prior[k] = round(prior.get(k, 0.0) + v, 1)
-            existing_timings["tool_ms"] = round(sum(prior.values()), 1)
-            existing_timings["tool_ms_by_name"] = prior
-            existing_meta["timings"] = existing_timings
-            updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
-            manager.log.messages[i] = updated_msg
-            manager.write()
-            logger.debug(
-                "Attached tool timings to assistant message: tool_ms=%.1f, by_name=%s",
-                existing_timings["tool_ms"],
-                existing_timings["tool_ms_by_name"],
-            )
-            return
-    logger.warning("_attach_tool_timings: no assistant message found in log")
+    with SessionManager.conversation_lock(conversation_id):
+        manager = LogManager.load(conversation_id, lock=False)
+        messages = manager.log.messages
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].role == "assistant":
+                msg = messages[i]
+                existing_meta = dict(msg.metadata) if msg.metadata else {}
+                _raw_timings = existing_meta.get("timings")
+                existing_timings = cast(
+                    MessageTimings,
+                    dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
+                )
+                # Merge with any tool timings already recorded by prior
+                # confirmation threads — each thread only has its own local
+                # measurements, so we must accumulate rather than replace to
+                # avoid losing earlier tools.
+                prior = {
+                    k: round(v, 1)
+                    for k, v in (existing_timings.get("tool_ms_by_name") or {}).items()
+                }
+                for k, v in tool_ms_by_name.items():
+                    prior[k] = round(prior.get(k, 0.0) + v, 1)
+                existing_timings["tool_ms"] = round(sum(prior.values()), 1)
+                existing_timings["tool_ms_by_name"] = prior
+                existing_meta["timings"] = existing_timings
+                updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
+                manager.log.messages[i] = updated_msg
+                manager.write()
+                logger.debug(
+                    "Attached tool timings to assistant message: tool_ms=%.1f, by_name=%s",
+                    existing_timings["tool_ms"],
+                    existing_timings["tool_ms_by_name"],
+                )
+                return
+        logger.warning("_attach_tool_timings: no assistant message found in log")
 
 
 def _persist_generation_error(
@@ -1100,7 +1112,7 @@ def start_tool_execution(
             # Persist aggregated tool timing in the assistant message that
             # triggered these tool calls so it is available in session records.
             if tool_ms_by_name:
-                _attach_tool_timings(manager, tool_ms_by_name)
+                _attach_tool_timings(conversation_id, tool_ms_by_name)
 
             # Only auto-step when all pending tools have been executed.
             # With multiple tools per message, we must wait until every tool

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -27,7 +27,7 @@ from ..hooks import HookType, trigger_hook
 from ..hooks.confirm import ConfirmationResult
 from ..llm import _chat_complete, _stream
 from ..logmanager import LogManager, prepare_messages
-from ..message import Message
+from ..message import Message, MessageMetadata, MessageTimings
 from ..telemetry import trace_function
 from ..tools import ToolUse, get_tools
 from ..tools.shell import set_workspace_cwd
@@ -227,6 +227,45 @@ def _append_and_notify(manager: LogManager, session: ConversationSession, msg: M
             "message": msg2dict(msg, manager.workspace, manager.logdir),
         },
     )
+
+
+def _attach_tool_timings(
+    manager: LogManager, tool_ms_by_name: dict[str, float]
+) -> None:
+    """Attach aggregated tool-execution timing to the last assistant message.
+
+    Walks the log backwards to find the most recent assistant message, merges
+    the per-tool timing data into its ``metadata.timings`` dict, and rewrites
+    the JSONL file.  This is a best-effort operation — failures are logged but
+    do not interrupt tool execution or step continuation.
+    """
+    from typing import cast
+
+    messages = manager.log.messages
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].role == "assistant":
+            msg = messages[i]
+            existing_meta = dict(msg.metadata) if msg.metadata else {}
+            _raw_timings = existing_meta.get("timings")
+            existing_timings = cast(
+                MessageTimings,
+                dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
+            )
+            existing_timings["tool_ms"] = round(sum(tool_ms_by_name.values()), 1)
+            existing_timings["tool_ms_by_name"] = {
+                k: round(v, 1) for k, v in tool_ms_by_name.items()
+            }
+            existing_meta["timings"] = existing_timings
+            updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
+            manager.log.messages[i] = updated_msg
+            manager.write()
+            logger.debug(
+                "Attached tool timings to assistant message: tool_ms=%.1f, by_name=%s",
+                existing_timings["tool_ms"],
+                existing_timings["tool_ms_by_name"],
+            )
+            return
+    logger.warning("_attach_tool_timings: no assistant message found in log")
 
 
 def _persist_generation_error(
@@ -935,6 +974,9 @@ def start_tool_execution(
             # to guarantee serial execution order.
             current_tool_id: str = tool_id
             current_edited_tooluse: ToolUse | None = edited_tooluse
+            # Accumulate per-tool durations across all chained executions so
+            # they can be persisted in the assistant message metadata at the end.
+            tool_ms_by_name: dict[str, float] = {}
 
             while True:
                 # Reload the conversation to pick up outputs from prior tools.
@@ -1016,9 +1058,12 @@ def start_tool_execution(
                     msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
                     _append_and_notify(manager, session, msg)
 
-                # Emit tool_complete with duration
+                # Emit tool_complete with duration; also accumulate for metadata.
                 if tool_exec.started_at is not None:
                     duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
+                    tool_ms_by_name[tooluse.tool] = (
+                        tool_ms_by_name.get(tooluse.tool, 0.0) + duration_ms
+                    )
                     SessionManager.add_event(
                         conversation_id,
                         {
@@ -1044,6 +1089,11 @@ def start_tool_execution(
                     current_edited_tooluse = None
                 else:
                     break
+
+            # Persist aggregated tool timing in the assistant message that
+            # triggered these tool calls so it is available in session records.
+            if tool_ms_by_name:
+                _attach_tool_timings(manager, tool_ms_by_name)
 
             # Only auto-step when all pending tools have been executed.
             # With multiple tools per message, we must wait until every tool

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1147,12 +1147,28 @@ def start_tool_execution(
 
                 # Chain to next pending auto-confirm tool (serial execution)
                 next_auto_id: str | None = None
+                next_auto_ts: datetime | None = None
                 for tid, texec in list(session.pending_tools.items()):
                     if texec.auto_confirm:
                         next_auto_id = tid
+                        next_auto_ts = texec.assistant_msg_timestamp
                         break
 
                 if next_auto_id is not None:
+                    # If the next chained tool belongs to a different assistant
+                    # message (e.g. added by a rerun while this thread is
+                    # running), flush accumulated timings for the current target
+                    # before switching — otherwise those durations would be
+                    # attached to the wrong step.
+                    if next_auto_ts != assistant_msg_timestamp and tool_ms_by_name:
+                        _attach_tool_timings(
+                            conversation_id,
+                            dict(tool_ms_by_name),
+                            assistant_msg_timestamp,
+                            branch=branch,
+                        )
+                        tool_ms_by_name.clear()
+                        assistant_msg_timestamp = next_auto_ts
                     current_tool_id = next_auto_id
                     current_edited_tooluse = None
                 else:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -233,6 +233,7 @@ def _attach_tool_timings(
     conversation_id: str,
     tool_ms_by_name: dict[str, float],
     target_timestamp: datetime | None = None,
+    branch: str = "main",
 ) -> None:
     """Attach aggregated tool-execution timing to the originating assistant message.
 
@@ -264,7 +265,7 @@ def _attach_tool_timings(
     from typing import cast
 
     with SessionManager.conversation_lock(conversation_id):
-        manager = LogManager.load(conversation_id, lock=False)
+        manager = LogManager.load(conversation_id, branch=branch, lock=False)
         messages = manager.log.messages
 
         target_idx: int | None = None
@@ -1110,7 +1111,9 @@ def start_tool_execution(
                     # rewrite the full JSONL, overwriting concurrent tool-result appends
                     # or timing patches written by other confirmation threads.
                     with SessionManager.conversation_lock(conversation_id):
-                        manager = LogManager.load(conversation_id, lock=False)
+                        manager = LogManager.load(
+                            conversation_id, branch=branch, lock=False
+                        )
                         for tool_output in tool_outputs:
                             _append_and_notify(manager, session, tool_output)
                 except Exception as e:
@@ -1118,7 +1121,9 @@ def start_tool_execution(
                     tool_exec.status = ToolStatus.FAILED
 
                     with SessionManager.conversation_lock(conversation_id):
-                        manager = LogManager.load(conversation_id, lock=False)
+                        manager = LogManager.load(
+                            conversation_id, branch=branch, lock=False
+                        )
                         msg = Message(
                             "system", f"Error: {e!s}", call_id=tooluse.call_id
                         )
@@ -1157,7 +1162,10 @@ def start_tool_execution(
             # triggered these tool calls so it is available in session records.
             if tool_ms_by_name:
                 _attach_tool_timings(
-                    conversation_id, tool_ms_by_name, assistant_msg_timestamp
+                    conversation_id,
+                    tool_ms_by_name,
+                    assistant_msg_timestamp,
+                    branch=branch,
                 )
 
             # Only auto-step when all pending tools have been executed.

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1104,14 +1104,25 @@ def start_tool_execution(
                     # ToolUse.execute() for real results; hook messages intentionally
                     # have no call_id — don't re-stamp here or hook messages become
                     # duplicate function_call_output entries (Responses API 400).
-                    for tool_output in tool_outputs:
-                        _append_and_notify(manager, session, tool_output)
+                    #
+                    # Reload under conversation_lock before appending: without this,
+                    # a stale in-memory manager (loaded at the top of the loop) would
+                    # rewrite the full JSONL, overwriting concurrent tool-result appends
+                    # or timing patches written by other confirmation threads.
+                    with SessionManager.conversation_lock(conversation_id):
+                        manager = LogManager.load(conversation_id, lock=False)
+                        for tool_output in tool_outputs:
+                            _append_and_notify(manager, session, tool_output)
                 except Exception as e:
                     logger.exception(f"Error executing tool {tooluse.tool}: {e}")
                     tool_exec.status = ToolStatus.FAILED
 
-                    msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
-                    _append_and_notify(manager, session, msg)
+                    with SessionManager.conversation_lock(conversation_id):
+                        manager = LogManager.load(conversation_id, lock=False)
+                        msg = Message(
+                            "system", f"Error: {e!s}", call_id=tooluse.call_id
+                        )
+                        _append_and_notify(manager, session, msg)
 
                 # Emit tool_complete with duration; also accumulate for metadata.
                 if tool_exec.started_at is not None:
@@ -1128,9 +1139,6 @@ def start_tool_execution(
                             "success": tool_exec.status != ToolStatus.FAILED,
                         },
                     )
-
-                # Persist tool outputs to disk
-                manager.write()
 
                 # Chain to next pending auto-confirm tool (serial execution)
                 next_auto_id: str | None = None

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -251,10 +251,17 @@ def _attach_tool_timings(
                 MessageTimings,
                 dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
             )
-            existing_timings["tool_ms"] = round(sum(tool_ms_by_name.values()), 1)
-            existing_timings["tool_ms_by_name"] = {
-                k: round(v, 1) for k, v in tool_ms_by_name.items()
+            # Merge with any tool timings already recorded by prior confirmation
+            # threads — each thread only has its own local measurements, so we
+            # must accumulate rather than replace to avoid losing earlier tools.
+            prior = {
+                k: round(v, 1)
+                for k, v in (existing_timings.get("tool_ms_by_name") or {}).items()
             }
+            for k, v in tool_ms_by_name.items():
+                prior[k] = round(prior.get(k, 0.0) + v, 1)
+            existing_timings["tool_ms"] = round(sum(prior.values()), 1)
+            existing_timings["tool_ms_by_name"] = prior
             existing_meta["timings"] = existing_timings
             updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
             manager.log.messages[i] = updated_msg

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -230,14 +230,27 @@ def _append_and_notify(manager: LogManager, session: ConversationSession, msg: M
 
 
 def _attach_tool_timings(
-    conversation_id: str, tool_ms_by_name: dict[str, float]
+    conversation_id: str,
+    tool_ms_by_name: dict[str, float],
+    target_timestamp: datetime | None = None,
 ) -> None:
-    """Attach aggregated tool-execution timing to the last assistant message.
+    """Attach aggregated tool-execution timing to the originating assistant message.
 
-    Walks the log backwards to find the most recent assistant message, merges
-    the per-tool timing data into its ``metadata.timings`` dict, and rewrites
-    the JSONL file.  This is a best-effort operation — failures are logged but
-    do not interrupt tool execution or step continuation.
+    Walks the log backwards looking for the assistant message whose timestamp
+    matches ``target_timestamp`` (the message that requested these tools),
+    merges the per-tool timing data into its ``metadata.timings`` dict, and
+    rewrites the JSONL file. This is a best-effort operation — failures are
+    logged but do not interrupt tool execution or step continuation.
+
+    ``target_timestamp`` matters because a continuation step can already have
+    appended a *newer* assistant message by the time a slower confirmation
+    thread finishes: two non-auto-confirm tools from the same message can be
+    confirmed on separate threads, and if the earlier one clears the last
+    pending tool it triggers auto-step (a new assistant message) before the
+    later thread gets here. Without a target, "most recent assistant message"
+    would then be the wrong one. Falls back to the most recent assistant
+    message if no ``target_timestamp`` is given (or no match is found), for
+    backward compatibility with callers that don't have it.
 
     Multiple confirmation threads for the same assistant message can call this
     concurrently, each with only its own local tool durations. Merging alone
@@ -253,37 +266,52 @@ def _attach_tool_timings(
     with SessionManager.conversation_lock(conversation_id):
         manager = LogManager.load(conversation_id, lock=False)
         messages = manager.log.messages
+
+        target_idx: int | None = None
+        fallback_idx: int | None = None
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].role == "assistant":
-                msg = messages[i]
-                existing_meta = dict(msg.metadata) if msg.metadata else {}
-                _raw_timings = existing_meta.get("timings")
-                existing_timings = cast(
-                    MessageTimings,
-                    dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
-                )
-                # Merge with any tool timings already recorded by prior
-                # confirmation threads — each thread only has its own local
-                # measurements, so we must accumulate rather than replace to
-                # avoid losing earlier tools.
-                prior = {
-                    k: round(v, 1)
-                    for k, v in (existing_timings.get("tool_ms_by_name") or {}).items()
-                }
-                for k, v in tool_ms_by_name.items():
-                    prior[k] = round(prior.get(k, 0.0) + v, 1)
-                existing_timings["tool_ms"] = round(sum(prior.values()), 1)
-                existing_timings["tool_ms_by_name"] = prior
-                existing_meta["timings"] = existing_timings
-                updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
-                manager.log.messages[i] = updated_msg
-                manager.write()
-                logger.debug(
-                    "Attached tool timings to assistant message: tool_ms=%.1f, by_name=%s",
-                    existing_timings["tool_ms"],
-                    existing_timings["tool_ms_by_name"],
-                )
-                return
+                if fallback_idx is None:
+                    fallback_idx = i
+                if (
+                    target_timestamp is not None
+                    and messages[i].timestamp == target_timestamp
+                ):
+                    target_idx = i
+                    break
+        if target_idx is None:
+            target_idx = fallback_idx
+
+        if target_idx is not None:
+            msg = messages[target_idx]
+            existing_meta = dict(msg.metadata) if msg.metadata else {}
+            _raw_timings = existing_meta.get("timings")
+            existing_timings = cast(
+                MessageTimings,
+                dict(_raw_timings) if isinstance(_raw_timings, dict) else {},
+            )
+            # Merge with any tool timings already recorded by prior
+            # confirmation threads — each thread only has its own local
+            # measurements, so we must accumulate rather than replace to
+            # avoid losing earlier tools.
+            prior = {
+                k: round(v, 1)
+                for k, v in (existing_timings.get("tool_ms_by_name") or {}).items()
+            }
+            for k, v in tool_ms_by_name.items():
+                prior[k] = round(prior.get(k, 0.0) + v, 1)
+            existing_timings["tool_ms"] = round(sum(prior.values()), 1)
+            existing_timings["tool_ms_by_name"] = prior
+            existing_meta["timings"] = existing_timings
+            updated_msg = msg.replace(metadata=cast(MessageMetadata, existing_meta))
+            manager.log.messages[target_idx] = updated_msg
+            manager.write()
+            logger.debug(
+                "Attached tool timings to assistant message: tool_ms=%.1f, by_name=%s",
+                existing_timings["tool_ms"],
+                existing_timings["tool_ms_by_name"],
+            )
+            return
         logger.warning("_attach_tool_timings: no assistant message found in log")
 
 
@@ -890,6 +918,7 @@ def step(
                 tooluse=tooluse,
                 auto_confirm=session.auto_confirm_count > 0 or auto_confirm,
                 branch=branch,
+                assistant_msg_timestamp=msg.timestamp,
             )
             session.pending_tools[tool_id] = tool_exec
 
@@ -996,6 +1025,11 @@ def start_tool_execution(
             # Accumulate per-tool durations across all chained executions so
             # they can be persisted in the assistant message metadata at the end.
             tool_ms_by_name: dict[str, float] = {}
+            # Timestamp of the assistant message that requested these tools —
+            # captured from the first tool claimed below, so timing is
+            # attached to that message even if a later one is appended before
+            # this thread finishes (see _attach_tool_timings).
+            assistant_msg_timestamp = None
 
             while True:
                 # Reload the conversation to pick up outputs from prior tools.
@@ -1018,6 +1052,8 @@ def start_tool_execution(
                         session.generating = False
                         session.generating_since = None
                     return  # another thread claimed this tool; don't trigger auto-step
+                if assistant_msg_timestamp is None:
+                    assistant_msg_timestamp = tool_exec.assistant_msg_timestamp
                 tool_exec.status = ToolStatus.EXECUTING
 
                 # use explicit tooluse if set (may be modified), else from pending
@@ -1112,7 +1148,9 @@ def start_tool_execution(
             # Persist aggregated tool timing in the assistant message that
             # triggered these tool calls so it is available in session records.
             if tool_ms_by_name:
-                _attach_tool_timings(conversation_id, tool_ms_by_name)
+                _attach_tool_timings(
+                    conversation_id, tool_ms_by_name, assistant_msg_timestamp
+                )
 
             # Only auto-step when all pending tools have been executed.
             # With multiple tools per message, we must wait until every tool

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import pkgutil
 import threading
+import time
 from contextvars import ContextVar
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -319,8 +320,21 @@ def execute_msg(
     msg: Message,
     log: Log | None = None,
     workspace: Path | None = None,
+    tool_timings: dict[str, float] | None = None,
 ) -> Generator[Message, None, None]:
-    """Uses any tools called in a message and returns the response."""
+    """Uses any tools called in a message and returns the response.
+
+    Args:
+        msg: The assistant message whose tool uses should be executed.
+        log: Optional conversation log (passed through to tool execution).
+        workspace: Optional workspace path (passed through to tool execution).
+        tool_timings: Optional dict to accumulate per-tool wall-clock durations
+            in milliseconds.  If provided, each executed tool's name is used as
+            the key and its duration (ms) is *added* to any existing value so
+            repeated calls to the same tool accumulate correctly.  Pass an empty
+            dict ``{}`` from the caller and read it back after the generator is
+            exhausted to obtain ``tool_ms_by_name`` for timing metadata.
+    """
     assert msg.role == "assistant", "Only assistant messages can be executed"
 
     # Snapshot runnability once per tool_use. Evaluating `is_runnable` a second
@@ -337,6 +351,7 @@ def execute_msg(
     for tooluse, runnable in remaining:
         if runnable:
             with terminal_state_title(f"🛠️ running {tooluse.tool}"):
+                t0 = time.monotonic()
                 try:
                     yield from tooluse.execute(log=log, workspace=workspace)
                 except KeyboardInterrupt:
@@ -357,6 +372,12 @@ def execute_msg(
                                 call_id=rem_tu.call_id,
                             )
                     return
+                finally:
+                    if tool_timings is not None:
+                        elapsed_ms = (time.monotonic() - t0) * 1000
+                        tool_timings[tooluse.tool] = (
+                            tool_timings.get(tooluse.tool, 0.0) + elapsed_ms
+                        )
         elif tooluse.call_id is not None:
             # A structured (tool-format) tool_use that isn't runnable still needs
             # a paired tool_result, or the next API request dangles it and 400s.

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1135,6 +1135,14 @@ class TestRerunEndpoint:
             assert "re-running" in data["message"].lower()
             assert "tool_ids" in data
             assert len(data["tool_ids"]) > initial_pending
+
+            # Regression: rerun-created ToolExecutions must carry the
+            # originating assistant message's timestamp so timing gets
+            # attached to the correct step, not misattributed to whatever
+            # assistant message happens to be last when the tool finishes.
+            for tool_id in data["tool_ids"]:
+                tool_exec = session.pending_tools[tool_id]
+                assert tool_exec.assistant_msg_timestamp is not None
         finally:
             session.pending_tools.clear()
 

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -6,6 +6,7 @@ Covers:
 - step() attaches timing to the assistant message before yielding it.
 """
 
+import importlib
 import json
 from unittest.mock import patch
 
@@ -142,7 +143,13 @@ def test_step_attaches_timings_to_assistant_message():
     mock_meta: MessageMetadata = {"model": "mock/model", "timings": mock_timings}
     mock_response = Message("assistant", "Hello!", metadata=mock_meta)
 
-    with patch("gptme.chat.reply", return_value=mock_response):
+    # Use patch.object on the module object (via importlib) rather than the
+    # string form patch("gptme.chat.reply"): gptme/__init__.py lazily exports
+    # the `chat` *function* as the `gptme.chat` package attribute, which can
+    # shadow the `gptme.chat` submodule and break string-path attribute
+    # lookup depending on test collection order.
+    chat_module = importlib.import_module("gptme.chat")
+    with patch.object(chat_module, "reply", return_value=mock_response):
         yielded = list(step(messages, stream=False))
 
     # The first yielded message should be the assistant response
@@ -176,7 +183,8 @@ def test_step_attaches_tool_timings():
         "assistant", "```shell\necho timing-test\n```", metadata=mock_meta
     )
 
-    with patch("gptme.chat.reply", return_value=mock_response):
+    chat_module = importlib.import_module("gptme.chat")
+    with patch.object(chat_module, "reply", return_value=mock_response):
         yielded = list(step(messages, stream=False))
 
     assistant_msgs = [m for m in yielded if m.role == "assistant"]

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -1,0 +1,195 @@
+"""Tests for per-step timing breakdown (ttft_ms, gen_ms, tool_ms, tool_ms_by_name).
+
+Covers:
+- MessageTimings TypedDict round-trips through JSON.
+- execute_msg() populates a tool_timings dict when provided.
+- step() attaches timing to the assistant message before yielding it.
+"""
+
+import json
+from unittest.mock import patch
+
+from gptme.message import Message, MessageMetadata, MessageTimings
+
+# ---------------------------------------------------------------------------
+# MessageTimings round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_message_timings_roundtrip_json():
+    """MessageTimings survives a JSON round-trip via to_dict()."""
+    timings: MessageTimings = {
+        "ttft_ms": 820.0,
+        "gen_ms": 4200.0,
+        "tool_ms": 1850.0,
+        "tool_ms_by_name": {"shell": 1600.0, "read": 250.0},
+    }
+    meta: MessageMetadata = {"model": "anthropic/claude-sonnet", "timings": timings}
+    msg = Message("assistant", "hello", metadata=meta)
+
+    d = msg.to_dict()
+    assert d["metadata"]["timings"]["ttft_ms"] == 820.0
+    assert d["metadata"]["timings"]["gen_ms"] == 4200.0
+    assert d["metadata"]["timings"]["tool_ms"] == 1850.0
+    assert d["metadata"]["timings"]["tool_ms_by_name"] == {
+        "shell": 1600.0,
+        "read": 250.0,
+    }
+
+    # JSON serialization
+    j = json.dumps(d)
+    restored = json.loads(j)
+    assert restored["metadata"]["timings"]["ttft_ms"] == 820.0
+    assert restored["metadata"]["timings"]["tool_ms_by_name"]["shell"] == 1600.0
+
+
+def test_message_timings_partial():
+    """MessageTimings with only LLM fields (no tool fields) serializes correctly."""
+    timings: MessageTimings = {"ttft_ms": 350.0, "gen_ms": 1100.0}
+    meta: MessageMetadata = {"model": "openai/gpt-4o", "timings": timings}
+    msg = Message("assistant", "hi", metadata=meta)
+
+    d = msg.to_dict()
+    assert d["metadata"]["timings"]["ttft_ms"] == 350.0
+    assert d["metadata"]["timings"]["gen_ms"] == 1100.0
+    assert "tool_ms" not in d["metadata"]["timings"]
+    assert "tool_ms_by_name" not in d["metadata"]["timings"]
+
+
+def test_message_timings_absent_when_empty():
+    """A message without timings has no 'timings' key in its dict."""
+    meta: MessageMetadata = {"model": "openai/gpt-4o", "cost": 0.001}
+    msg = Message("assistant", "hi", metadata=meta)
+    d = msg.to_dict()
+    assert "timings" not in d["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# execute_msg() tool_timings accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_execute_msg_collects_tool_timings():
+    """execute_msg accumulates per-tool durations in the tool_timings dict."""
+    from gptme.tools import execute_msg, init_tools
+
+    init_tools(allowlist=["shell"])
+
+    # The shell tool registers the "shell" block type (not "bash")
+    msg = Message("assistant", "```shell\necho hello\n```")
+    tool_timings: dict[str, float] = {}
+
+    outputs = list(execute_msg(msg, tool_timings=tool_timings))
+
+    # At least one tool output should have been produced
+    assert outputs, "expected tool output messages"
+    # shell tool duration should be present
+    assert "shell" in tool_timings, (
+        f"expected 'shell' in tool_timings, got {tool_timings}"
+    )
+    assert tool_timings["shell"] > 0, "timing should be positive"
+
+
+def test_execute_msg_accumulates_repeated_tool():
+    """Multiple calls to the same tool accumulate correctly in tool_timings."""
+    from gptme.tools import execute_msg, init_tools
+
+    init_tools(allowlist=["shell"])
+
+    # Two shell blocks in one message (uses "shell" block type)
+    msg = Message("assistant", "```shell\necho one\n```\n\n```shell\necho two\n```")
+    tool_timings: dict[str, float] = {}
+
+    list(execute_msg(msg, tool_timings=tool_timings))
+
+    assert "shell" in tool_timings
+    # Both invocations should contribute — sum must be positive
+    assert tool_timings["shell"] > 0
+
+
+def test_execute_msg_no_timings_when_no_tools():
+    """execute_msg produces no timings for messages with no runnable tool blocks."""
+    from gptme.tools import execute_msg, init_tools
+
+    init_tools(allowlist=["shell"])
+
+    msg = Message("assistant", "Just a plain response, no tools.")
+    tool_timings: dict[str, float] = {}
+
+    outputs = list(execute_msg(msg, tool_timings=tool_timings))
+
+    assert outputs == []
+    assert tool_timings == {}
+
+
+# ---------------------------------------------------------------------------
+# step() integration: timing attached to assistant message
+# ---------------------------------------------------------------------------
+
+
+def test_step_attaches_timings_to_assistant_message():
+    """step() should yield an assistant message whose metadata.timings has ttft_ms/gen_ms."""
+    from gptme.chat import step
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+
+    messages = [Message("user", "say hello")]
+
+    # Mock reply() so no real LLM call is made.
+    # The returned Message simulates what _reply_stream produces: metadata with timings.
+    mock_timings: MessageTimings = {"ttft_ms": 250.0, "gen_ms": 800.0}
+    mock_meta: MessageMetadata = {"model": "mock/model", "timings": mock_timings}
+    mock_response = Message("assistant", "Hello!", metadata=mock_meta)
+
+    with patch("gptme.chat.reply", return_value=mock_response):
+        yielded = list(step(messages, stream=False))
+
+    # The first yielded message should be the assistant response
+    assistant_msgs = [m for m in yielded if m.role == "assistant"]
+    assert assistant_msgs, "expected at least one assistant message"
+
+    assistant_msg = assistant_msgs[0]
+    assert assistant_msg.metadata is not None
+    assert "timings" in assistant_msg.metadata, (
+        f"expected 'timings' in assistant metadata, got {assistant_msg.metadata}"
+    )
+    timings = assistant_msg.metadata["timings"]
+    assert timings.get("ttft_ms") == 250.0
+    assert timings.get("gen_ms") == 800.0
+
+
+def test_step_attaches_tool_timings():
+    """step() should merge tool_ms/tool_ms_by_name into the assistant message timings."""
+    from gptme.chat import step
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+
+    messages = [Message("user", "run something")]
+
+    # Mock response contains a shell tool call so execute_msg actually runs.
+    mock_timings: MessageTimings = {"ttft_ms": 100.0, "gen_ms": 500.0}
+    mock_meta: MessageMetadata = {"model": "mock/model", "timings": mock_timings}
+    # Use "shell" block type (not "bash") to match the shell tool's block_types
+    mock_response = Message(
+        "assistant", "```shell\necho timing-test\n```", metadata=mock_meta
+    )
+
+    with patch("gptme.chat.reply", return_value=mock_response):
+        yielded = list(step(messages, stream=False))
+
+    assistant_msgs = [m for m in yielded if m.role == "assistant"]
+    assert assistant_msgs
+    assistant_msg = assistant_msgs[0]
+    assert assistant_msg.metadata is not None
+
+    timings = assistant_msg.metadata.get("timings", {})
+    # LLM timings from mock should be preserved
+    assert timings.get("ttft_ms") == 100.0
+    assert timings.get("gen_ms") == 500.0
+    # Tool timings should be added
+    assert "tool_ms" in timings, f"expected tool_ms in timings, got {timings}"
+    assert timings["tool_ms"] > 0
+    assert "tool_ms_by_name" in timings
+    assert "shell" in timings["tool_ms_by_name"]

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -8,6 +8,7 @@ Covers:
 
 import importlib
 import json
+import threading
 from unittest.mock import patch
 
 from gptme.message import Message, MessageMetadata, MessageTimings
@@ -201,3 +202,52 @@ def test_step_attaches_tool_timings():
     assert timings["tool_ms"] > 0
     assert "tool_ms_by_name" in timings
     assert "shell" in timings["tool_ms_by_name"]
+
+
+# ---------------------------------------------------------------------------
+# _attach_tool_timings() concurrent confirmation threads (server path)
+# ---------------------------------------------------------------------------
+
+
+def test_attach_tool_timings_concurrent_threads_do_not_lose_updates(
+    monkeypatch, tmp_path
+):
+    """Two confirmation threads racing to attach tool timings for the same
+    assistant message must both survive — neither read-merge-write should
+    silently discard the other's contribution (lost-update race)."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path))
+
+    from gptme.logmanager import LogManager
+    from gptme.server.session_step import _attach_tool_timings
+
+    conversation_id = "test-concurrent-tool-timings"
+    manager = LogManager.load(conversation_id, create=True, lock=False)
+    manager.append(Message("user", "run two tools"))
+    manager.append(Message("assistant", "running tools"))
+
+    # Force both threads to call _attach_tool_timings at (as close to)
+    # the same instant as possible, to exercise the race.
+    barrier = threading.Barrier(2)
+
+    def run(tool_name: str, value: float) -> None:
+        barrier.wait(timeout=5)
+        _attach_tool_timings(conversation_id, {tool_name: value})
+
+    t1 = threading.Thread(target=run, args=("shell", 100.0))
+    t2 = threading.Thread(target=run, args=("read", 50.0))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert not t1.is_alive() and not t2.is_alive()
+
+    final = LogManager.load(conversation_id, lock=False)
+    assistant_msgs = [m for m in final.log.messages if m.role == "assistant"]
+    assert assistant_msgs
+    metadata = assistant_msgs[-1].metadata
+    assert metadata is not None
+    timings = metadata.get("timings", {})
+    assert timings.get("tool_ms_by_name") == {"shell": 100.0, "read": 50.0}, (
+        f"expected both threads' timings preserved, got {timings}"
+    )
+    assert timings.get("tool_ms") == 150.0

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -11,7 +11,20 @@ import json
 import threading
 from unittest.mock import patch
 
+import pytest
+
 from gptme.message import Message, MessageMetadata, MessageTimings
+
+
+def _has_flask() -> bool:
+    """Check if flask is available (required for server components)."""
+    try:
+        import flask  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
 
 # ---------------------------------------------------------------------------
 # MessageTimings round-trip tests
@@ -209,6 +222,9 @@ def test_step_attaches_tool_timings():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _has_flask(), reason="flask not installed, install server extras (-E server)"
+)
 def test_attach_tool_timings_concurrent_threads_do_not_lose_updates(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
Closes #3434.

Already-computed TTFT and generation timing (from `_reply_stream()`) and per-tool durations (from `execute_msg()` / `execute_tool_thread()`) were being discarded. This routes all of that data into `MessageMetadata.timings` so it is written to `conversation.jsonl` alongside the assistant message.

## Changes

### `gptme/message.py`
- Add `MessageTimings` TypedDict (`total=False`) with `ttft_ms`, `gen_ms`, `tool_ms`, `tool_ms_by_name` fields.
- Add `timings: MessageTimings` field to `MessageMetadata`.

### `gptme/llm/__init__.py`
- In `_reply_stream()` finally-block, capture computed TTFT / gen_ms and attach them to `stream.metadata` so the caller sees them on the returned `Message`.

### `gptme/tools/__init__.py`
- Add optional `tool_timings: dict[str, float]` parameter to `execute_msg()`.
- Accumulate per-tool wall-clock durations into that dict (keyed by `tooluse.tool`, additive for repeated tools in one message).

### `gptme/chat.py`
- In `step()`, buffer tool outputs via `list(execute_msg(..., tool_timings))` before yielding the assistant message. Once all tools have run, merge `tool_ms` / `tool_ms_by_name` into the assistant message's existing timings (preserving `ttft_ms` / `gen_ms` from the LLM), then yield the fully-annotated message followed by the tool outputs.

### `gptme/server/session_step.py`
- In `execute_tool_thread()`, accumulate per-tool durations into a local `tool_ms_by_name` dict alongside the existing SSE `duration_ms` event.
- Add `_attach_tool_timings()` helper that walks the log backwards to find the last assistant message, merges timing into its metadata, and rewrites the JSONL file. Called once after all tools in the step finish executing.

### `tests/test_timings.py` (new)
- 8 tests covering `MessageTimings` JSON round-trip, partial timings, `execute_msg()` accumulation, repeated-tool accumulation, and `step()` end-to-end with both LLM and tool timings attached to the assistant message.

## Example output in `conversation.jsonl`

```json
{
  "role": "assistant",
  "content": "...",
  "metadata": {
    "model": "anthropic/claude-sonnet-4-5",
    "cost": 0.00142,
    "timings": {
      "ttft_ms": 820.0,
      "gen_ms": 4200.0,
      "tool_ms": 1850.0,
      "tool_ms_by_name": {"shell": 1600.0, "read": 250.0}
    }
  }
}
```

<!-- gptme-id:v1:gai_NkpMkIcNTTWsjeX288hqC45AOF0OKxl8UAdBzcVivrR -->