### PR TITLE
feat(cli): add 'gptme providers add' command for interactive custom provider setup

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -145,7 +145,8 @@ def providers_list():
     if not config.user.providers:
         click.echo("📭 No custom providers configured")
         click.echo()
-        click.echo("To add a custom provider, add to your gptme.toml:")
+        click.echo("Run `gptme providers add` to configure one interactively, or")
+        click.echo("add manually to your gptme.toml:")
         click.echo()
         click.echo("[[providers]]")
         click.echo('name = "my-provider"')
@@ -197,11 +198,10 @@ def providers_test(provider_name: str):
             names = [p.name for p in config.user.providers]
             click.echo(f"Available providers: {', '.join(names)}")
         else:
-            click.echo("No custom providers configured. Add one to your gptme.toml:")
-            click.echo()
-            click.echo("[[providers]]")
-            click.echo(f'name = "{provider_name}"')
-            click.echo('base_url = "http://localhost:8000/v1"')
+            click.echo(
+                "No custom providers configured. Run `gptme providers add` "
+                "to configure one interactively."
+            )
         sys.exit(1)
 
     click.echo(f"🔌 Testing provider: {provider_name}")
@@ -267,6 +267,21 @@ def providers_test(provider_name: str):
     except Exception as e:
         click.echo(f"   ❌ Connection failed: {e}")
         sys.exit(1)
+
+
+@providers.command("add")
+def providers_add():
+    """Interactively add a custom OpenAI-compatible provider.
+
+    Prompts for provider name, base URL, API key, and default model, then
+    writes the configuration to gptme.toml.
+
+    Example providers: Ollama (http://localhost:11434/v1), LM Studio
+    (http://localhost:1234/v1), vLLM, or any OpenAI-compatible relay.
+    """
+    from .setup import _setup_custom_provider  # local import to avoid circular dep
+
+    _setup_custom_provider()
 
 
 @main.group()

--- a/tests/test_util_cli_providers.py
+++ b/tests/test_util_cli_providers.py
@@ -123,7 +123,7 @@ class TestProvidersTest:
         result = runner.invoke(main, ["providers", "test", "nonexistent"])
         assert result.exit_code == 1
         assert "not found" in result.output
-        assert "gptme.toml" in result.output
+        assert "gptme providers add" in result.output
 
     def test_missing_api_key_env(self, mock_config, make_provider, monkeypatch):
         """Test when API key env var is not set."""
@@ -335,3 +335,24 @@ class TestProvidersTest:
         assert "Connected" in result.output
         # No default model message
         assert "Default model" not in result.output
+
+
+class TestProvidersAdd:
+    """Tests for 'providers add' command."""
+
+    def test_add_invokes_setup_wizard(self):
+        """Test that 'providers add' calls the interactive setup wizard."""
+        with patch("gptme.cli.setup._setup_custom_provider") as mock_setup:
+            mock_setup.return_value = ("my-provider", "sk-test")
+            runner = CliRunner()
+            result = runner.invoke(main, ["providers", "add"])
+
+        assert result.exit_code == 0
+        mock_setup.assert_called_once()
+
+    def test_list_empty_mentions_add_command(self, mock_config):
+        """Test that empty providers list mentions 'gptme providers add'."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "gptme providers add" in result.output


### PR DESCRIPTION
## Summary

Exposes the existing `_setup_custom_provider()` interactive wizard as a
dedicated `gptme providers add` subcommand under the `providers` group.

### Problem

Adding a custom OpenAI-compatible provider (Ollama, LM Studio, vLLM, any
relay) requires manually editing `gptme.toml` — there's no CLI path.
The interactive wizard already exists in `gptme/cli/setup.py` (option 6
in the first-run auth flow) but isn't reachable as a standalone command.
`gptme providers list` also only printed TOML boilerplate with no hint
that an easier interactive path exists.

**User demand:** three separate requests in 60 days:
- Issue #3055 (MIKUbiu): custom OpenAI-compatible providers in interactive setup
- Discussion #224: Groq API provider support
- Discussion #3250 (Aurelo): first-class provider listing

### Changes

- **`gptme providers add`**: new command that calls `_setup_custom_provider()` interactively — prompts for name, base URL, API key, and default model, then writes config
- **`gptme providers list`**: empty-state now says `gptme providers add` alongside the manual TOML snippet
- **`gptme providers test`**: no-providers message now points to `gptme providers add`
- **Tests**: 2 new tests (`TestProvidersAdd`), 1 assertion updated; all 20 tests passing

### Usage

```
$ gptme providers add
╭──────────────────────────────╮
│ 🔧 Custom Provider Setup     │
╰──────────────────────────────╯
Configure any OpenAI-compatible provider (self-hosted, relay, proxy, etc.)

Provider name [custom]: ollama
Base URL [https://api.example.com/v1]: http://localhost:11434/v1
API key (leave blank to skip):
Default model (leave blank to skip): llama3.2

╭──────────────────────────────────────────╮
│ ✅ Custom provider 'ollama' saved!       │
╰──────────────────────────────────────────╯
```