### PR TITLE
feat(browser): support custom executable path in GPTME_BROWSER_ENGINE

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,142 @@
+# Browser Tool
+
+gptme includes a browser tool that lets the assistant load pages, read their
+content, take screenshots, and interact with web pages.
+
+## Backends
+
+### Playwright (recommended)
+
+Full browser automation with screenshots, ARIA snapshots, clicking, form
+filling, and scrolling.
+
+**Installation:**
+
+```bash
+pipx install 'gptme[browser]'
+PW_VERSION=$(pipx runpip gptme show playwright | grep Version | cut -d' ' -f2)
+pipx run playwright==$PW_VERSION install chromium-headless-shell
+```
+
+### Lynx
+
+Text-only fallback for basic page reading and web search.  No screenshot
+support.
+
+```bash
+# Ubuntu / Debian
+sudo apt install lynx
+# macOS
+brew install lynx
+```
+
+---
+
+## Engine Configuration (`GPTME_BROWSER_ENGINE`)
+
+The Playwright backend accepts three forms for `GPTME_BROWSER_ENGINE`:
+
+| Value | Meaning |
+|-------|---------|
+| `chromium` (default) | Playwright's bundled Chromium headless shell |
+| `firefox` | Playwright's bundled Firefox |
+| `/path/to/binary` | Custom executable at a filesystem path |
+| `executable-name` | Executable resolved via `$PATH` (`shutil.which`) |
+
+Custom executables (path or name) are always launched with the **Firefox**
+engine so they receive the same Playwright browser-context options.
+
+### Use Firefox instead of Chromium
+
+Useful for pages that detect and block headless Chromium.
+
+```bash
+PW_VERSION=$(pipx runpip gptme show playwright | grep Version | cut -d' ' -f2)
+pipx run playwright==$PW_VERSION install firefox
+export GPTME_BROWSER_ENGINE=firefox
+gptme "read https://example.com"
+```
+
+### Use a fingerprint-patched Firefox (anti-detection)
+
+Some pages fingerprint headless browsers even when Firefox is used.
+A patched build such as [Camoufox](https://camoufox.com/) or
+[invisible-playwright](https://github.com/QIN2DIM/undetected-playwright)
+is a drop-in replacement that passes most fingerprint checks.
+
+**By absolute path:**
+
+```bash
+export GPTME_BROWSER_ENGINE=/usr/local/bin/camoufox-runner
+gptme "read https://bot-detection-test.vercel.app"
+```
+
+**By executable name on `$PATH`:**
+
+```bash
+# Assuming camoufox is on your PATH
+export GPTME_BROWSER_ENGINE=camoufox
+gptme "screenshot https://example.com"
+```
+
+gptme detects that the value is not a named engine, resolves it via
+`shutil.which`, and passes it to Playwright's `executable_path=` kwarg when
+launching Firefox.
+
+#### Example: Camoufox setup
+
+```bash
+# Install Camoufox (fingerprint-patched Firefox)
+pip install camoufox
+python -m camoufox fetch           # downloads the patched Firefox binary
+
+# Point gptme at it
+export GPTME_BROWSER_ENGINE=$(python -m camoufox path)
+gptme "read https://example.com"
+```
+
+---
+
+## CDP Mode (`GPTME_BROWSER_CDP_URL`)
+
+Connect to an already-running Chromium-based browser over the Chrome DevTools
+Protocol instead of launching a new one.  Useful when you want to reuse an
+existing authenticated browser session.
+
+```bash
+# Start Chrome/Chromium with remote debugging
+chromium --remote-debugging-port=9222
+
+# Connect gptme to it
+export GPTME_BROWSER_CDP_URL=http://127.0.0.1:9222
+gptme "read https://example.com"
+```
+
+> **Note:** CDP only works with Chromium-based browsers.  `GPTME_BROWSER_ENGINE`
+> is ignored in CDP mode.
+
+---
+
+## Session Persistence (`GPTME_BROWSER_STORAGE_STATE`)
+
+Save login cookies and local storage so authenticated sessions persist across
+restarts.
+
+```bash
+# Log in once and save state
+gptme "open https://x.com/login and log in with user@example.com / hunter2, then save_browser_state ~/.config/gptme/twitter.json"
+
+# Reuse in the next session
+export GPTME_BROWSER_STORAGE_STATE=~/.config/gptme/twitter.json
+gptme "tweet 'hello from gptme'"
+```
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GPTME_BROWSER_ENGINE` | `chromium` | Engine or executable: `chromium`, `firefox`, a path, or a name on `$PATH` |
+| `GPTME_BROWSER_CDP_URL` | *(unset)* | WebSocket URL of an existing Chrome DevTools Protocol server |
+| `GPTME_BROWSER_STORAGE_STATE` | *(unset)* | Path to a Playwright storage-state JSON file for persistent sessions |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    cookbook
    howto/index
    tools
+   browser
    commands
    cli
    tui

--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import shutil
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -20,6 +21,8 @@ TIMEOUT = 20  # seconds - accounts for retry attempts with browser restarts
 
 # Supported browser engines for the Playwright backend.
 # Set GPTME_BROWSER_ENGINE=firefox to use Firefox instead of Chromium.
+# Set GPTME_BROWSER_ENGINE to a filesystem path or executable name to use a
+# custom browser binary (e.g. a fingerprint-patched Firefox build).
 BrowserEngine = Literal["chromium", "firefox"]
 _VALID_ENGINES: tuple[BrowserEngine, ...] = ("chromium", "firefox")
 
@@ -125,10 +128,61 @@ class Command:
 Action = Literal["stop"]
 
 
+def _parse_engine_env(raw: str) -> tuple[BrowserEngine, str | None]:
+    """Parse a GPTME_BROWSER_ENGINE value into (engine, executable_path).
+
+    Handles three forms:
+
+    - **Named engine** — ``"chromium"`` or ``"firefox"`` → ``(engine, None)``
+    - **Filesystem path** — value containing ``"/"`` or ``"\\"`` →
+      ``("firefox", path)``
+    - **PATH-resident executable** — resolved via :func:`shutil.which` →
+      ``("firefox", resolved_path)``
+
+    Custom executables default to the ``"firefox"`` engine because
+    fingerprint-patched builds (e.g. Camoufox, invisible-playwright) are
+    Firefox-based.  Returns ``("chromium", None)`` with a warning for
+    unrecognised values.
+    """
+    lower = raw.lower()
+    if lower in _VALID_ENGINES:
+        return cast(BrowserEngine, lower), None
+
+    # Filesystem path: contains a directory separator → treat as-is.
+    if "/" in raw or "\\" in raw:
+        logger.info(
+            "GPTME_BROWSER_ENGINE='%s' looks like a path; "
+            "using firefox engine with custom executable_path",
+            raw,
+        )
+        return "firefox", raw
+
+    # Executable name on PATH: resolve to absolute path.
+    resolved = shutil.which(raw)
+    if resolved:
+        logger.info(
+            "GPTME_BROWSER_ENGINE='%s' resolved to '%s' on PATH; "
+            "using firefox engine with custom executable_path",
+            raw,
+            resolved,
+        )
+        return "firefox", resolved
+
+    logger.warning(
+        "Invalid GPTME_BROWSER_ENGINE='%s'; falling back to 'chromium'. "
+        "Valid named engines: %s. "
+        "Or set to a filesystem path or executable name for a custom binary.",
+        raw,
+        ", ".join(_VALID_ENGINES),
+    )
+    return "chromium", None
+
+
 def _connect_or_launch_browser(
     playwright: Playwright,
     cdp_url: str | None,
     engine: BrowserEngine = "chromium",
+    executable_path: str | None = None,
 ) -> Browser:
     if cdp_url:
         # CDP is only supported for Chromium-based browsers.
@@ -142,32 +196,40 @@ def _connect_or_launch_browser(
         return browser
 
     browser_launcher = getattr(playwright, engine)
-    browser = browser_launcher.launch()
-    logger.info("Browser launched (engine=%s)", engine)
+    launch_kwargs: dict[str, Any] = {}
+    if executable_path:
+        launch_kwargs["executable_path"] = executable_path
+    browser = browser_launcher.launch(**launch_kwargs)
+    if executable_path:
+        logger.info(
+            "Browser launched (engine=%s, executable=%s)", engine, executable_path
+        )
+    else:
+        logger.info("Browser launched (engine=%s)", engine)
     return browser
 
 
 class BrowserThread:
     def __init__(
-        self, cdp_url: str | None = None, engine: BrowserEngine | None = None
+        self,
+        cdp_url: str | None = None,
+        engine: BrowserEngine | None = None,
+        executable_path: str | None = None,
     ) -> None:
         self.cdp_url = cdp_url or get_config().get_env("BROWSER_CDP_URL")
 
-        # Resolve engine: explicit arg > env var > default "chromium"
+        # Resolve engine and executable_path: explicit args > env var > default "chromium"
         if engine is None:
-            raw = (get_config().get_env("BROWSER_ENGINE") or "").strip().lower()
-            if raw in _VALID_ENGINES:
-                engine = cast(BrowserEngine, raw)
+            raw = (get_config().get_env("BROWSER_ENGINE") or "").strip()
+            if raw:
+                parsed_engine, parsed_executable = _parse_engine_env(raw)
+                engine = parsed_engine
+                if executable_path is None:
+                    executable_path = parsed_executable
             else:
-                if raw:
-                    logger.warning(
-                        "Invalid GPTME_BROWSER_ENGINE='%s'; falling back to 'chromium'. "
-                        "Valid values: %s",
-                        raw,
-                        ", ".join(_VALID_ENGINES),
-                    )
                 engine = "chromium"
         self.engine: BrowserEngine = engine
+        self.executable_path: str | None = executable_path
         self.queue: Queue[tuple[Command | Action, object]] = Queue()
         self.results: dict[object, tuple[Any, Exception | None]] = {}
         self.lock = Lock()
@@ -210,7 +272,7 @@ class BrowserThread:
                         pass
                     self._session_context = None
                 browser = _connect_or_launch_browser(
-                    playwright, self.cdp_url, self.engine
+                    playwright, self.cdp_url, self.engine, self.executable_path
                 )
                 # For CDP, (re)create an isolated session context so parallel
                 # gptme instances don't share cookies/tabs. Recreated on every
@@ -224,15 +286,21 @@ class BrowserThread:
                 error: Exception
 
                 if "Executable doesn't exist" in str(e):
-                    pw_version = importlib.metadata.version("playwright")
-                    install_target = (
-                        "chromium-headless-shell"
-                        if self.engine == "chromium"
-                        else self.engine
-                    )
-                    error = RuntimeError(
-                        f"Browser executable not found. Run: pipx run playwright=={pw_version} install {install_target}"
-                    )
+                    if self.executable_path:
+                        error = RuntimeError(
+                            f"Custom browser executable not found: {self.executable_path}. "
+                            "Ensure the path exists and is executable."
+                        )
+                    else:
+                        pw_version = importlib.metadata.version("playwright")
+                        install_target = (
+                            "chromium-headless-shell"
+                            if self.engine == "chromium"
+                            else self.engine
+                        )
+                        error = RuntimeError(
+                            f"Browser executable not found. Run: pipx run playwright=={pw_version} install {install_target}"
+                        )
                 else:
                     error = e
                 logger.error(f"Failed to launch browser: {e}", exc_info=True)

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -30,6 +30,21 @@ Playwright backend:
        pipx run playwright==$PW_VERSION install firefox
        export GPTME_BROWSER_ENGINE=firefox
 
+ - To use a custom browser executable (e.g. a fingerprint-patched Firefox build
+   such as `Camoufox <https://camoufox.com/>`_):
+
+   .. code-block:: bash
+
+       # Absolute or relative filesystem path
+       export GPTME_BROWSER_ENGINE=/usr/local/bin/camoufox
+
+       # Executable name on PATH (resolved via which)
+       export GPTME_BROWSER_ENGINE=camoufox
+
+   Custom executables are launched with the Firefox engine so they receive the
+   same Playwright context options.  This is the recommended approach for
+   evading bot-detection on pages that fingerprint headless browsers.
+
  - To use an existing Chromium-compatible browser over Chrome DevTools Protocol
    instead of launching Playwright's bundled Chromium, start it with remote
    debugging enabled and set GPTME_BROWSER_CDP_URL:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -437,3 +437,78 @@ def test_scroll_invalid_amount():
         scroll_page("down", -100)
     with pytest.raises(ValueError, match="amount must be positive"):
         scroll_page("down", 0)
+
+
+# ---------------------------------------------------------------------------
+# Engine / executable-path parsing (no browser launch required)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_engine_named_chromium():
+    """Named engine 'chromium' → (chromium, None)."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("chromium")
+    assert engine == "chromium"
+    assert path is None
+
+
+def test_parse_engine_named_firefox():
+    """Named engine 'firefox' → (firefox, None)."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("firefox")
+    assert engine == "firefox"
+    assert path is None
+
+
+def test_parse_engine_named_case_insensitive():
+    """Named engines match case-insensitively."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("Firefox")
+    assert engine == "firefox"
+    assert path is None
+
+    engine, path = _parse_engine_env("CHROMIUM")
+    assert engine == "chromium"
+    assert path is None
+
+
+def test_parse_engine_absolute_path():
+    """Absolute path → firefox engine with that executable_path."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("/usr/local/bin/camoufox")
+    assert engine == "firefox"
+    assert path == "/usr/local/bin/camoufox"
+
+
+def test_parse_engine_relative_path():
+    """Path containing '/' but not absolute → firefox engine with that path."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("./custom-firefox")
+    assert engine == "firefox"
+    assert path == "./custom-firefox"
+
+
+def test_parse_engine_executable_on_path():
+    """Executable name on $PATH is resolved and used as custom executable."""
+    import shutil
+
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    # python3 is guaranteed to be on PATH in the test environment
+    engine, path = _parse_engine_env("python3")
+    assert engine == "firefox"
+    assert path == shutil.which("python3")
+
+
+def test_parse_engine_invalid_falls_back_to_chromium():
+    """Unrecognised value that isn't a path → (chromium, None) with a warning."""
+    from gptme.tools._browser_thread import _parse_engine_env
+
+    engine, path = _parse_engine_env("nonexistent-browser-xyz")
+    assert engine == "chromium"
+    assert path is None

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -499,10 +499,12 @@ def test_parse_engine_executable_on_path():
 
     from gptme.tools._browser_thread import _parse_engine_env
 
-    # python3 is guaranteed to be on PATH in the test environment
-    engine, path = _parse_engine_env("python3")
+    # git is required to check out the repo, so it's guaranteed to be on
+    # PATH wherever this test runs (unlike e.g. "python3", which is not the
+    # interpreter name on Windows)
+    engine, path = _parse_engine_env("git")
     assert engine == "firefox"
-    assert path == shutil.which("python3")
+    assert path == shutil.which("git")
 
 
 def test_parse_engine_invalid_falls_back_to_chromium():


### PR DESCRIPTION
## Summary

Allow `GPTME_BROWSER_ENGINE` to accept a **filesystem path** or an **executable name on `$PATH`** in addition to the named engines (`chromium`, `firefox`).

This is the follow-up feature requested by @feder-cr in gptme/gptme#2994 after the original `GPTME_BROWSER_ENGINE` PR (#2996) merged. The key insight: switching to Playwright's bundled Firefox doesn't improve fingerprint detectability on its own — the gain comes from pointing the env var at a **fingerprint-patched build** like [Camoufox](https://camoufox.com/) or [invisible-playwright](https://github.com/QIN2DIM/undetected-playwright).

## How it works

When `GPTME_BROWSER_ENGINE` is set:
- To a **named engine** (`chromium`/`firefox`) → existing behaviour, unchanged
- To a value **containing `/` or `\`** → treated as a filesystem path, passed to `launch(executable_path=...)`
- To a name **resolving via `shutil.which()`** → treated as executable on PATH, same path treatment

Custom executables always use the **Firefox engine** since patched builds (Camoufox, invisible-playwright) are Firefox-based.

## Usage

```bash
# Absolute path
export GPTME_BROWSER_ENGINE=/usr/local/bin/camoufox
gptme "screenshot https://example.com"

# Executable on PATH
export GPTME_BROWSER_ENGINE=camoufox
gptme "read https://example.com"
```

## Changes

- **`gptme/tools/_browser_thread.py`**: add `_parse_engine_env()` helper, extend `_connect_or_launch_browser()` with `executable_path` kwarg, store on `BrowserThread`, better error for missing custom executables
- **`gptme/tools/browser.py`**: document the new custom-executable form  
- **`docs/browser.md`**: new reference page covering all engine/env config options
- **`tests/test_browser.py`**: 7 unit tests for `_parse_engine_env()`

## Tests

```
tests/test_browser.py::test_parse_engine_named_chromium PASSED
tests/test_browser.py::test_parse_engine_named_firefox PASSED
tests/test_browser.py::test_parse_engine_named_case_insensitive PASSED
tests/test_browser.py::test_parse_engine_absolute_path PASSED
tests/test_browser.py::test_parse_engine_relative_path PASSED
tests/test_browser.py::test_parse_engine_executable_on_path PASSED
tests/test_browser.py::test_parse_engine_invalid_falls_back_to_chromium PASSED
```