### PR TITLE
feat(review): converge review-watch and shared review pipeline (#3442)

### DIFF
--- a/gptme/cli/cmd_review.py
+++ b/gptme/cli/cmd_review.py
@@ -28,8 +28,8 @@ def review() -> None:
 
 
 # Attach the ``watch`` subcommand from cmd_review_watch, renamed for the group.
-# We import lazily inside the function to match the rest of the CLI pattern
-# and avoid importing heavy deps at module import time.
+# The import runs at module initialization (via the add_command call below);
+# the watch module currently has no heavy import-time dependencies.
 def _get_watch_command() -> click.Command:
     from .cmd_review_watch import review_watch
 
@@ -50,7 +50,6 @@ def _get_watch_command() -> click.Command:
     return cmd
 
 
-# Register the watch command eagerly so ``gptme-util review --help`` lists it.
-# The callback itself does a lazy import so the actual implementation is only
-# loaded when the subcommand is actually invoked.
+# Register the watch command at import time so ``gptme-util review --help``
+# lists it without needing to invoke the subcommand first.
 review.add_command(_get_watch_command())

--- a/gptme/cli/cmd_review.py
+++ b/gptme/cli/cmd_review.py
@@ -1,0 +1,56 @@
+"""Unified ``gptme-util review`` command group.
+
+Groups review-related subcommands under a single ``review`` namespace:
+
+    gptme-util review watch 1234     # poll a PR for feedback and iterate fixes
+    gptme-util review pr 1234        # (future) run an AI review pass on a PR
+
+See gptme#3442 for the convergence design between pr_review (gptme-contrib)
+and review-watch.
+
+Backward compatibility: ``gptme-util review-watch`` continues to work as a
+top-level alias so existing scripts are not broken.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group("review")
+def review() -> None:
+    """Review pipeline commands.
+
+    \b
+    Subcommands:
+        watch   Poll a PR for review feedback and iterate fixes automatically.
+    """
+
+
+# Attach the ``watch`` subcommand from cmd_review_watch, renamed for the group.
+# We import lazily inside the function to match the rest of the CLI pattern
+# and avoid importing heavy deps at module import time.
+def _get_watch_command() -> click.Command:
+    from .cmd_review_watch import review_watch
+
+    # Clone the command with the name "watch" so it appears as
+    # ``gptme-util review watch`` in help output.
+    cmd = click.Command(
+        name="watch",
+        callback=review_watch.callback,
+        params=review_watch.params,
+        help=review_watch.help,
+        epilog=review_watch.epilog,
+        short_help=review_watch.short_help,
+        add_help_option=review_watch.add_help_option,
+        no_args_is_help=review_watch.no_args_is_help,
+        hidden=review_watch.hidden,
+        deprecated=review_watch.deprecated,
+    )
+    return cmd
+
+
+# Register the watch command eagerly so ``gptme-util review --help`` lists it.
+# The callback itself does a lazy import so the actual implementation is only
+# loaded when the subcommand is actually invoked.
+review.add_command(_get_watch_command())

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -2,11 +2,14 @@
 
 Polls a GitHub PR for new review comments and spawns a continuation gptme session
 to address feedback automatically — enabling a fully autonomous review loop.
+
+This module is part of the unified review pipeline described in gptme#3442.
+Shared GitHub helpers live in ``gptme.util.gh``; this module owns the
+polling loop and fix-session spawning logic.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import shutil
@@ -17,11 +20,9 @@ from datetime import datetime, timedelta, timezone
 
 import click
 
-logger = logging.getLogger(__name__)
+from ..util.gh import is_trusted_reviewer, run_gh_json
 
-# author_association values that indicate the commenter has write access.
-# Used to gate autonomous fix sessions against prompt injection from untrusted users.
-_TRUSTED_ASSOCIATIONS: frozenset[str] = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -38,31 +39,12 @@ def _gh_json(
     *,
     timeout: float = 30,
 ) -> dict | list | None:
-    """Run a ``gh`` command and parse its JSON output.
+    """Thin alias for ``gptme.util.gh.run_gh_json``.
 
-    Returns ``None`` on error so callers can handle gracefully.
+    Kept for backward compatibility so existing tests that monkeypatch
+    ``cmd_review_watch._gh_json`` continue to work unchanged.
     """
-    try:
-        result = subprocess.run(
-            args,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=timeout,
-        )
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        logger.debug("gh command failed: %s", exc)
-        return None
-
-    if result.returncode != 0:
-        logger.debug("gh exited %d: %s", result.returncode, result.stderr.strip())
-        return None
-
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        logger.debug("gh returned non-JSON output")
-        return None
+    return run_gh_json(args, timeout=timeout)
 
 
 def get_pr_state(owner: str, repo: str, pr_num: int) -> dict | None:
@@ -459,16 +441,9 @@ def review_watch(
             # a public PR would otherwise be able to direct the autonomous fix
             # session to make attacker-controlled commits and push them.
             # Bot/automated accounts are also excluded to avoid self-loops.
-            def _is_trusted(comment: dict) -> bool:
-                login = comment.get("user", {}).get("login", "")
-                utype = comment.get("user", {}).get("type", "")
-                if utype == "Bot" or login.endswith("[bot]"):
-                    return False
-                assoc = comment.get("author_association", "")
-                return assoc in _TRUSTED_ASSOCIATIONS
-
-            inline = [c for c in inline if _is_trusted(c)]
-            conversation = [c for c in conversation if _is_trusted(c)]
+            # The trust gate is implemented in gptme.util.gh.is_trusted_reviewer.
+            inline = [c for c in inline if is_trusted_reviewer(c)]
+            conversation = [c for c in conversation if is_trusted_reviewer(c)]
 
             # Drop comments already handled in a prior iteration *and
             # unchanged since*. Needed because the cursor is advanced with a

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -55,6 +55,9 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
     "resume": (".cmd_resume", "resume"),
+    # Unified review group (gptme#3442): ``gptme-util review watch``
+    "review": (".cmd_review", "review"),
+    # Backward-compat alias kept so existing scripts are not broken.
     "review-watch": (".cmd_review_watch", "review_watch"),
     "skills": (".cmd_skills", "skills"),
     "slop": (".cmd_slop", "slop"),

--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -16,6 +16,80 @@ from .git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Low-level shared helpers (used by review-watch and other gh-backed tools)
+# ---------------------------------------------------------------------------
+
+#: author_association values that indicate the commenter has write access.
+#: Used to gate autonomous sessions against prompt injection from untrusted users.
+TRUSTED_ASSOCIATIONS: frozenset[str] = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
+def run_gh_json(
+    args: list[str],
+    *,
+    timeout: float = 30,
+) -> dict | list | None:
+    """Run a ``gh`` command and parse its JSON output.
+
+    Returns ``None`` on error so callers can handle gracefully.
+    This is a shared primitive used by review-watch and other GitHub-backed
+    tools to avoid duplicating subprocess/JSON boilerplate.
+    """
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("gh command failed: %s", exc)
+        return None
+
+    if result.returncode != 0:
+        logger.debug("gh exited %d: %s", result.returncode, result.stderr.strip())
+        return None
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.debug("gh returned non-JSON output")
+        return None
+
+
+def is_bot_user(user: dict) -> bool:
+    """Return ``True`` when a GitHub user dict describes a bot account.
+
+    GitHub bots can be detected by either ``type == "Bot"`` or a login
+    that ends with ``[bot]`` (e.g. ``dependabot[bot]``, ``greptile-ai[bot]``).
+    This check is used by review-watch (and any future autonomous session that
+    consumes PR comments) to exclude bot-generated noise from trusted-reviewer
+    filtering.
+    """
+    utype = user.get("type", "")
+    login = user.get("login", "")
+    return utype == "Bot" or login.endswith("[bot]")
+
+
+def is_trusted_reviewer(comment: dict) -> bool:
+    """Return ``True`` when a PR comment comes from a trusted human contributor.
+
+    A comment is trusted when:
+    - The author is NOT a bot account (``is_bot_user``).
+    - The ``author_association`` is one of OWNER / MEMBER / COLLABORATOR.
+
+    Used by review-watch to gate autonomous fix sessions against prompt
+    injection from untrusted users who can comment on a public PR.
+    """
+    user = comment.get("user", {})
+    if is_bot_user(user):
+        return False
+    assoc = comment.get("author_association", "")
+    return assoc in TRUSTED_ASSOCIATIONS
+
+
 # Default threshold for truncating long comment bodies
 # Based on empirical sampling: human comments typically <500 tokens,
 # verbose bot comments (Greptile, Ellipsis) can reach 900+ tokens

--- a/gptme/util/review.py
+++ b/gptme/util/review.py
@@ -1,0 +1,253 @@
+"""Shared data types for the gptme review pipeline (gptme#3442).
+
+The review pipeline is a two-stage autonomous loop:
+
+    pr_review (gptme-contrib)     →   review-watch (gptme)
+    ─────────────────────────         ─────────────────────
+    AI reviews PR diff                AI acts as author
+    Posts structured findings         Reads comments → fixes
+    ReviewArtifact produced           ReviewArtifact consumed (optional)
+
+``ReviewArtifact`` is the structured JSON handoff between the two stages.
+When ``pr_review`` produces one, ``review-watch`` can consume it for
+richer context (exact file/line, severity, confirmed/dropped status).
+
+All fields are optional so the artifact degrades gracefully to the
+plain-text comment path when not available.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FindingSeverity(str, Enum):
+    """Severity levels for review findings, ordered low → high."""
+
+    NOTE = "note"
+    WARNING = "warning"
+    ERROR = "error"
+    CRITICAL = "critical"
+
+
+class FindingStatus(str, Enum):
+    """Lifecycle status of a finding during the review-watch fix loop."""
+
+    OPEN = "open"
+    """Finding has not been addressed yet."""
+    CONFIRMED = "confirmed"
+    """Reviewer confirmed the fix is correct."""
+    DROPPED = "dropped"
+    """Finding was intentionally not acted on (e.g. won't-fix, out-of-scope)."""
+    IN_PROGRESS = "in_progress"
+    """A fix session is currently working on this finding."""
+
+
+@dataclass
+class ReviewFinding:
+    """A single review finding produced by an AI reviewer.
+
+    Corresponds to one inline PR comment or review note.  ``file`` and
+    ``line`` mirror the GitHub PR review comment fields so the data can be
+    round-tripped to/from the API without loss.
+    """
+
+    #: Short description of the finding (matches the reviewer comment body
+    #: when the artifact is produced from existing review comments).
+    body: str
+
+    #: File path relative to repo root, or empty string for PR-level findings.
+    file: str = ""
+
+    #: Line number (1-based) in the file, or ``None`` for file-level comments.
+    line: int | None = None
+
+    #: Severity of the finding.
+    severity: FindingSeverity = FindingSeverity.WARNING
+
+    #: Current lifecycle status.
+    status: FindingStatus = FindingStatus.OPEN
+
+    #: GitHub review comment ID, if produced from an API comment.
+    github_comment_id: int | None = None
+
+    #: Optional reviewer login for attribution.
+    reviewer: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "body": self.body,
+            "file": self.file,
+            "line": self.line,
+            "severity": self.severity.value,
+            "status": self.status.value,
+            "github_comment_id": self.github_comment_id,
+            "reviewer": self.reviewer,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ReviewFinding:
+        return cls(
+            body=d.get("body", ""),
+            file=d.get("file", ""),
+            line=d.get("line"),
+            severity=FindingSeverity(d.get("severity", FindingSeverity.WARNING.value)),
+            status=FindingStatus(d.get("status", FindingStatus.OPEN.value)),
+            github_comment_id=d.get("github_comment_id"),
+            reviewer=d.get("reviewer", ""),
+        )
+
+    @classmethod
+    def from_github_comment(
+        cls,
+        comment: dict,
+        *,
+        severity: FindingSeverity = FindingSeverity.WARNING,
+    ) -> ReviewFinding:
+        """Construct a finding from a raw GitHub PR review comment dict."""
+        return cls(
+            body=comment.get("body", "").strip(),
+            file=comment.get("path", ""),
+            line=comment.get("original_line") or comment.get("line"),
+            severity=severity,
+            status=FindingStatus.OPEN,
+            github_comment_id=comment.get("id"),
+            reviewer=comment.get("user", {}).get("login", ""),
+        )
+
+
+@dataclass
+class ReviewArtifact:
+    """Structured output of a review pass, consumed by review-watch.
+
+    Produced by ``pr_review`` (gptme-contrib) and optionally consumed by
+    ``review-watch`` to give the fix session exact coordinates (file, line,
+    severity) instead of raw comment text.
+
+    The artifact can be serialised to/from JSON for disk persistence and
+    inter-process handoff.
+
+    Example JSON schema::
+
+        {
+          "schema_version": 1,
+          "pr": {"owner": "gptme", "repo": "gptme", "number": 1234},
+          "findings": [
+            {
+              "body": "This variable name is unclear.",
+              "file": "gptme/util/review.py",
+              "line": 42,
+              "severity": "warning",
+              "status": "open",
+              "github_comment_id": 99887766,
+              "reviewer": "ErikBjare"
+            }
+          ]
+        }
+    """
+
+    #: The PR this artifact was produced for.
+    pr_owner: str
+    pr_repo: str
+    pr_number: int
+
+    #: Findings from the review pass.
+    findings: list[ReviewFinding] = field(default_factory=list)
+
+    #: Schema version for forward-compatibility.
+    schema_version: Literal[1] = 1
+
+    # ------------------------------------------------------------------
+    # Derived views
+    # ------------------------------------------------------------------
+
+    @property
+    def open_findings(self) -> list[ReviewFinding]:
+        """Return only findings that have not yet been addressed."""
+        return [f for f in self.findings if f.status == FindingStatus.OPEN]
+
+    @property
+    def confirmed_count(self) -> int:
+        return sum(1 for f in self.findings if f.status == FindingStatus.CONFIRMED)
+
+    @property
+    def dropped_count(self) -> int:
+        return sum(1 for f in self.findings if f.status == FindingStatus.DROPPED)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "pr": {
+                "owner": self.pr_owner,
+                "repo": self.pr_repo,
+                "number": self.pr_number,
+            },
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def save(self, path: Path) -> None:
+        """Persist the artifact to a JSON file."""
+        path.write_text(self.to_json())
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ReviewArtifact:
+        pr = d.get("pr", {})
+        return cls(
+            pr_owner=pr.get("owner", ""),
+            pr_repo=pr.get("repo", ""),
+            pr_number=int(pr.get("number", 0)),
+            findings=[ReviewFinding.from_dict(f) for f in d.get("findings", [])],
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> ReviewArtifact:
+        return cls.from_dict(json.loads(text))
+
+    @classmethod
+    def load(cls, path: Path) -> ReviewArtifact:
+        """Load an artifact from a JSON file."""
+        return cls.from_json(path.read_text())
+
+    @classmethod
+    def from_github_comments(
+        cls,
+        *,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        inline_comments: list[dict],
+        conversation_comments: list[dict],
+    ) -> ReviewArtifact:
+        """Build an artifact from raw GitHub API comment dicts.
+
+        Inline PR review comments are treated as ``WARNING`` severity by
+        default.  Conversation-level comments (PR thread, not inline) use
+        ``NOTE`` severity to reflect their lower specificity.
+        """
+        findings: list[ReviewFinding] = [
+            ReviewFinding.from_github_comment(c, severity=FindingSeverity.WARNING)
+            for c in inline_comments
+        ]
+        findings.extend(
+            ReviewFinding.from_github_comment(c, severity=FindingSeverity.NOTE)
+            for c in conversation_comments
+        )
+        return cls(
+            pr_owner=owner,
+            pr_repo=repo,
+            pr_number=pr_number,
+            findings=findings,
+        )

--- a/tests/test_util_review.py
+++ b/tests/test_util_review.py
@@ -1,0 +1,330 @@
+"""Tests for the shared review pipeline utilities (gptme#3442).
+
+Covers:
+- gptme.util.gh shared helpers (run_gh_json, is_bot_user, is_trusted_reviewer)
+- gptme.util.review (ReviewFinding, ReviewArtifact)
+- gptme-util review command group (CLI integration)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from click.testing import CliRunner
+
+from gptme.cli.util import main as util_main
+from gptme.util import gh as gh_util
+from gptme.util.review import (
+    FindingSeverity,
+    FindingStatus,
+    ReviewArtifact,
+    ReviewFinding,
+)
+
+# ---------------------------------------------------------------------------
+# gptme.util.gh shared helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRunGhJson:
+    def test_returns_none_on_nonzero_exit(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, returncode=1, stdout="", stderr="error"
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.run_gh_json(["gh", "pr", "view", "99"]) is None
+
+    def test_returns_none_on_invalid_json(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, returncode=0, stdout="not json", stderr=""
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.run_gh_json(["gh", "something"]) is None
+
+    def test_parses_list(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args,
+                returncode=0,
+                stdout=json.dumps([{"id": 1}, {"id": 2}]),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        result = gh_util.run_gh_json(["gh", "api", "/some/path"])
+        assert result == [{"id": 1}, {"id": 2}]
+
+    def test_parses_dict(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args,
+                returncode=0,
+                stdout=json.dumps({"state": "OPEN"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.run_gh_json(["gh", "pr", "view", "1"]) == {"state": "OPEN"}
+
+    def test_returns_none_on_timeout(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=5)
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.run_gh_json(["gh", "pr", "view", "1"]) is None
+
+
+class TestIsBotUser:
+    def test_bot_type(self):
+        assert gh_util.is_bot_user({"type": "Bot", "login": "some-bot"})
+
+    def test_bot_login_suffix(self):
+        assert gh_util.is_bot_user({"type": "User", "login": "greptile-ai[bot]"})
+
+    def test_human_user(self):
+        assert not gh_util.is_bot_user({"type": "User", "login": "ErikBjare"})
+
+    def test_empty_dict(self):
+        assert not gh_util.is_bot_user({})
+
+
+class TestIsTrustedReviewer:
+    def _make_comment(self, login: str, utype: str, assoc: str) -> dict:
+        return {
+            "user": {"login": login, "type": utype},
+            "author_association": assoc,
+        }
+
+    def test_owner_is_trusted(self):
+        assert gh_util.is_trusted_reviewer(
+            self._make_comment("ErikBjare", "User", "OWNER")
+        )
+
+    def test_member_is_trusted(self):
+        assert gh_util.is_trusted_reviewer(
+            self._make_comment("contributor", "User", "MEMBER")
+        )
+
+    def test_collaborator_is_trusted(self):
+        assert gh_util.is_trusted_reviewer(
+            self._make_comment("collab", "User", "COLLABORATOR")
+        )
+
+    def test_none_association_not_trusted(self):
+        assert not gh_util.is_trusted_reviewer(
+            self._make_comment("random-user", "User", "NONE")
+        )
+
+    def test_bot_not_trusted_even_with_owner_assoc(self):
+        # Bots should never be treated as trusted reviewers regardless of
+        # their association level (they might have OWNER assoc in some repos).
+        assert not gh_util.is_trusted_reviewer(
+            self._make_comment("bot[bot]", "Bot", "OWNER")
+        )
+
+    def test_bot_login_suffix_not_trusted(self):
+        assert not gh_util.is_trusted_reviewer(
+            self._make_comment("greptile-ai[bot]", "User", "COLLABORATOR")
+        )
+
+
+# ---------------------------------------------------------------------------
+# ReviewFinding
+# ---------------------------------------------------------------------------
+
+
+class TestReviewFinding:
+    def test_round_trip(self):
+        f = ReviewFinding(
+            body="Rename this variable.",
+            file="gptme/util/review.py",
+            line=42,
+            severity=FindingSeverity.WARNING,
+            status=FindingStatus.OPEN,
+            github_comment_id=12345,
+            reviewer="ErikBjare",
+        )
+        assert ReviewFinding.from_dict(f.to_dict()) == f
+
+    def test_from_github_comment_inline(self):
+        comment = {
+            "id": 99,
+            "path": "src/app.py",
+            "original_line": 10,
+            "body": "This is unclear.",
+            "user": {"login": "reviewer1"},
+        }
+        f = ReviewFinding.from_github_comment(comment)
+        assert f.file == "src/app.py"
+        assert f.line == 10
+        assert f.body == "This is unclear."
+        assert f.reviewer == "reviewer1"
+        assert f.github_comment_id == 99
+        assert f.severity == FindingSeverity.WARNING
+        assert f.status == FindingStatus.OPEN
+
+    def test_from_github_comment_severity_override(self):
+        comment = {"id": 1, "path": "a.py", "body": "note", "user": {"login": "u"}}
+        f = ReviewFinding.from_github_comment(
+            comment, severity=FindingSeverity.CRITICAL
+        )
+        assert f.severity == FindingSeverity.CRITICAL
+
+    def test_defaults(self):
+        f = ReviewFinding(body="simple finding")
+        assert f.file == ""
+        assert f.line is None
+        assert f.severity == FindingSeverity.WARNING
+        assert f.status == FindingStatus.OPEN
+        assert f.github_comment_id is None
+        assert f.reviewer == ""
+
+
+# ---------------------------------------------------------------------------
+# ReviewArtifact
+# ---------------------------------------------------------------------------
+
+
+class TestReviewArtifact:
+    def _make_artifact(self) -> ReviewArtifact:
+        return ReviewArtifact(
+            pr_owner="gptme",
+            pr_repo="gptme",
+            pr_number=1234,
+            findings=[
+                ReviewFinding(
+                    body="Rename this.",
+                    file="app.py",
+                    line=5,
+                    status=FindingStatus.OPEN,
+                ),
+                ReviewFinding(
+                    body="Add a test.",
+                    file="",
+                    status=FindingStatus.CONFIRMED,
+                ),
+                ReviewFinding(
+                    body="Minor nit.",
+                    file="util.py",
+                    status=FindingStatus.DROPPED,
+                ),
+            ],
+        )
+
+    def test_round_trip_json(self):
+        a = self._make_artifact()
+        restored = ReviewArtifact.from_json(a.to_json())
+        assert restored.pr_owner == a.pr_owner
+        assert restored.pr_repo == a.pr_repo
+        assert restored.pr_number == a.pr_number
+        assert len(restored.findings) == len(a.findings)
+        assert restored.findings[0].body == "Rename this."
+
+    def test_open_findings(self):
+        a = self._make_artifact()
+        assert len(a.open_findings) == 1
+        assert a.open_findings[0].body == "Rename this."
+
+    def test_counts(self):
+        a = self._make_artifact()
+        assert a.confirmed_count == 1
+        assert a.dropped_count == 1
+
+    def test_schema_version(self):
+        a = self._make_artifact()
+        d = a.to_dict()
+        assert d["schema_version"] == 1
+
+    def test_pr_metadata(self):
+        a = self._make_artifact()
+        d = a.to_dict()
+        assert d["pr"] == {"owner": "gptme", "repo": "gptme", "number": 1234}
+
+    def test_save_and_load(self, tmp_path):
+        a = self._make_artifact()
+        path = tmp_path / "artifact.json"
+        a.save(path)
+        loaded = ReviewArtifact.load(path)
+        assert loaded.pr_number == 1234
+        assert len(loaded.findings) == 3
+
+    def test_from_github_comments(self):
+        inline = [
+            {
+                "id": 1,
+                "path": "app.py",
+                "original_line": 3,
+                "body": "Rename.",
+                "user": {"login": "reviewer"},
+                "author_association": "MEMBER",
+            }
+        ]
+        convo = [
+            {
+                "id": 2,
+                "path": "",
+                "body": "LGTM overall.",
+                "user": {"login": "reviewer"},
+                "author_association": "MEMBER",
+            }
+        ]
+        a = ReviewArtifact.from_github_comments(
+            owner="gptme",
+            repo="gptme",
+            pr_number=42,
+            inline_comments=inline,
+            conversation_comments=convo,
+        )
+        assert a.pr_number == 42
+        assert len(a.findings) == 2
+        # Inline → WARNING, conversation → NOTE
+        assert a.findings[0].severity == FindingSeverity.WARNING
+        assert a.findings[1].severity == FindingSeverity.NOTE
+
+    def test_empty_artifact(self):
+        a = ReviewArtifact(pr_owner="o", pr_repo="r", pr_number=1)
+        assert a.open_findings == []
+        assert a.confirmed_count == 0
+        assert a.dropped_count == 0
+        assert json.loads(a.to_json())["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI: gptme-util review group
+# ---------------------------------------------------------------------------
+
+
+class TestReviewCommandGroup:
+    def test_review_help_shows_watch_subcommand(self):
+        """``gptme-util review --help`` should list the ``watch`` subcommand."""
+        runner = CliRunner()
+        result = runner.invoke(util_main, ["review", "--help"])
+        assert result.exit_code == 0
+        assert "watch" in result.output
+
+    def test_review_watch_subcommand_help(self):
+        """``gptme-util review watch --help`` should be reachable and show PR arg."""
+        runner = CliRunner()
+        result = runner.invoke(util_main, ["review", "watch", "--help"])
+        assert result.exit_code == 0
+        # Should mention the PR argument (inherited from cmd_review_watch)
+        assert "PR" in result.output or "pr" in result.output.lower()
+
+    def test_review_watch_reachable_without_gh(self, monkeypatch):
+        """``gptme-util review watch`` should fail gracefully when gh is missing.
+
+        This also verifies the watch subcommand is wired into the review group
+        (not just review-watch at the top level).
+        """
+        from gptme.cli import cmd_review_watch
+
+        monkeypatch.setattr(cmd_review_watch, "_gh_available", lambda: False)
+        runner = CliRunner()
+        result = runner.invoke(util_main, ["review", "watch", "1", "--repo", "o/r"])
+        assert result.exit_code != 0
+        assert "gh" in result.output.lower()


### PR DESCRIPTION
Closes #3442

## Summary

First convergence pass between `review-watch` (gptme) and `pr_review` (gptme-contrib) as proposed in #3442. This PR implements the four highest-priority items from the issue's next-steps list.

## Changes

### 1. Shared GitHub helpers (`gptme/util/gh.py`)

Extracted the duplicated primitives from `cmd_review_watch.py` into the existing shared util:

- `run_gh_json()` — subprocess/JSON wrapper (was `_gh_json` in cmd_review_watch, now shared)
- `is_bot_user(user: dict)` — detects bot accounts by `type == "Bot"` or `[bot]` login suffix
- `is_trusted_reviewer(comment: dict)` — full trust gate (bot-check + `author_association`)
- `TRUSTED_ASSOCIATIONS` — frozenset of OWNER / MEMBER / COLLABORATOR

### 2. `cmd_review_watch.py` deduplication

Imports the shared helpers from `gptme.util.gh` instead of defining them locally. Keeps `_gh_json()` as a thin backward-compat alias so all existing tests pass unchanged.

### 3. Unified CLI group (`gptme/cli/cmd_review.py`)

New `review` Click group exposing `gptme-util review watch` as the canonical entry point:

```
gptme-util review watch 1234 --repo owner/repo
```

The old `gptme-util review-watch` alias is preserved in `util.py` for backward compatibility.

### 4. `ReviewArtifact` for structured handoff (`gptme/util/review.py`)

`ReviewFinding` and `ReviewArtifact` dataclasses for structured JSON handoff from `pr_review` → `review-watch`:

- Severity levels: `note` / `warning` / `error` / `critical`
- Lifecycle status: `open` / `in_progress` / `confirmed` / `dropped`
- JSON round-trip (`to_json()` / `from_json()`)
- Disk persistence (`save()` / `load()`)
- Construction from raw GitHub API comment dicts (`from_github_comments()`)

### 5. Tests (`tests/test_util_review.py`)

30 new tests covering:
- `run_gh_json` / `is_bot_user` / `is_trusted_reviewer`
- `ReviewFinding` round-trip, construction from GitHub comments, defaults
- `ReviewArtifact` JSON round-trip, open/confirmed/dropped counts, save/load, `from_github_comments`
- `gptme-util review watch --help` and `review watch` reachability

## What's not in this PR (follow-ups)

- `review-watch` local/GitHub-less mode (item 4 from #3442)
- Consuming `ReviewArtifact` in the `review-watch` fix-session prompt (needs the `pr_review` contrib side to produce one)
- GitHub App webhook triggering (item 5, longer term)

<!-- gptme-id:v1:gai_snScoJOiFupuVH8KhQip30JJ0pYPXjpWWq22zy8zzKj -->