### PR TITLE
fix(webui): make settings dialog full-screen on mobile, fixed-height on desktop

### DIFF
--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -47,7 +47,15 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
     return (
       <Dialog open={open} onOpenChange={handleOpenChange}>
         {children !== undefined && <DialogTrigger asChild>{children}</DialogTrigger>}
-        <DialogContent className="flex max-h-[90vh] w-[calc(100vw-2rem)] flex-col overflow-hidden p-0 sm:max-h-[80vh] sm:max-w-4xl">
+        {/* Full-screen on mobile; fixed (not content-sized) height on desktop so the
+            dialog doesn't resize when switching tabs or expanding sections. */}
+        <DialogContent
+          className="flex h-dvh w-screen max-w-none flex-col overflow-hidden border-0 p-0 sm:h-[80vh] sm:w-full sm:max-w-4xl sm:border"
+          style={{
+            paddingTop: 'env(safe-area-inset-top, 0px)',
+            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          }}
+        >
           <DialogHeader className="border-b px-6 py-3">
             <DialogTitle className="flex items-center gap-2">
               <Settings className="h-5 w-5" />

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -54,6 +54,8 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
           style={{
             paddingTop: 'env(safe-area-inset-top, 0px)',
             paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+            paddingLeft: 'env(safe-area-inset-left, 0px)',
+            paddingRight: 'env(safe-area-inset-right, 0px)',
           }}
         >
           <DialogHeader className="border-b px-6 py-3">


### PR DESCRIPTION
Feedback from testing the new Android app (signed builds from #3409):

> settings should probably be full-screen on mobile/small screens instead of trying to be a modal that changes size (bounces vertically when opening details/switching tab)

The settings dialog used `max-h-[90vh]`/`sm:max-h-[80vh]`, i.e. content-sized up to a cap — so its height changed whenever tab content or an expanded section changed, and on phones it floated as a resizing modal.

- Mobile (<sm): true full-screen — `h-dvh w-screen`, no border, with `env(safe-area-inset-top/bottom)` padding matching MenuBar/MobileBottomNav.
- Desktop (sm+): fixed `h-[80vh]` instead of `max-h`, so switching tabs or expanding sections no longer resizes the dialog.

Content scrolling is unchanged (SettingsContent already handles `flex-1 min-h-0` + `overflow-y-auto`).