### PR TITLE
fix(webui): keep setup wizard reachable after skip and on mobile Tauri

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -206,6 +206,12 @@ export const WelcomeView = () => {
   // their disconnected banner is left unchanged.
   const isFirstVisit = !settings.hasCompletedSetup;
   const showGuidedSetup = isDefaultLocalServer && isFirstVisit && !demoMode;
+  // Wizard CTA stays available after setup was skipped/completed so onboarding
+  // remains reachable, and on remote-only Tauri (mobile) where the wizard is the
+  // primary way to configure a server URL. Desktop Tauri manages its own server
+  // and keeps the CTA hidden (#3407).
+  const isRemoteOnlyTauri = isTauri && managesLocalServer === false;
+  const showWizardCta = isDefaultLocalServer && !demoMode && (!isTauri || isRemoteOnlyTauri);
 
   // Classify the last connection failure into actionable buckets for targeted guidance.
   const errorBucket = (() => {
@@ -435,7 +441,7 @@ export const WelcomeView = () => {
                       </div>
                     )}
                   <div className="flex flex-wrap gap-2">
-                    {showGuidedSetup && !isTauri && (
+                    {showWizardCta && (
                       <Button
                         type="button"
                         size="sm"
@@ -444,7 +450,7 @@ export const WelcomeView = () => {
                           setupWizard$.open.set(true);
                         }}
                       >
-                        Get started
+                        {isFirstVisit ? 'Get started' : 'Run setup'}
                       </Button>
                     )}
                     {isTauri && managesLocalServer && (

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -356,6 +356,46 @@ describe('WelcomeView', () => {
     });
   });
 
+  it('keeps a "Run setup" CTA for returning users so onboarding stays reachable after skip', async () => {
+    // Skipping the wizard sets hasCompletedSetup=true; the wizard must remain
+    // reachable from the disconnected banner (regression: skip left no way back).
+    seedReturningUser();
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByRole('button', { name: /get started/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /run setup/i }));
+
+    await waitFor(() => {
+      expect(setupWizard$.get()).toMatchObject({ open: true, step: 'welcome' });
+    });
+  });
+
+  it('shows the wizard CTA on remote-only Tauri (mobile) builds', () => {
+    // Mobile Tauri builds don't manage a local server; the wizard is the primary
+    // way to configure a server URL, so the CTA must not be hidden there.
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: null,
+    });
+    isConnected$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument();
+  });
+
   it('shows docs link (but not install step) when a non-default server is disconnected', () => {
     mockBaseUrl = 'http://my-server.example.com:5700';
     isConnected$.set(false);


### PR DESCRIPTION
Feedback from testing the new Android app (signed builds from #3409):

> during onboarding i couldn't select cloud-setup ("not available yet" or some such) and after i'd clicked "skip" there was no way to get back to the onboarding

Two compounding gates made onboarding unreachable on the Android app:

1. `showGuidedSetup` requires `isFirstVisit` (`!hasCompletedSetup`) — clicking **Skip** sets `hasCompletedSetup=true`, removing the "Get started" CTA everywhere.
2. The `!isTauri` gate added in #3407 (to hide CLI server guidance in the desktop app) also swept up the wizard CTA on **all** Tauri builds — including remote-only mobile, where the wizard is the primary way to configure a server URL.

## Fix

Show the wizard CTA whenever the disconnected banner is up on the default server: label stays "Get started" for first-timers, becomes "Run setup" for returning users. Remains hidden on desktop Tauri (which manages its own server, per #3407) and in demo mode. The Settings → About → "Re-run Setup" path is unchanged.

Not addressed here: cloud setup being disabled on mobile builds is by design ("coming soon on mobile") — this PR just makes sure skipping past it isn't a dead end.

## Tests

Two new WelcomeView tests: returning users get a working "Run setup" CTA (regression), and remote-only Tauri shows the CTA. All 31 pass locally.