### PR TITLE
fix(tasks): align list-archived param name and include status code in errors

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -686,11 +686,11 @@ def api_tasks_list():
     """List all tasks.
 
     List tasks with their cached status information.
-    Archived tasks are excluded by default; include ?archived=true to show them.
+    Archived tasks are excluded by default; include ?include_archived=true to show them.
     Filter by cached status with ?status=pending|active|completed|failed.
     """
     try:
-        archived_str = flask.request.args.get("archived", "false")
+        archived_str = flask.request.args.get("include_archived", "false")
         include_archived = archived_str.lower() in ("true", "1")
 
         status_filter = flask.request.args.get("status")

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -594,7 +594,7 @@ class TestTasksListAPI:
         assert resp.status_code == 200
         assert resp.json == {"tasks": []}
 
-        resp = client.get("/api/v2/tasks?archived=true&status=pending")
+        resp = client.get("/api/v2/tasks?include_archived=true&status=pending")
         assert resp.status_code == 200
         data = resp.json
         assert len(data["tasks"]) == 1

--- a/webui/src/utils/taskApi.ts
+++ b/webui/src/utils/taskApi.ts
@@ -39,7 +39,7 @@ export const taskApi = {
 
     const response = await fetch(url.toString(), getFetchOptions());
     if (!response.ok) {
-      throw new Error(`Failed to list tasks: ${response.statusText}`);
+      throw new Error(`Failed to list tasks: ${response.status} ${response.statusText}`);
     }
     const data = await response.json();
     return data.tasks;


### PR DESCRIPTION
## Summary

Two small follow-up fixes to gptme/gptme-cloud#827 (the \"Failed to load tasks\" issue), as noted in [the investigation comment](https://github.com/gptme/gptme-cloud/issues/827#issuecomment-new).

- **Param name mismatch**: the frontend sends `?include_archived=true` but the backend was reading `?archived=`. The \"show archived tasks\" toggle was silently broken — passing the wrong param meant archived tasks were never shown regardless of the toggle state. Fixed by renaming the query param in `tasks_api.py` to `include_archived` and updating the corresponding test.

- **Status code in error message**: `listTasks` threw `"Failed to list tasks: Unauthorized"` instead of `"Failed to list tasks: 401 Unauthorized"`. Over HTTP/2 and behind proxies `statusText` can also be empty, so including `response.status` makes PostHog event filtering actionable and keeps the pattern consistent with `api.ts` (which already uses `${response.status} ${response.statusText}`).

## Test plan

- [x] `pytest tests/test_tasks_api.py` — 93 tests, all pass
- [x] Manually verified the `include_archived` param is now read correctly by the endpoint