### PR TITLE
fix(tests): catch TypeError in _has_flask() for Python 3.13 compatibility

### DIFF
--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -17,12 +17,12 @@ from gptme.message import Message, MessageMetadata, MessageTimings
 
 
 def _has_flask() -> bool:
-    """Check if flask is available (required for server components)."""
+    """Check if flask is available and importable (required for server components)."""
     try:
         import flask  # noqa: F401
 
         return True
-    except ImportError:
+    except (ImportError, TypeError):
         return False
 
 


### PR DESCRIPTION
## Summary

Follow-up to #3436 (per-step timing breakdown).

`_has_flask()` in `tests/test_timings.py` only caught `ImportError`, but Flask 3.0 raises `TypeError` (not `ImportError`) when running on Python 3.13 — the `ConfigAttribute[bool]` subscript syntax is not supported. This caused pytest collection to fail with:

```
TypeError: type 'ConfigAttribute' is not subscriptable
```

instead of gracefully skipping the server-path test.

## Change

- Catch `(ImportError, TypeError)` in `_has_flask()` so the `@pytest.mark.skipif` decorator works correctly on Python 3.13 environments where Flask is installed but broken.

## Verification

```
8 passed, 1 skipped  # (server test correctly skipped when Flask is broken)
```

<!-- gptme-id:v1:gai_ZsiLSszgeUVRlx8FtObey5UTlaioBtcxhx9FcpR92bg -->