### PR TITLE
fix(lessons): port BM25 z-score gate to HybridLessonMatcher no-embedder path

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -438,6 +438,20 @@ class HybridLessonMatcher(LessonMatcher):
                     score += 1.0
                     matched_by.append(f"pattern:{pattern[:30]}...")
 
+            # Skill name matching (Anthropic format) — parity with LessonMatcher.match
+            if lesson.metadata.name:
+                name_lower = lesson.metadata.name.lower()
+                name_variants = [
+                    name_lower,
+                    name_lower.replace("-", " "),
+                    name_lower.replace("-", ""),
+                ]
+                for variant in name_variants:
+                    if variant in message_lower:
+                        score += 1.5
+                        matched_by.append(f"skill:{lesson.metadata.name}")
+                        break
+
             if context.tools_used and lesson.metadata.tools:
                 tools_lower = {t.lower() for t in context.tools_used}
                 for tool in lesson.metadata.tools:

--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -3,7 +3,9 @@
 import importlib.util
 import json
 import logging
+import math
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -12,6 +14,107 @@ from .matcher import LessonMatcher, MatchContext, MatchResult, _match_keyword
 from .parser import Lesson
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# BM25 semantic scoring (no-embedder fallback)
+# ---------------------------------------------------------------------------
+# Raw BM25 scores scale with query length (a 50-token prompt tops out ~45,
+# a 3000-token prompt ~1200), so an absolute floor cannot separate "relevant"
+# from "shares a few common words."  Gate on how far a lesson *stands out*
+# from the background z-score distribution of this query's own scores instead.
+# Ported from gptme-contrib CC hook (PR #1371, merged 2026-08-05).
+
+_BM25_K1 = 1.2
+_BM25_B = 0.75
+_BM25_WEIGHT = 0.4  # additive weight for the z-score contribution
+_BM25_MIN_Z = 4.0  # minimum z-score to admit a lesson via BM25
+_BM25_MIN_RAW = 40.0  # absolute floor — guards degenerate tiny-corpus cases
+# A z-score over n samples cannot exceed (n-1)/sqrt(n), so a fixed z=4 is
+# unreachable below ~17 scoring lessons.  Scale down proportionally.
+_BM25_STANDOUT_FRACTION = 0.8
+
+
+def _build_bm25_index(lessons: list["Lesson"]) -> dict:
+    """Build BM25 index over lesson descriptions, titles, and keywords."""
+    corpus: list[list[str]] = []
+    for lesson in lessons:
+        desc = lesson.metadata.description or lesson.description or ""
+        doc = " ".join(
+            [
+                desc,
+                lesson.title or "",
+                " ".join(lesson.metadata.keywords or []),
+            ]
+        )
+        corpus.append(re.findall(r"[a-z0-9]+", doc.lower()))
+
+    N = len(corpus)
+    avg_dl = sum(len(d) for d in corpus) / max(N, 1)
+    df: dict[str, int] = {}
+    for doc_tokens in corpus:
+        for term in set(doc_tokens):
+            df[term] = df.get(term, 0) + 1
+
+    return {"corpus": corpus, "df": df, "N": N, "avg_dl": avg_dl}
+
+
+def _bm25_score(query_terms: list[str], doc_terms: list[str], index: dict) -> float:
+    """Compute BM25 score for query_terms against a document's term list."""
+    k1, b = _BM25_K1, _BM25_B
+    N, avg_dl = index["N"], index["avg_dl"]
+    dl = len(doc_terms)
+    if not dl or not query_terms:
+        return 0.0
+
+    tf: dict[str, int] = {}
+    for term in doc_terms:
+        tf[term] = tf.get(term, 0) + 1
+
+    df = index["df"]
+    score = 0.0
+    for term in query_terms:
+        if term not in tf:
+            continue
+        tf_td = tf[term]
+        df_t = df.get(term, 0)
+        idf = math.log((N - df_t + 0.5) / (df_t + 0.5) + 1)
+        tf_norm = (tf_td * (k1 + 1)) / (tf_td + k1 * (1 - b + b * dl / max(avg_dl, 1)))
+        score += idf * tf_norm
+
+    return score
+
+
+def _bm25_min_z(n_nonzero: int) -> float:
+    """Minimum z-score a lesson must reach to count as a semantic match.
+
+    When only 1-2 lessons overlap the query, admits them on the raw floor
+    alone — the gate exists to stop the opposite failure where hundreds of
+    lessons share common words and nothing is actually about the query.
+    """
+    if n_nonzero < 3:
+        return -math.inf
+    max_attainable = (n_nonzero - 1) / math.sqrt(n_nonzero)
+    return min(_BM25_MIN_Z, _BM25_STANDOUT_FRACTION * max_attainable)
+
+
+def _bm25_zscores(scores: list[float]) -> list[float]:
+    """Standardize raw BM25 scores against the nonzero score distribution.
+
+    Lessons with score 0 (no term overlap) get 0.0.  If fewer than two
+    lessons score nonzero, or the spread is degenerate, every z is 0.0.
+    """
+    nonzero = [s for s in scores if s > 0]
+    if len(nonzero) < 2:
+        return [0.0] * len(scores)
+    mean = sum(nonzero) / len(nonzero)
+    var = sum((s - mean) ** 2 for s in nonzero) / len(nonzero)
+    sd = math.sqrt(var)
+    if sd <= 0:
+        return [0.0] * len(scores)
+    return [(s - mean) / sd if s > 0 else 0.0 for s in scores]
+
+
+# ---------------------------------------------------------------------------
 
 # Optional embedding support — availability checked lazily to avoid a 10+ second
 # cumulative import of sentence_transformers/transformers/sklearn at CLI startup.
@@ -221,6 +324,12 @@ class HybridLessonMatcher(LessonMatcher):
         # candidates each turn is wasted compute. See _semantic_score.
         self._lesson_embed_cache: dict[str, Any] = {}
 
+        # BM25 index cache — used as semantic fallback when embeddings are
+        # unavailable.  Keyed on the tuple of lesson paths so it rebuilds
+        # automatically when the lesson set changes.
+        self._bm25_index: dict | None = None
+        self._bm25_index_key: tuple[str, ...] = ()
+
     def match(
         self, lessons: list[Lesson], context: MatchContext, threshold: float = 0.0
     ) -> list[MatchResult]:
@@ -236,9 +345,11 @@ class HybridLessonMatcher(LessonMatcher):
         Returns:
             List of match results, sorted by hybrid score (descending)
         """
-        # Fallback to keyword-only if semantic matching unavailable
+        # Fallback to BM25+keyword when sentence embeddings are unavailable.
+        # This mirrors the CC hook's scoring path so both runtimes apply the
+        # same z-score gate rather than gptme falling back to keyword-only.
         if not self.embedder:
-            return super().match(lessons, context, threshold)
+            return self._match_with_bm25(lessons, context, threshold)
 
         # Stage 1: Fast candidate filtering (keyword + tool)
         candidates = self._get_candidates(lessons, context)
@@ -269,6 +380,94 @@ class HybridLessonMatcher(LessonMatcher):
 
         # Cap at max_lessons to prevent context explosion
         return filtered[: self.config.max_lessons]
+
+    def _get_bm25_index(self, lessons: list[Lesson]) -> dict:
+        """Return a cached BM25 index, rebuilding when the lesson set changes."""
+        key = tuple(str(lesson.path) for lesson in lessons)
+        if self._bm25_index is None or key != self._bm25_index_key:
+            self._bm25_index = _build_bm25_index(lessons)
+            self._bm25_index_key = key
+        return self._bm25_index
+
+    def _match_with_bm25(
+        self,
+        lessons: list[Lesson],
+        context: MatchContext,
+        threshold: float = 0.0,
+    ) -> list[MatchResult]:
+        """Keyword + BM25 z-score scoring — used when embeddings are unavailable.
+
+        Matches the CC hook's scoring contract: each lesson receives a keyword
+        score (1.0 per match) plus a BM25 contribution weighted by
+        _BM25_WEIGHT * z-score, gated on _bm25_min_z.
+        """
+        index = self._get_bm25_index(lessons)
+        query_terms = re.findall(r"[a-z0-9]+", context.message.lower())
+
+        # Compute all BM25 scores up-front (z-gate is per-query, not per-lesson)
+        bm_scores: list[float] = [
+            _bm25_score(query_terms, doc_terms, index) for doc_terms in index["corpus"]
+        ]
+        bm_zs = _bm25_zscores(bm_scores)
+        bm_n_nonzero = sum(1 for s in bm_scores if s > 0)
+        bm_min_z = _bm25_min_z(bm_n_nonzero)
+
+        # Score each lesson with keyword + BM25 (deduplicated by path)
+        seen_paths: set[str] = set()
+        results: list[MatchResult] = []
+        message_lower = context.message.lower()
+
+        for i, lesson in enumerate(lessons):
+            resolved = os.path.realpath(lesson.path)
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
+
+            score = 0.0
+            matched_by: list[str] = []
+
+            for keyword in lesson.metadata.keywords:
+                if _match_keyword(keyword, message_lower):
+                    score += 1.0
+                    matched_by.append(f"keyword:{keyword}")
+
+            for pattern in lesson.metadata.patterns:
+                from gptme.util.keyword_matching import _match_pattern
+
+                if _match_pattern(pattern, message_lower):
+                    score += 1.0
+                    matched_by.append(f"pattern:{pattern[:30]}...")
+
+            if context.tools_used and lesson.metadata.tools:
+                tools_lower = {t.lower() for t in context.tools_used}
+                for tool in lesson.metadata.tools:
+                    if tool.lower() in tools_lower:
+                        score += 2.0
+                        matched_by.append(f"tool:{tool}")
+
+            # BM25 contribution (z-score gated, scale-free)
+            bm_score = bm_scores[i]
+            bm_z = bm_zs[i]
+            small_corpus = bm_n_nonzero < 3
+            if bm_z >= bm_min_z and (
+                bm_score >= _BM25_MIN_RAW or (small_corpus and bm_score > 0)
+            ):
+                if bm_n_nonzero >= 3:
+                    bm_contribution = bm_z
+                elif bm_n_nonzero == 2:
+                    bm_contribution = max(bm_z, 0.5)
+                else:
+                    bm_contribution = 1.0
+                score += _BM25_WEIGHT * max(bm_contribution, 0.0)
+                matched_by.append(f"bm25:{bm_score:.2f}")
+
+            if score > threshold:
+                results.append(
+                    MatchResult(lesson=lesson, score=score, matched_by=matched_by)
+                )
+
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[: self.config.max_lessons]
 
     def _get_candidates(
         self, lessons: list[Lesson], context: MatchContext

--- a/tests/lessons/test_bm25_parity.py
+++ b/tests/lessons/test_bm25_parity.py
@@ -328,6 +328,40 @@ class TestHybridMatcherBm25Fallback:
         results = matcher.match(corpus, ctx)
         assert len(results) == 2
 
+    def test_skill_name_match_in_bm25_path(self):
+        """Skills matched by metadata.name must surface in the no-embedder path.
+
+        Regression guard for the P1 Greptile finding: _match_with_bm25 previously
+        omitted the name-variant matching present in LessonMatcher.match, causing
+        name-only skills to score 0 and disappear from auto-injected lessons.
+        """
+        skill_lesson = Lesson(
+            path=Path("/fake/lessons/python-repl.md"),
+            metadata=LessonMetadata(keywords=[], name="python-repl"),
+            title="Python REPL",
+            description="",
+            category="test",
+            body="# Python REPL",
+        )
+        corpus = [skill_lesson] + self._make_corpus()
+        matcher = make_matcher_no_embedder()
+
+        # Plain name
+        results = matcher.match(
+            corpus, MatchContext(message="use the python-repl skill")
+        )
+        slugs = [r.lesson.path.stem for r in results]
+        assert "python-repl" in slugs, "name match (hyphen) failed"
+
+        # Hyphen→space variant
+        results = matcher.match(corpus, MatchContext(message="run python repl now"))
+        slugs = [r.lesson.path.stem for r in results]
+        assert "python-repl" in slugs, "name match (space variant) failed"
+
+        # Matched_by tag must reflect skill: prefix
+        hit = next(r for r in results if r.lesson.path.stem == "python-repl")
+        assert any(tag.startswith("skill:") for tag in hit.matched_by)
+
     def test_result_count_capped_by_max_lessons(self):
         """Should not exceed config.max_lessons even with a broad query."""
         corpus = [

--- a/tests/lessons/test_bm25_parity.py
+++ b/tests/lessons/test_bm25_parity.py
@@ -1,0 +1,342 @@
+"""Tests for BM25 z-score semantic scoring in HybridLessonMatcher.
+
+Verifies parity with the CC hook's BM25 gate (gptme-contrib#1371):
+- _bm25_zscores standardizes against per-query distribution
+- _bm25_min_z scales down for small corpora
+- HybridLessonMatcher falls back to BM25+keyword (not keyword-only) when
+  sentence_transformers are unavailable
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+from gptme.lessons.hybrid_matcher import (
+    _BM25_MIN_Z,
+    _BM25_STANDOUT_FRACTION,
+    HybridConfig,
+    HybridLessonMatcher,
+    _bm25_min_z,
+    _bm25_score,
+    _bm25_zscores,
+    _build_bm25_index,
+)
+from gptme.lessons.matcher import MatchContext
+from gptme.lessons.parser import Lesson, LessonMetadata
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_lesson(
+    name: str,
+    description: str = "",
+    keywords: list[str] | None = None,
+    title: str = "",
+) -> Lesson:
+    return Lesson(
+        path=Path(f"/fake/lessons/{name}.md"),
+        metadata=LessonMetadata(
+            keywords=keywords or [],
+            description=description,
+        ),
+        title=title or name,
+        description=description,
+        category="test",
+        body=f"# {name}\n{description}",
+    )
+
+
+def make_matcher_no_embedder() -> HybridLessonMatcher:
+    """Return a HybridLessonMatcher with embeddings forcibly disabled."""
+    m = HybridLessonMatcher(HybridConfig(enable_semantic=False))
+    m.embedder = None  # ensure embedder is None regardless of env
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _bm25_zscores
+# ---------------------------------------------------------------------------
+
+
+class TestBm25Zscores:
+    def test_empty(self):
+        assert _bm25_zscores([]) == []
+
+    def test_all_zero(self):
+        # No nonzero scores → all z = 0.0
+        assert _bm25_zscores([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+    def test_single_nonzero(self):
+        # Only one nonzero → degenerate, all z = 0.0
+        result = _bm25_zscores([5.0, 0.0, 0.0])
+        assert result == [0.0, 0.0, 0.0]
+
+    def test_two_nonzero_ordered(self):
+        # Two nonzero: z-scores are ±1 (symmetric). Higher raw → higher z.
+        scores = [10.0, 2.0, 0.0]
+        zs = _bm25_zscores(scores)
+        assert zs[0] > zs[1]  # stronger match ranks higher
+        assert zs[2] == 0.0  # zero-score gets 0.0
+
+    def test_three_nonzero_standout(self):
+        # The clear outlier should have a large positive z-score.
+        scores = [100.0, 3.0, 3.0]
+        zs = _bm25_zscores(scores)
+        assert zs[0] > 0.0
+        assert zs[0] > zs[1]
+        assert zs[1] == zs[2]  # equal raw → equal z
+
+    def test_all_equal_nonzero(self):
+        # All equal non-zero → standard deviation is 0 → all z = 0.0
+        result = _bm25_zscores([5.0, 5.0, 5.0])
+        assert result == [0.0, 0.0, 0.0]
+
+    def test_zero_scores_get_zero_z(self):
+        scores = [50.0, 30.0, 0.0, 0.0]
+        zs = _bm25_zscores(scores)
+        assert zs[2] == 0.0
+        assert zs[3] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _bm25_min_z
+# ---------------------------------------------------------------------------
+
+
+class TestBm25MinZ:
+    def test_zero_nonzero(self):
+        # n<3 → -inf (admit anything that passes the raw floor)
+        assert _bm25_min_z(0) == -math.inf
+
+    def test_one_nonzero(self):
+        assert _bm25_min_z(1) == -math.inf
+
+    def test_two_nonzero(self):
+        assert _bm25_min_z(2) == -math.inf
+
+    def test_three_nonzero_below_fixed(self):
+        # With n=3, max attainable z ≈ 2/sqrt(3) ≈ 1.15, well below _BM25_MIN_Z=4.
+        result = _bm25_min_z(3)
+        max_attainable = (3 - 1) / math.sqrt(3)
+        assert result == pytest.approx(_BM25_STANDOUT_FRACTION * max_attainable)
+        assert result < _BM25_MIN_Z
+
+    def test_large_corpus_caps_at_min_z(self):
+        # With n=1000, max attainable ≫ _BM25_MIN_Z; result should be _BM25_MIN_Z.
+        result = _bm25_min_z(1000)
+        assert result == pytest.approx(_BM25_MIN_Z)
+
+    def test_monotone(self):
+        # Threshold should be non-decreasing with corpus size.
+        thresholds = [_bm25_min_z(n) for n in range(3, 50)]
+        for a, b in zip(thresholds, thresholds[1:]):
+            assert a <= b + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _bm25_score
+# ---------------------------------------------------------------------------
+
+
+class TestBm25Score:
+    def _index_from_docs(self, docs: list[str]) -> dict:
+        """Build a minimal BM25 index from raw text strings."""
+        import re
+
+        corpus = [re.findall(r"[a-z0-9]+", d.lower()) for d in docs]
+        N = len(corpus)
+        avg_dl = sum(len(d) for d in corpus) / max(N, 1)
+        df: dict[str, int] = {}
+        for tokens in corpus:
+            for t in set(tokens):
+                df[t] = df.get(t, 0) + 1
+        return {"corpus": corpus, "df": df, "N": N, "avg_dl": avg_dl}
+
+    def test_empty_query(self):
+        idx = self._index_from_docs(["hello world"])
+        assert _bm25_score([], ["hello", "world"], idx) == 0.0
+
+    def test_empty_doc(self):
+        idx = self._index_from_docs([""])
+        assert _bm25_score(["hello"], [], idx) == 0.0
+
+    def test_exact_match_scores_positive(self):
+        idx = self._index_from_docs(["git commit amend workflow"])
+        score = _bm25_score(["git", "commit"], ["git", "commit", "amend"], idx)
+        assert score > 0.0
+
+    def test_no_overlap_zero(self):
+        idx = self._index_from_docs(["database schema migration"])
+        score = _bm25_score(["git", "commit"], ["database", "schema", "migration"], idx)
+        assert score == 0.0
+
+    def test_more_overlap_higher_score(self):
+        idx = self._index_from_docs(["git commit amend", "database schema"])
+        s1 = _bm25_score(["git", "commit"], ["git", "commit", "amend"], idx)
+        s2 = _bm25_score(["git", "commit"], ["database", "schema"], idx)
+        assert s1 > s2
+
+
+# ---------------------------------------------------------------------------
+# _build_bm25_index
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBm25Index:
+    def test_returns_expected_keys(self):
+        lessons = [make_lesson("a", description="git commit amend guard")]
+        idx = _build_bm25_index(lessons)
+        assert "corpus" in idx
+        assert "df" in idx
+        assert "N" in idx
+        assert "avg_dl" in idx
+
+    def test_corpus_length_matches_lesson_count(self):
+        lessons = [make_lesson(f"l{i}") for i in range(5)]
+        idx = _build_bm25_index(lessons)
+        assert idx["N"] == 5
+        assert len(idx["corpus"]) == 5
+
+    def test_keywords_included_in_index(self):
+        lessons = [make_lesson("a", keywords=["amend", "git"])]
+        idx = _build_bm25_index(lessons)
+        assert "amend" in idx["df"]
+        assert "git" in idx["df"]
+
+    def test_empty_lessons(self):
+        idx = _build_bm25_index([])
+        assert idx["N"] == 0
+        assert idx["corpus"] == []
+
+
+# ---------------------------------------------------------------------------
+# HybridLessonMatcher BM25 fallback (no embedder)
+# ---------------------------------------------------------------------------
+
+
+class TestHybridMatcherBm25Fallback:
+    """When embeddings are unavailable, match() must use BM25+keyword scoring."""
+
+    def _make_corpus(self) -> list[Lesson]:
+        """A small diverse corpus for integration tests."""
+        return [
+            make_lesson(
+                "git-amend",
+                description="guard git commit amend shared worktree index sweep",
+                keywords=["git commit --amend", "amend guard"],
+            ),
+            make_lesson(
+                "bm25-scoring",
+                description="bm25 relevance ranking term frequency inverse document frequency",
+                keywords=[],
+            ),
+            make_lesson(
+                "unrelated-topic",
+                description="kubernetes pod resource limits memory cpu quota",
+                keywords=[],
+            ),
+            make_lesson(
+                "another-unrelated",
+                description="ansible playbook idempotent deployment automation",
+                keywords=[],
+            ),
+            make_lesson(
+                "yet-another",
+                description="docker image layer caching build performance",
+                keywords=[],
+            ),
+        ]
+
+    def test_no_embedder_calls_bm25_not_keyword_only(self):
+        """BM25-matched lesson should appear even when it has no matching keyword."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        context = MatchContext(
+            message="bm25 term frequency relevance ranking lesson system"
+        )
+        results = matcher.match(corpus, context)
+        slugs = [r.lesson.path.stem for r in results]
+        # bm25-scoring has no keywords but IS the topic; it should surface via BM25
+        assert "bm25-scoring" in slugs
+
+    def test_bm25_tag_in_matched_by(self):
+        """BM25-matched lessons should have a bm25:* tag in matched_by."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        context = MatchContext(
+            message="bm25 term frequency relevance ranking lesson system"
+        )
+        results = matcher.match(corpus, context)
+        bm25_hit = next(
+            (r for r in results if r.lesson.path.stem == "bm25-scoring"), None
+        )
+        assert bm25_hit is not None
+        assert any(tag.startswith("bm25:") for tag in bm25_hit.matched_by)
+
+    def test_keyword_match_still_works(self):
+        """Keyword-backed lessons should still surface in the BM25 path."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        context = MatchContext(message="I need to git commit --amend the last commit")
+        results = matcher.match(corpus, context)
+        slugs = [r.lesson.path.stem for r in results]
+        assert "git-amend" in slugs
+
+    def test_unrelated_prompt_suppresses_weak_matches(self):
+        """A very focused prompt should not return every lesson in the corpus."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        context = MatchContext(message="amend the last git commit safely")
+        results = matcher.match(corpus, context)
+        # Should NOT surface kubernetes or ansible lessons
+        slugs = [r.lesson.path.stem for r in results]
+        assert "unrelated-topic" not in slugs
+        assert "another-unrelated" not in slugs
+
+    def test_bm25_index_cached_across_calls(self):
+        """Index should be rebuilt only when the lesson set changes."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        ctx = MatchContext(message="git commit amend guard")
+        matcher.match(corpus, ctx)
+        index_id_first = id(matcher._bm25_index)
+        matcher.match(corpus, ctx)
+        assert id(matcher._bm25_index) == index_id_first  # same object reused
+
+    def test_bm25_index_rebuilt_on_lesson_change(self):
+        """Index should rebuild when a different lesson set is passed."""
+        corpus = self._make_corpus()
+        matcher = make_matcher_no_embedder()
+        ctx = MatchContext(message="test query")
+        matcher.match(corpus, ctx)
+        new_corpus = corpus[:-1]  # remove one lesson
+        matcher.match(new_corpus, ctx)
+        assert matcher._bm25_index is not None
+        assert matcher._bm25_index["N"] == len(new_corpus)
+
+    def test_two_lesson_corpus_both_returned(self):
+        """With only 2 highly relevant lessons, both should surface (n<3 gate)."""
+        corpus = [
+            make_lesson("a", description="git commit amend rewrite history"),
+            make_lesson("b", description="git commit message conventional format"),
+        ]
+        matcher = make_matcher_no_embedder()
+        ctx = MatchContext(message="how to write a git commit message")
+        results = matcher.match(corpus, ctx)
+        assert len(results) == 2
+
+    def test_result_count_capped_by_max_lessons(self):
+        """Should not exceed config.max_lessons even with a broad query."""
+        corpus = [
+            make_lesson(f"l{i}", description=f"lesson about topic {i} with details")
+            for i in range(30)
+        ]
+        config = HybridConfig(max_lessons=5)
+        matcher = make_matcher_no_embedder()
+        matcher.config = config
+        ctx = MatchContext(message="lesson about topic with details")
+        results = matcher.match(corpus, ctx)
+        assert len(results) <= 5


### PR DESCRIPTION
## Summary

- When `sentence_transformers` is unavailable, `HybridLessonMatcher.match()` fell back to pure keyword-only scoring. The CC hook (`gptme-contrib`) uses BM25 with a per-query z-score gate that reduced BM25-only injections from 86% → 17% on 40 real prompts (PR #1371, merged 2026-08-05).
- This PR ports the same three BM25 building blocks to `hybrid_matcher.py` so both runtimes apply the same z-score gate rather than gptme degrading to keyword-only on embedder-less deployments.
- 30 new unit tests cover: z-score math, min-z scaling, BM25 scoring, index construction, and HybridLessonMatcher no-embedder integration.

### What changes

**`gptme/lessons/hybrid_matcher.py`**:
- Added `_build_bm25_index`, `_bm25_score`, `_bm25_min_z`, `_bm25_zscores` (ported from CC hook, adapted for `Lesson` objects)
- Added `_match_with_bm25` method: keyword + BM25 z-score scoring with index caching
- Changed no-embedder fallback in `match()` from `super().match()` to `_match_with_bm25()`

**`tests/lessons/test_bm25_parity.py`**: 30 new unit tests

## Test plan

- [ ] `uv run python3 -m pytest tests/lessons/ -q` → 65 tests pass (35 existing + 30 new)
- [ ] No-embedder path now injects BM25-matched lessons that have no matching keyword
- [ ] Unrelated lessons are suppressed for focused queries (z-gate working)
- [ ] BM25 index is cached across calls; rebuilt on lesson set change