### PR TITLE
feat(lessons): Stage 1 shadow logging — policy_class/policy_version in dropout logs

### DIFF
--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -243,7 +243,8 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         if not isinstance(category_list, list):
             continue
         for k in category_list:
-            key_to_class.setdefault(k, class_name)
+            if isinstance(k, str):  # skip non-string (YAML mappings, nested lists)
+                key_to_class.setdefault(k, class_name)
 
     # Iterate candidate keys longest-first: the most specific match wins.
     for key in sorted(candidate_keys, key=len, reverse=True):

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -183,6 +183,14 @@ def _load_policy_manifest() -> "dict[str, Any]":
         logger.warning("Failed to load lesson-policy manifest: %s", e)
         manifest = _missing_default
 
+    # Resolve the manifest path once at load time and store it as a meta key.
+    # _classify_lesson uses this to anchor relative `root:` values without
+    # re-resolving against the process CWD — which may have changed since the
+    # manifest was first cached (the Greptile "cached manifest loses its anchor"
+    # finding).
+    if not manifest.get("_manifest_missing"):
+        manifest["_manifest_abs_path"] = manifest_path.resolve()
+
     _policy_manifest_cache = manifest
     return _policy_manifest_cache
 
@@ -244,7 +252,14 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
             # the manifest is always found at an absolute path, so its parent is stable.
             manifest_root = Path(manifest_root_str)
             if not manifest_root.is_absolute():
-                manifest_file_abs = _get_policy_manifest_path().resolve()
+                # Use the path resolved at manifest-load time, not now — the
+                # process CWD may have changed since the manifest was cached,
+                # and re-resolving a relative manifest path against the new CWD
+                # would anchor the relative `root:` to the wrong directory.
+                manifest_file_abs = (
+                    manifest.get("_manifest_abs_path")
+                    or _get_policy_manifest_path().resolve()
+                )
                 manifest_root = (manifest_file_abs.parent / manifest_root_str).resolve()
             abs_path = path if path.is_absolute() else path.resolve()
             rel = abs_path.relative_to(manifest_root)

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -163,17 +163,17 @@ def _load_policy_manifest() -> "dict[str, Any]":
                 manifest_path,
                 type(raw).__name__,
             )
-            manifest: dict[str, Any] = _default
+            manifest: dict[str, Any] = _missing_default
         else:
-            manifest = raw or _default
+            manifest = raw or _missing_default
     except ImportError:
         logger.warning(
             "yaml not available; lesson-policy manifest at %s ignored", manifest_path
         )
-        manifest = _default
+        manifest = _missing_default
     except Exception as e:
         logger.warning("Failed to load lesson-policy manifest: %s", e)
-        manifest = _default
+        manifest = _missing_default
 
     _policy_manifest_cache = manifest
     return _policy_manifest_cache
@@ -219,7 +219,8 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         ("exempt", "exempt"),
         ("holdout_population", "holdout"),
     ]:
-        if key in (manifest.get(category) or []):
+        category_list = manifest.get(category)
+        if isinstance(category_list, list) and key in category_list:
             return class_name, policy_version
 
     # No manifest on disk → default evaluation population is "holdout".

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -208,41 +208,44 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     except (TypeError, ValueError):
         policy_version = 1
 
-    # Normalize: extract the category/name part after the "lessons" directory,
-    # dropping the .md suffix to match manifest key format.
+    # Normalize: extract the category/name part for manifest key lookup.
+    # Priority order:
+    #   1. Manifest declares `root` → exact relative-path match. This guard takes
+    #      precedence over the `lessons` heuristic so a path from an outside workspace
+    #      that happens to contain a `lessons` component cannot inherit entries that
+    #      were intended for this root.
+    #   2. No root declared, path contains `lessons` dir component → key after that.
+    #   3. No root, no `lessons` component → return unknown/holdout conservatively;
+    #      suffix enumeration would accept unrelated custom-root lessons.
     path = Path(lesson_path)
     parts = path.parts
-    try:
-        lessons_idx = list(parts).index("lessons")
-        candidate_keys = ["/".join(parts[lessons_idx + 1 :]).removesuffix(".md")]
-    except ValueError:
-        # No "lessons" dir component (custom lesson root).
-        # If the manifest declares its `root`, use exact relative-path matching to
-        # prevent shorter-suffix false positives from unrelated roots.
-        manifest_root_str = manifest.get("root") if isinstance(manifest, dict) else None
-        if manifest_root_str:
-            try:
-                rel = path.relative_to(Path(manifest_root_str))
-                candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]
-            except ValueError:
-                # Path is outside the declared root — it belongs to a different
-                # lesson tree and must not inherit entries from this manifest.
-                if manifest.get("_manifest_missing"):
-                    return "holdout", policy_version
-                return "unknown", policy_version
-        else:
-            # No root anchor and no "lessons" dir component. Try every suffix
-            # depth so nested categories still match (e.g. /opt/guidance/patterns/
-            # sub/foo.md → "patterns/sub/foo"). Known limitation: a short manifest
-            # key (e.g. "foo") can accidentally match an unrelated lesson at a
-            # different custom root. Set `root:` in the manifest to eliminate
-            # false positives.
-            stem = path.stem
-            max_dirs = len(parts) - 1  # directory components (excludes filename)
-            candidate_keys = [
-                "/".join((*parts[-(depth + 1) : -1], stem)) if depth > 0 else stem
-                for depth in range(0, max_dirs + 1)
-            ]
+    manifest_root_str = manifest.get("root") if isinstance(manifest, dict) else None
+
+    if manifest_root_str:
+        # Declared root: use exact relative-path matching for ALL paths (including
+        # those that happen to contain a "lessons" dir component).
+        try:
+            rel = path.relative_to(Path(manifest_root_str))
+            candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]
+        except ValueError:
+            # Path is outside the declared root — it belongs to a different lesson
+            # tree and must not inherit entries from this manifest.
+            if manifest.get("_manifest_missing"):
+                return "holdout", policy_version
+            return "unknown", policy_version
+    else:
+        # No root declared. Use the "lessons" dir component as a heuristic anchor.
+        try:
+            lessons_idx = list(parts).index("lessons")
+            candidate_keys = ["/".join(parts[lessons_idx + 1 :]).removesuffix(".md")]
+        except ValueError:
+            # No root and no "lessons" component. Suffix enumeration would accept
+            # lessons from unrelated custom roots — return unknown/holdout
+            # conservatively. Set `root:` in the manifest to classify custom-root
+            # lessons accurately.
+            if manifest.get("_manifest_missing"):
+                return "holdout", policy_version
+            return "unknown", policy_version
 
     # Build a lookup from manifest key → policy class so we can pick the
     # most specific (longest) matching suffix first, regardless of class order.

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -173,7 +173,7 @@ def _load_policy_manifest() -> "dict[str, Any]":
             # classifies nothing — distinct from a missing manifest, so lessons
             # should resolve to "unknown" rather than the missing-manifest
             # "holdout" default. Don't conflate the two via truthiness.
-            manifest = raw or _default
+            manifest = raw
     except ImportError:
         logger.warning(
             "yaml not available; lesson-policy manifest at %s ignored", manifest_path

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -144,16 +144,28 @@ def _load_policy_manifest() -> "dict[str, Any]":
         "exempt": [],
         "holdout_population": [],
     }
+    # Sentinel used by _classify_lesson to distinguish "no manifest" (→ holdout)
+    # from "manifest exists but lesson not listed" (→ unknown).
+    _missing_default = {**_default, "_manifest_missing": True}
 
     if not manifest_path.exists():
-        _policy_manifest_cache = _default
+        _policy_manifest_cache = _missing_default
         return _policy_manifest_cache
 
     try:
         import yaml
 
         with open(manifest_path, encoding="utf-8") as f:
-            manifest: dict[str, Any] = yaml.safe_load(f) or {}
+            raw = yaml.safe_load(f)
+        if not isinstance(raw, dict):
+            logger.warning(
+                "Lesson-policy manifest at %s has unexpected type (%s); using defaults",
+                manifest_path,
+                type(raw).__name__,
+            )
+            manifest: dict[str, Any] = _default
+        else:
+            manifest = raw or _default
     except ImportError:
         logger.warning(
             "yaml not available; lesson-policy manifest at %s ignored", manifest_path
@@ -183,7 +195,10 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         - ``"unknown"``: not in manifest (created after manifest timestamp)
     """
     manifest = _load_policy_manifest()
-    policy_version = int(manifest.get("version", 1))
+    try:
+        policy_version = int(manifest.get("version", 1))
+    except (TypeError, ValueError):
+        policy_version = 1
 
     # Normalize: extract the category/name part after the "lessons" directory,
     # dropping the .md suffix to match manifest key format.
@@ -193,7 +208,10 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         lessons_idx = list(parts).index("lessons")
         key = "/".join(parts[lessons_idx + 1 :])
     except ValueError:
-        key = path.stem  # fallback: just the filename stem
+        # No "lessons" dir component; use parent/stem so manifest keys like
+        # "category/name" can match custom lesson roots without a literal
+        # "lessons" directory (e.g. /opt/guidance/patterns/foo.md → patterns/foo).
+        key = f"{parts[-2]}/{path.stem}" if len(parts) >= 2 else path.stem
     key = key.removesuffix(".md")
 
     for category, class_name in [
@@ -204,6 +222,10 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         if key in (manifest.get(category) or []):
             return class_name, policy_version
 
+    # No manifest on disk → default evaluation population is "holdout".
+    # Manifest exists but lesson not listed → "unknown" (added after manifest stamp).
+    if manifest.get("_manifest_missing"):
+        return "holdout", policy_version
     return "unknown", policy_version
 
 

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -7,7 +7,7 @@ import random
 import time
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .index import LessonIndex
 from .matcher import LessonMatcher, MatchContext
@@ -107,6 +107,106 @@ def _get_dropout_log_dir() -> Path:
     return Path(os.environ.get("LESSON_DROPOUT_LOG_DIR", "state/lesson-dropout"))
 
 
+# --- Lesson policy manifest (Stage 1 shadow logging) ---
+
+_policy_manifest_cache: "dict[str, Any] | None" = None
+
+
+def _get_policy_manifest_path() -> Path:
+    """Return path to lesson-policy manifest.
+
+    Overridable via ``LESSON_POLICY_MANIFEST_PATH`` for testing.
+    Defaults to ``state/lesson-policy/manifest.yaml`` relative to cwd.
+    """
+    return Path(
+        os.environ.get(
+            "LESSON_POLICY_MANIFEST_PATH", "state/lesson-policy/manifest.yaml"
+        )
+    )
+
+
+def _load_policy_manifest() -> "dict[str, Any]":
+    """Load and cache the lesson-policy manifest (YAML).
+
+    Returns dict with keys: version, updated_at, validated_core, exempt, holdout_population.
+    On load failure or missing file, returns a safe default (all lessons in holdout).
+    Failures are swallowed — manifest loading must never break lesson injection.
+    """
+    global _policy_manifest_cache
+    if _policy_manifest_cache is not None:
+        return _policy_manifest_cache
+
+    manifest_path = _get_policy_manifest_path()
+    _default: dict[str, Any] = {
+        "version": 1,
+        "updated_at": "",
+        "validated_core": [],
+        "exempt": [],
+        "holdout_population": [],
+    }
+
+    if not manifest_path.exists():
+        _policy_manifest_cache = _default
+        return _policy_manifest_cache
+
+    try:
+        import yaml
+
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest: dict[str, Any] = yaml.safe_load(f) or {}
+    except ImportError:
+        logger.warning(
+            "yaml not available; lesson-policy manifest at %s ignored", manifest_path
+        )
+        manifest = _default
+    except Exception as e:
+        logger.warning("Failed to load lesson-policy manifest: %s", e)
+        manifest = _default
+
+    _policy_manifest_cache = manifest
+    return _policy_manifest_cache
+
+
+def _classify_lesson(lesson_path: str) -> tuple[str, int]:
+    """Classify a lesson by its path against the policy manifest.
+
+    Args:
+        lesson_path: Filesystem path to the lesson file, e.g.
+            ``/home/bob/lessons/patterns/foo.md`` or ``lessons/patterns/foo.md``.
+
+    Returns:
+        ``(policy_class, policy_version)`` where policy_class is one of:
+
+        - ``"validated_core"``: high-ROI, recommended for all sessions
+        - ``"exempt"``: safety/retention policy, exempt from dropout
+        - ``"holdout"``: under evaluation (default)
+        - ``"unknown"``: not in manifest (created after manifest timestamp)
+    """
+    manifest = _load_policy_manifest()
+    policy_version = int(manifest.get("version", 1))
+
+    # Normalize: extract the category/name part after the "lessons" directory,
+    # dropping the .md suffix to match manifest key format.
+    path = Path(lesson_path)
+    parts = path.parts
+    try:
+        lessons_idx = list(parts).index("lessons")
+        key = "/".join(parts[lessons_idx + 1 :])
+    except ValueError:
+        key = path.stem  # fallback: just the filename stem
+    key = key.removesuffix(".md")
+
+    for category, class_name in [
+        ("validated_core", "validated_core"),
+        ("exempt", "exempt"),
+        ("holdout_population", "holdout"),
+    ]:
+        if key in (manifest.get(category) or []):
+            return class_name, policy_version
+
+    return "unknown", policy_version
+
+
 def _apply_lesson_dropout(matches: list) -> list:
     """Randomly withhold matched lessons for causal LOO measurement.
 
@@ -137,13 +237,17 @@ def _apply_lesson_dropout(matches: list) -> list:
         else:
             kept.append(match)
 
-    _log_dropout(epsilon, withheld)
+    _log_dropout(epsilon, kept, withheld)
 
     return kept
 
 
-def _log_dropout(epsilon: float, withheld: list[dict]) -> None:
+def _log_dropout(epsilon: float, kept: list, withheld: list[dict]) -> None:
     """Append a randomized-dropout record for causal LOO analysis.
+
+    Stage 1 shadow logging: includes ``policy_class`` and ``policy_version``
+    for every lesson (both kept and withheld) so manifest classification can
+    be verified without changing dropout behavior.
 
     Failures are logged and swallowed — dropout logging must never break lesson
     injection.
@@ -152,11 +256,39 @@ def _log_dropout(epsilon: float, withheld: list[dict]) -> None:
         session_id = _get_dropout_session_id()
         log_dir = _get_dropout_log_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Enrich withheld entries with policy classification (Stage 1 shadow).
+        enriched_withheld = []
+        for entry in withheld:
+            policy_class, policy_version = _classify_lesson(entry.get("path", ""))
+            enriched_withheld.append(
+                {
+                    **entry,
+                    "policy_class": policy_class,
+                    "policy_version": policy_version,
+                }
+            )
+
+        # Log kept (matched) lessons for treatment-assignment verification.
+        enriched_matched = []
+        for match in kept:
+            lesson = match.lesson
+            policy_class, policy_version = _classify_lesson(str(lesson.path))
+            enriched_matched.append(
+                {
+                    "path": str(lesson.path),
+                    "title": lesson.title,
+                    "policy_class": policy_class,
+                    "policy_version": policy_version,
+                }
+            )
+
         record = {
             "ts": time.time(),
             "session_id": session_id,
             "epsilon": epsilon,
-            "withheld": withheld,
+            "withheld": enriched_withheld,
+            "matched": enriched_matched,
         }
         with open(log_dir / f"{session_id}.jsonl", "a") as f:
             f.write(json.dumps(record) + "\n")

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -261,9 +261,13 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
                     or _get_policy_manifest_path().resolve()
                 )
                 manifest_root = (manifest_file_abs.parent / manifest_root_str).resolve()
+            else:
+                # Always resolve absolute roots too so that paths containing `..`
+                # or symlink components compare correctly against lesson paths.
+                manifest_root = manifest_root.resolve()
             abs_path = path if path.is_absolute() else path.resolve()
             rel = abs_path.relative_to(manifest_root)
-            candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]
+            candidate_keys = [str(rel).replace("\\", "/").removesuffix(".md")]
         except (ValueError, OSError):
             # Path is outside the declared root — it belongs to a different lesson
             # tree and must not inherit entries from this manifest.

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -235,9 +235,17 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
             # works correctly when the lesson path is absolute. Python's
             # Path.relative_to() raises ValueError if the base is relative but the
             # target is absolute, misclassifying every valid in-root lesson.
+            #
+            # Anchor against the manifest file's directory — NOT the process CWD.
+            # When the hook runs from a workspace subdirectory, CWD-based resolve()
+            # maps `root: lessons` to `<subdirectory>/lessons` while lesson paths are
+            # rooted at the workspace root, misclassifying every in-root lesson as
+            # `unknown`. Anchoring to the manifest file's parent is CWD-independent:
+            # the manifest is always found at an absolute path, so its parent is stable.
             manifest_root = Path(manifest_root_str)
             if not manifest_root.is_absolute():
-                manifest_root = manifest_root.resolve()
+                manifest_file_abs = _get_policy_manifest_path().resolve()
+                manifest_root = (manifest_file_abs.parent / manifest_root_str).resolve()
             abs_path = path if path.is_absolute() else path.resolve()
             rel = abs_path.relative_to(manifest_root)
             candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -110,7 +110,7 @@ def _get_dropout_log_dir() -> Path:
 # --- Lesson policy manifest (Stage 1 shadow logging) ---
 
 _policy_manifest_cache: "dict[str, Any] | None" = None
-_policy_manifest_cache_key: "tuple[str, Path, int | None, int | None] | None" = None
+_policy_manifest_cache_key: "tuple[str, Path, int | None, int | None, int | None] | None" = None
 
 
 def _get_policy_manifest_path() -> Path:
@@ -150,11 +150,19 @@ def _load_policy_manifest() -> "dict[str, Any]":
     try:
         stat = manifest_abs_path.stat()
         manifest_mtime_ns = stat.st_mtime_ns
+        manifest_ctime_ns = stat.st_ctime_ns
         manifest_size = stat.st_size
     except OSError:
         manifest_mtime_ns = None
+        manifest_ctime_ns = None
         manifest_size = None
-    cache_key = (configured_path, manifest_abs_path, manifest_mtime_ns, manifest_size)
+    cache_key = (
+        configured_path,
+        manifest_abs_path,
+        manifest_mtime_ns,
+        manifest_ctime_ns,
+        manifest_size,
+    )
     if _policy_manifest_cache is not None and _policy_manifest_cache_key == cache_key:
         return _policy_manifest_cache
     _default: dict[str, Any] = {
@@ -176,7 +184,7 @@ def _load_policy_manifest() -> "dict[str, Any]":
     try:
         import yaml
 
-        with open(manifest_path, encoding="utf-8") as f:
+        with open(manifest_abs_path, encoding="utf-8") as f:
             raw = yaml.safe_load(f)
         if raw is None:
             # Empty file (e.g. `yaml.safe_load` of a blank/whitespace-only

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -266,7 +266,22 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
                 # or symlink components compare correctly against lesson paths.
                 manifest_root = manifest_root.resolve()
             abs_path = path if path.is_absolute() else path.resolve()
-            rel = abs_path.relative_to(manifest_root)
+            try:
+                rel = abs_path.relative_to(manifest_root)
+            except ValueError:
+                # `manifest_root` is always fully resolved above, but an absolute
+                # lesson path is used as-is — so the two sides are normalized
+                # asymmetrically. When any component of the lesson path is a
+                # symlink or `..` (a symlinked workspace root, `/tmp` on macOS,
+                # `$HOME` behind a symlink), the same file has two spellings and
+                # relative_to() fails, mislabelling every in-root lesson
+                # "unknown". Retry fully resolved.
+                #
+                # Ordering matters: the unresolved comparison is tried first so a
+                # lesson file that is itself a symlink *out of* the root (the
+                # index deliberately keeps such entries, deduping by realpath)
+                # still classifies against the root it was discovered under.
+                rel = abs_path.resolve().relative_to(manifest_root)
             candidate_keys = [str(rel).replace("\\", "/").removesuffix(".md")]
         except (ValueError, OSError):
             # Path is outside the declared root — it belongs to a different lesson

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -216,18 +216,33 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         lessons_idx = list(parts).index("lessons")
         candidate_keys = ["/".join(parts[lessons_idx + 1 :]).removesuffix(".md")]
     except ValueError:
-        # No "lessons" dir component (custom lesson root). We don't know where
-        # the configured root ends, so try every suffix depth — stem,
-        # parent/stem, grandparent/parent/stem, ... — and check them all, so
-        # nested categories (e.g. /opt/guidance/patterns/sub/foo.md →
-        # "patterns/sub/foo") match instead of only the immediate parent
-        # (which would collapse to "sub/foo" and lose "patterns").
-        stem = path.stem
-        max_dirs = len(parts) - 1  # directory components available (excludes filename)
-        candidate_keys = [
-            "/".join((*parts[-(depth + 1) : -1], stem)) if depth > 0 else stem
-            for depth in range(0, max_dirs + 1)
-        ]
+        # No "lessons" dir component (custom lesson root).
+        # If the manifest declares its `root`, use exact relative-path matching to
+        # prevent shorter-suffix false positives from unrelated roots.
+        manifest_root_str = manifest.get("root") if isinstance(manifest, dict) else None
+        if manifest_root_str:
+            try:
+                rel = path.relative_to(Path(manifest_root_str))
+                candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]
+            except ValueError:
+                # Path is outside the declared root — it belongs to a different
+                # lesson tree and must not inherit entries from this manifest.
+                if manifest.get("_manifest_missing"):
+                    return "holdout", policy_version
+                return "unknown", policy_version
+        else:
+            # No root anchor and no "lessons" dir component. Try every suffix
+            # depth so nested categories still match (e.g. /opt/guidance/patterns/
+            # sub/foo.md → "patterns/sub/foo"). Known limitation: a short manifest
+            # key (e.g. "foo") can accidentally match an unrelated lesson at a
+            # different custom root. Set `root:` in the manifest to eliminate
+            # false positives.
+            stem = path.stem
+            max_dirs = len(parts) - 1  # directory components (excludes filename)
+            candidate_keys = [
+                "/".join((*parts[-(depth + 1) : -1], stem)) if depth > 0 else stem
+                for depth in range(0, max_dirs + 1)
+            ]
 
     # Build a lookup from manifest key → policy class so we can pick the
     # most specific (longest) matching suffix first, regardless of class order.

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -110,6 +110,7 @@ def _get_dropout_log_dir() -> Path:
 # --- Lesson policy manifest (Stage 1 shadow logging) ---
 
 _policy_manifest_cache: "dict[str, Any] | None" = None
+_policy_manifest_cache_key: "tuple[str, Path, int | None, int | None] | None" = None
 
 
 def _get_policy_manifest_path() -> Path:
@@ -132,11 +133,30 @@ def _load_policy_manifest() -> "dict[str, Any]":
     On load failure or missing file, returns a safe default (all lessons in holdout).
     Failures are swallowed — manifest loading must never break lesson injection.
     """
-    global _policy_manifest_cache
-    if _policy_manifest_cache is not None:
-        return _policy_manifest_cache
+    global _policy_manifest_cache, _policy_manifest_cache_key
 
     manifest_path = _get_policy_manifest_path()
+    configured_path = str(manifest_path)
+    # A relative configured path is CWD-dependent only until it has loaded. Keep
+    # using that load-time anchor across later CWD changes, while still allowing
+    # a different configured path or an in-place file update to invalidate it.
+    cached_abs_path = (
+        _policy_manifest_cache_key[1]
+        if _policy_manifest_cache_key is not None
+        and _policy_manifest_cache_key[0] == configured_path
+        else None
+    )
+    manifest_abs_path = cached_abs_path or manifest_path.resolve()
+    try:
+        stat = manifest_abs_path.stat()
+        manifest_mtime_ns = stat.st_mtime_ns
+        manifest_size = stat.st_size
+    except OSError:
+        manifest_mtime_ns = None
+        manifest_size = None
+    cache_key = (configured_path, manifest_abs_path, manifest_mtime_ns, manifest_size)
+    if _policy_manifest_cache is not None and _policy_manifest_cache_key == cache_key:
+        return _policy_manifest_cache
     _default: dict[str, Any] = {
         "version": 1,
         "updated_at": "",
@@ -148,8 +168,9 @@ def _load_policy_manifest() -> "dict[str, Any]":
     # from "manifest exists but lesson not listed" (→ unknown).
     _missing_default = {**_default, "_manifest_missing": True}
 
-    if not manifest_path.exists():
+    if manifest_mtime_ns is None:
         _policy_manifest_cache = _missing_default
+        _policy_manifest_cache_key = cache_key
         return _policy_manifest_cache
 
     try:
@@ -189,9 +210,10 @@ def _load_policy_manifest() -> "dict[str, Any]":
     # manifest was first cached (the Greptile "cached manifest loses its anchor"
     # finding).
     if not manifest.get("_manifest_missing"):
-        manifest["_manifest_abs_path"] = manifest_path.resolve()
+        manifest["_manifest_abs_path"] = manifest_abs_path
 
     _policy_manifest_cache = manifest
+    _policy_manifest_cache_key = cache_key
     return _policy_manifest_cache
 
 
@@ -265,7 +287,9 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
                 # Always resolve absolute roots too so that paths containing `..`
                 # or symlink components compare correctly against lesson paths.
                 manifest_root = manifest_root.resolve()
-            abs_path = path if path.is_absolute() else path.resolve()
+            # LessonIndex normally yields absolute paths. Accept relative paths too,
+            # anchoring them to the declared lesson root instead of the process CWD.
+            abs_path = path if path.is_absolute() else manifest_root / path
             try:
                 rel = abs_path.relative_to(manifest_root)
             except ValueError:
@@ -290,18 +314,36 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
                 return "holdout", policy_version
             return "unknown", policy_version
     else:
-        # No root declared. Use the "lessons" dir component as a heuristic anchor.
-        try:
-            lessons_idx = list(parts).index("lessons")
-            candidate_keys = ["/".join(parts[lessons_idx + 1 :]).removesuffix(".md")]
-        except ValueError:
-            # No root and no "lessons" component. Suffix enumeration would accept
-            # lessons from unrelated custom roots — return unknown/holdout
-            # conservatively. Set `root:` in the manifest to classify custom-root
-            # lessons accurately.
-            if manifest.get("_manifest_missing"):
-                return "holdout", policy_version
-            return "unknown", policy_version
+        # A relative path is scoped by its LessonIndex caller, so preserve the
+        # legacy ``lessons/`` heuristic. An absolute path is only safe when its
+        # ``lessons`` directory is anchored to the manifest's workspace.
+        if path.is_absolute():
+            manifest_file_abs = manifest.get("_manifest_abs_path")
+            if manifest_file_abs is None:
+                if manifest.get("_manifest_missing"):
+                    return "holdout", policy_version
+                return "unknown", policy_version
+            inferred_root = Path(manifest_file_abs).parent / "lessons"
+            try:
+                rel = path.relative_to(inferred_root)
+            except ValueError:
+                try:
+                    rel = path.resolve().relative_to(inferred_root.resolve())
+                except (ValueError, OSError):
+                    return "unknown", policy_version
+            candidate_keys = [str(rel).replace("\\", "/").removesuffix(".md")]
+        else:
+            try:
+                lessons_idx = list(parts).index("lessons")
+                candidate_keys = [
+                    "/".join(parts[lessons_idx + 1 :]).removesuffix(".md")
+                ]
+            except ValueError:
+                # No root and no "lessons" component. Suffix enumeration would
+                # accept unrelated custom-root lessons, so classify conservatively.
+                if manifest.get("_manifest_missing"):
+                    return "holdout", policy_version
+                return "unknown", policy_version
 
     # Build a lookup from manifest key → policy class so we can pick the
     # most specific (longest) matching suffix first, regardless of class order.
@@ -315,6 +357,12 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     ]:
         category_list = manifest.get(category)
         if not isinstance(category_list, list):
+            if category_list is not None:
+                logger.warning(
+                    "Lesson-policy manifest category %s has unexpected type (%s); ignoring it",
+                    category,
+                    type(category_list).__name__,
+                )
             continue
         for k in category_list:
             if isinstance(k, str):  # skip non-string (YAML mappings, nested lists)

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -231,9 +231,17 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         # Declared root: use exact relative-path matching for ALL paths (including
         # those that happen to contain a "lessons" dir component).
         try:
-            rel = path.relative_to(Path(manifest_root_str))
+            # Resolve to absolute so a relative `root:` value (e.g. `root: lessons`)
+            # works correctly when the lesson path is absolute. Python's
+            # Path.relative_to() raises ValueError if the base is relative but the
+            # target is absolute, misclassifying every valid in-root lesson.
+            manifest_root = Path(manifest_root_str)
+            if not manifest_root.is_absolute():
+                manifest_root = manifest_root.resolve()
+            abs_path = path if path.is_absolute() else path.resolve()
+            rel = abs_path.relative_to(manifest_root)
             candidate_keys = [str(rel.with_suffix("")).replace("\\", "/")]
-        except ValueError:
+        except (ValueError, OSError):
             # Path is outside the declared root — it belongs to a different lesson
             # tree and must not inherit entries from this manifest.
             if manifest.get("_manifest_missing"):

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -157,15 +157,23 @@ def _load_policy_manifest() -> "dict[str, Any]":
 
         with open(manifest_path, encoding="utf-8") as f:
             raw = yaml.safe_load(f)
-        if not isinstance(raw, dict):
+        if raw is None:
+            # Empty file (e.g. `yaml.safe_load` of a blank/whitespace-only
+            # document) — treat like a missing manifest.
+            manifest: dict[str, Any] = _missing_default
+        elif not isinstance(raw, dict):
             logger.warning(
                 "Lesson-policy manifest at %s has unexpected type (%s); using defaults",
                 manifest_path,
                 type(raw).__name__,
             )
-            manifest: dict[str, Any] = _missing_default
+            manifest = _missing_default
         else:
-            manifest = raw or _missing_default
+            # A valid-but-empty mapping (`{}`) means the manifest *exists* but
+            # classifies nothing — distinct from a missing manifest, so lessons
+            # should resolve to "unknown" rather than the missing-manifest
+            # "holdout" default. Don't conflate the two via truthiness.
+            manifest = raw or _default
     except ImportError:
         logger.warning(
             "yaml not available; lesson-policy manifest at %s ignored", manifest_path
@@ -206,13 +214,20 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     parts = path.parts
     try:
         lessons_idx = list(parts).index("lessons")
-        key = "/".join(parts[lessons_idx + 1 :])
+        candidate_keys = ["/".join(parts[lessons_idx + 1 :]).removesuffix(".md")]
     except ValueError:
-        # No "lessons" dir component; use parent/stem so manifest keys like
-        # "category/name" can match custom lesson roots without a literal
-        # "lessons" directory (e.g. /opt/guidance/patterns/foo.md → patterns/foo).
-        key = f"{parts[-2]}/{path.stem}" if len(parts) >= 2 else path.stem
-    key = key.removesuffix(".md")
+        # No "lessons" dir component (custom lesson root). We don't know where
+        # the configured root ends, so try every suffix depth — stem,
+        # parent/stem, grandparent/parent/stem, ... — and check them all, so
+        # nested categories (e.g. /opt/guidance/patterns/sub/foo.md →
+        # "patterns/sub/foo") match instead of only the immediate parent
+        # (which would collapse to "sub/foo" and lose "patterns").
+        stem = path.stem
+        max_dirs = len(parts) - 1  # directory components available (excludes filename)
+        candidate_keys = [
+            "/".join((*parts[-(depth + 1) : -1], stem)) if depth > 0 else stem
+            for depth in range(0, max_dirs + 1)
+        ]
 
     for category, class_name in [
         ("validated_core", "validated_core"),
@@ -220,7 +235,9 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         ("holdout_population", "holdout"),
     ]:
         category_list = manifest.get(category)
-        if isinstance(category_list, list) and key in category_list:
+        if not isinstance(category_list, list):
+            continue
+        if any(key in category_list for key in candidate_keys):
             return class_name, policy_version
 
     # No manifest on disk → default evaluation population is "holdout".

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -229,6 +229,11 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
             for depth in range(0, max_dirs + 1)
         ]
 
+    # Build a lookup from manifest key → policy class so we can pick the
+    # most specific (longest) matching suffix first, regardless of class order.
+    # Without this, a shorter suffix in validated_core would shadow the intended
+    # longer key in holdout_population (the Greptile-identified suffix-priority bug).
+    key_to_class: dict[str, str] = {}
     for category, class_name in [
         ("validated_core", "validated_core"),
         ("exempt", "exempt"),
@@ -237,8 +242,13 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         category_list = manifest.get(category)
         if not isinstance(category_list, list):
             continue
-        if any(key in category_list for key in candidate_keys):
-            return class_name, policy_version
+        for k in category_list:
+            key_to_class.setdefault(k, class_name)
+
+    # Iterate candidate keys longest-first: the most specific match wins.
+    for key in sorted(candidate_keys, key=len, reverse=True):
+        if key in key_to_class:
+            return key_to_class[key], policy_version
 
     # No manifest on disk → default evaluation population is "holdout".
     # Manifest exists but lesson not listed → "unknown" (added after manifest stamp).

--- a/gptme/lessons/auto_include.py
+++ b/gptme/lessons/auto_include.py
@@ -219,7 +219,13 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     #      suffix enumeration would accept unrelated custom-root lessons.
     path = Path(lesson_path)
     parts = path.parts
-    manifest_root_str = manifest.get("root") if isinstance(manifest, dict) else None
+    # Validate `root` is a string before using it — a malformed YAML value
+    # (int, list, dict) would raise TypeError in Path(), which the outer
+    # _log_dropout handler would catch, suppressing the entire dropout record.
+    manifest_root_raw = manifest.get("root") if isinstance(manifest, dict) else None
+    manifest_root_str = (
+        manifest_root_raw if isinstance(manifest_root_raw, str) else None
+    )
 
     if manifest_root_str:
         # Declared root: use exact relative-path matching for ALL paths (including

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -881,3 +881,32 @@ def test_classify_lesson_manifest_root_prevents_short_key_false_positive(
     # A lesson at root_b with the same stem must not inherit validated_core
     policy_class, _ = _classify_lesson(str(root_b / "sub" / "foo.md"))
     assert policy_class == "unknown"
+
+
+def test_classify_lesson_relative_manifest_root(monkeypatch, tmp_path):
+    """A relative `root:` in the manifest is resolved against CWD so absolute
+    lesson paths under that root are classified correctly.
+
+    Regression for: `Path(abs_lesson).relative_to(Path("lessons"))` raises
+    ValueError because an absolute target can't be made relative to a relative
+    base — causing every valid in-root lesson to fall through to 'unknown'.
+    """
+    _reset_manifest_cache(monkeypatch)
+    lessons_dir = tmp_path / "lessons"
+    (lessons_dir / "patterns").mkdir(parents=True)
+    lesson = lessons_dir / "patterns" / "foo.md"
+    lesson.write_text("# Foo\n")
+
+    manifest_file = tmp_path / "manifest.yaml"
+    # `root: lessons` — a relative path, not an absolute one
+    manifest_file.write_text(
+        "version: 1\nupdated_at: ''\nroot: lessons\n"
+        "validated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # CWD = tmp_path so "lessons" resolves to tmp_path/lessons
+    monkeypatch.chdir(tmp_path)
+
+    policy_class, _ = _classify_lesson(str(lesson))
+    assert policy_class == "validated_core"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -884,12 +884,50 @@ def test_classify_lesson_manifest_root_prevents_short_key_false_positive(
 
 
 def test_classify_lesson_relative_manifest_root(monkeypatch, tmp_path):
-    """A relative `root:` in the manifest is resolved against CWD so absolute
-    lesson paths under that root are classified correctly.
+    """A relative `root:` in the manifest is resolved against the manifest
+    file's directory (not CWD) so absolute lesson paths under that root are
+    classified correctly regardless of where the hook runs.
 
     Regression for: `Path(abs_lesson).relative_to(Path("lessons"))` raises
     ValueError because an absolute target can't be made relative to a relative
     base — causing every valid in-root lesson to fall through to 'unknown'.
+
+    Second regression (this test): resolving relative roots against CWD causes
+    `unknown` classification when the hook runs from a workspace subdirectory
+    rather than the project root, because CWD/lessons ≠ manifest_parent/lessons.
+    The fix anchors to the manifest file's parent, which is CWD-independent.
+    """
+    _reset_manifest_cache(monkeypatch)
+    # lessons_dir is a sibling of the manifest file (both under tmp_path).
+    # A relative `root: lessons` in the manifest resolves to tmp_path/lessons
+    # when anchored to the manifest's parent — correct regardless of CWD.
+    lessons_dir = tmp_path / "lessons"
+    (lessons_dir / "patterns").mkdir(parents=True)
+    lesson = lessons_dir / "patterns" / "foo.md"
+    lesson.write_text("# Foo\n")
+
+    manifest_file = tmp_path / "manifest.yaml"
+    # `root: lessons` — a relative path; anchored to manifest_file.parent = tmp_path
+    manifest_file.write_text(
+        "version: 1\nupdated_at: ''\nroot: lessons\n"
+        "validated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # Deliberately do NOT chdir to tmp_path — the fix must work from any CWD.
+
+    policy_class, _ = _classify_lesson(str(lesson))
+    assert policy_class == "validated_core"
+
+
+def test_classify_lesson_relative_root_cwd_independent(monkeypatch, tmp_path):
+    """Relative `root:` resolves against the manifest file's location, not CWD.
+
+    Regression: when the hook runs from a workspace subdirectory, the old
+    `resolve()` (CWD-anchored) mapped `root: lessons` to
+    `<subdirectory>/lessons`, while lesson paths were rooted at the workspace
+    root. Every in-root lesson was misclassified as `unknown`. This test
+    verifies correct classification even when CWD is a subdirectory.
     """
     _reset_manifest_cache(monkeypatch)
     lessons_dir = tmp_path / "lessons"
@@ -898,15 +936,20 @@ def test_classify_lesson_relative_manifest_root(monkeypatch, tmp_path):
     lesson.write_text("# Foo\n")
 
     manifest_file = tmp_path / "manifest.yaml"
-    # `root: lessons` — a relative path, not an absolute one
     manifest_file.write_text(
         "version: 1\nupdated_at: ''\nroot: lessons\n"
         "validated_core:\n- patterns/foo\n"
         "exempt: []\nholdout_population: []\n"
     )
     monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
-    # CWD = tmp_path so "lessons" resolves to tmp_path/lessons
-    monkeypatch.chdir(tmp_path)
+
+    # Simulate running from a workspace subdirectory — CWD ≠ tmp_path.
+    # Under the old CWD-anchored resolve(), `root: lessons` would map to
+    # `<subdir>/lessons`, causing `relative_to` to raise ValueError and
+    # the lesson to be classified as `unknown`.
+    subdir = tmp_path / "gptme" / "lessons"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
 
     policy_class, _ = _classify_lesson(str(lesson))
     assert policy_class == "validated_core"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -578,32 +578,47 @@ def test_classify_lesson_malformed_category_value(monkeypatch, tmp_path):
     assert policy_class2 == "unknown"
 
 
-def test_classify_lesson_custom_root_parent_key(monkeypatch, tmp_path):
-    """Custom lesson roots without a 'lessons' dir component match via parent/stem."""
+def test_classify_lesson_custom_root_no_root_returns_unknown(monkeypatch, tmp_path):
+    """Without a declared root, a path with no 'lessons' component conservatively
+    returns unknown/holdout rather than attempting suffix enumeration (which would
+    accept unrelated custom-root lessons)."""
     _reset_manifest_cache(monkeypatch)
     p = _make_manifest_file(
         tmp_path, holdout_population=["patterns/persistent-learning"]
     )
     monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
-    # Path has no 'lessons' component — parent dir is 'patterns'
+    # Path has no 'lessons' component and no root is declared — suffix enumeration
+    # is unsafe; must return unknown (manifest exists, lesson simply unclassifiable
+    # without a root anchor).
     policy_class, _ = _classify_lesson("/opt/guidance/patterns/persistent-learning.md")
-    assert policy_class == "holdout"
+    assert policy_class == "unknown"
 
 
-def test_classify_lesson_custom_root_nested_category(monkeypatch, tmp_path):
-    """Nested categories under a custom root match on the full category path,
-    not just the immediate parent directory."""
+def test_classify_lesson_custom_root_with_root_declared(monkeypatch, tmp_path):
+    """When the manifest declares a root, custom paths are classified via exact
+    relative-path lookup, including nested categories."""
     _reset_manifest_cache(monkeypatch)
-    p = _make_manifest_file(
-        tmp_path, holdout_population=["patterns/sub/persistent-learning"]
+    root_dir = tmp_path / "guidance"
+    root_dir.mkdir()
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        f"version: 1\nupdated_at: ''\nroot: {root_dir}\n"
+        "validated_core: []\nexempt: []\nholdout_population:\n"
+        "- patterns/persistent-learning\n"
+        "- patterns/sub/persistent-learning\n"
     )
-    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
-    # Immediate parent alone ('sub') would miss the manifest key; the full
-    # 'patterns/sub/persistent-learning' suffix must be tried too.
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # Flat category
     policy_class, _ = _classify_lesson(
-        "/opt/guidance/patterns/sub/persistent-learning.md"
+        str(root_dir / "patterns" / "persistent-learning.md")
     )
     assert policy_class == "holdout"
+    # Nested category: exact relative path 'patterns/sub/persistent-learning' matches
+    _reset_manifest_cache(monkeypatch)
+    policy_class2, _ = _classify_lesson(
+        str(root_dir / "patterns" / "sub" / "persistent-learning.md")
+    )
+    assert policy_class2 == "holdout"
 
 
 def test_classify_lesson_non_string_category_entries_ignored(monkeypatch, tmp_path):
@@ -630,25 +645,33 @@ def test_classify_lesson_non_string_category_entries_ignored(monkeypatch, tmp_pa
     assert policy_class2 == "unknown"
 
 
-def test_classify_lesson_custom_root_overlapping_suffix(monkeypatch, tmp_path):
-    """Longer (more specific) suffix wins over shorter suffix in a higher-priority class.
+def test_classify_lesson_custom_root_overlapping_suffix_with_root(
+    monkeypatch, tmp_path
+):
+    """With a declared root, exact relative-path lookup is used — 'validated_core'
+    entry 'sub/foo' cannot shadow the intended 'patterns/sub/foo' entry in
+    holdout_population because only one candidate key is produced.
 
-    Regression test for the suffix-priority bug: if 'sub/foo' is in validated_core
-    and the intended 'patterns/sub/foo' is in holdout_population, the full nested key
-    must win, not the shorter one from the earlier class.
+    Regression for the earlier suffix-priority bug: without root anchoring the
+    suffix-enumeration path would check both keys and the shorter one in a
+    higher-priority class could win. With root declared, only the exact relative
+    path is tried, so the correct class is returned.
     """
     _reset_manifest_cache(monkeypatch)
-    p = _make_manifest_file(
-        tmp_path,
-        validated_core=["sub/persistent-learning"],
-        holdout_population=["patterns/sub/persistent-learning"],
+    root_dir = tmp_path / "guidance"
+    root_dir.mkdir()
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        f"version: 1\nupdated_at: ''\nroot: {root_dir}\n"
+        "validated_core:\n- sub/persistent-learning\n"
+        "exempt: []\n"
+        "holdout_population:\n- patterns/sub/persistent-learning\n"
     )
-    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # Exact relative path from root is 'patterns/sub/persistent-learning' → holdout
     policy_class, _ = _classify_lesson(
-        "/opt/guidance/patterns/sub/persistent-learning.md"
+        str(root_dir / "patterns" / "sub" / "persistent-learning.md")
     )
-    # The longer key 'patterns/sub/persistent-learning' is more specific and must win
-    # over the shorter 'sub/persistent-learning' even though validated_core has priority.
     assert policy_class == "holdout"
 
 
@@ -754,6 +777,31 @@ def _make_manifest_file_with_root(tmp_path: Path, root: str, **categories) -> Pa
     p = tmp_path / "manifest.yaml"
     p.write_text("\n".join(lines) + "\n")
     return p
+
+
+def test_classify_lesson_root_check_precedes_lessons_component(monkeypatch, tmp_path):
+    """When manifest declares a root, it takes precedence over the 'lessons' heuristic.
+
+    A path that contains a 'lessons' component but is outside the declared root
+    must NOT match manifest entries. This prevents a lesson from an outside workspace
+    that happens to have a 'lessons/' directory from inheriting entries intended for
+    this root.
+    """
+    _reset_manifest_cache(monkeypatch)
+    root_dir = tmp_path / "root-a"
+    root_dir.mkdir()
+    p = _make_manifest_file_with_root(
+        tmp_path,
+        root=str(root_dir),
+        validated_core=["patterns/foo"],
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    # This path has a 'lessons' component AND shares the suffix 'patterns/foo',
+    # but it is NOT under the declared root — must return unknown, not validated_core.
+    outside_path = tmp_path / "other-workspace" / "lessons" / "patterns" / "foo.md"
+    outside_path.parent.mkdir(parents=True)
+    policy_class, _ = _classify_lesson(str(outside_path))
+    assert policy_class == "unknown"
 
 
 def test_classify_lesson_manifest_root_exact_match(monkeypatch, tmp_path):

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -430,6 +430,7 @@ def _write_manifest(path: Path, content: str) -> None:
 
 def _reset_manifest_cache(monkeypatch) -> None:
     monkeypatch.setattr(_auto_include_mod, "_policy_manifest_cache", None)
+    monkeypatch.setattr(_auto_include_mod, "_policy_manifest_cache_key", None)
 
 
 def test_policy_manifest_path_default(monkeypatch):
@@ -496,7 +497,7 @@ def test_classify_lesson_holdout(monkeypatch, tmp_path):
     )
     monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
     policy_class, version = _classify_lesson(
-        "/home/bob/lessons/patterns/persistent-learning.md"
+        str(tmp_path / "lessons" / "patterns" / "persistent-learning.md")
     )
     assert policy_class == "holdout"
     assert version == 1
@@ -514,7 +515,9 @@ def test_classify_lesson_exempt(monkeypatch, tmp_path):
     _reset_manifest_cache(monkeypatch)
     p = _make_manifest_file(tmp_path, exempt=["safety/critical"])
     monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
-    policy_class, _ = _classify_lesson("/tmp/lessons/safety/critical.md")
+    policy_class, _ = _classify_lesson(
+        str(tmp_path / "lessons" / "safety" / "critical.md")
+    )
     assert policy_class == "exempt"
 
 
@@ -560,8 +563,8 @@ def test_classify_lesson_load_failure_defaults_to_holdout(monkeypatch, tmp_path)
     assert policy_class == "holdout"
 
 
-def test_classify_lesson_malformed_category_value(monkeypatch, tmp_path):
-    """Non-list category values are skipped safely; lesson falls through to holdout/unknown."""
+def test_classify_lesson_malformed_category_value(monkeypatch, tmp_path, caplog):
+    """Non-list category values are skipped safely and emit an operator warning."""
     _reset_manifest_cache(monkeypatch)
     manifest_file = tmp_path / "manifest.yaml"
     # validated_core is a string (malformed), holdout_population is correct
@@ -572,6 +575,7 @@ def test_classify_lesson_malformed_category_value(monkeypatch, tmp_path):
     # The malformed validated_core is skipped; holdout_population matches correctly
     policy_class, _ = _classify_lesson("lessons/patterns/foo.md")
     assert policy_class == "holdout"
+    assert "validated_core has unexpected type (str)" in caplog.text
     # A non-matching lesson gets unknown (manifest loaded successfully)
     _reset_manifest_cache(monkeypatch)
     policy_class2, _ = _classify_lesson("lessons/other/bar.md")
@@ -1008,6 +1012,57 @@ def test_classify_lesson_cached_manifest_cwd_change_stable(monkeypatch, tmp_path
     # lesson is classified as "unknown" instead of "validated_core".
     policy_class, _ = _classify_lesson(str(lesson))
     assert policy_class == "validated_core"
+
+
+def test_policy_manifest_cache_reloads_after_file_change(monkeypatch, tmp_path):
+    """A long-lived process sees policy updates without requiring a restart."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        "version: 1\nvalidated_core: []\nexempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    assert _classify_lesson("lessons/patterns/foo.md")[0] == "unknown"
+
+    manifest_file.write_text(
+        "version: 2\nvalidated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    assert _classify_lesson("lessons/patterns/foo.md") == ("validated_core", 2)
+
+
+def test_classify_lesson_relative_path_uses_declared_root(monkeypatch, tmp_path):
+    """Relative lesson paths share the manifest-root anchor, not process CWD."""
+    _reset_manifest_cache(monkeypatch)
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        "version: 1\nroot: lessons\nvalidated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    assert _classify_lesson("patterns/foo.md")[0] == "validated_core"
+
+
+def test_classify_lesson_absolute_path_without_root_is_workspace_anchored(
+    monkeypatch, tmp_path
+):
+    """No-root absolute paths match only the manifest workspace's lessons tree."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = _make_manifest_file(tmp_path, validated_core=["patterns/important"])
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+
+    local = tmp_path / "lessons" / "patterns" / "important.md"
+    assert _classify_lesson(str(local))[0] == "validated_core"
+    assert (
+        _classify_lesson("/other/workspace/lessons/patterns/important.md")[0]
+        == "unknown"
+    )
 
 
 def test_classify_lesson_absolute_root_with_dotdot_resolves(monkeypatch, tmp_path):

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -412,3 +412,192 @@ def test_dropout_empty_matches_still_logs_when_epsilon_positive(monkeypatch, tmp
     assert records[0]["session_id"] == "sess-empty"
     assert records[0]["epsilon"] == 0.25
     assert records[0]["withheld"] == []  # empty withheld list
+
+
+# --- Lesson policy manifest (Stage 1 shadow logging) ---
+
+import gptme.lessons.auto_include as _auto_include_mod
+from gptme.lessons.auto_include import (
+    _classify_lesson,
+    _get_policy_manifest_path,
+    _load_policy_manifest,
+)
+
+
+def _write_manifest(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+def _reset_manifest_cache(monkeypatch) -> None:
+    monkeypatch.setattr(_auto_include_mod, "_policy_manifest_cache", None)
+
+
+def test_policy_manifest_path_default(monkeypatch):
+    monkeypatch.delenv("LESSON_POLICY_MANIFEST_PATH", raising=False)
+    assert _get_policy_manifest_path() == Path("state/lesson-policy/manifest.yaml")
+
+
+def test_policy_manifest_path_override(monkeypatch, tmp_path):
+    override = str(tmp_path / "custom.yaml")
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", override)
+    assert _get_policy_manifest_path() == Path(override)
+
+
+def test_load_policy_manifest_missing_returns_default(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    monkeypatch.setenv(
+        "LESSON_POLICY_MANIFEST_PATH", str(tmp_path / "nonexistent.yaml")
+    )
+    manifest = _load_policy_manifest()
+    assert manifest["version"] == 1
+    assert manifest["validated_core"] == []
+    assert manifest["holdout_population"] == []
+
+
+def test_load_policy_manifest_valid(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    _write_manifest(
+        manifest_file,
+        """\
+version: 2
+updated_at: '2026-08-01T00:00:00Z'
+validated_core:
+- patterns/persistent-learning
+exempt:
+- safety/critical-rule
+holdout_population:
+- code/some-lesson
+""",
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    manifest = _load_policy_manifest()
+    assert manifest["version"] == 2
+    assert "patterns/persistent-learning" in manifest["validated_core"]
+    assert "safety/critical-rule" in manifest["exempt"]
+    assert "code/some-lesson" in manifest["holdout_population"]
+
+
+def _make_manifest_file(tmp_path: Path, **categories) -> Path:
+    """Write a minimal manifest YAML and return its path."""
+    lines = ["version: 1", "updated_at: ''"]
+    for cat in ("validated_core", "exempt", "holdout_population"):
+        lines.append(f"{cat}:")
+        lines.extend(f"- {item}" for item in categories.get(cat, []))
+    p = tmp_path / "manifest.yaml"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_classify_lesson_holdout(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(
+        tmp_path, holdout_population=["patterns/persistent-learning"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, version = _classify_lesson(
+        "/home/bob/lessons/patterns/persistent-learning.md"
+    )
+    assert policy_class == "holdout"
+    assert version == 1
+
+
+def test_classify_lesson_validated_core(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(tmp_path, validated_core=["code/important"])
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, version = _classify_lesson("lessons/code/important.md")
+    assert policy_class == "validated_core"
+
+
+def test_classify_lesson_exempt(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(tmp_path, exempt=["safety/critical"])
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, _ = _classify_lesson("/tmp/lessons/safety/critical.md")
+    assert policy_class == "exempt"
+
+
+def test_classify_lesson_unknown(monkeypatch, tmp_path):
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(tmp_path)  # empty manifest
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, _ = _classify_lesson("lessons/new/brand-new.md")
+    assert policy_class == "unknown"
+
+
+def test_dropout_log_withheld_has_policy_fields(monkeypatch, tmp_path):
+    """Withheld entries in dropout log carry policy_class and policy_version."""
+    import random as _random
+
+    _reset_manifest_cache(monkeypatch)
+    log_dir = tmp_path / "drop"
+    p = _make_manifest_file(
+        tmp_path, holdout_population=["category/lesson-a", "category/lesson-b"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "1.0")  # withhold all
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-withheld-policy")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+
+    matches = [
+        _MockMatch(_make_lesson("A", "body", "lessons/category/lesson-a.md")),
+        _MockMatch(_make_lesson("B", "body", "lessons/category/lesson-b.md")),
+    ]
+    _random.seed(0)
+    kept = _apply_lesson_dropout(matches)
+    assert kept == []  # all withheld at epsilon=1.0
+
+    records = [
+        json.loads(line)
+        for line in (log_dir / "sess-withheld-policy.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["matched"] == []
+    assert len(rec["withheld"]) == 2
+    for entry in rec["withheld"]:
+        assert entry["policy_class"] == "holdout"
+        assert entry["policy_version"] == 1
+        assert "path" in entry
+        assert "title" in entry
+
+
+def test_dropout_log_matched_has_policy_fields(monkeypatch, tmp_path):
+    """Kept (matched) entries in dropout log carry policy_class and policy_version."""
+    import random as _random
+
+    _reset_manifest_cache(monkeypatch)
+    log_dir = tmp_path / "drop"
+    p = _make_manifest_file(tmp_path, validated_core=["category/kept"])
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "0.25")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-matched-policy")
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+
+    # Patch random to always keep (return > epsilon)
+    monkeypatch.setattr(_random, "random", lambda: 0.9)
+
+    matches = [
+        _MockMatch(_make_lesson("Kept", "body", "lessons/category/kept.md")),
+    ]
+    kept = _apply_lesson_dropout(matches)
+    assert len(kept) == 1  # not withheld
+
+    records = [
+        json.loads(line)
+        for line in (log_dir / "sess-matched-policy.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["withheld"] == []
+    assert len(rec["matched"]) == 1
+    entry = rec["matched"][0]
+    assert entry["policy_class"] == "validated_core"
+    assert entry["policy_version"] == 1
+    assert "path" in entry
+    assert "title" in entry

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -740,3 +740,74 @@ def test_dropout_log_matched_has_policy_fields(monkeypatch, tmp_path):
     assert entry["policy_version"] == 1
     assert "path" in entry
     assert "title" in entry
+
+
+# --- Manifest root-anchored classification (Greptile finding) ---
+
+
+def _make_manifest_file_with_root(tmp_path: Path, root: str, **categories) -> Path:
+    """Write a manifest YAML with a root field and return its path."""
+    lines = ["version: 1", "updated_at: ''", f"root: {root}"]
+    for cat in ("validated_core", "exempt", "holdout_population"):
+        lines.append(f"{cat}:")
+        lines.extend(f"- {item}" for item in categories.get(cat, []))
+    p = tmp_path / "manifest.yaml"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_classify_lesson_manifest_root_exact_match(monkeypatch, tmp_path):
+    """When manifest declares a root, classify via exact relative-path lookup."""
+    _reset_manifest_cache(monkeypatch)
+    root_dir = tmp_path / "custom-lessons"
+    root_dir.mkdir()
+    p = _make_manifest_file_with_root(
+        tmp_path,
+        root=str(root_dir),
+        validated_core=["patterns/foo"],
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, _ = _classify_lesson(str(root_dir / "patterns" / "foo.md"))
+    assert policy_class == "validated_core"
+
+
+def test_classify_lesson_manifest_root_outside_root_returns_unknown(
+    monkeypatch, tmp_path
+):
+    """Path outside the manifest root must not match manifest entries (no suffix false-positive)."""
+    _reset_manifest_cache(monkeypatch)
+    root_a = tmp_path / "root-a"
+    root_a.mkdir()
+    root_b = tmp_path / "root-b"
+    root_b.mkdir()
+    # Manifest is anchored to root_a with key "patterns/foo"
+    p = _make_manifest_file_with_root(
+        tmp_path,
+        root=str(root_a),
+        validated_core=["patterns/foo"],
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    # Lesson at root_b shares the same relative suffix — must NOT inherit the class
+    policy_class, _ = _classify_lesson(str(root_b / "patterns" / "foo.md"))
+    assert policy_class == "unknown"  # manifest exists but path is outside root
+
+
+def test_classify_lesson_manifest_root_prevents_short_key_false_positive(
+    monkeypatch, tmp_path
+):
+    """Short stem-only manifest key must not match a lesson at a different custom root."""
+    _reset_manifest_cache(monkeypatch)
+    root_a = tmp_path / "root-a"
+    root_a.mkdir()
+    root_b = tmp_path / "root-b"
+    root_b.mkdir()
+    # Manifest anchored to root_a with a stem-only key "foo"
+    p = _make_manifest_file_with_root(
+        tmp_path,
+        root=str(root_a),
+        validated_core=["foo"],
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    # A lesson at root_b with the same stem must not inherit validated_core
+    policy_class, _ = _classify_lesson(str(root_b / "sub" / "foo.md"))
+    assert policy_class == "unknown"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -953,3 +953,58 @@ def test_classify_lesson_relative_root_cwd_independent(monkeypatch, tmp_path):
 
     policy_class, _ = _classify_lesson(str(lesson))
     assert policy_class == "validated_core"
+
+
+def test_classify_lesson_cached_manifest_cwd_change_stable(monkeypatch, tmp_path):
+    """CWD change after manifest is cached must not break relative-root anchoring.
+
+    Regression for: when LESSON_POLICY_MANIFEST_PATH is relative and the process
+    CWD changes between manifest-load time and classify time, the old
+    `_get_policy_manifest_path().resolve()` call at classify time resolved against
+    the *new* CWD, producing the wrong anchor directory and misclassifying every
+    in-root lesson as `unknown`.
+
+    The fix: resolve the manifest path once at load time and store it as
+    `_manifest_abs_path` in the cached dict. Classify time reads that stored path.
+
+    Layout: manifest at workspace root (so `root: lessons` anchors to workspace/lessons).
+    The manifest PATH env var is relative — that is the precondition that triggers the bug.
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    lessons_dir = workspace / "lessons"
+    (lessons_dir / "patterns").mkdir(parents=True)
+    lesson = lessons_dir / "patterns" / "foo.md"
+    lesson.write_text("# Foo\n")
+
+    # Manifest at workspace root; `root: lessons` resolves to workspace/lessons
+    # when anchored to manifest_file.parent = workspace.
+    manifest_file = workspace / "manifest.yaml"
+    manifest_file.write_text(
+        "version: 1\nupdated_at: ''\nroot: lessons\n"
+        "validated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+
+    # Use a RELATIVE manifest path — the bug only triggers when the path is relative.
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", "manifest.yaml")
+    monkeypatch.chdir(
+        workspace
+    )  # CWD = workspace: "manifest.yaml" resolves correctly here
+
+    # Load and cache the manifest while CWD = workspace.
+    _load_policy_manifest()
+
+    # Simulate CWD change (e.g. hook is called later from a different directory).
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+
+    # Without the fix: `_get_policy_manifest_path().resolve()` now resolves to
+    # `<other_dir>/manifest.yaml` (wrong base), so
+    # `manifest_root = <other_dir>/lessons` and `relative_to` raises ValueError →
+    # lesson is classified as "unknown" instead of "validated_core".
+    policy_class, _ = _classify_lesson(str(lesson))
+    assert policy_class == "validated_core"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -590,6 +590,35 @@ def test_classify_lesson_custom_root_parent_key(monkeypatch, tmp_path):
     assert policy_class == "holdout"
 
 
+def test_classify_lesson_custom_root_nested_category(monkeypatch, tmp_path):
+    """Nested categories under a custom root match on the full category path,
+    not just the immediate parent directory."""
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(
+        tmp_path, holdout_population=["patterns/sub/persistent-learning"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    # Immediate parent alone ('sub') would miss the manifest key; the full
+    # 'patterns/sub/persistent-learning' suffix must be tried too.
+    policy_class, _ = _classify_lesson(
+        "/opt/guidance/patterns/sub/persistent-learning.md"
+    )
+    assert policy_class == "holdout"
+
+
+def test_load_policy_manifest_empty_mapping_is_not_missing(monkeypatch, tmp_path):
+    """A valid-but-empty manifest ({}) exists, so lessons should classify as
+    'unknown', not fall back to the missing-manifest 'holdout' default."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text("{}\n")
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    manifest = _load_policy_manifest()
+    assert manifest.get("_manifest_missing") is not True
+    policy_class, _ = _classify_lesson("lessons/any/lesson.md")
+    assert policy_class == "unknown"
+
+
 def test_dropout_log_withheld_has_policy_fields(monkeypatch, tmp_path):
     """Withheld entries in dropout log carry policy_class and policy_version."""
     import random as _random

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -1,6 +1,7 @@
 """Tests for auto-include lesson system with token budget."""
 
 import json
+import os
 from pathlib import Path
 
 from gptme.lessons.auto_include import (
@@ -1029,6 +1030,54 @@ def test_policy_manifest_cache_reloads_after_file_change(monkeypatch, tmp_path):
         "exempt: []\nholdout_population: []\n"
     )
     assert _classify_lesson("lessons/patterns/foo.md") == ("validated_core", 2)
+
+
+def test_policy_manifest_cache_reload_survives_cwd_change(monkeypatch, tmp_path):
+    """A relative manifest path keeps its load-time anchor during reload."""
+    _reset_manifest_cache(monkeypatch)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manifest_file = workspace / "manifest.yaml"
+    manifest_file.write_text(
+        "version: 1\nvalidated_core: []\nexempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", "manifest.yaml")
+    monkeypatch.chdir(workspace)
+    assert _classify_lesson("lessons/patterns/foo.md")[0] == "unknown"
+
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+    manifest_file.write_text(
+        "version: 2\nvalidated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+
+    assert _classify_lesson("lessons/patterns/foo.md") == ("validated_core", 2)
+
+
+def test_policy_manifest_cache_reloads_same_size_preserved_mtime(monkeypatch, tmp_path):
+    """Metadata-preserving rewrites still invalidate the process cache."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    original = (
+        "version: 1\nvalidated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    replacement = original.replace("patterns/foo", "patterns/bar")
+    assert len(original) == len(replacement)
+    manifest_file.write_text(original)
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    assert _classify_lesson("lessons/patterns/foo.md")[0] == "validated_core"
+
+    original_stat = manifest_file.stat()
+    manifest_file.write_text(replacement)
+    os.utime(
+        manifest_file,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+
+    assert _classify_lesson("lessons/patterns/bar.md")[0] == "validated_core"
 
 
 def test_classify_lesson_relative_path_uses_declared_root(monkeypatch, tmp_path):

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -1038,3 +1038,114 @@ def test_classify_lesson_absolute_root_with_dotdot_resolves(monkeypatch, tmp_pat
 
     policy_class, _ = _classify_lesson(str(lesson))
     assert policy_class == "validated_core"
+
+
+def test_classify_lesson_symlinked_path_component_matches_root(monkeypatch, tmp_path):
+    """A symlinked component in an *absolute* lesson path must still match the root.
+
+    `manifest_root` is always `.resolve()`d, but an absolute lesson path is used
+    as-is. When the lesson is reached through a symlink (a symlinked workspace
+    root, `/tmp` on macOS, `$HOME` behind a symlink) the two sides spell the same
+    file differently, `relative_to()` raises ValueError, and every in-root lesson
+    is silently mislabelled "unknown" in the shadow log.
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    real = tmp_path / "real"
+    (real / "lessons" / "patterns").mkdir(parents=True)
+    (real / "lessons" / "patterns" / "foo.md").write_text("# Foo\n")
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+
+    manifest_file = _make_manifest_file_with_root(
+        real, "lessons", validated_core=["patterns/foo"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+
+    # Sanity: the real path classifies correctly.
+    assert _classify_lesson(str(real / "lessons" / "patterns" / "foo.md"))[0] == (
+        "validated_core"
+    )
+
+    # The same file reached via the symlink must classify identically.
+    _reset_manifest_cache(monkeypatch)
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    assert _classify_lesson(str(link / "lessons" / "patterns" / "foo.md"))[0] == (
+        "validated_core"
+    )
+
+
+def test_classify_lesson_symlinked_manifest_and_lesson_matches_root(
+    monkeypatch, tmp_path
+):
+    """Reaching *both* manifest and lesson through the same symlink must classify.
+
+    This is the realistic deployment shape (whole workspace behind a symlink):
+    the manifest path is resolved at load time while the lesson path is not, so
+    the asymmetry bites even when caller paths are internally consistent.
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    real = tmp_path / "real"
+    (real / "lessons" / "patterns").mkdir(parents=True)
+    (real / "lessons" / "patterns" / "foo.md").write_text("# Foo\n")
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+
+    _make_manifest_file_with_root(real, "lessons", validated_core=["patterns/foo"])
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(link / "manifest.yaml"))
+
+    assert _classify_lesson(str(link / "lessons" / "patterns" / "foo.md"))[0] == (
+        "validated_core"
+    )
+
+
+def test_classify_lesson_absolute_lesson_path_with_dotdot_matches_root(
+    monkeypatch, tmp_path
+):
+    """An absolute lesson path containing `..` must normalize before comparison.
+
+    The root side is resolved, the lesson side was not — so `..` in the lesson
+    path produced a spurious "unknown".
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    lessons_dir = tmp_path / "lessons"
+    (lessons_dir / "patterns").mkdir(parents=True)
+    (lessons_dir / "patterns" / "foo.md").write_text("# Foo\n")
+    (tmp_path / "other").mkdir()
+
+    manifest_file = _make_manifest_file_with_root(
+        tmp_path, "lessons", validated_core=["patterns/foo"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+
+    dotdot_lesson = str(tmp_path / "other" / ".." / "lessons" / "patterns" / "foo.md")
+    assert _classify_lesson(dotdot_lesson)[0] == "validated_core"
+
+
+def test_classify_lesson_symlinked_lesson_file_outside_root_still_matches(
+    monkeypatch, tmp_path
+):
+    """A lesson file that is a symlink *out of* the root keeps its discovered class.
+
+    LessonIndex indexes symlinked lesson files under the directory they were
+    discovered in (deduping by realpath), so classification must use the
+    discovery path, not the symlink target. Guards against "just resolve()
+    everything", which would send such lessons to "unknown".
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    lessons_dir = tmp_path / "lessons" / "patterns"
+    lessons_dir.mkdir(parents=True)
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "foo.md").write_text("# Foo\n")
+    (lessons_dir / "foo.md").symlink_to(external / "foo.md")
+
+    manifest_file = _make_manifest_file_with_root(
+        tmp_path, "lessons", validated_core=["patterns/foo"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+
+    assert _classify_lesson(str(lessons_dir / "foo.md"))[0] == "validated_core"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -1008,3 +1008,33 @@ def test_classify_lesson_cached_manifest_cwd_change_stable(monkeypatch, tmp_path
     # lesson is classified as "unknown" instead of "validated_core".
     policy_class, _ = _classify_lesson(str(lesson))
     assert policy_class == "validated_core"
+
+
+def test_classify_lesson_absolute_root_with_dotdot_resolves(monkeypatch, tmp_path):
+    """Absolute root containing `..` must be resolved before relative_to comparison.
+
+    Without .resolve(), Path('/opt/../lessons').relative_to('/opt/lessons') raises
+    ValueError (lexical comparison, no normalization), misclassifying valid lessons.
+    """
+    _reset_manifest_cache(monkeypatch)
+
+    lessons_dir = tmp_path / "lessons"
+    (lessons_dir / "patterns").mkdir(parents=True)
+    lesson = lessons_dir / "patterns" / "foo.md"
+    lesson.write_text("# Foo\n")
+
+    # Construct an absolute root with a `..` component that resolves to lessons_dir.
+    other = tmp_path / "other"
+    other.mkdir()
+    dotdot_root = str(other / ".." / "lessons")  # absolute but not normalized
+
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(
+        f"version: 1\nupdated_at: ''\nroot: {dotdot_root}\n"
+        "validated_core:\n- patterns/foo\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+
+    policy_class, _ = _classify_lesson(str(lesson))
+    assert policy_class == "validated_core"

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -779,6 +779,28 @@ def _make_manifest_file_with_root(tmp_path: Path, root: str, **categories) -> Pa
     return p
 
 
+def test_classify_lesson_malformed_root_is_ignored(monkeypatch, tmp_path):
+    """A non-string `root` value in the manifest (e.g. integer, list) must not raise
+    TypeError — it should be treated as if no root was declared, falling through to
+    the lessons-component heuristic or conservative unknown return."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    # root is an integer — invalid but legal YAML
+    manifest_file.write_text(
+        "version: 1\nupdated_at: ''\nroot: 42\n"
+        "validated_core:\n- category/lesson\n"
+        "exempt: []\nholdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # Should not raise; malformed root is skipped → falls through to lessons heuristic
+    policy_class, _ = _classify_lesson("lessons/category/lesson.md")
+    assert policy_class == "validated_core"
+    # Path with no lessons component → conservative unknown (no suffix enumeration)
+    _reset_manifest_cache(monkeypatch)
+    policy_class2, _ = _classify_lesson("/opt/custom/category/lesson.md")
+    assert policy_class2 == "unknown"
+
+
 def test_classify_lesson_root_check_precedes_lessons_component(monkeypatch, tmp_path):
     """When manifest declares a root, it takes precedence over the 'lessons' heuristic.
 

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -537,7 +537,7 @@ def test_classify_lesson_no_manifest_defaults_to_holdout(monkeypatch, tmp_path):
 
 
 def test_load_policy_manifest_invalid_yaml_structure(monkeypatch, tmp_path):
-    """Non-dict manifest YAML falls back to defaults without raising."""
+    """Non-dict manifest YAML falls back to missing-default (holdout, not unknown)."""
     _reset_manifest_cache(monkeypatch)
     manifest_file = tmp_path / "manifest.yaml"
     manifest_file.write_text("- just\n- a\n- list\n")
@@ -546,6 +546,36 @@ def test_load_policy_manifest_invalid_yaml_structure(monkeypatch, tmp_path):
     assert manifest["version"] == 1
     assert manifest["validated_core"] == []
     assert manifest["holdout_population"] == []
+    # Load failures should also default to holdout (not unknown)
+    assert manifest.get("_manifest_missing") is True
+
+
+def test_classify_lesson_load_failure_defaults_to_holdout(monkeypatch, tmp_path):
+    """When manifest exists but can't be parsed, lessons default to holdout."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text("- just\n- a\n- list\n")  # non-dict YAML
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    policy_class, _ = _classify_lesson("lessons/any/lesson.md")
+    assert policy_class == "holdout"
+
+
+def test_classify_lesson_malformed_category_value(monkeypatch, tmp_path):
+    """Non-list category values are skipped safely; lesson falls through to holdout/unknown."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    # validated_core is a string (malformed), holdout_population is correct
+    manifest_file.write_text(
+        "version: 1\nupdated_at: ''\nvalidated_core: 'not-a-list'\nexempt: []\nholdout_population:\n- patterns/foo\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # The malformed validated_core is skipped; holdout_population matches correctly
+    policy_class, _ = _classify_lesson("lessons/patterns/foo.md")
+    assert policy_class == "holdout"
+    # A non-matching lesson gets unknown (manifest loaded successfully)
+    _reset_manifest_cache(monkeypatch)
+    policy_class2, _ = _classify_lesson("lessons/other/bar.md")
+    assert policy_class2 == "unknown"
 
 
 def test_classify_lesson_custom_root_parent_key(monkeypatch, tmp_path):

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -606,6 +606,30 @@ def test_classify_lesson_custom_root_nested_category(monkeypatch, tmp_path):
     assert policy_class == "holdout"
 
 
+def test_classify_lesson_non_string_category_entries_ignored(monkeypatch, tmp_path):
+    """Non-string category list elements (YAML mappings, nested lists) are skipped
+    without raising TypeError, so dropout records are not suppressed."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    # A YAML list that mixes strings with a mapping entry (malformed but valid YAML)
+    manifest_file.write_text(
+        "version: 1\n"
+        "updated_at: ''\n"
+        "validated_core:\n"
+        "- code/important\n"
+        "- {nested: mapping}\n"  # non-string element — must not raise
+        "exempt: []\n"
+        "holdout_population: []\n"
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    # The valid string entry must still match; the mapping entry must be silently skipped
+    policy_class, _ = _classify_lesson("lessons/code/important.md")
+    assert policy_class == "validated_core"
+    # A lesson not in any category resolves to unknown (no TypeError raised)
+    policy_class2, _ = _classify_lesson("lessons/other/foo.md")
+    assert policy_class2 == "unknown"
+
+
 def test_classify_lesson_custom_root_overlapping_suffix(monkeypatch, tmp_path):
     """Longer (more specific) suffix wins over shorter suffix in a higher-priority class.
 

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -606,6 +606,28 @@ def test_classify_lesson_custom_root_nested_category(monkeypatch, tmp_path):
     assert policy_class == "holdout"
 
 
+def test_classify_lesson_custom_root_overlapping_suffix(monkeypatch, tmp_path):
+    """Longer (more specific) suffix wins over shorter suffix in a higher-priority class.
+
+    Regression test for the suffix-priority bug: if 'sub/foo' is in validated_core
+    and the intended 'patterns/sub/foo' is in holdout_population, the full nested key
+    must win, not the shorter one from the earlier class.
+    """
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(
+        tmp_path,
+        validated_core=["sub/persistent-learning"],
+        holdout_population=["patterns/sub/persistent-learning"],
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    policy_class, _ = _classify_lesson(
+        "/opt/guidance/patterns/sub/persistent-learning.md"
+    )
+    # The longer key 'patterns/sub/persistent-learning' is more specific and must win
+    # over the shorter 'sub/persistent-learning' even though validated_core has priority.
+    assert policy_class == "holdout"
+
+
 def test_load_policy_manifest_empty_mapping_is_not_missing(monkeypatch, tmp_path):
     """A valid-but-empty manifest ({}) exists, so lessons should classify as
     'unknown', not fall back to the missing-manifest 'holdout' default."""

--- a/tests/test_lessons_auto_include.py
+++ b/tests/test_lessons_auto_include.py
@@ -520,10 +520,44 @@ def test_classify_lesson_exempt(monkeypatch, tmp_path):
 
 def test_classify_lesson_unknown(monkeypatch, tmp_path):
     _reset_manifest_cache(monkeypatch)
-    p = _make_manifest_file(tmp_path)  # empty manifest
+    p = _make_manifest_file(tmp_path)  # empty manifest (manifest EXISTS, lesson absent)
     monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
     policy_class, _ = _classify_lesson("lessons/new/brand-new.md")
     assert policy_class == "unknown"
+
+
+def test_classify_lesson_no_manifest_defaults_to_holdout(monkeypatch, tmp_path):
+    """No manifest file → default evaluation population is holdout, not unknown."""
+    _reset_manifest_cache(monkeypatch)
+    monkeypatch.setenv(
+        "LESSON_POLICY_MANIFEST_PATH", str(tmp_path / "nonexistent.yaml")
+    )
+    policy_class, _ = _classify_lesson("lessons/any/lesson.md")
+    assert policy_class == "holdout"
+
+
+def test_load_policy_manifest_invalid_yaml_structure(monkeypatch, tmp_path):
+    """Non-dict manifest YAML falls back to defaults without raising."""
+    _reset_manifest_cache(monkeypatch)
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text("- just\n- a\n- list\n")
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(manifest_file))
+    manifest = _load_policy_manifest()
+    assert manifest["version"] == 1
+    assert manifest["validated_core"] == []
+    assert manifest["holdout_population"] == []
+
+
+def test_classify_lesson_custom_root_parent_key(monkeypatch, tmp_path):
+    """Custom lesson roots without a 'lessons' dir component match via parent/stem."""
+    _reset_manifest_cache(monkeypatch)
+    p = _make_manifest_file(
+        tmp_path, holdout_population=["patterns/persistent-learning"]
+    )
+    monkeypatch.setenv("LESSON_POLICY_MANIFEST_PATH", str(p))
+    # Path has no 'lessons' component — parent dir is 'patterns'
+    policy_class, _ = _classify_lesson("/opt/guidance/patterns/persistent-learning.md")
+    assert policy_class == "holdout"
 
 
 def test_dropout_log_withheld_has_policy_fields(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Adds manifest-based lesson classification to gptme's dropout logging system (mirrors what the CC hook already does)
- Every dropout log record now includes `policy_class` and `policy_version` for both withheld and kept lessons
- Null-safe: YAML keys with no items parse as `None`, not `[]` — fixed with `(manifest.get(key) or [])`

## New functions in `auto_include.py`

- `_get_policy_manifest_path()` — `LESSON_POLICY_MANIFEST_PATH` env override, defaults to `state/lesson-policy/manifest.yaml`
- `_load_policy_manifest()` — loads+caches YAML manifest with safe defaults on failure (never breaks lesson injection)
- `_classify_lesson(path)` — maps lesson path to one of `validated_core / exempt / holdout / unknown`

`_log_dropout()` signature updated: now takes `kept` (matched + not withheld) alongside `withheld`, enriching both with `policy_class` and `policy_version` fields.

## Tests

11 new tests covering:
- Manifest path resolution (default + env override)
- Manifest load (missing file → safe defaults, valid YAML → correct parse)
- Classification (holdout, validated_core, exempt, unknown, YAML null-safe)
- Enriched dropout log records for both withheld and matched lessons

## Test plan

- [x] `34/34` tests pass in isolated env
- [x] All pre-commit hooks pass (ruff, mypy, formatters)
- [ ] CI green