### PR TITLE
test: thread-leak detector + dict-race thread dump (residue of #3257)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import logging
 import os
 import queue
 import socket
+import sys
 import tempfile
 import threading
 import time
@@ -14,6 +15,13 @@ from contextlib import contextmanager
 
 import pytest
 import requests
+from thread_leak import (
+    diff_threads,
+    format_leaks,
+    format_thread_stacks,
+    is_dict_iteration_race,
+    snapshot_threads,
+)
 
 import gptme.init as _gptme_init
 from gptme.config import get_config, set_config
@@ -125,6 +133,28 @@ def pytest_configure(config):
     os.environ["GPTME_CHECK"] = "false"
     # Disable chat history context during tests for predictable prompts
     os.environ["GPTME_CHAT_HISTORY"] = "false"
+
+
+def pytest_exception_interact(node, call, report):
+    """Dump every live thread's stack when the dict-iteration race fires.
+
+    CI only ever showed a single truncated frame for this failure
+    (``contextlib.py:135`` in ``_GeneratorContextManager.__enter__``), naming
+    neither the generator that was iterating nor the thread that mutated the
+    dict underneath it. Without the thread stacks the class is undiagnosable,
+    which is why five instance-level fixes chased the crash site instead of the
+    leaker. Print them at the moment of failure.
+    """
+    if not is_dict_iteration_race(
+        getattr(call, "excinfo", None) and call.excinfo.value
+    ):
+        return
+    print(
+        f"\n=== dict-iteration race in {node.nodeid} ({report.when}) ===\n"
+        f"{format_thread_stacks()}\n"
+        "=== end thread dump ===",
+        file=sys.stderr,
+    )
 
 
 @pytest.hookimpl(wrapper=True)
@@ -254,6 +284,57 @@ def download_model():
 def auth_headers():
     """Provide authentication headers for HTTP requests to test server."""
     return {"Authorization": "Bearer test-token-for-server-thread"}
+
+
+#: nodeid -> leaked thread names, collected across the session for the summary.
+_thread_leaks: dict[str, list[str]] = {}
+
+
+@pytest.fixture(autouse=True)
+def detect_leaked_threads(request):
+    """Name any thread a test leaves running past teardown.
+
+    A leaked thread that later lazy-imports mutates ``sys.modules`` while an
+    unrelated test's main thread iterates it, producing ``RuntimeError:
+    dictionary changed size during iteration`` in a file that has no threads of
+    its own. #3257 fixed this for registered *subagent* threads; gptme starts
+    threads from ~27 other sites (server, ACP, computer transport, shell, hooks,
+    oauth, sound, tokens), so the class needs a generic detector.
+
+    Defined first among the autouse fixtures so its teardown runs *last* —
+    after ``cleanup_subagents_after`` has had its chance to join.
+
+    Reports only by default. Set ``GPTME_STRICT_THREAD_LEAKS=1`` to fail the
+    offending test instead, which is how a specific leaker gets pinned down
+    once the summary points at it.
+    """
+    before = snapshot_threads()
+    yield
+    leaks = diff_threads(before)
+    if not leaks:
+        return
+    nodeid = request.node.nodeid
+    _thread_leaks[nodeid] = [leak.name for leak in leaks]
+    report = format_leaks(nodeid, leaks)
+    logger.warning("%s", report)
+    if os.environ.get("GPTME_STRICT_THREAD_LEAKS") == "1":
+        pytest.fail(report, pytrace=False)
+
+
+def pytest_terminal_summary(terminalreporter):
+    """List the tests that leaked threads, worst offenders first."""
+    if not _thread_leaks:
+        return
+    terminalreporter.section("thread leaks")
+    ranked = sorted(_thread_leaks.items(), key=lambda kv: -len(kv[1]))
+    for nodeid, names in ranked[:20]:
+        terminalreporter.write_line(f"{len(names):3d}  {nodeid}  {sorted(set(names))}")
+    if len(ranked) > 20:
+        terminalreporter.write_line(f"... and {len(ranked) - 20} more")
+    terminalreporter.write_line(
+        "Leaked threads can race main-thread dict iteration in unrelated files. "
+        "Re-run with GPTME_STRICT_THREAD_LEAKS=1 to fail on leak."
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,7 +318,9 @@ def detect_leaked_threads(request):
     report = format_leaks(nodeid, leaks)
     logger.warning("%s", report)
     if os.environ.get("GPTME_STRICT_THREAD_LEAKS") == "1":
-        pytest.fail(report, pytrace=False)
+        hard_leaks = [lk for lk in leaks if not lk.soft]
+        if hard_leaks:
+            pytest.fail(format_leaks(nodeid, hard_leaks), pytrace=False)
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/tests/test_thread_leak.py
+++ b/tests/test_thread_leak.py
@@ -28,13 +28,16 @@ def _frame():
 
 
 def test_snapshot_includes_main_thread():
-    assert threading.current_thread().ident in snapshot_threads()
+    snap = snapshot_threads()
+    main_ident = threading.current_thread().ident
+    assert any(ident == main_ident for ident, _ in snap)
 
 
 def test_diff_reports_only_new_live_threads():
-    before = {1}
+    old = FakeThread("old", 1)
+    before = frozenset({(1, id(old))})
     threads = [
-        FakeThread("old", 1),
+        old,
         FakeThread("new-leaker", 2),
         FakeThread("finished", 3, alive=False),
     ]
@@ -45,28 +48,49 @@ def test_diff_reports_only_new_live_threads():
 
 
 def test_diff_ignores_known_long_lived_threads():
+    """MainThread and pytest watchdog are suppressed unconditionally."""
     threads = [
         FakeThread("MainThread", 1, daemon=False),
         FakeThread("pytest-timeout thread", 2),
+    ]
+    assert diff_threads(frozenset(), threads=threads, frames={}) == []
+
+
+def test_diff_reports_executor_threads_as_leaks():
+    """Per-test executor workers that outlive teardown are reported, not suppressed."""
+    threads = [
         FakeThread("ThreadPoolExecutor-0_1", 3),
         FakeThread("asyncio_0", 4),
     ]
-    assert diff_threads(set(), threads=threads, frames={}) == []
+    leaks = diff_threads(frozenset(), threads=threads, frames={})
+    leak_names = {leak.name for leak in leaks}
+    assert "ThreadPoolExecutor-0_1" in leak_names
+    assert "asyncio_0" in leak_names
+
+
+def test_diff_catches_ident_reuse():
+    """A replacement thread that reuses a prior thread's ident is still reported."""
+    dead = FakeThread("dead-thread", 1, alive=False)
+    replacement = FakeThread("replacement-thread", 1)  # same ident, different object
+    # before-snapshot captured the dead thread; replacement was started during the test
+    before = frozenset({(1, id(dead))})
+    leaks = diff_threads(before, threads=[replacement], frames={})
+    assert [leak.name for leak in leaks] == ["replacement-thread"]
 
 
 def test_diff_captures_stack_when_frame_available():
     threads = [FakeThread("leaker", 7)]
-    leaks = diff_threads(set(), threads=threads, frames={7: _frame()})
+    leaks = diff_threads(frozenset(), threads=threads, frames={7: _frame()})
     assert "test_diff_captures_stack_when_frame_available" in leaks[0].stack
 
 
 def test_diff_tolerates_missing_frame():
-    leaks = diff_threads(set(), threads=[FakeThread("leaker", 7)], frames={})
+    leaks = diff_threads(frozenset(), threads=[FakeThread("leaker", 7)], frames={})
     assert leaks[0].stack == ""
 
 
 def test_format_leaks_names_test_and_threads():
-    leaks = diff_threads(set(), threads=[FakeThread("acp-close", 9)], frames={})
+    leaks = diff_threads(frozenset(), threads=[FakeThread("acp-close", 9)], frames={})
     out = format_leaks("tests/test_x.py::test_y", leaks)
     assert "tests/test_x.py::test_y" in out
     assert "acp-close" in out

--- a/tests/test_thread_leak.py
+++ b/tests/test_thread_leak.py
@@ -1,0 +1,106 @@
+"""Tests for the thread-leak detector helpers (tests/thread_leak.py)."""
+
+import sys
+import threading
+
+from thread_leak import (
+    diff_threads,
+    format_leaks,
+    format_thread_stacks,
+    is_dict_iteration_race,
+    snapshot_threads,
+)
+
+
+class FakeThread:
+    def __init__(self, name, ident, daemon=True, alive=True):
+        self.name = name
+        self.ident = ident
+        self.daemon = daemon
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def _frame():
+    return sys._getframe()
+
+
+def test_snapshot_includes_main_thread():
+    assert threading.current_thread().ident in snapshot_threads()
+
+
+def test_diff_reports_only_new_live_threads():
+    before = {1}
+    threads = [
+        FakeThread("old", 1),
+        FakeThread("new-leaker", 2),
+        FakeThread("finished", 3, alive=False),
+    ]
+    leaks = diff_threads(before, threads=threads, frames={})
+    assert [leak.name for leak in leaks] == ["new-leaker"]
+    assert leaks[0].ident == 2
+    assert leaks[0].daemon is True
+
+
+def test_diff_ignores_known_long_lived_threads():
+    threads = [
+        FakeThread("MainThread", 1, daemon=False),
+        FakeThread("pytest-timeout thread", 2),
+        FakeThread("ThreadPoolExecutor-0_1", 3),
+        FakeThread("asyncio_0", 4),
+    ]
+    assert diff_threads(set(), threads=threads, frames={}) == []
+
+
+def test_diff_captures_stack_when_frame_available():
+    threads = [FakeThread("leaker", 7)]
+    leaks = diff_threads(set(), threads=threads, frames={7: _frame()})
+    assert "test_diff_captures_stack_when_frame_available" in leaks[0].stack
+
+
+def test_diff_tolerates_missing_frame():
+    leaks = diff_threads(set(), threads=[FakeThread("leaker", 7)], frames={})
+    assert leaks[0].stack == ""
+
+
+def test_format_leaks_names_test_and_threads():
+    leaks = diff_threads(set(), threads=[FakeThread("acp-close", 9)], frames={})
+    out = format_leaks("tests/test_x.py::test_y", leaks)
+    assert "tests/test_x.py::test_y" in out
+    assert "acp-close" in out
+    assert "ident=9" in out
+
+
+def test_is_dict_iteration_race():
+    assert is_dict_iteration_race(
+        RuntimeError("dictionary changed size during iteration")
+    )
+    assert not is_dict_iteration_race(RuntimeError("something else"))
+    assert not is_dict_iteration_race(ValueError("dictionary changed size"))
+    assert not is_dict_iteration_race(None)
+
+
+def test_format_thread_stacks_lists_threads_and_frames():
+    threads = [FakeThread("worker-1", 11), FakeThread("worker-2", 12)]
+    out = format_thread_stacks(threads=threads, frames={11: _frame()})
+    assert "LIVE THREADS (2):" in out
+    assert "worker-1" in out and "worker-2" in out
+    assert "<no frame captured>" in out  # worker-2 has none
+    assert "test_format_thread_stacks_lists_threads_and_frames" in out
+
+
+def test_detector_sees_a_real_leaked_thread():
+    """End-to-end: a thread started after the snapshot is reported."""
+    stop = threading.Event()
+    before = snapshot_threads()
+    t = threading.Thread(target=stop.wait, name="deliberate-leaker", daemon=True)
+    t.start()
+    try:
+        names = [leak.name for leak in diff_threads(before)]
+        assert "deliberate-leaker" in names
+    finally:
+        stop.set()
+        t.join(timeout=5)
+    assert "deliberate-leaker" not in [leak.name for leak in diff_threads(before)]

--- a/tests/test_thread_leak.py
+++ b/tests/test_thread_leak.py
@@ -56,8 +56,8 @@ def test_diff_ignores_known_long_lived_threads():
     assert diff_threads(frozenset(), threads=threads, frames={}) == []
 
 
-def test_diff_reports_executor_threads_as_leaks():
-    """Per-test executor workers that outlive teardown are reported, not suppressed."""
+def test_diff_reports_executor_threads_as_soft_leaks():
+    """Executor workers appear in leak reports but are marked soft (no strict-mode fail)."""
     threads = [
         FakeThread("ThreadPoolExecutor-0_1", 3),
         FakeThread("asyncio_0", 4),
@@ -66,6 +66,10 @@ def test_diff_reports_executor_threads_as_leaks():
     leak_names = {leak.name for leak in leaks}
     assert "ThreadPoolExecutor-0_1" in leak_names
     assert "asyncio_0" in leak_names
+    # All executor leaks are soft — they never cause GPTME_STRICT_THREAD_LEAKS=1 failures.
+    assert all(lk.soft for lk in leaks), (
+        "executor leaks should be soft-warned, not hard-failed"
+    )
 
 
 def test_diff_catches_ident_reuse():

--- a/tests/thread_leak.py
+++ b/tests/thread_leak.py
@@ -1,0 +1,177 @@
+"""Thread-leak detection and dict-race diagnostics for the test suite.
+
+Background
+----------
+`RuntimeError: dictionary changed size during iteration` has surfaced at pytest
+setup/teardown across many unrelated test files.  The mechanism is always the
+same: a background thread outlives the test that started it and later mutates a
+process-global dict (usually ``sys.modules`` via a lazy import) while the main
+thread iterates it.
+
+#3257 fixed this for *registered subagent* threads.  gptme starts threads from
+~27 other sites (server, ACP, computer transport, shell, hooks, oauth, sound,
+tokens); any of those can reproduce the same race.  This module provides the
+class-level tools:
+
+* :func:`diff_threads` — name the threads a test left running.
+* :func:`format_thread_stacks` — dump every live thread's stack, so the *next*
+  CI occurrence names the mutating thread instead of showing a single truncated
+  ``contextlib.__enter__`` frame.
+"""
+
+import sys
+import threading
+import traceback
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import FrameType
+from typing import Protocol
+
+__all__ = [
+    "DICT_RACE_MESSAGE",
+    "LeakedThread",
+    "diff_threads",
+    "format_leaks",
+    "format_thread_stacks",
+    "is_dict_iteration_race",
+    "snapshot_threads",
+]
+
+#: The exact CPython message for the race this module exists to diagnose.
+DICT_RACE_MESSAGE = "dictionary changed size during iteration"
+
+#: Threads that legitimately live for the whole worker process.  Leaks matching
+#: these names are noise, not evidence.
+_IGNORED_THREAD_NAMES = frozenset(
+    {
+        "MainThread",
+        # pytest-timeout's per-item watchdog
+        "pytest-timeout thread",
+    }
+)
+
+#: Prefixes for pooled/shared executors that are intentionally reused across
+#: tests rather than torn down per test.
+_IGNORED_THREAD_PREFIXES = (
+    "ThreadPoolExecutor-",
+    "asyncio_",
+)
+
+
+class _ThreadLike(Protocol):
+    """Structural view of the parts of ``threading.Thread`` we inspect."""
+
+    name: str
+    ident: int | None
+    daemon: bool
+
+    def is_alive(self) -> bool: ...
+
+
+@dataclass
+class LeakedThread:
+    """A thread that was started during a test and outlived its teardown."""
+
+    name: str
+    ident: int | None
+    daemon: bool
+    stack: str = field(default="", repr=False)
+
+
+def _is_ignored(name: str) -> bool:
+    if name in _IGNORED_THREAD_NAMES:
+        return True
+    return name.startswith(_IGNORED_THREAD_PREFIXES)
+
+
+def snapshot_threads() -> set[int]:
+    """Return the idents of all threads currently alive."""
+    return {t.ident for t in threading.enumerate() if t.ident is not None}
+
+
+def diff_threads(
+    before: set[int],
+    *,
+    threads: Sequence[_ThreadLike] | None = None,
+    frames: Mapping[int, FrameType] | None = None,
+) -> list[LeakedThread]:
+    """Return threads alive now that were not alive in ``before``.
+
+    ``threads``/``frames`` are injectable for testing; by default the live
+    interpreter state is used.
+    """
+    live = threading.enumerate() if threads is None else threads
+    if frames is None:
+        frames = dict(sys._current_frames())
+
+    leaked: list[LeakedThread] = []
+    for thread in live:
+        ident = thread.ident
+        if ident is None or ident in before:
+            continue
+        if not thread.is_alive():
+            continue
+        if _is_ignored(thread.name):
+            continue
+        frame = frames.get(ident)
+        stack = "".join(traceback.format_stack(frame)) if frame is not None else ""
+        leaked.append(
+            LeakedThread(
+                name=thread.name,
+                ident=ident,
+                daemon=bool(thread.daemon),
+                stack=stack,
+            )
+        )
+    return leaked
+
+
+def format_leaks(nodeid: str, leaks: list[LeakedThread]) -> str:
+    """Render a leak report naming the test and each surviving thread."""
+    lines = [
+        (
+            f"THREAD LEAK: {nodeid} left {len(leaks)} thread(s) running past "
+            f"teardown. A leaked thread that lazy-imports can race main-thread "
+            f"dict iteration ({DICT_RACE_MESSAGE!r}) in an unrelated test file."
+        )
+    ]
+    for leak in leaks:
+        lines.append(f"  - {leak.name} (ident={leak.ident}, daemon={leak.daemon})")
+        if leak.stack:
+            lines.extend(f"      {line}" for line in leak.stack.rstrip().splitlines())
+    return "\n".join(lines)
+
+
+def is_dict_iteration_race(exc: BaseException | None) -> bool:
+    """True if ``exc`` is the dict-mutated-during-iteration race."""
+    return isinstance(exc, RuntimeError) and DICT_RACE_MESSAGE in str(exc)
+
+
+def format_thread_stacks(
+    *,
+    threads: Sequence[_ThreadLike] | None = None,
+    frames: Mapping[int, FrameType] | None = None,
+) -> str:
+    """Dump every live thread with its stack.
+
+    Used when the race fires: CI only shows a single truncated
+    ``contextlib.__enter__`` frame, which names neither the generator that was
+    iterating nor the thread that mutated the dict underneath it.
+    """
+    live = threading.enumerate() if threads is None else threads
+    if frames is None:
+        frames = dict(sys._current_frames())
+
+    lines = [f"LIVE THREADS ({len(live)}):"]
+    for thread in live:
+        lines.append(
+            f"  --- {thread.name} (ident={thread.ident}, daemon={thread.daemon}, "
+            f"alive={thread.is_alive()})"
+        )
+        frame = frames.get(thread.ident) if thread.ident is not None else None
+        if frame is None:
+            lines.append("      <no frame captured>")
+            continue
+        stack = "".join(traceback.format_stack(frame))
+        lines.extend(f"      {line}" for line in stack.rstrip().splitlines())
+    return "\n".join(lines)

--- a/tests/thread_leak.py
+++ b/tests/thread_leak.py
@@ -50,11 +50,21 @@ _IGNORED_THREAD_NAMES = frozenset(
     }
 )
 
-# Note: no prefix-based ignore list.  Per-test executor workers (ThreadPoolExecutor-*,
-# asyncio_*) are real leaks when they outlive teardown — silencing them by prefix
-# prevents the detector from reporting them.  The before-snapshot already suppresses
-# threads that were alive before the test started (including shared executors that
-# persisted from earlier tests), so no additional prefix guard is needed.
+#: Thread-name prefixes that produce *soft* warnings instead of hard failures.
+#:
+#: ``ThreadPoolExecutor-`` and ``asyncio_`` workers are reported in the terminal
+#: leak summary so per-test executor leaks remain visible, but they are never
+#: failed by ``GPTME_STRICT_THREAD_LEAKS=1``.  The reason: lazily initialised
+#: process-lifetime executors (e.g. a cached regex or I/O pool) start *after* the
+#: per-test snapshot, making them look like leaks for the first test that triggers
+#: them even though they persist intentionally.  The before-snapshot suppresses
+#: these workers for every *subsequent* test (they're in the snapshot by then), so
+#: they do not produce noise across the suite — only the first-trigger test sees
+#: the warning, which is still useful signal worth reviewing.
+_SOFT_WARN_THREAD_PREFIXES = (
+    "ThreadPoolExecutor-",
+    "asyncio_",
+)
 
 
 class _ThreadLike(Protocol):
@@ -75,10 +85,19 @@ class LeakedThread:
     ident: int | None
     daemon: bool
     stack: str = field(default="", repr=False)
+    #: If True, this thread is visible in the terminal summary but is never
+    #: failed by ``GPTME_STRICT_THREAD_LEAKS=1``.  Used for executor workers
+    #: whose lazy initialisation makes them look like per-test leaks.
+    soft: bool = False
 
 
 def _is_ignored(name: str) -> bool:
     return name in _IGNORED_THREAD_NAMES
+
+
+def _is_soft_warned(name: str) -> bool:
+    """True for threads that are reported but never failed in strict mode."""
+    return name.startswith(_SOFT_WARN_THREAD_PREFIXES)
 
 
 def snapshot_threads() -> frozenset[tuple[int, int]]:
@@ -128,6 +147,7 @@ def diff_threads(
                 ident=ident,
                 daemon=bool(thread.daemon),
                 stack=stack,
+                soft=_is_soft_warned(thread.name),
             )
         )
     return leaked

--- a/tests/thread_leak.py
+++ b/tests/thread_leak.py
@@ -50,12 +50,11 @@ _IGNORED_THREAD_NAMES = frozenset(
     }
 )
 
-#: Prefixes for pooled/shared executors that are intentionally reused across
-#: tests rather than torn down per test.
-_IGNORED_THREAD_PREFIXES = (
-    "ThreadPoolExecutor-",
-    "asyncio_",
-)
+# Note: no prefix-based ignore list.  Per-test executor workers (ThreadPoolExecutor-*,
+# asyncio_*) are real leaks when they outlive teardown — silencing them by prefix
+# prevents the detector from reporting them.  The before-snapshot already suppresses
+# threads that were alive before the test started (including shared executors that
+# persisted from earlier tests), so no additional prefix guard is needed.
 
 
 class _ThreadLike(Protocol):
@@ -79,18 +78,24 @@ class LeakedThread:
 
 
 def _is_ignored(name: str) -> bool:
-    if name in _IGNORED_THREAD_NAMES:
-        return True
-    return name.startswith(_IGNORED_THREAD_PREFIXES)
+    return name in _IGNORED_THREAD_NAMES
 
 
-def snapshot_threads() -> set[int]:
-    """Return the idents of all threads currently alive."""
-    return {t.ident for t in threading.enumerate() if t.ident is not None}
+def snapshot_threads() -> frozenset[tuple[int, int]]:
+    """Return (ident, object-id) pairs for all currently alive threads.
+
+    Pairing the ident with ``id(thread)`` catches the ident-reuse case: CPython
+    thread identifiers are unique among *living* threads but may be reused once a
+    thread exits.  A replacement thread has a different object id even when it
+    inherits the same integer ident.
+    """
+    return frozenset(
+        (t.ident, id(t)) for t in threading.enumerate() if t.ident is not None
+    )
 
 
 def diff_threads(
-    before: set[int],
+    before: frozenset[tuple[int, int]],
     *,
     threads: Sequence[_ThreadLike] | None = None,
     frames: Mapping[int, FrameType] | None = None,
@@ -107,7 +112,9 @@ def diff_threads(
     leaked: list[LeakedThread] = []
     for thread in live:
         ident = thread.ident
-        if ident is None or ident in before:
+        if ident is None:
+            continue
+        if (ident, id(thread)) in before:
             continue
         if not thread.is_alive():
             continue


### PR DESCRIPTION
## Problem

`RuntimeError: dictionary changed size during iteration` (plus "previous item was not torn down properly") keeps surfacing at pytest setup/teardown across unrelated test files. #3257 fixed one class — leaked *subagent* threads — but master CI hit it again after that fix landed:

- [run 29733285095](https://github.com/gptme/gptme/actions/runs/29733285095) (2026-07-20) — `test_subagent_unit.py::TestMaxTimeWatchdog::test_subagent_wait_polls_cache_after_join_timeout`
- [run 29840116091](https://github.com/gptme/gptme/actions/runs/29840116091) (2026-07-21) — `test_tools_computer.py::test_coordinate_scaling_max_corner` teardown + cascade into the next test

Both head SHAs contain `0c8a90891`, so the class is not dead.

Two structural reasons it keeps recurring:

1. **It is undiagnosable from CI.** The failure reports exactly one frame — `contextlib.py:135` in `_GeneratorContextManager.__enter__` — which names neither the generator that was iterating nor the thread that mutated the dict underneath it. Five instance-level fixes went to crash sites because that is all the log showed.
2. **The #3257 cleanup is subagent-scoped.** `cleanup_subagents_after` interrupts and joins *registered* subagent threads. gptme starts threads from ~27 other sites (`server/session_step.py`, `server/cli.py`, `tools/computer_transport.py`, `tools/shell.py`, `tools/shell_background.py`, `hooks/registry.py`, `oauth/`, `llm/*_subscription.py`, `util/sound.py`, `util/tokens.py`, …), almost all daemon and unjoined. Any of them can reproduce the same global-dict race. The 07-21 hit was on **computer** tests, not subagent — consistent with a non-subagent leaker.

## What this adds

`tests/thread_leak.py` plus two conftest wirings:

- **`detect_leaked_threads`** — autouse fixture that snapshots live threads at setup and names any that survive teardown, with their stacks. Defined first among the autouse fixtures so its teardown runs *last*, after `cleanup_subagents_after` has had its chance to join. Reports by default (warning + ranked terminal summary); `GPTME_STRICT_THREAD_LEAKS=1` fails the offending test instead, which is how a specific leaker gets pinned once the summary points at it.
- **`pytest_exception_interact`** — on this exact `RuntimeError`, dumps every live thread's stack. The next occurrence identifies the mutating thread instead of showing one truncated frame.

Ignore-list covers `MainThread`, the pytest-timeout watchdog, and pooled executors so the signal is leaks, not noise.

## It already found something

A clean local run of `tests/test_subagent_unit.py tests/test_tools_computer.py`:

```
================================= thread leaks =================================
  1  tests/test_subagent_unit.py::TestContextWindowValidation::test_context_window_zero_is_valid  ['Thread-15 (run_subagent)']
```

That test de-registers its own entry from `_subagents` in its cleanup block, so `cleanup_subagents_after` never sees it and never interrupts or joins the `run_subagent` thread — a leak of exactly the class #3257 targeted, made invisible to the fixture that exists to catch it.

I tried the obvious fix (stub `_create_subagent_thread`, drop the manual de-registration) and the thread still leaked, so I've **left that test alone rather than ship an unverified change**. The detector reporting it is the deliverable here; the fix belongs in a follow-up once the stack dump says why the thread survives the join.

## Scope / risk

Test-infrastructure only, no `gptme/` changes. Report-only by default, so it cannot turn a green suite red.

## Verification

- `tests/test_thread_leak.py` — 9 unit tests covering the diff, ignore-list, stack capture, missing-frame tolerance, race matcher, and an end-to-end real-thread leak/no-leak assertion.
- `pytest tests/test_subagent_unit.py tests/test_tools_computer.py tests/test_thread_leak.py` → 404 passed, 3 skipped.
- ruff check + format clean; mypy clean (pre-commit passed).