### PR TITLE
fix(webui): expose Accept All as direct one-click button + compact tool cards (#3440)

### DIFF
--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -75,6 +75,7 @@ export function InlineToolConfirmation({
       if (
         pendingTool &&
         !isEditing &&
+        !confirmLoading &&
         e.key === 'Enter' &&
         !e.shiftKey &&
         !e.ctrlKey &&
@@ -87,7 +88,7 @@ export function InlineToolConfirmation({
 
     window.addEventListener('keypress', handleKeyPress);
     return () => window.removeEventListener('keypress', handleKeyPress);
-  }, [pendingTool, isEditing, handleConfirm]);
+  }, [pendingTool, isEditing, confirmLoading, handleConfirm]);
 
   const handleEdit = async () => {
     setConfirmLoading(true);
@@ -118,6 +119,20 @@ export function InlineToolConfirmation({
       setConfirmLoading(false);
     }
   };
+
+  const handleAuto = React.useCallback(
+    async (count: number) => {
+      setConfirmLoading(true);
+      try {
+        await onAuto(count);
+      } catch (error) {
+        console.error('Error auto-confirming tools:', error);
+      } finally {
+        setConfirmLoading(false);
+      }
+    },
+    [onAuto]
+  );
 
   // Format args for display
   const formatArgs = (args: string[]) => {
@@ -259,10 +274,10 @@ export function InlineToolConfirmation({
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end" className="w-44">
-                            <DropdownMenuItem onClick={() => onAuto(5)}>
+                            <DropdownMenuItem onClick={() => handleAuto(5)}>
                               Auto-confirm 5×
                             </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => onAuto(10)}>
+                            <DropdownMenuItem onClick={() => handleAuto(10)}>
                               Auto-confirm 10×
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
@@ -292,7 +307,7 @@ export function InlineToolConfirmation({
                                     variant="ghost"
                                     className="h-6 px-2 text-xs"
                                     onClick={() => {
-                                      onAuto(customCount);
+                                      handleAuto(customCount);
                                       setShowCustomInput(false);
                                     }}
                                   >

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -217,7 +217,7 @@ export function InlineToolConfirmation({
                     </Button>
                   </div>
 
-                  <div className="flex items-center gap-1.5">
+                  <div className="flex flex-wrap items-center gap-1.5">
                     {/* Accept All — direct one-click action */}
                     {!isEditing && (
                       <Button

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -66,6 +66,17 @@ export function InlineToolConfirmation({
     setConfirmLoading(false);
   }, []);
 
+  // Timeout-only release: unlocks the UI so it doesn't stay frozen indefinitely
+  // (Greptile P1: "Missed SSE leaves controls locked"), but intentionally retains
+  // confirmedToolId so that all handlers can detect the already-submitted tool and
+  // refuse a second POST (Greptile P1: "Timeout re-enables submitted tool").
+  const releaseOnTimeout = React.useCallback(() => {
+    lockTimeoutRef.current = null;
+    isConfirmingRef.current = false;
+    // confirmedToolId.current kept — handlers check it before each submission.
+    setConfirmLoading(false);
+  }, []);
+
   // Reset state when the pending tool changes (including when it becomes null after confirmation)
   React.useEffect(() => {
     if (pendingTool) {
@@ -91,20 +102,23 @@ export function InlineToolConfirmation({
   const handleConfirm = React.useCallback(async () => {
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
+    // Block re-submission when the same tool was already confirmed but SSE was missed
+    if (confirmedToolId.current !== null && confirmedToolId.current === pendingTool?.id) return;
     isConfirmingRef.current = true;
     confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onConfirm();
       // Lock intentionally held until pendingTool clears via SSE (useEffect releases it).
-      // Safety timeout: if tool_executing SSE is missed during a disconnect, release
-      // the lock after 15 s so the UI doesn't stay frozen indefinitely.
-      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
+      // Safety timeout: if tool_executing SSE is missed during a disconnect, use
+      // releaseOnTimeout (not releaseLock) so confirmedToolId is retained and blocks
+      // re-submission of the already-confirmed tool.
+      lockTimeoutRef.current = setTimeout(releaseOnTimeout, 15_000);
     } catch (error) {
       console.error('Error confirming tool:', error);
       releaseLock();
     }
-  }, [onConfirm, pendingTool, releaseLock]);
+  }, [onConfirm, pendingTool, releaseLock, releaseOnTimeout]);
 
   // Add keyboard handler for Enter key
   React.useEffect(() => {
@@ -131,12 +145,13 @@ export function InlineToolConfirmation({
   const handleEdit = async () => {
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
+    if (confirmedToolId.current !== null && confirmedToolId.current === pendingTool?.id) return;
     isConfirmingRef.current = true;
     confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onEdit(editedContent);
-      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
+      lockTimeoutRef.current = setTimeout(releaseOnTimeout, 15_000);
     } catch (error) {
       console.error('Error confirming edited tool:', error);
       releaseLock();
@@ -146,12 +161,13 @@ export function InlineToolConfirmation({
   const handleSkip = async () => {
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
+    if (confirmedToolId.current !== null && confirmedToolId.current === pendingTool?.id) return;
     isConfirmingRef.current = true;
     confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onSkip();
-      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
+      lockTimeoutRef.current = setTimeout(releaseOnTimeout, 15_000);
     } catch (error) {
       console.error('Error skipping tool:', error);
       releaseLock();
@@ -161,12 +177,13 @@ export function InlineToolConfirmation({
   const handleAcceptAll = async () => {
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
+    if (confirmedToolId.current !== null && confirmedToolId.current === pendingTool?.id) return;
     isConfirmingRef.current = true;
     confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onAuto(999999);
-      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
+      lockTimeoutRef.current = setTimeout(releaseOnTimeout, 15_000);
     } catch (error) {
       console.error('Error accepting all tools:', error);
       releaseLock();
@@ -177,18 +194,19 @@ export function InlineToolConfirmation({
     async (count: number) => {
       // Check synchronously before any async work (prevents render-time race)
       if (isConfirmingRef.current) return;
+      if (confirmedToolId.current !== null && confirmedToolId.current === pendingTool?.id) return;
       isConfirmingRef.current = true;
       confirmedToolId.current = pendingTool?.id ?? null;
       setConfirmLoading(true);
       try {
         await onAuto(count);
-        lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
+        lockTimeoutRef.current = setTimeout(releaseOnTimeout, 15_000);
       } catch (error) {
         console.error('Error auto-confirming tools:', error);
         releaseLock();
       }
     },
-    [onAuto, pendingTool, releaseLock]
+    [onAuto, pendingTool, releaseLock, releaseOnTimeout]
   );
 
   // Format args for display

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -109,10 +109,13 @@ export function InlineToolConfirmation({
   };
 
   const handleAcceptAll = async () => {
+    setConfirmLoading(true);
     try {
       await onAuto(999999);
     } catch (error) {
       console.error('Error accepting all tools:', error);
+    } finally {
+      setConfirmLoading(false);
     }
   };
 
@@ -190,7 +193,7 @@ export function InlineToolConfirmation({
                 </div>
 
                 {/* Action buttons */}
-                <div className="flex items-center justify-between border-t border-amber-200 pt-2 dark:border-amber-800">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 border-t border-amber-200 pt-2 dark:border-amber-800">
                   <div className="flex items-center gap-1.5">
                     <Button
                       variant="outline"

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -47,6 +47,9 @@ export function InlineToolConfirmation({
   const [showCustomInput, setShowCustomInput] = useState(false);
   const pendingTool = use$(pendingTool$);
 
+  // Use a ref to track pending requests synchronously (prevents render-time race conditions)
+  const isConfirmingRef = React.useRef(false);
+
   // Reset state when the pending tool changes
   React.useEffect(() => {
     if (pendingTool) {
@@ -55,10 +58,14 @@ export function InlineToolConfirmation({
       setIsEditing(false);
       setConfirmLoading(false);
       setShowCustomInput(false);
+      isConfirmingRef.current = false;
     }
   }, [pendingTool]);
 
   const handleConfirm = React.useCallback(async () => {
+    // Check synchronously before any async work (prevents render-time race)
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
     setConfirmLoading(true);
     try {
       await onConfirm();
@@ -66,6 +73,7 @@ export function InlineToolConfirmation({
       console.error('Error confirming tool:', error);
     } finally {
       setConfirmLoading(false);
+      isConfirmingRef.current = false;
     }
   }, [onConfirm]);
 
@@ -76,6 +84,7 @@ export function InlineToolConfirmation({
         pendingTool &&
         !isEditing &&
         !confirmLoading &&
+        !isConfirmingRef.current &&
         e.key === 'Enter' &&
         !e.shiftKey &&
         !e.ctrlKey &&
@@ -110,6 +119,9 @@ export function InlineToolConfirmation({
   };
 
   const handleAcceptAll = async () => {
+    // Check synchronously before any async work (prevents render-time race)
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
     setConfirmLoading(true);
     try {
       await onAuto(999999);
@@ -117,11 +129,15 @@ export function InlineToolConfirmation({
       console.error('Error accepting all tools:', error);
     } finally {
       setConfirmLoading(false);
+      isConfirmingRef.current = false;
     }
   };
 
   const handleAuto = React.useCallback(
     async (count: number) => {
+      // Check synchronously before any async work (prevents render-time race)
+      if (isConfirmingRef.current) return;
+      isConfirmingRef.current = true;
       setConfirmLoading(true);
       try {
         await onAuto(count);
@@ -129,6 +145,7 @@ export function InlineToolConfirmation({
         console.error('Error auto-confirming tools:', error);
       } finally {
         setConfirmLoading(false);
+        isConfirmingRef.current = false;
       }
     },
     [onAuto]

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -2,7 +2,15 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import type { PendingTool } from '@/stores/conversations';
-import { Loader2, Play, Edit, SkipForward, Settings, ChevronDown } from 'lucide-react';
+import {
+  Loader2,
+  Play,
+  Edit,
+  SkipForward,
+  Settings,
+  ChevronDown,
+  ChevronsRight,
+} from 'lucide-react';
 import { type Observable, observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import { CodeDisplay } from '@/components/CodeDisplay';
@@ -100,6 +108,14 @@ export function InlineToolConfirmation({
     }
   };
 
+  const handleAcceptAll = async () => {
+    try {
+      await onAuto(999999);
+    } catch (error) {
+      console.error('Error accepting all tools:', error);
+    }
+  };
+
   // Format args for display
   const formatArgs = (args: string[]) => {
     if (!args || args.length === 0) return 'No arguments';
@@ -110,7 +126,7 @@ export function InlineToolConfirmation({
   if (!pendingTool) return null;
 
   return (
-    <div className="role-system mb-4 mt-4">
+    <div className="role-system mb-2 mt-2">
       <div className="mx-auto max-w-3xl px-4">
         <div className="relative">
           <MessageAvatar
@@ -121,49 +137,48 @@ export function InlineToolConfirmation({
           />
           <div className="md:px-12">
             <div className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20">
-              <div className="border-b border-amber-200 px-4 py-3 dark:border-amber-800">
-                <div className="flex items-center gap-2">
-                  <Settings className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-                  <h3 className="font-medium text-amber-800 dark:text-amber-200">
-                    Tool Execution Confirmation
-                  </h3>
-                </div>
-
-                <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
-                  The assistant wants to use
-                  <code className="rounded bg-muted px-2 py-1 font-mono text-sm">
+              {/* Compact header */}
+              <div className="flex items-center gap-2 border-b border-amber-200 px-3 py-2 dark:border-amber-800">
+                <Settings className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+                <span className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                  Run{' '}
+                  <code className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-xs dark:bg-amber-900/40">
                     {pendingTool.tooluse.tool}
                   </code>
-                </p>
+                  ?
+                </span>
+                <span className="ml-auto text-xs text-amber-600 dark:text-amber-400">
+                  Press Enter to execute
+                </span>
               </div>
 
-              <div className="space-y-4 p-4">
+              <div className="space-y-3 p-3">
                 {/* Arguments */}
                 {pendingTool.tooluse.args.length > 0 && (
-                  <div className="space-y-2">
-                    <span className="text-sm font-medium text-muted-foreground">Arguments:</span>
+                  <div className="space-y-1">
+                    <span className="text-xs font-medium text-muted-foreground">Arguments:</span>
                     <CodeDisplay
                       code={formatArgs(pendingTool.tooluse.args)}
-                      maxHeight="120px"
+                      maxHeight="80px"
                       showLineNumbers={false}
                     />
                   </div>
                 )}
 
                 {/* Code */}
-                <div className="space-y-2">
+                <div className="space-y-1">
                   {isEditing ? (
                     <Textarea
                       value={editedContent}
                       onChange={(e) => setEditedContent(e.target.value)}
-                      rows={Math.min(12, editedContent.split('\n').length + 2)}
+                      rows={Math.min(10, editedContent.split('\n').length + 2)}
                       className="resize-none font-mono text-sm"
                       placeholder="Edit the code to be executed..."
                     />
                   ) : (
                     <CodeDisplay
                       code={pendingTool.tooluse.content}
-                      maxHeight="240px"
+                      maxHeight="200px"
                       showLineNumbers={true}
                       language={detectToolLanguage(
                         pendingTool.tooluse.tool,
@@ -175,15 +190,16 @@ export function InlineToolConfirmation({
                 </div>
 
                 {/* Action buttons */}
-                <div className="flex items-center justify-between border-t border-amber-200 pt-3 dark:border-amber-800">
-                  <div className="flex items-center gap-2">
+                <div className="flex items-center justify-between border-t border-amber-200 pt-2 dark:border-amber-800">
+                  <div className="flex items-center gap-1.5">
                     <Button
                       variant="outline"
                       size="sm"
                       onClick={() => setIsEditing(!isEditing)}
                       disabled={confirmLoading}
+                      className="h-7 px-2 text-xs"
                     >
-                      <Edit className="mr-1 h-4 w-4" />
+                      <Edit className="mr-1 h-3.5 w-3.5" />
                       {isEditing ? 'Cancel' : 'Edit'}
                     </Button>
                     <Button
@@ -191,81 +207,101 @@ export function InlineToolConfirmation({
                       size="sm"
                       onClick={handleSkip}
                       disabled={confirmLoading}
+                      className="h-7 px-2 text-xs"
                     >
-                      <SkipForward className="mr-1 h-4 w-4" />
+                      <SkipForward className="mr-1 h-3.5 w-3.5" />
                       Skip
                     </Button>
                   </div>
 
-                  <div className="flex items-center">
-                    <Button
-                      onClick={isEditing ? handleEdit : handleConfirm}
-                      disabled={confirmLoading}
-                      size="sm"
-                      className="rounded-r-none border-r-0 bg-amber-600 text-white hover:bg-amber-700"
-                    >
-                      {confirmLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                      <Play className="mr-1 h-4 w-4" />
-                      {isEditing ? 'Save & Execute' : 'Execute'}
-                    </Button>
+                  <div className="flex items-center gap-1.5">
+                    {/* Accept All — direct one-click action */}
+                    {!isEditing && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleAcceptAll}
+                        disabled={confirmLoading}
+                        className="h-7 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/30"
+                        title="Auto-accept all remaining tool confirmations"
+                      >
+                        <ChevronsRight className="mr-1 h-3.5 w-3.5" />
+                        Accept All
+                      </Button>
+                    )}
 
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          disabled={confirmLoading}
-                          size="sm"
-                          className="rounded-l-none border-l border-amber-500 bg-amber-600 px-2 text-white hover:bg-amber-700"
-                        >
-                          <ChevronDown className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-48">
-                        <DropdownMenuItem onClick={() => onAuto(999999)}>
-                          Auto-accept all
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => onAuto(5)}>
-                          Auto-confirm 5x
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => onAuto(10)}>
-                          Auto-confirm 10x
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          onClick={() => setShowCustomInput(!showCustomInput)}
-                          className="flex items-center justify-between"
-                        >
-                          Custom count
-                          {showCustomInput && (
-                            <div
-                              className="ml-2 flex items-center gap-2"
-                              onClick={(e) => e.stopPropagation()}
+                    {/* Execute (primary) + dropdown for 5x/10x/custom */}
+                    <div className="flex items-center">
+                      <Button
+                        onClick={isEditing ? handleEdit : handleConfirm}
+                        disabled={confirmLoading}
+                        size="sm"
+                        className="h-7 rounded-r-none border-r-0 bg-amber-600 px-2 text-xs text-white hover:bg-amber-700"
+                      >
+                        {confirmLoading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                        <Play className="mr-1 h-3.5 w-3.5" />
+                        {isEditing ? 'Save & Execute' : 'Execute'}
+                      </Button>
+
+                      {!isEditing && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              disabled={confirmLoading}
+                              size="sm"
+                              className="h-7 rounded-l-none border-l border-amber-500 bg-amber-600 px-1.5 text-white hover:bg-amber-700"
+                              title="Auto-confirm multiple tools"
                             >
-                              <Input
-                                type="number"
-                                min="1"
-                                max="50"
-                                value={customCount}
-                                onChange={(e) => setCustomCount(parseInt(e.target.value, 10) || 1)}
-                                className="h-6 w-16 px-1 text-xs"
-                                autoFocus
-                              />
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                className="h-6 px-2 text-xs"
-                                onClick={() => {
-                                  onAuto(customCount);
-                                  setShowCustomInput(false);
-                                }}
-                              >
-                                Apply
-                              </Button>
-                            </div>
-                          )}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                              <ChevronDown className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-44">
+                            <DropdownMenuItem onClick={() => onAuto(5)}>
+                              Auto-confirm 5×
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => onAuto(10)}>
+                              Auto-confirm 10×
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => setShowCustomInput(!showCustomInput)}
+                              className="flex items-center justify-between"
+                            >
+                              Custom count
+                              {showCustomInput && (
+                                <div
+                                  className="ml-2 flex items-center gap-1.5"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Input
+                                    type="number"
+                                    min="1"
+                                    max="50"
+                                    value={customCount}
+                                    onChange={(e) =>
+                                      setCustomCount(parseInt(e.target.value, 10) || 1)
+                                    }
+                                    className="h-6 w-14 px-1 text-xs"
+                                    autoFocus
+                                  />
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    className="h-6 px-2 text-xs"
+                                    onClick={() => {
+                                      onAuto(customCount);
+                                      setShowCustomInput(false);
+                                    }}
+                                  >
+                                    Go
+                                  </Button>
+                                </div>
+                              )}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -49,37 +49,62 @@ export function InlineToolConfirmation({
 
   // Use a ref to track pending requests synchronously (prevents render-time race conditions)
   const isConfirmingRef = React.useRef(false);
+  // Track which tool was being confirmed so reconnect restoring the same tool doesn't
+  // prematurely clear the lock (Greptile: "Reconnect releases confirmation lock").
+  const confirmedToolId = React.useRef<string | null>(null);
+  // Safety timeout ref — releases the lock if tool_executing SSE is missed after a
+  // successful POST (Greptile: "Missed SSE leaves controls locked").
+  const lockTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const releaseLock = React.useCallback(() => {
+    if (lockTimeoutRef.current !== null) {
+      clearTimeout(lockTimeoutRef.current);
+      lockTimeoutRef.current = null;
+    }
+    isConfirmingRef.current = false;
+    confirmedToolId.current = null;
+    setConfirmLoading(false);
+  }, []);
 
   // Reset state when the pending tool changes (including when it becomes null after confirmation)
   React.useEffect(() => {
     if (pendingTool) {
-      setEditedContent(pendingTool.tooluse.content);
-      setIsEditing(false);
-      setShowCustomInput(false);
+      // Only release the lock when a genuinely new tool arrives (different ID).
+      // If reconnect restores the same pending tool with a fresh object reference,
+      // pendingTool.id matches confirmedToolId — retain the lock to prevent a
+      // duplicate submission on that already-confirmed tool.
+      const isNewTool =
+        confirmedToolId.current === null || pendingTool.id !== confirmedToolId.current;
+      if (isNewTool) {
+        setEditedContent(pendingTool.tooluse.content);
+        setIsEditing(false);
+        setShowCustomInput(false);
+        releaseLock();
+      }
+      // else: same tool restored by reconnect — lock retained intentionally
+    } else {
+      // pendingTool became null — tool_executing SSE arrived, canonical release point.
+      releaseLock();
     }
-    // Always release the lock when the tool lifecycle ends (null) or a new tool arrives.
-    // This is the canonical release point for successful confirmations — the lock is held
-    // intentionally between POST resolve and SSE clear to prevent duplicate submissions.
-    setConfirmLoading(false);
-    isConfirmingRef.current = false;
-  }, [pendingTool]);
+  }, [pendingTool, releaseLock]);
 
   const handleConfirm = React.useCallback(async () => {
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
+    confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onConfirm();
-      // Lock intentionally NOT released here — held until pendingTool clears via SSE
-      // (useEffect releases it). Releasing early creates a window where a second click
-      // can submit the already-confirmed tool before the backend clears it.
+      // Lock intentionally held until pendingTool clears via SSE (useEffect releases it).
+      // Safety timeout: if tool_executing SSE is missed during a disconnect, release
+      // the lock after 15 s so the UI doesn't stay frozen indefinitely.
+      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
     } catch (error) {
       console.error('Error confirming tool:', error);
-      isConfirmingRef.current = false;
-      setConfirmLoading(false);
+      releaseLock();
     }
-  }, [onConfirm]);
+  }, [onConfirm, pendingTool, releaseLock]);
 
   // Add keyboard handler for Enter key
   React.useEffect(() => {
@@ -107,14 +132,14 @@ export function InlineToolConfirmation({
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
+    confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onEdit(editedContent);
-      // Lock held until pendingTool clears via SSE (see handleConfirm)
+      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
     } catch (error) {
       console.error('Error confirming edited tool:', error);
-      isConfirmingRef.current = false;
-      setConfirmLoading(false);
+      releaseLock();
     }
   };
 
@@ -122,14 +147,14 @@ export function InlineToolConfirmation({
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
+    confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onSkip();
-      // Lock held until pendingTool clears via SSE (see handleConfirm)
+      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
     } catch (error) {
       console.error('Error skipping tool:', error);
-      isConfirmingRef.current = false;
-      setConfirmLoading(false);
+      releaseLock();
     }
   };
 
@@ -137,14 +162,14 @@ export function InlineToolConfirmation({
     // Check synchronously before any async work (prevents render-time race)
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
+    confirmedToolId.current = pendingTool?.id ?? null;
     setConfirmLoading(true);
     try {
       await onAuto(999999);
-      // Lock held until pendingTool clears via SSE (see handleConfirm)
+      lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
     } catch (error) {
       console.error('Error accepting all tools:', error);
-      isConfirmingRef.current = false;
-      setConfirmLoading(false);
+      releaseLock();
     }
   };
 
@@ -153,17 +178,17 @@ export function InlineToolConfirmation({
       // Check synchronously before any async work (prevents render-time race)
       if (isConfirmingRef.current) return;
       isConfirmingRef.current = true;
+      confirmedToolId.current = pendingTool?.id ?? null;
       setConfirmLoading(true);
       try {
         await onAuto(count);
-        // Lock held until pendingTool clears via SSE (see handleConfirm)
+        lockTimeoutRef.current = setTimeout(releaseLock, 15_000);
       } catch (error) {
         console.error('Error auto-confirming tools:', error);
-        isConfirmingRef.current = false;
-        setConfirmLoading(false);
+        releaseLock();
       }
     },
-    [onAuto]
+    [onAuto, pendingTool, releaseLock]
   );
 
   // Format args for display

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -43,6 +43,9 @@ export function InlineToolConfirmation({
   const [editedContent, setEditedContent] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
+  // True when POST succeeded but tool_executing SSE hasn't arrived (missed-SSE timeout path).
+  // Replaces action buttons with a status message so the UI never looks interactive-but-broken.
+  const [isConfirmed, setIsConfirmed] = useState(false);
   const [customCount, setCustomCount] = useState(10);
   const [showCustomInput, setShowCustomInput] = useState(false);
   const pendingTool = use$(pendingTool$);
@@ -64,17 +67,19 @@ export function InlineToolConfirmation({
     isConfirmingRef.current = false;
     confirmedToolId.current = null;
     setConfirmLoading(false);
+    setIsConfirmed(false);
   }, []);
 
-  // Timeout-only release: unlocks the UI so it doesn't stay frozen indefinitely
-  // (Greptile P1: "Missed SSE leaves controls locked"), but intentionally retains
-  // confirmedToolId so that all handlers can detect the already-submitted tool and
-  // refuse a second POST (Greptile P1: "Timeout re-enables submitted tool").
+  // Timeout-only release: fires when POST succeeded but tool_executing SSE was missed.
+  // Unlocks the UI (avoids frozen-forever) and shows isConfirmed banner instead of
+  // re-enabling the action buttons — those would appear clickable but silently no-op
+  // (Greptile P1: "Timeout leaves inert controls").
+  // confirmedToolId is retained so any stray handler still exits early (belt-and-suspenders).
   const releaseOnTimeout = React.useCallback(() => {
     lockTimeoutRef.current = null;
     isConfirmingRef.current = false;
-    // confirmedToolId.current kept — handlers check it before each submission.
     setConfirmLoading(false);
+    setIsConfirmed(true);
   }, []);
 
   // Reset state when the pending tool changes (including when it becomes null after confirmation)
@@ -127,6 +132,7 @@ export function InlineToolConfirmation({
         pendingTool &&
         !isEditing &&
         !confirmLoading &&
+        !isConfirmed &&
         !isConfirmingRef.current &&
         e.key === 'Enter' &&
         !e.shiftKey &&
@@ -140,7 +146,7 @@ export function InlineToolConfirmation({
 
     window.addEventListener('keypress', handleKeyPress);
     return () => window.removeEventListener('keypress', handleKeyPress);
-  }, [pendingTool, isEditing, confirmLoading, handleConfirm]);
+  }, [pendingTool, isEditing, confirmLoading, isConfirmed, handleConfirm]);
 
   const handleEdit = async () => {
     // Check synchronously before any async work (prevents render-time race)
@@ -284,118 +290,131 @@ export function InlineToolConfirmation({
 
                 {/* Action buttons */}
                 <div className="flex flex-wrap items-center justify-between gap-y-2 border-t border-amber-200 pt-2 dark:border-amber-800">
-                  <div className="flex items-center gap-1.5">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setIsEditing(!isEditing)}
-                      disabled={confirmLoading}
-                      className="h-7 px-2 text-xs"
-                    >
-                      <Edit className="mr-1 h-3.5 w-3.5" />
-                      {isEditing ? 'Cancel' : 'Edit'}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={handleSkip}
-                      disabled={confirmLoading}
-                      className="h-7 px-2 text-xs"
-                    >
-                      <SkipForward className="mr-1 h-3.5 w-3.5" />
-                      Skip
-                    </Button>
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    {/* Accept All — direct one-click action */}
-                    {!isEditing && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleAcceptAll}
-                        disabled={confirmLoading}
-                        className="h-7 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/30"
-                        title="Auto-accept all remaining tool confirmations"
-                      >
-                        <ChevronsRight className="mr-1 h-3.5 w-3.5" />
-                        Accept All
-                      </Button>
-                    )}
-
-                    {/* Execute (primary) + dropdown for 5x/10x/custom */}
-                    <div className="flex items-center">
-                      <Button
-                        onClick={isEditing ? handleEdit : handleConfirm}
-                        disabled={confirmLoading}
-                        size="sm"
-                        className="h-7 rounded-r-none border-r-0 bg-amber-600 px-2 text-xs text-white hover:bg-amber-700"
-                      >
-                        {confirmLoading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
-                        <Play className="mr-1 h-3.5 w-3.5" />
-                        {isEditing ? 'Save & Execute' : 'Execute'}
-                      </Button>
-
-                      {!isEditing && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              disabled={confirmLoading}
-                              size="sm"
-                              className="h-7 rounded-l-none border-l border-amber-500 bg-amber-600 px-1.5 text-white hover:bg-amber-700"
-                              title="Auto-confirm multiple tools"
-                            >
-                              <ChevronDown className="h-3.5 w-3.5" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-44">
-                            <DropdownMenuItem onClick={() => handleAuto(5)}>
-                              Auto-confirm 5×
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => handleAuto(10)}>
-                              Auto-confirm 10×
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onClick={() => setShowCustomInput(!showCustomInput)}
-                              className="flex items-center justify-between"
-                            >
-                              Custom count
-                              {showCustomInput && (
-                                <div
-                                  className="ml-2 flex items-center gap-1.5"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Input
-                                    type="number"
-                                    min="1"
-                                    max="50"
-                                    value={customCount}
-                                    onChange={(e) =>
-                                      setCustomCount(parseInt(e.target.value, 10) || 1)
-                                    }
-                                    className="h-6 w-14 px-1 text-xs"
-                                    autoFocus
-                                  />
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="h-6 px-2 text-xs"
-                                    onClick={() => {
-                                      handleAuto(customCount);
-                                      setShowCustomInput(false);
-                                    }}
-                                  >
-                                    Go
-                                  </Button>
-                                </div>
-                              )}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
+                  {isConfirmed ? (
+                    /* Missed-SSE timeout path: POST succeeded but tool_executing event was lost.
+                       Show a status message instead of re-enabling buttons that would silently no-op. */
+                    <div className="flex w-full items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Confirmed — waiting for server… (refresh if this persists)
                     </div>
-                  </div>
+                  ) : (
+                    <>
+                      <div className="flex items-center gap-1.5">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsEditing(!isEditing)}
+                          disabled={confirmLoading}
+                          className="h-7 px-2 text-xs"
+                        >
+                          <Edit className="mr-1 h-3.5 w-3.5" />
+                          {isEditing ? 'Cancel' : 'Edit'}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleSkip}
+                          disabled={confirmLoading}
+                          className="h-7 px-2 text-xs"
+                        >
+                          <SkipForward className="mr-1 h-3.5 w-3.5" />
+                          Skip
+                        </Button>
+                      </div>
+
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {/* Accept All — direct one-click action */}
+                        {!isEditing && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleAcceptAll}
+                            disabled={confirmLoading}
+                            className="h-7 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/30"
+                            title="Auto-accept all remaining tool confirmations"
+                          >
+                            <ChevronsRight className="mr-1 h-3.5 w-3.5" />
+                            Accept All
+                          </Button>
+                        )}
+
+                        {/* Execute (primary) + dropdown for 5x/10x/custom */}
+                        <div className="flex items-center">
+                          <Button
+                            onClick={isEditing ? handleEdit : handleConfirm}
+                            disabled={confirmLoading}
+                            size="sm"
+                            className="h-7 rounded-r-none border-r-0 bg-amber-600 px-2 text-xs text-white hover:bg-amber-700"
+                          >
+                            {confirmLoading && (
+                              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                            )}
+                            <Play className="mr-1 h-3.5 w-3.5" />
+                            {isEditing ? 'Save & Execute' : 'Execute'}
+                          </Button>
+
+                          {!isEditing && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  disabled={confirmLoading}
+                                  size="sm"
+                                  className="h-7 rounded-l-none border-l border-amber-500 bg-amber-600 px-1.5 text-white hover:bg-amber-700"
+                                  title="Auto-confirm multiple tools"
+                                >
+                                  <ChevronDown className="h-3.5 w-3.5" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end" className="w-44">
+                                <DropdownMenuItem onClick={() => handleAuto(5)}>
+                                  Auto-confirm 5×
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => handleAuto(10)}>
+                                  Auto-confirm 10×
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  onClick={() => setShowCustomInput(!showCustomInput)}
+                                  className="flex items-center justify-between"
+                                >
+                                  Custom count
+                                  {showCustomInput && (
+                                    <div
+                                      className="ml-2 flex items-center gap-1.5"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <Input
+                                        type="number"
+                                        min="1"
+                                        max="50"
+                                        value={customCount}
+                                        onChange={(e) =>
+                                          setCustomCount(parseInt(e.target.value, 10) || 1)
+                                        }
+                                        className="h-6 w-14 px-1 text-xs"
+                                        autoFocus
+                                      />
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-6 px-2 text-xs"
+                                        onClick={() => {
+                                          handleAuto(customCount);
+                                          setShowCustomInput(false);
+                                        }}
+                                      >
+                                        Go
+                                      </Button>
+                                    </div>
+                                  )}
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </div>
+                      </div>
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -100,6 +100,9 @@ export function InlineToolConfirmation({
   }, [pendingTool, isEditing, confirmLoading, handleConfirm]);
 
   const handleEdit = async () => {
+    // Check synchronously before any async work (prevents render-time race)
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
     setConfirmLoading(true);
     try {
       await onEdit(editedContent);
@@ -107,14 +110,22 @@ export function InlineToolConfirmation({
       console.error('Error confirming edited tool:', error);
     } finally {
       setConfirmLoading(false);
+      isConfirmingRef.current = false;
     }
   };
 
   const handleSkip = async () => {
+    // Check synchronously before any async work (prevents render-time race)
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
+    setConfirmLoading(true);
     try {
       await onSkip();
     } catch (error) {
       console.error('Error skipping tool:', error);
+    } finally {
+      setConfirmLoading(false);
+      isConfirmingRef.current = false;
     }
   };
 

--- a/webui/src/components/InlineToolConfirmation.tsx
+++ b/webui/src/components/InlineToolConfirmation.tsx
@@ -50,16 +50,18 @@ export function InlineToolConfirmation({
   // Use a ref to track pending requests synchronously (prevents render-time race conditions)
   const isConfirmingRef = React.useRef(false);
 
-  // Reset state when the pending tool changes
+  // Reset state when the pending tool changes (including when it becomes null after confirmation)
   React.useEffect(() => {
     if (pendingTool) {
-      const content = pendingTool.tooluse.content;
-      setEditedContent(content);
+      setEditedContent(pendingTool.tooluse.content);
       setIsEditing(false);
-      setConfirmLoading(false);
       setShowCustomInput(false);
-      isConfirmingRef.current = false;
     }
+    // Always release the lock when the tool lifecycle ends (null) or a new tool arrives.
+    // This is the canonical release point for successful confirmations — the lock is held
+    // intentionally between POST resolve and SSE clear to prevent duplicate submissions.
+    setConfirmLoading(false);
+    isConfirmingRef.current = false;
   }, [pendingTool]);
 
   const handleConfirm = React.useCallback(async () => {
@@ -69,11 +71,13 @@ export function InlineToolConfirmation({
     setConfirmLoading(true);
     try {
       await onConfirm();
+      // Lock intentionally NOT released here — held until pendingTool clears via SSE
+      // (useEffect releases it). Releasing early creates a window where a second click
+      // can submit the already-confirmed tool before the backend clears it.
     } catch (error) {
       console.error('Error confirming tool:', error);
-    } finally {
-      setConfirmLoading(false);
       isConfirmingRef.current = false;
+      setConfirmLoading(false);
     }
   }, [onConfirm]);
 
@@ -106,11 +110,11 @@ export function InlineToolConfirmation({
     setConfirmLoading(true);
     try {
       await onEdit(editedContent);
+      // Lock held until pendingTool clears via SSE (see handleConfirm)
     } catch (error) {
       console.error('Error confirming edited tool:', error);
-    } finally {
-      setConfirmLoading(false);
       isConfirmingRef.current = false;
+      setConfirmLoading(false);
     }
   };
 
@@ -121,11 +125,11 @@ export function InlineToolConfirmation({
     setConfirmLoading(true);
     try {
       await onSkip();
+      // Lock held until pendingTool clears via SSE (see handleConfirm)
     } catch (error) {
       console.error('Error skipping tool:', error);
-    } finally {
-      setConfirmLoading(false);
       isConfirmingRef.current = false;
+      setConfirmLoading(false);
     }
   };
 
@@ -136,11 +140,11 @@ export function InlineToolConfirmation({
     setConfirmLoading(true);
     try {
       await onAuto(999999);
+      // Lock held until pendingTool clears via SSE (see handleConfirm)
     } catch (error) {
       console.error('Error accepting all tools:', error);
-    } finally {
-      setConfirmLoading(false);
       isConfirmingRef.current = false;
+      setConfirmLoading(false);
     }
   };
 
@@ -152,11 +156,11 @@ export function InlineToolConfirmation({
       setConfirmLoading(true);
       try {
         await onAuto(count);
+        // Lock held until pendingTool clears via SSE (see handleConfirm)
       } catch (error) {
         console.error('Error auto-confirming tools:', error);
-      } finally {
-        setConfirmLoading(false);
         isConfirmingRef.current = false;
+        setConfirmLoading(false);
       }
     },
     [onAuto]

--- a/webui/src/components/InlineToolExecution.tsx
+++ b/webui/src/components/InlineToolExecution.tsx
@@ -85,7 +85,7 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
   if (!executingTool) return null;
 
   return (
-    <div className="role-system mb-4 mt-4">
+    <div className="role-system mb-2 mt-2">
       <div className="mx-auto max-w-3xl px-4">
         <div className="relative">
           <MessageAvatar
@@ -96,38 +96,36 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
           />
           <div className="md:px-12">
             <div className="rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20">
-              <div className="border-b border-blue-200 px-4 py-3 dark:border-blue-800">
-                <div className="flex items-center gap-2">
-                  <Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" />
-                  <h3 className="font-medium text-blue-800 dark:text-blue-200">Tool Executing</h3>
-                  <ElapsedTimer startedAt={executingTool.startedAt} />
-                </div>
-                <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
-                  The assistant is currently using{' '}
-                  <code className="rounded bg-muted px-2 py-1 font-mono text-sm">
+              {/* Compact header */}
+              <div className="flex items-center gap-2 border-b border-blue-200 px-3 py-2 dark:border-blue-800">
+                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-blue-600 dark:text-blue-400" />
+                <span className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                  Running{' '}
+                  <code className="rounded bg-blue-100 px-1.5 py-0.5 font-mono text-xs dark:bg-blue-900/40">
                     {executingTool.tooluse.tool}
                   </code>
-                </p>
+                </span>
+                <ElapsedTimer startedAt={executingTool.startedAt} />
               </div>
 
-              <div className="space-y-4 p-4">
+              <div className="space-y-3 p-3">
                 {/* Arguments */}
                 {executingTool.tooluse.args.length > 0 && (
-                  <div className="space-y-2">
-                    <span className="text-sm font-medium text-muted-foreground">Arguments:</span>
+                  <div className="space-y-1">
+                    <span className="text-xs font-medium text-muted-foreground">Arguments:</span>
                     <CodeDisplay
                       code={formatArgs(executingTool.tooluse.args)}
-                      maxHeight="120px"
+                      maxHeight="80px"
                       showLineNumbers={false}
                     />
                   </div>
                 )}
 
                 {/* Code */}
-                <div className="space-y-2">
+                <div className="space-y-1">
                   <CodeDisplay
                     code={executingTool.tooluse.content}
-                    maxHeight="240px"
+                    maxHeight="200px"
                     showLineNumbers={true}
                     language={detectToolLanguage(
                       executingTool.tooluse.tool,
@@ -139,26 +137,19 @@ export function InlineToolExecution({ executingTool$ }: InlineToolExecutionProps
 
                 {/* Partial output */}
                 {executingTool.partialOutput && executingTool.partialOutput.length > 0 && (
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                       <Terminal className="h-3.5 w-3.5" />
                       Output
                     </div>
                     <CodeDisplay
                       code={executingTool.partialOutput}
-                      maxHeight="200px"
+                      maxHeight="160px"
                       showLineNumbers={false}
                       language=""
                     />
                   </div>
                 )}
-
-                {/* Status indicator */}
-                <div className="flex items-center gap-2 border-t border-blue-200 pt-3 dark:border-blue-800">
-                  <span className="text-sm text-blue-700 dark:text-blue-300">
-                    Executing tool...
-                  </span>
-                </div>
               </div>
             </div>
           </div>

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -627,12 +627,14 @@ describe('scroll stability during tool execution (gptme#3440)', () => {
     });
     renderComponent();
     // The card header text appears when executingTool is set
-    expect(screen.getByText(/tool executing/i)).toBeInTheDocument();
+    expect(screen.getByText(/running/i)).toBeInTheDocument();
+    expect(screen.getByText(/shell/i)).toBeInTheDocument();
   });
 
   it('InlineToolExecution is absent when executingTool$ is null', () => {
     renderComponent();
-    expect(screen.queryByText(/tool executing/i)).toBeNull();
+    // The compact "Running <tool>" header must not appear without an executing tool
+    expect(screen.queryByRole('code', { name: /shell/i })).toBeNull();
   });
 
   it('scrollToIndex is called when executingTool$ transitions null → set', () => {

--- a/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
+++ b/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for InlineToolConfirmation — gptme/gptme#3440
+ *
+ * Verifies that the "Accept All" button is directly visible (one click, not buried
+ * in a dropdown), and that action callbacks fire correctly.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { observable } from '@legendapp/state';
+import { InlineToolConfirmation } from '../InlineToolConfirmation';
+import type { PendingTool } from '@/stores/conversations';
+
+function makePendingTool(overrides: Partial<PendingTool['tooluse']> = {}): PendingTool {
+  return {
+    id: 'tool-1',
+    tooluse: {
+      tool: 'shell',
+      args: [],
+      content: 'ls -la',
+      ...overrides,
+    },
+  };
+}
+
+function renderConfirmation({
+  pendingTool = makePendingTool(),
+  onConfirm = jest.fn().mockResolvedValue(undefined),
+  onEdit = jest.fn().mockResolvedValue(undefined),
+  onSkip = jest.fn().mockResolvedValue(undefined),
+  onAuto = jest.fn().mockResolvedValue(undefined),
+}: {
+  pendingTool?: PendingTool | null;
+  onConfirm?: jest.Mock;
+  onEdit?: jest.Mock;
+  onSkip?: jest.Mock;
+  onAuto?: jest.Mock;
+} = {}) {
+  const pendingTool$ = observable<PendingTool | null>(pendingTool);
+  render(
+    <InlineToolConfirmation
+      pendingTool$={pendingTool$}
+      onConfirm={onConfirm}
+      onEdit={onEdit}
+      onSkip={onSkip}
+      onAuto={onAuto}
+    />
+  );
+  return { pendingTool$, onConfirm, onEdit, onSkip, onAuto };
+}
+
+describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
+  it('renders nothing when pendingTool$ is null', () => {
+    renderConfirmation({ pendingTool: null });
+    expect(screen.queryByText(/accept all/i)).toBeNull();
+    expect(screen.queryByText(/execute/i)).toBeNull();
+  });
+
+  it('shows the tool name in the header', () => {
+    renderConfirmation();
+    expect(screen.getByText(/shell/i)).toBeInTheDocument();
+  });
+
+  it('shows "Accept All" as a directly visible button (not buried in dropdown)', () => {
+    // The regression: "accept all" was hidden behind a ChevronDown dropdown,
+    // requiring 2 clicks. It must now be a first-class visible button.
+    renderConfirmation();
+    const acceptAllBtn = screen.getByRole('button', { name: /accept all/i });
+    expect(acceptAllBtn).toBeInTheDocument();
+    // It must be visible — not inside a collapsed dropdown
+    expect(acceptAllBtn).toBeVisible();
+  });
+
+  it('calls onAuto(999999) when "Accept All" is clicked', async () => {
+    const onAuto = jest.fn().mockResolvedValue(undefined);
+    renderConfirmation({ onAuto });
+
+    fireEvent.click(screen.getByRole('button', { name: /accept all/i }));
+
+    await waitFor(() => {
+      expect(onAuto).toHaveBeenCalledWith(999999);
+    });
+  });
+
+  it('calls onConfirm when "Execute" is clicked', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    renderConfirmation({ onConfirm });
+
+    fireEvent.click(screen.getByRole('button', { name: /execute/i }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  it('calls onSkip when "Skip" is clicked', async () => {
+    const onSkip = jest.fn().mockResolvedValue(undefined);
+    renderConfirmation({ onSkip });
+
+    fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+
+    await waitFor(() => {
+      expect(onSkip).toHaveBeenCalled();
+    });
+  });
+
+  it('"Accept All" button is absent in edit mode (while editing tool content)', () => {
+    renderConfirmation();
+
+    // Switch to edit mode
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    // In edit mode the Accept All button should disappear (saving & executing has
+    // different semantics — accepting all after an edit would be confusing)
+    expect(screen.queryByRole('button', { name: /accept all/i })).toBeNull();
+    // The primary button changes to "Save & Execute"
+    expect(screen.getByRole('button', { name: /save & execute/i })).toBeInTheDocument();
+  });
+
+  it('calls onEdit with edited content when "Save & Execute" is clicked', async () => {
+    const onEdit = jest.fn().mockResolvedValue(undefined);
+    renderConfirmation({ onEdit });
+
+    // Enter edit mode
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    // Edit the content
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'echo hello' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save & execute/i }));
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledWith('echo hello');
+    });
+  });
+
+  it('shows the hint that Enter key executes the tool', () => {
+    renderConfirmation();
+    expect(screen.getByText(/press enter to execute/i)).toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
+++ b/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
@@ -208,4 +208,44 @@ describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
       jest.useRealTimers();
     }
   });
+
+  it('blocks re-submission after timeout when SSE was missed (Greptile P1: Timeout re-enables submitted tool)', async () => {
+    // After the 15 s timeout releases the UI lock (to prevent indefinite freeze),
+    // the same tool must NOT be resubmittable — confirmedToolId is retained and
+    // all handlers check it before sending a POST.
+    jest.useFakeTimers();
+    try {
+      const onConfirm = jest.fn().mockResolvedValue(undefined);
+      renderConfirmation({ onConfirm });
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /execute/i }));
+      });
+
+      // Flush Promise microtasks so onConfirm's await resolves and the timeout is scheduled
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+
+      // Advance past the safety timeout (pendingTool never cleared = SSE missed)
+      act(() => {
+        jest.advanceTimersByTime(15_000);
+      });
+
+      // Timeout unlocks the UI — button re-enables to avoid indefinite freeze
+      const executeBtn = screen.getByRole('button', { name: /execute/i });
+      expect(executeBtn).not.toBeDisabled();
+
+      // But clicking again must NOT send a second POST — the tool was already confirmed
+      fireEvent.click(executeBtn);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
+++ b/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
@@ -138,4 +138,20 @@ describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
     renderConfirmation();
     expect(screen.getByText(/press enter to execute/i)).toBeInTheDocument();
   });
+
+  it('prevents duplicate submissions between POST resolve and pendingTool SSE clear', async () => {
+    // Regression guard for Greptile P1: "Confirmation lock releases too early".
+    // The POST may resolve before the SSE event clears pendingTool. Without the
+    // fix, a second click in that window would submit the already-confirmed tool.
+    const onAuto = jest.fn().mockResolvedValue(undefined);
+    renderConfirmation({ onAuto });
+
+    const acceptAllBtn = screen.getByRole('button', { name: /accept all/i });
+    fireEvent.click(acceptAllBtn);
+    await waitFor(() => expect(onAuto).toHaveBeenCalledTimes(1));
+
+    // Second click before pendingTool clears (SSE hasn't fired yet) — must be ignored
+    fireEvent.click(acceptAllBtn);
+    expect(onAuto).toHaveBeenCalledTimes(1);
+  });
 });

--- a/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
+++ b/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
@@ -202,17 +202,19 @@ describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
         jest.advanceTimersByTime(15_000);
       });
 
-      // Lock released by timeout — UI is no longer frozen
-      expect(screen.getByRole('button', { name: /execute/i })).not.toBeDisabled();
+      // After timeout: action buttons are replaced by a "Confirmed — waiting for server" banner
+      // so the UI doesn't appear interactive-but-broken (Greptile P1: "Timeout leaves inert controls").
+      expect(screen.queryByRole('button', { name: /execute/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/confirmed.*waiting for server/i)).toBeInTheDocument();
     } finally {
       jest.useRealTimers();
     }
   });
 
-  it('blocks re-submission after timeout when SSE was missed (Greptile P1: Timeout re-enables submitted tool)', async () => {
-    // After the 15 s timeout releases the UI lock (to prevent indefinite freeze),
-    // the same tool must NOT be resubmittable — confirmedToolId is retained and
-    // all handlers check it before sending a POST.
+  it('shows confirmed banner and blocks re-submission after timeout when SSE was missed (Greptile P1: Timeout leaves inert controls)', async () => {
+    // After the 15 s timeout, the action buttons are replaced by a "Confirmed — waiting"
+    // banner. This prevents the card from looking interactive when clicks would silently
+    // no-op (confirmedToolId guard). No second POST is possible.
     jest.useFakeTimers();
     try {
       const onConfirm = jest.fn().mockResolvedValue(undefined);
@@ -234,15 +236,11 @@ describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
         jest.advanceTimersByTime(15_000);
       });
 
-      // Timeout unlocks the UI — button re-enables to avoid indefinite freeze
-      const executeBtn = screen.getByRole('button', { name: /execute/i });
-      expect(executeBtn).not.toBeDisabled();
+      // Action buttons replaced by banner — no interactive-but-broken state
+      expect(screen.queryByRole('button', { name: /execute/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/confirmed.*waiting for server/i)).toBeInTheDocument();
 
-      // But clicking again must NOT send a second POST — the tool was already confirmed
-      fireEvent.click(executeBtn);
-      await act(async () => {
-        await Promise.resolve();
-      });
+      // No second POST possible — buttons are gone
       expect(onConfirm).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();

--- a/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
+++ b/webui/src/components/__tests__/InlineToolConfirmation.test.tsx
@@ -5,7 +5,7 @@
  * in a dropdown), and that action callbacks fire correctly.
  */
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { InlineToolConfirmation } from '../InlineToolConfirmation';
 import type { PendingTool } from '@/stores/conversations';
@@ -153,5 +153,59 @@ describe('InlineToolConfirmation — Accept All UX (gptme#3440)', () => {
     // Second click before pendingTool clears (SSE hasn't fired yet) — must be ignored
     fireEvent.click(acceptAllBtn);
     expect(onAuto).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains the lock when reconnect restores the same pending tool (same id)', async () => {
+    // Regression guard for Greptile P1: "Reconnect releases confirmation lock".
+    // When SSE reconnects and the backend restores the same pending tool with a
+    // fresh object reference, the lock must NOT be released — otherwise a second
+    // click can submit the already-confirmed tool before the backend clears it.
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const { pendingTool$ } = renderConfirmation({ onConfirm });
+
+    fireEvent.click(screen.getByRole('button', { name: /execute/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+
+    // Simulate reconnect restoring the same tool with a fresh object (same id = 'tool-1')
+    act(() => {
+      pendingTool$.set(makePendingTool());
+    });
+
+    // Lock must NOT be released — buttons still disabled
+    expect(screen.getByRole('button', { name: /execute/i })).toBeDisabled();
+  });
+
+  it('releases the lock after 15 s when tool_executing SSE is missed (safety timeout)', async () => {
+    // Regression guard for Greptile P1: "Missed SSE leaves controls locked".
+    // If the POST succeeds but the tool_executing SSE is lost during a disconnect,
+    // the lock must eventually release so the UI doesn't stay frozen indefinitely.
+    jest.useFakeTimers();
+    try {
+      const onConfirm = jest.fn().mockResolvedValue(undefined);
+      renderConfirmation({ onConfirm });
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /execute/i }));
+      });
+
+      // Flush the Promise microtask chain so onConfirm's await resolves
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+      // Lock is held — button disabled while waiting for SSE
+      expect(screen.getByRole('button', { name: /execute/i })).toBeDisabled();
+
+      // Advance past the 15 s safety timeout (pendingTool never cleared = SSE missed)
+      act(() => {
+        jest.advanceTimersByTime(15_000);
+      });
+
+      // Lock released by timeout — UI is no longer frozen
+      expect(screen.getByRole('button', { name: /execute/i })).not.toBeDisabled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## What

This PR addresses the last open UX item from #3440:

> *make the 'accept all' a much easier click*

### Before

"Accept All" was buried two clicks deep: click the **▼** dropdown chevron on the Execute button → click "Auto-accept all" inside the dropdown menu.

### After

**Accept All** is a first-class visible button in the action bar — one click, always visible, no menu navigation required.

The dropdown is retained for the less-common **5×**, **10×**, and **custom** count options that don't need to be primary actions.

### Compactness pass

Both InlineToolConfirmation and InlineToolExecution cards now use tighter spacing to reduce vertical footprint during multi-step tool runs (the "less large card-y" request from #3440):

- Outer margin: `mb-4 mt-4` → `mb-2 mt-2`
- Padding: `p-4` → `p-3`, `py-3` → `py-2`
- Gaps: `gap-2` → `gap-1.5` in action row
- Code/output max-height reduced slightly
- Icon/text size in action row: standard → xs/3.5

### Status

- ✅ Model selector shows wrong model on load — fixed (PR #3441)
- ✅ Multiple spinner icons — fixed (PR #3441)
- ✅ Scroll jumps during multi-step tool runs — fixed (PR #3450)
- ✅ Accept All needs to be a direct button (this PR)

## Tests

9 new unit tests in `InlineToolConfirmation.test.tsx`:

- **Accept All is directly visible** (not inside a collapsed dropdown)
- **onAuto(999999) fires** on Accept All click
- **Accept All hidden in edit mode** (edit semantics are different)
- Execute, Skip, Save & Execute callbacks all fire correctly
- "Press Enter to execute" hint text visible in header
- Null pendingTool renders nothing

All 690 webui unit tests pass (`npx jest --no-coverage`).

Closes #3440

<!-- gptme-id:v1:gai_2BPY4RyyR4bV0ztQOheXrlDnU1xJq298HqAX1d2idld -->