### PR TITLE
fix(complete): enable stuck detection for interactive/web sessions

### DIFF
--- a/gptme/tools/complete.py
+++ b/gptme/tools/complete.py
@@ -691,15 +691,14 @@ def stuck_detect_hook(
 
     Registered as a separate LOOP_CONTINUE hook at higher priority than
     ``auto_reply_hook`` so it can observe the yes-tool-but-repeating case the
-    latter early-returns on. Mutates nothing; only yields a system nudge and,
-    after repeated escalations, raises SessionCompleteException.
+    latter early-returns on. Yields a system nudge when stuck; in non-interactive
+    mode, raises SessionCompleteException after repeated escalations.
 
-    See gptme/gptme#2725 and the design note in Bob's workspace.
+    In interactive mode (e.g. gptme.ai web sessions) the nudge fires normally
+    but the session is never force-exited — the human can break the loop.
+
+    See gptme/gptme#2725, gptme/gptme#3459, and the design note in Bob's workspace.
     """
-    # Only run in non-interactive mode — a human can break their own loop.
-    if interactive:
-        return
-
     if not _env_flag("GPTME_STUCK_DETECT", "1"):
         return
 
@@ -752,6 +751,10 @@ def stuck_detect_hook(
     repeated_tool_str = "/".join(repeated_tools)
 
     if escalation_count >= escalate_max:
+        if interactive:
+            # In interactive mode (e.g. web sessions), don't force-exit — the
+            # user can break the loop by stopping generation or replying.
+            return
         logger.warning(
             "Stuck loop not broken after %d escalations (repeated `%s`). Exiting.",
             escalate_max,

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -8,7 +8,11 @@ from gptme.logmanager import Log
 from gptme.message import Message
 from gptme.tools import todo
 from gptme.tools.base import ToolUse
-from gptme.tools.complete import SessionCompleteException, auto_reply_hook
+from gptme.tools.complete import (
+    SessionCompleteException,
+    auto_reply_hook,
+    stuck_detect_hook,
+)
 
 
 class TestAutoReplyHook:
@@ -408,3 +412,87 @@ class TestTodoHelpers:
             "updated": "2025-01-01T00:00:00",
         }
         assert todo.get_incomplete_todos_summary() == ""
+
+
+# ---------------------------------------------------------------------------
+# TestStuckDetectHook
+# ---------------------------------------------------------------------------
+
+
+def _make_stuck_manager(repeat: int, extra_user_nudges: int = 0):
+    """Build a LogManager mock that looks like a session with `repeat` identical
+    assistant turns (each calling the `shell` tool with the same args)."""
+    shell_content = "```shell\nwhich python3\n```"
+
+    msgs: list[Message] = []
+    for _ in range(repeat):
+        msgs.append(Message("assistant", shell_content))
+        msgs.append(Message("system", "/usr/bin/python3", call_id="call_001"))
+
+    # Prepend any already-injected stuck nudges (simulate prior escalations)
+    for _ in range(extra_user_nudges):
+        msgs.insert(0, Message("user", "<system>You appear stuck: …</system>"))
+
+    log = MagicMock()
+    log.messages = msgs
+    manager = MagicMock()
+    manager.log = log
+    return manager
+
+
+class TestStuckDetectHook:
+    """Tests for stuck_detect_hook behavior in interactive vs non-interactive mode."""
+
+    def test_non_interactive_nudges_when_stuck(self, monkeypatch):
+        """In non-interactive mode, nudge is injected after repeat_threshold repeats."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
+        manager = _make_stuck_manager(repeat=3)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert len(results) == 1
+        assert isinstance(results[0], Message)
+        assert "appear stuck" in results[0].content
+
+    def test_non_interactive_raises_after_escalations(self, monkeypatch):
+        """After escalate_max escalations in non-interactive mode, raises SessionCompleteException."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_ESCALATE_MAX", "1")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
+        manager = _make_stuck_manager(repeat=3, extra_user_nudges=1)
+        with pytest.raises(SessionCompleteException):
+            list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+
+    def test_interactive_nudges_when_stuck(self, monkeypatch):
+        """In interactive mode (e.g. web sessions), nudge is still injected when stuck."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
+        manager = _make_stuck_manager(repeat=3)
+        results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
+        assert len(results) == 1
+        assert isinstance(results[0], Message)
+        assert "appear stuck" in results[0].content
+
+    def test_interactive_does_not_raise_after_escalations(self, monkeypatch):
+        """After escalate_max escalations in interactive mode, returns quietly (no force-exit)."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_ESCALATE_MAX", "1")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
+        manager = _make_stuck_manager(repeat=3, extra_user_nudges=1)
+        # Must NOT raise — user can break the loop manually
+        results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
+        assert results == []
+
+    def test_below_threshold_no_action(self, monkeypatch):
+        """Below repeat_threshold, no nudge is emitted."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
+        manager = _make_stuck_manager(repeat=2)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []
+
+    def test_disabled_via_env_var(self, monkeypatch):
+        """GPTME_STUCK_DETECT=0 disables the hook entirely."""
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "0")
+        manager = _make_stuck_manager(repeat=5)
+        results = list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+        assert results == []

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -1144,11 +1144,16 @@ class TestStuckDetectHook:
     _SAVE_A = "```save a.txt\nhello\n```"
     _SAVE_B = "```save b.txt\nworld\n```"
 
-    def test_interactive_noop(self):
-        """No action in interactive mode, even with identical repeats."""
+    def test_interactive_nudges_when_stuck(self):
+        """In interactive mode, nudge is still injected when stuck (but no force-exit)."""
         manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
         results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
-        assert results == []
+        assert len(results) == 1
+        msg = results[0]
+        assert isinstance(msg, Message)
+        assert msg.role == "user"
+        assert "appear stuck" in msg.content.lower()
+        assert "save" in msg.content
 
     def test_disabled_via_env_noop(self, monkeypatch):
         """No action when GPTME_STUCK_DETECT is turned off."""
@@ -1254,6 +1259,25 @@ class TestStuckDetectHook:
         )
         with pytest.raises(SessionCompleteException, match="escalations"):
             list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
+
+    def test_interactive_does_not_raise_after_escalations(self):
+        """After escalate_max escalations in interactive mode, returns quietly (no force-exit).
+
+        The user can break the loop manually by stopping generation or replying.
+        """
+        marker = "<system>You appear stuck: same action repeated.</system>"
+        manager = _mock_manager(
+            [
+                _assistant(self._SAVE_A),
+                _user(marker),
+                _assistant(self._SAVE_A),
+                _user(marker),
+                _assistant(self._SAVE_A),
+            ]
+        )
+        # Must NOT raise in interactive mode — user can break the loop
+        results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
+        assert results == []
 
     def test_custom_threshold_via_env(self, monkeypatch):
         """Repeat threshold is configurable; 2 identical turns trip a lower one."""

--- a/tests/test_tools_complete.py
+++ b/tests/test_tools_complete.py
@@ -1144,8 +1144,10 @@ class TestStuckDetectHook:
     _SAVE_A = "```save a.txt\nhello\n```"
     _SAVE_B = "```save b.txt\nworld\n```"
 
-    def test_interactive_nudges_when_stuck(self):
+    def test_interactive_nudges_when_stuck(self, monkeypatch):
         """In interactive mode, nudge is still injected when stuck (but no force-exit)."""
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
         manager = _mock_manager([_assistant(self._SAVE_A)] * 3)
         results = list(stuck_detect_hook(manager, interactive=True, prompt_queue=None))
         assert len(results) == 1
@@ -1260,11 +1262,14 @@ class TestStuckDetectHook:
         with pytest.raises(SessionCompleteException, match="escalations"):
             list(stuck_detect_hook(manager, interactive=False, prompt_queue=None))
 
-    def test_interactive_does_not_raise_after_escalations(self):
+    def test_interactive_does_not_raise_after_escalations(self, monkeypatch):
         """After escalate_max escalations in interactive mode, returns quietly (no force-exit).
 
         The user can break the loop manually by stopping generation or replying.
         """
+        monkeypatch.setenv("GPTME_STUCK_REPEAT_THRESHOLD", "3")
+        monkeypatch.setenv("GPTME_STUCK_ESCALATE_MAX", "2")
+        monkeypatch.setenv("GPTME_STUCK_DETECT", "1")
         marker = "<system>You appear stuck: same action repeated.</system>"
         manager = _mock_manager(
             [


### PR DESCRIPTION
## Summary

Fixes #3459.

Previously `stuck_detect_hook` returned immediately in interactive mode (`if interactive: return`), leaving web sessions (e.g. gptme.ai) with no safety net against infinite tool call loops.

This caused the DeepSeek loop from #3459: the model repeated the same shell commands 4+ times without making progress, and nothing caught or interrupted it.

## Root cause

The original guard comment reads: *"Only run in non-interactive mode — a human can break their own loop."* While the intent is sound for CLI sessions where the human sees live output, it accidentally disables the detection for **web sessions** too (which also run `interactive=True`). A human watching a chat UI has limited ability to interrupt a tight generation loop mid-stream, especially on models like DeepSeek that don't self-detect stuck states.

## Change

Instead of a blanket early-return, separate the two behaviors:

- **Nudge** (inject `<system>You appear stuck…</system>`): now fires in **both** interactive and non-interactive sessions
- **Force-exit** (`SessionCompleteException`): only after `escalate_max` escalations in **non-interactive** mode; in interactive mode, the function returns quietly after enough escalations (the user can stop generation manually)

## Test plan

Added `TestStuckDetectHook` with 6 tests:

| Test | What it verifies |
|------|-----------------|
| `test_non_interactive_nudges_when_stuck` | Nudge fires after threshold in non-interactive mode |
| `test_non_interactive_raises_after_escalations` | Force-exit after escalate_max in non-interactive |
| `test_interactive_nudges_when_stuck` | Nudge fires after threshold in interactive mode too ✅ |
| `test_interactive_does_not_raise_after_escalations` | No force-exit in interactive mode ✅ |
| `test_below_threshold_no_action` | No action below repeat_threshold |
| `test_disabled_via_env_var` | `GPTME_STUCK_DETECT=0` disables entirely |

All 139 tests in `test_complete.py` + `test_llm_openai.py` pass.