### PR TITLE
fix(deepseek): extract <think> reasoning into reasoning_content for deepseek-reasoner tool calls

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1393,6 +1393,39 @@ def stream(
     return captured_metadata
 
 
+def _extract_and_strip_reasoning(
+    content: str | None,
+) -> tuple[str, str]:
+    """Extract reasoning from <think>/<thinking> tags and return cleaned content.
+
+    Returns:
+        Tuple of (reasoning_content, cleaned_content_without_think_tags)
+    """
+    if not content:
+        return "", ""
+
+    # Extract content from <think>...</think> and <thinking>...</thinking> blocks
+    think_matches = re.findall(r"<think>(.*?)</think>", content, flags=re.DOTALL)
+    thinking_matches = re.findall(
+        r"<thinking>(.*?)</thinking>", content, flags=re.DOTALL
+    )
+    all_reasoning = think_matches + thinking_matches
+    reasoning = (
+        "\n".join(r.strip() for r in all_reasoning if r.strip())
+        if all_reasoning
+        else ""
+    )
+
+    # Remove <think> and <thinking> tags from content to prevent duplication
+    cleaned_content = re.sub(r"<think>.*?</think>\s*", "", content, flags=re.DOTALL)
+    cleaned_content = re.sub(
+        r"<thinking>.*?</thinking>\s*", "", cleaned_content, flags=re.DOTALL
+    )
+    cleaned_content = cleaned_content.strip()
+
+    return reasoning, cleaned_content
+
+
 def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
     # Non-tool system messages between an assistant tool_calls message and the
     # corresponding tool responses break strict APIs like DeepSeek. Buffer them
@@ -1657,15 +1690,16 @@ def _transform_msgs_for_special_provider(
         result: list[MessageDict] = []
         for msg in messages_dicts:
             content = msg.get("content")
-            # Handle messages without content (e.g., tool call messages)
+            is_assistant_tool_call = (
+                model.provider == "deepseek"
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+            )
+            # Handle messages without content (e.g., tool call messages with no text)
             if content is None:
                 # DeepSeek requires reasoning_content for assistant messages with tool_calls
-                # Since we don't store reasoning_content in Message objects, add empty reasoning_content field
-                if (
-                    model.provider == "deepseek"
-                    and msg.get("role") == "assistant"
-                    and msg.get("tool_calls")
-                ):
+                # since we don't store reasoning_content in Message objects, add empty field
+                if is_assistant_tool_call:
                     result.append(cast(MessageDict, {**msg, "reasoning_content": ""}))
                 else:
                     result.append(cast(MessageDict, msg))
@@ -1678,12 +1712,39 @@ def _transform_msgs_for_special_provider(
                     if isinstance(part, dict) and part.get("type") == "text"
                 ]
                 # Use placeholder if all parts are non-text (e.g., images only)
-                transformed = (
+                text_content = (
                     "\n\n".join(text_parts) if text_parts else "[non-text content]"
                 )
-                result.append(cast(MessageDict, {**msg, "content": transformed}))
+                # For DeepSeek reasoner with tool calls: extract <think> into reasoning_content.
+                # deepseek-reasoner embeds reasoning in <think> tags in gptme's log;
+                # the API expects it in a separate reasoning_content field.
+                if is_assistant_tool_call and model.supports_reasoning:
+                    reasoning, cleaned = _extract_and_strip_reasoning(text_content)
+                    result_msg: dict[str, Any] = {**msg, "reasoning_content": reasoning}
+                    if cleaned:
+                        result_msg["content"] = cleaned
+                    else:
+                        result_msg.pop("content", None)
+                    result.append(cast(MessageDict, result_msg))
+                else:
+                    result.append(cast(MessageDict, {**msg, "content": text_content}))
             else:
-                result.append(cast(MessageDict, msg))
+                # content is a string
+                # For DeepSeek reasoner with tool calls: extract <think> into reasoning_content
+                if (
+                    is_assistant_tool_call
+                    and model.supports_reasoning
+                    and ("<think>" in content or "<thinking>" in content)
+                ):
+                    reasoning, cleaned = _extract_and_strip_reasoning(content)
+                    result_msg = {**msg, "reasoning_content": reasoning}
+                    if cleaned:
+                        result_msg["content"] = cleaned
+                    else:
+                        result_msg.pop("content", None)
+                    result.append(cast(MessageDict, result_msg))
+                else:
+                    result.append(cast(MessageDict, msg))
         return result
 
     # Reasoning models need the structured field restored from gptme's <think>
@@ -1693,43 +1754,6 @@ def _transform_msgs_for_special_provider(
     if (model.provider == "openrouter" and model.supports_reasoning) or (
         preserve_all_reasoning
     ):
-
-        def _extract_and_strip_reasoning(
-            content: str | None,
-        ) -> tuple[str, str]:
-            """Extract reasoning from <think>/<thinking> tags and return cleaned content.
-
-            Returns:
-                Tuple of (reasoning_content, cleaned_content_without_think_tags)
-            """
-            if not content:
-                return "", ""
-
-            # Extract content from <think>...</think> and <thinking>...</thinking> blocks
-            think_matches = re.findall(
-                r"<think>(.*?)</think>", content, flags=re.DOTALL
-            )
-            thinking_matches = re.findall(
-                r"<thinking>(.*?)</thinking>", content, flags=re.DOTALL
-            )
-            all_reasoning = think_matches + thinking_matches
-            reasoning = (
-                "\n".join(r.strip() for r in all_reasoning if r.strip())
-                if all_reasoning
-                else ""
-            )
-
-            # Remove <think> and <thinking> tags from content to prevent duplication
-            cleaned_content = re.sub(
-                r"<think>.*?</think>\s*", "", content, flags=re.DOTALL
-            )
-            cleaned_content = re.sub(
-                r"<thinking>.*?</thinking>\s*", "", cleaned_content, flags=re.DOTALL
-            )
-            cleaned_content = cleaned_content.strip()
-
-            return reasoning, cleaned_content
-
         openrouter_result: list[MessageDict] = []
         for msg in messages_dicts:
             if (
@@ -1752,17 +1776,17 @@ def _transform_msgs_for_special_provider(
                     content = "\n".join(text_parts)
 
                 reasoning, cleaned_content = _extract_and_strip_reasoning(content)
-                result_msg: dict[str, Any] = {
+                openrouter_msg: dict[str, Any] = {
                     **msg,
                     "reasoning_content": reasoning,
                 }
                 if cleaned_content:
-                    result_msg["content"] = cleaned_content
+                    openrouter_msg["content"] = cleaned_content
                 else:
                     # Remove empty content to avoid provider errors (e.g. Z.AI/GLM
                     # rejects messages with empty text content)
-                    result_msg.pop("content", None)
-                openrouter_result.append(cast(MessageDict, result_msg))
+                    openrouter_msg.pop("content", None)
+                openrouter_result.append(cast(MessageDict, openrouter_msg))
             else:
                 openrouter_result.append(cast(MessageDict, msg))
         return openrouter_result

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -288,6 +288,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.55,
             "price_output": 2.19,
             "preferred_edit_format": "diff",
+            "supports_reasoning": True,
         },
     },
     # https://groq.com/pricing/

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1419,6 +1419,146 @@ def test_transform_msgs_for_deepseek_tool_results():
     assert result[0] == messages[0]
 
 
+def test_transform_msgs_for_deepseek_reasoner_think_content_string():
+    """Test that deepseek-reasoner assistant messages with <think> content and tool_calls
+    get <think> extracted into reasoning_content, not embedded in content.
+
+    This is the root cause of the tool-call loop: sending <think> tags embedded in
+    content instead of the separate reasoning_content field causes deepseek-reasoner
+    to misinterpret the conversation history and retry the same tool call.
+    """
+    from typing import Any
+
+    from gptme.llm.llm_openai import _transform_msgs_for_special_provider
+    from gptme.llm.models import ModelMeta
+
+    deepseek_reasoner_model = ModelMeta(
+        provider="deepseek",
+        model="deepseek-reasoner",
+        context=128_000,
+        supports_reasoning=True,
+    )
+
+    # Typical assistant message after streaming: <think> block + tool call in content
+    # (tool_calls field already extracted by _handle_tools, content retains <think> text)
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": "<think>\nLet me install numpy.\n</think>\n\n",
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": '{"command": "pip install numpy"}',
+                    },
+                }
+            ],
+        },
+    ]
+
+    result = list(
+        _transform_msgs_for_special_provider(messages, deepseek_reasoner_model)
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    # reasoning_content should contain the extracted reasoning, not empty string
+    assert "reasoning_content" in msg
+    assert "Let me install numpy." in msg["reasoning_content"]
+    # content should be cleaned — no <think> tags
+    assert "<think>" not in (msg.get("content") or "")
+    assert "<think>" not in msg.get("reasoning_content", "")
+    # tool_calls must be preserved
+    assert msg["tool_calls"] == messages[0]["tool_calls"]
+
+
+def test_transform_msgs_for_deepseek_reasoner_think_content_list():
+    """Test that deepseek-reasoner assistant messages with list content containing
+    <think> tags and tool_calls get <think> extracted into reasoning_content.
+
+    _handle_tools returns content as a list when there is text before the tool call.
+    """
+    from typing import Any
+
+    from gptme.llm.llm_openai import _transform_msgs_for_special_provider
+    from gptme.llm.models import ModelMeta
+
+    deepseek_reasoner_model = ModelMeta(
+        provider="deepseek",
+        model="deepseek-reasoner",
+        context=128_000,
+        supports_reasoning=True,
+    )
+
+    # content is a list (as produced by _handle_tools when there's text before the call)
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "<think>\nReasoning here.\n</think>\n\n"}
+            ],
+            "tool_calls": [
+                {
+                    "id": "call_xyz",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": '{"command": "pip install numpy"}',
+                    },
+                }
+            ],
+        },
+    ]
+
+    result = list(
+        _transform_msgs_for_special_provider(messages, deepseek_reasoner_model)
+    )
+
+    assert len(result) == 1
+    msg = result[0]
+    assert "reasoning_content" in msg
+    assert "Reasoning here." in msg["reasoning_content"]
+    assert "<think>" not in (msg.get("content") or "")
+    assert msg["tool_calls"] == messages[0]["tool_calls"]
+
+
+def test_transform_msgs_for_deepseek_chat_no_think_unchanged():
+    """Test that deepseek-chat (non-reasoner) messages without <think> are unchanged."""
+    from typing import Any
+
+    from gptme.llm.llm_openai import _transform_msgs_for_special_provider
+    from gptme.llm.models import ModelMeta
+
+    deepseek_chat_model = ModelMeta(
+        provider="deepseek",
+        model="deepseek-chat",
+        context=128_000,
+    )
+
+    # deepseek-chat doesn't generate <think> content; no content here = None case
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "shell", "arguments": '{"command": "ls"}'},
+                }
+            ],
+        },
+    ]
+
+    result = list(_transform_msgs_for_special_provider(messages, deepseek_chat_model))
+
+    assert len(result) == 1
+    # reasoning_content: "" is still required even for deepseek-chat (PR #918)
+    assert result[0]["reasoning_content"] == ""
+    assert result[0]["tool_calls"] == messages[0]["tool_calls"]
+
+
 # Tests for OpenAI retry logic
 class TestOpenAIRetryLogic:
     """Tests for OpenAI API retry logic."""


### PR DESCRIPTION
## Problem

When `deepseek-reasoner` (R1) makes a tool call, its API response has two separate fields:
- `reasoning_content`: the chain-of-thought reasoning
- `content`: null (or the actual answer text)
- `tool_calls`: the tool invocation

gptme serializes the reasoning as `<think>...</think>` in the assistant message content (alongside the `@tool(id): {args}` call). On the next API turn, `_handle_tools()` correctly extracts the tool call into `tool_calls`, leaving the `<think>...</think>` block as the `content`. But `_transform_msgs_for_special_provider()` was NOT extracting the reasoning back into the separate `reasoning_content` field.

DeepSeek-R1's API received:
```json
{"role": "assistant", "content": "<think>\nreasoning...\n</think>\n\n", "tool_calls": [...]}
```

Instead of the correct form:
```json
{"role": "assistant", "content": null, "reasoning_content": "reasoning...", "tool_calls": [...]}
```

This caused R1 to misinterpret its own conversation history and retry the same tool call without acknowledging the prior result — the tool call loop reported in #3459.

## Fix

- **Extract `_extract_and_strip_reasoning` to module level** — previously a nested function inside the OpenRouter branch of `_transform_msgs_for_special_provider`; now shared by both DeepSeek and OpenRouter branches
- **Add `supports_reasoning: True` to `deepseek-reasoner`** in `models/data.py` — marks R1 as a reasoning model, which also prevents sending `temperature` (not accepted by R1's API)
- **Update DeepSeek branch of `_transform_msgs_for_special_provider`** — for `deepseek-reasoner` assistant messages with `tool_calls`, extract `<think>` content from `content` (whether string or list) into the `reasoning_content` field and clean the `content` field

## Tests

Three new tests in `tests/test_llm_openai.py`:
- `test_transform_msgs_for_deepseek_reasoner_think_content_string` — `<think>` in string content gets extracted to `reasoning_content`, content is cleaned
- `test_transform_msgs_for_deepseek_reasoner_think_content_list` — same for list content (as produced by `_handle_tools` when there's text before the tool call)
- `test_transform_msgs_for_deepseek_chat_no_think_unchanged` — `deepseek-chat` (non-reasoner) still gets `reasoning_content: ''` for the `content is None` case (existing PR #918 behavior preserved)

Closes #3459