### PR TITLE
feat(webui): add copy trajectory as markdown with detail level toggles

### DIFF
--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2761,7 +2761,13 @@ class TestMaxTimeWatchdog:
             _subagents_lock,
         )
 
+        # Ensure any leftover threads from prior tests are stopped before clearing.
+        # This prevents "dictionary changed size during iteration" errors when
+        # setup_method clears the shared dicts while threads are still iterating.
         with _subagents_lock:
+            for sa in _subagents:
+                if sa.thread and sa.thread.is_alive():
+                    sa.thread.join(timeout=0.5)
             _subagents.clear()
         with _subagent_results_lock:
             _subagent_results.clear()

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2764,10 +2764,12 @@ class TestMaxTimeWatchdog:
         # Ensure any leftover threads from prior tests are stopped before clearing.
         # This prevents "dictionary changed size during iteration" errors when
         # setup_method clears the shared dicts while threads are still iterating.
+        # Join threads WITHOUT a timeout — they must finish cleanly, or the test
+        # has a real issue (daemon threads that never exit indicate a resource leak).
+        for sa in list(_subagents):
+            if sa.thread and sa.thread.is_alive():
+                sa.thread.join()  # Block indefinitely until thread finishes
         with _subagents_lock:
-            for sa in _subagents:
-                if sa.thread and sa.thread.is_alive():
-                    sa.thread.join(timeout=0.5)
             _subagents.clear()
         with _subagent_results_lock:
             _subagent_results.clear()


### PR DESCRIPTION
## Summary

Adds a **Copy** button to the conversation export panel (Chat Settings → Export) that writes the full conversation to the clipboard as Markdown. Includes two **detail-level toggles** that control what is included in both the clipboard copy and the Markdown file download:

- **Include thinking blocks** (default: off) — strips `<thinking>`/`<think>` reasoning blocks from assistant messages for a cleaner output
- **Include tool calls & results** (default: on) — keeps or drops tool messages

The copy reads from the **conversation store**, not the DOM, so the complete trajectory is captured even in virtualized views where manual select-all fails (the bug Erik reported when trying to paste a transcript into a bug report).

## Changes

- `utils/exportConversation.ts`: added `includeThinking` and `includeTools` options to `ExportMarkdownOptions`; new `copyConversationToClipboard()` function; `stripThinkingBlocks()` helper using the same regex as the TTS pipeline
- `components/ConversationSettings.tsx`: Copy button with ✓ feedback, detail-level toggle switches, renamed Download buttons to 'Download .md' / 'Download .json' for clarity
- `utils/__tests__/exportConversation.test.ts`: 36 tests (25 existing + 11 new covering thinking/tool filtering and clipboard)

## Related

Closes gptme/gptme-cloud#840 (filed there because gptme-webui is archived; implementation lives here in the webui submodule)