### PR TITLE
feat(webui/model-picker): add free-text custom model ID entry

### DIFF
--- a/webui/src/components/ModelPicker.tsx
+++ b/webui/src/components/ModelPicker.tsx
@@ -177,10 +177,11 @@ const ModelCommandList: FC<{
 
         {/* Custom model ID entry — shown when the typed text isn't a known model.
             Useful for specifying exact OpenRouter subproviders or any model not
-            in the curated list. The ID is passed through verbatim. */}
+            in the curated list. The ID is passed through verbatim (including
+            leading/trailing whitespace). */}
         {showCustomEntry && (
           <CommandGroup heading="Custom model ID">
-            <CommandItem value={customId} onSelect={() => onSelect(customId)}>
+            <CommandItem value={customId} onSelect={() => onSelect(search)}>
               <div className="flex items-center gap-2">
                 <Keyboard className="h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="flex min-w-0 flex-col">

--- a/webui/src/components/ModelPicker.tsx
+++ b/webui/src/components/ModelPicker.tsx
@@ -142,8 +142,8 @@ const ModelCommandList: FC<{
   // `openrouter/deepseek/deepseek-v4-flash-0731@deepseek`) that the curated
   // list doesn't include. The value is passed through verbatim — the
   // `@subprovider` suffix is preserved.
-  const customId = search.trim();
-  const showCustomEntry = customId.length > 0 && !models.some((m) => m.id === customId);
+  const customId = search;
+  const showCustomEntry = customId.trim().length > 0 && !models.some((m) => m.id === customId);
 
   const renderItem = (model: ModelInfo, showProvider: boolean) => (
     <CommandItem

--- a/webui/src/components/ModelPicker.tsx
+++ b/webui/src/components/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import { Star, Check, ChevronsUpDown } from 'lucide-react';
+import { Star, Check, ChevronsUpDown, Keyboard } from 'lucide-react';
 import { useMemo, useState, type FC } from 'react';
 import {
   Command,
@@ -120,8 +120,15 @@ const ModelCommandList: FC<{
   value?: string;
   onSelect: (modelId: string) => void;
 }> = ({ value, onSelect }) => {
-  const { availableFavorites, availableRecommended, providerGroups, favoriteSet, toggleFavorite } =
-    useModelGroups();
+  const [search, setSearch] = useState('');
+  const {
+    models,
+    availableFavorites,
+    availableRecommended,
+    providerGroups,
+    favoriteSet,
+    toggleFavorite,
+  } = useModelGroups();
 
   // Substring filter instead of cmdk's default fuzzy match
   const filter = (value: string, search: string, keywords?: string[]) => {
@@ -129,6 +136,14 @@ const ModelCommandList: FC<{
     const terms = search.toLowerCase().split(/\s+/);
     return terms.every((term) => haystack.includes(term)) ? 1 : 0;
   };
+
+  // Show "use as custom model ID" when the typed value isn't an exact known model.
+  // This lets users pin specific OpenRouter subproviders (e.g.
+  // `openrouter/deepseek/deepseek-v4-flash-0731@deepseek`) that the curated
+  // list doesn't include. The value is passed through verbatim — the
+  // `@subprovider` suffix is preserved.
+  const customId = search.trim();
+  const showCustomEntry = customId.length > 0 && !models.some((m) => m.id === customId);
 
   const renderItem = (model: ModelInfo, showProvider: boolean) => (
     <CommandItem
@@ -149,12 +164,33 @@ const ModelCommandList: FC<{
 
   return (
     <Command className="rounded-lg" filter={filter}>
-      <CommandInput placeholder="Search models..." />
+      <CommandInput
+        placeholder="Search models or enter model ID..."
+        value={search}
+        onValueChange={setSearch}
+      />
       {/* stopPropagation lets the wheel scroll this list even when rendered
           inside a Radix Dialog, whose react-remove-scroll otherwise eats the
           wheel event on document. Harmless outside a dialog. */}
       <CommandList className="max-h-[350px]" onWheel={(e) => e.stopPropagation()}>
         <CommandEmpty>No models found.</CommandEmpty>
+
+        {/* Custom model ID entry — shown when the typed text isn't a known model.
+            Useful for specifying exact OpenRouter subproviders or any model not
+            in the curated list. The ID is passed through verbatim. */}
+        {showCustomEntry && (
+          <CommandGroup heading="Custom model ID">
+            <CommandItem value={customId} onSelect={() => onSelect(customId)}>
+              <div className="flex items-center gap-2">
+                <Keyboard className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate font-mono text-sm">{customId}</span>
+                  <span className="text-xs text-muted-foreground">Use this model ID directly</span>
+                </div>
+              </div>
+            </CommandItem>
+          </CommandGroup>
+        )}
 
         {availableFavorites.length > 0 && (
           <CommandGroup heading="Favorites">

--- a/webui/src/components/__tests__/ModelPicker.test.tsx
+++ b/webui/src/components/__tests__/ModelPicker.test.tsx
@@ -1,0 +1,162 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// cmdk uses ResizeObserver and scrollIntoView; jsdom doesn't implement them.
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockToggleFavorite = jest.fn();
+
+const KNOWN_MODELS = [
+  {
+    id: 'anthropic/claude-sonnet-4-6',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    context: 200000,
+    supports_streaming: true,
+    supports_vision: true,
+    supports_reasoning: true,
+    price_input: 3,
+    price_output: 15,
+  },
+  {
+    id: 'openrouter/deepseek/deepseek-chat',
+    provider: 'openrouter',
+    model: 'deepseek/deepseek-chat',
+    context: 64000,
+    supports_streaming: true,
+    supports_vision: false,
+    supports_reasoning: false,
+    price_input: 0.14,
+    price_output: 1.1,
+  },
+];
+
+jest.mock('@/hooks/useModels', () => ({
+  useModels: () => ({
+    models: KNOWN_MODELS,
+    availableModels: KNOWN_MODELS.map((m) => m.id),
+    defaultModel: null,
+    isLoading: false,
+    error: null,
+    recommendedModels: [KNOWN_MODELS[0].id],
+    favorites: [],
+    saveFavorites: jest.fn(),
+    toggleFavorite: mockToggleFavorite,
+    saveDefaultModel: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/ApiContext', () => ({
+  useApi: () => ({
+    api: { baseUrl: 'http://localhost:5700', authHeader: null },
+    isConnected$: { get: () => true },
+  }),
+}));
+
+jest.mock('@legendapp/state/react', () => ({
+  use$: (obs: { get: () => unknown } | null) => (obs ? obs.get() : null),
+}));
+
+jest.mock('@/utils/connectionConfig', () => ({
+  isDemoMode: () => false,
+}));
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+import { ModelPicker } from '../ModelPicker';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+/** Wrap with TooltipProvider (required by ProviderIcon inside ModelItem). */
+function renderPicker(onSelect: (id: string) => void, value?: string) {
+  return render(
+    <TooltipProvider>
+      <ModelPicker onSelect={onSelect} value={value} />
+    </TooltipProvider>
+  );
+}
+
+describe('ModelPicker — custom model ID entry', () => {
+  const onSelect = jest.fn();
+
+  beforeEach(() => {
+    onSelect.mockClear();
+  });
+
+  it('renders the search input with the updated placeholder', () => {
+    renderPicker(onSelect);
+    expect(screen.getByPlaceholderText('Search models or enter model ID...')).toBeInTheDocument();
+  });
+
+  it('shows no custom entry when input is empty', () => {
+    renderPicker(onSelect);
+    expect(screen.queryByText('Use this model ID directly')).not.toBeInTheDocument();
+  });
+
+  it('shows no custom entry when typed text exactly matches a known model ID', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    await user.type(input, 'anthropic/claude-sonnet-4-6');
+
+    expect(screen.queryByText('Use this model ID directly')).not.toBeInTheDocument();
+  });
+
+  it('shows a custom entry when typed text is not a known model ID', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    await user.type(input, 'openrouter/deepseek/deepseek-v4-flash-0731@deepseek');
+
+    expect(screen.getByText('Use this model ID directly')).toBeInTheDocument();
+    expect(
+      screen.getByText('openrouter/deepseek/deepseek-v4-flash-0731@deepseek')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Custom model ID')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the exact typed ID (including @subprovider suffix)', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    const customId = 'openrouter/deepseek/deepseek-v4-flash-0731@deepseek';
+    await user.type(input, customId);
+
+    const customItem = screen.getByText('Use this model ID directly');
+    await user.click(customItem);
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(customId);
+    });
+  });
+
+  it('shows a custom entry for partial/unknown model IDs (e.g. just a vendor path)', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    await user.type(input, 'openrouter/my-org/my-private-model');
+
+    expect(screen.getByText('Use this model ID directly')).toBeInTheDocument();
+  });
+
+  it('does not show custom entry when input matches second known model exactly', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    await user.type(input, 'openrouter/deepseek/deepseek-chat');
+
+    expect(screen.queryByText('Use this model ID directly')).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/components/__tests__/ModelPicker.test.tsx
+++ b/webui/src/components/__tests__/ModelPicker.test.tsx
@@ -175,4 +175,23 @@ describe('ModelPicker — custom model ID entry', () => {
       expect(onSelect).toHaveBeenCalledWith(customId);
     });
   });
+
+  it('shows custom entry and passes verbatim input for whitespace-padded known model ID', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    const paddedId = '  anthropic/claude-sonnet-4-6  ';
+    await user.type(input, paddedId);
+
+    // Whitespace-padded ID does not match the canonical model.id, so custom entry must appear
+    expect(screen.getByText('Use this model ID directly')).toBeInTheDocument();
+
+    const customItem = screen.getByText('Use this model ID directly');
+    await user.click(customItem);
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(paddedId);
+    });
+  });
 });

--- a/webui/src/components/__tests__/ModelPicker.test.tsx
+++ b/webui/src/components/__tests__/ModelPicker.test.tsx
@@ -159,4 +159,20 @@ describe('ModelPicker — custom model ID entry', () => {
 
     expect(screen.queryByText('Use this model ID directly')).not.toBeInTheDocument();
   });
+
+  it('calls onSelect with verbatim input including leading/trailing whitespace', async () => {
+    const user = userEvent.setup();
+    renderPicker(onSelect);
+
+    const input = screen.getByPlaceholderText('Search models or enter model ID...');
+    const customId = '  openrouter/deepseek/deepseek-v4  ';
+    await user.type(input, customId);
+
+    const customItem = screen.getByText('Use this model ID directly');
+    await user.click(customItem);
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith(customId);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a free-text escape hatch to the model picker, allowing users to specify any model ID directly — including ones with `@subprovider` suffixes that the curated list doesn't enumerate.

## Motivation

When debugging provider-specific issues on OpenRouter (e.g. gptme/gptme#3459), it's necessary to pin the exact subprovider:

```
openrouter/deepseek/deepseek-v4-flash-0731@deepseek
```

The curated picker has no way to express this, so the subprovider cannot be tested or isolated.

## Behaviour

- While the user types in the search input, if the typed string **does not match any known model ID exactly**, a **'Custom model ID'** group appears at the top of the list with a single selectable item showing the typed text.
- Selecting it calls `onSelect` with the **exact string verbatim** — the `@subprovider` suffix is preserved without normalisation.
- When the typed text **matches an existing model ID exactly**, no custom entry appears (the regular item handles it).
- The placeholder is updated from `Search models...` to `Search models or enter model ID...` to surface the new capability.

## Tests

7 new unit tests in `ModelPicker.test.tsx` covering:
- Placeholder text
- No custom entry when input is empty
- No custom entry when input matches a known model exactly
- Custom entry appears for unknown IDs (including `@subprovider` suffix)
- `onSelect` receives the exact typed string verbatim
- Custom entry for partial/private model paths

Closes: gptme/gptme-cloud#841