### PR TITLE
ci(webui): auto-post before/after screenshots on PRs with visual diffs

### DIFF
--- a/.github/scripts/diff-screenshots.sh
+++ b/.github/scripts/diff-screenshots.sh
@@ -52,6 +52,21 @@ for after_file in "$AFTER_DIR"/*.png; do
   fi
 done
 
+# Also report screenshots that were removed in the PR branch (exist only in before).
+for before_file in "$BEFORE_DIR"/*.png; do
+  [ -f "$before_file" ] || continue
+  name=$(basename "$before_file")
+  after_file="$AFTER_DIR/$name"
+  [ -f "$after_file" ] && continue  # already handled above
+  TOTAL=$((TOTAL + 1))
+  [ "$FIRST" -eq 0 ] && RESULTS="$RESULTS,"
+  FIRST=0
+  echo "REMOVED: $name"
+  cp "$before_file" "$OUTPUT_DIR/before-$name"
+  RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"removed\",\"pixels\":0}"
+  CHANGED=$((CHANGED + 1))
+done
+
 RESULTS="$RESULTS]"
 SAME=$((TOTAL - CHANGED))
 

--- a/.github/scripts/diff-screenshots.sh
+++ b/.github/scripts/diff-screenshots.sh
@@ -17,9 +17,13 @@ CHANGED=0
 RESULTS="["
 FIRST=1
 
+# JSON-encode a string value (handles quotes, backslashes, control chars).
+json_str() { python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"; }
+
 for after_file in "$AFTER_DIR"/*.png; do
   [ -f "$after_file" ] || continue
   name=$(basename "$after_file")
+  name_json=$(json_str "$name")
   before_file="$BEFORE_DIR/$name"
   TOTAL=$((TOTAL + 1))
   [ "$FIRST" -eq 0 ] && RESULTS="$RESULTS,"
@@ -28,7 +32,7 @@ for after_file in "$AFTER_DIR"/*.png; do
   if [ ! -f "$before_file" ]; then
     echo "NEW: $name"
     cp "$after_file" "$OUTPUT_DIR/after-$name"
-    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"new\",\"pixels\":0}"
+    RESULTS="$RESULTS{\"name\":$name_json,\"status\":\"new\",\"pixels\":0}"
     CHANGED=$((CHANGED + 1))
     continue
   fi
@@ -44,11 +48,11 @@ for after_file in "$AFTER_DIR"/*.png; do
     echo "CHANGED: $name (${diff_count} pixels)"
     cp "$before_file" "$OUTPUT_DIR/before-$name"
     cp "$after_file" "$OUTPUT_DIR/after-$name"
-    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"changed\",\"pixels\":$diff_count}"
+    RESULTS="$RESULTS{\"name\":$name_json,\"status\":\"changed\",\"pixels\":$diff_count}"
     CHANGED=$((CHANGED + 1))
   else
     echo "SAME: $name"
-    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"same\",\"pixels\":0}"
+    RESULTS="$RESULTS{\"name\":$name_json,\"status\":\"same\",\"pixels\":0}"
   fi
 done
 
@@ -56,6 +60,7 @@ done
 for before_file in "$BEFORE_DIR"/*.png; do
   [ -f "$before_file" ] || continue
   name=$(basename "$before_file")
+  name_json=$(json_str "$name")
   after_file="$AFTER_DIR/$name"
   [ -f "$after_file" ] && continue  # already handled above
   TOTAL=$((TOTAL + 1))
@@ -63,7 +68,7 @@ for before_file in "$BEFORE_DIR"/*.png; do
   FIRST=0
   echo "REMOVED: $name"
   cp "$before_file" "$OUTPUT_DIR/before-$name"
-  RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"removed\",\"pixels\":0}"
+  RESULTS="$RESULTS{\"name\":$name_json,\"status\":\"removed\",\"pixels\":0}"
   CHANGED=$((CHANGED + 1))
 done
 

--- a/.github/scripts/diff-screenshots.sh
+++ b/.github/scripts/diff-screenshots.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Compare two directories of PNG screenshots using ImageMagick.
+# Usage: diff-screenshots.sh <before_dir> <after_dir> <output_dir>
+#
+# Writes output_dir/summary.json with { total, changed, same, results: [...] }.
+# Exits 0 always (caller checks summary.json).
+set -euo pipefail
+
+BEFORE_DIR="$1"
+AFTER_DIR="$2"
+OUTPUT_DIR="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+TOTAL=0
+CHANGED=0
+RESULTS="["
+FIRST=1
+
+for after_file in "$AFTER_DIR"/*.png; do
+  [ -f "$after_file" ] || continue
+  name=$(basename "$after_file")
+  before_file="$BEFORE_DIR/$name"
+  TOTAL=$((TOTAL + 1))
+  [ "$FIRST" -eq 0 ] && RESULTS="$RESULTS,"
+  FIRST=0
+
+  if [ ! -f "$before_file" ]; then
+    echo "NEW: $name"
+    cp "$after_file" "$OUTPUT_DIR/after-$name"
+    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"new\",\"pixels\":0}"
+    CHANGED=$((CHANGED + 1))
+    continue
+  fi
+
+  # compare returns exit 1 when images differ; capture stderr (pixel count)
+  diff_count=$(compare -metric AE "$before_file" "$after_file" \
+    "$OUTPUT_DIR/diff-$name" 2>&1 || true)
+
+  # Strip whitespace; non-numeric output means compare errored
+  diff_count=$(echo "$diff_count" | tr -d '[:space:]' | grep -oE '^[0-9]+' || echo "0")
+
+  if [ "${diff_count:-0}" -gt 0 ]; then
+    echo "CHANGED: $name (${diff_count} pixels)"
+    cp "$before_file" "$OUTPUT_DIR/before-$name"
+    cp "$after_file" "$OUTPUT_DIR/after-$name"
+    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"changed\",\"pixels\":$diff_count}"
+    CHANGED=$((CHANGED + 1))
+  else
+    echo "SAME: $name"
+    RESULTS="$RESULTS{\"name\":\"$name\",\"status\":\"same\",\"pixels\":0}"
+  fi
+done
+
+RESULTS="$RESULTS]"
+SAME=$((TOTAL - CHANGED))
+
+cat > "$OUTPUT_DIR/summary.json" <<EOF
+{
+  "total": $TOTAL,
+  "changed": $CHANGED,
+  "same": $SAME,
+  "results": $RESULTS
+}
+EOF
+
+echo ""
+echo "Result: $CHANGED/$TOTAL screenshots changed"

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -153,8 +153,11 @@ jobs:
           // Build the table rows from summary.json
           const summary = JSON.parse(fs.readFileSync('screenshots/diff/summary.json', 'utf8'));
           const icon = { changed: '⚠️', new: '🆕', removed: '🗑️', same: '✅' };
+          // Escape Markdown metacharacters that could break the table or code span.
+          // Filenames come from fork-controlled artifact content, so we must sanitize.
+          const escapeMd = s => s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\|/g, '\\|');
           const rows = summary.results.map(r =>
-            `| \`${r.name}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
+            `| \`${escapeMd(r.name)}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
           ).join('\n');
 
           const body = [

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -59,7 +59,8 @@ jobs:
         PR_NUMBER="${PR_NUMBER_FROM_EVENT}"
         if [ -z "$PR_NUMBER" ]; then
           echo "pull_requests[] empty (likely fork PR) — looking up by head SHA"
-          PR_NUMBER=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&head_sha=${HEAD_SHA}&per_page=10" \
+          PR_NUMBER=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+            --paginate \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" 2>/dev/null | head -1 || true)
         fi
         if [ -z "$PR_NUMBER" ]; then

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -153,11 +153,17 @@ jobs:
           // Build the table rows from summary.json
           const summary = JSON.parse(fs.readFileSync('screenshots/diff/summary.json', 'utf8'));
           const icon = { changed: '⚠️', new: '🆕', removed: '🗑️', same: '✅' };
-          // Escape Markdown metacharacters that could break the table or code span.
-          // Filenames come from fork-controlled artifact content, so we must sanitize.
-          const escapeMd = s => s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\|/g, '\\|');
+          // Sanitize fork-controlled filenames for Markdown table rows.
+          // Backslash-escaping backticks does NOT work inside CommonMark code spans
+          // (the spec renders code-span content verbatim), so we replace backticks
+          // with their HTML entity instead. CR/LF would break the table row, so we
+          // collapse them to space. Pipes are backslash-escaped.
+          const sanitizeMd = s => s
+            .replace(/\r?\n|\r/g, ' ')  // newlines → space (prevent row-break injection)
+            .replace(/`/g, '&#96;')     // backtick → HTML entity (code-span safe)
+            .replace(/\|/g, '\\|');     // pipe → escaped (prevent cell injection)
           const rows = summary.results.map(r =>
-            `| \`${escapeMd(r.name)}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
+            `| \`${sanitizeMd(r.name)}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
           ).join('\n');
 
           const body = [

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -179,7 +179,10 @@ jobs:
             repo: context.repo.repo,
             issue_number: prNumber,
           });
-          const existing = comments.find(c => c.body && c.body.includes(marker));
+          const existing = comments.find(c =>
+            c.user.login === 'github-actions[bot]' &&
+            c.body && c.body.includes(marker)
+          );
 
           if (existing) {
             await github.rest.issues.updateComment({

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -51,19 +51,28 @@ jobs:
         fi
         echo "screenshots_found=true" >> $GITHUB_OUTPUT
 
-        # Always derive PR number from trusted event data, never from the artifact.
-        # github.event.workflow_run.pull_requests[0].number is populated by GitHub
-        # from the triggering workflow's event, not from fork-supplied content.
+        # Derive PR number from trusted event data.
+        # github.event.workflow_run.pull_requests[0].number is populated for
+        # same-repo PRs but is EMPTY for fork PRs (GitHub limitation).
+        # Fall back to a GitHub API lookup by head SHA — the SHA is set by
+        # GitHub's infrastructure, not by user-supplied artifact content.
         PR_NUMBER="${PR_NUMBER_FROM_EVENT}"
         if [ -z "$PR_NUMBER" ]; then
-          echo "Could not determine PR number from event — skipping"
+          echo "pull_requests[] empty (likely fork PR) — looking up by head SHA"
+          PR_NUMBER=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&head_sha=${HEAD_SHA}&per_page=10" \
+            --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" 2>/dev/null | head -1 || true)
+        fi
+        if [ -z "$PR_NUMBER" ]; then
+          echo "Could not determine PR number from event or API — skipping"
           echo "skip=true" >> $GITHUB_OUTPUT
           exit 0
         fi
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         echo "skip=false" >> $GITHUB_OUTPUT
       env:
+        GH_TOKEN: ${{ github.token }}
         PR_NUMBER_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     - uses: actions/checkout@v7
       if: steps.setup.outputs.skip != 'true'

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -51,15 +51,12 @@ jobs:
         fi
         echo "screenshots_found=true" >> $GITHUB_OUTPUT
 
-        # PR number: written by the screenshots job into the artifact.
-        # For non-fork PRs we can also fall back to the event payload.
-        if [ -f "screenshots/after/pr-number.txt" ]; then
-          PR_NUMBER=$(cat screenshots/after/pr-number.txt | tr -d '[:space:]')
-        else
-          PR_NUMBER="${PR_NUMBER_FROM_EVENT}"
-        fi
+        # Always derive PR number from trusted event data, never from the artifact.
+        # github.event.workflow_run.pull_requests[0].number is populated by GitHub
+        # from the triggering workflow's event, not from fork-supplied content.
+        PR_NUMBER="${PR_NUMBER_FROM_EVENT}"
         if [ -z "$PR_NUMBER" ]; then
-          echo "Could not determine PR number — skipping"
+          echo "Could not determine PR number from event — skipping"
           echo "skip=true" >> $GITHUB_OUTPUT
           exit 0
         fi
@@ -145,7 +142,7 @@ jobs:
 
           // Build the table rows from summary.json
           const summary = JSON.parse(fs.readFileSync('screenshots/diff/summary.json', 'utf8'));
-          const icon = { changed: '⚠️', new: '🆕', same: '✅' };
+          const icon = { changed: '⚠️', new: '🆕', removed: '🗑️', same: '✅' };
           const rows = summary.results.map(r =>
             `| \`${r.name}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
           ).join('\n');

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -1,0 +1,191 @@
+name: WebUI Visual Diff
+
+# Trusted context: triggered after the WebUI workflow completes on a PR.
+# Downloads the "after" screenshots captured on the PR branch, takes "before"
+# screenshots from master, diffs them pixel-by-pixel, and posts a PR comment
+# only when at least one view has changed visually.
+#
+# Security model: this workflow runs in the base-repo context (not the fork),
+# so github.token has write access to post PR comments even on fork PRs.  The
+# "after" screenshots come from the untrusted fork run as artifacts — we never
+# execute fork code here.
+# See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+on:
+  workflow_run:
+    workflows: ["WebUI"]
+    types: [completed]
+
+jobs:
+  visual-diff:
+    # Only for pull_request-triggered WebUI runs; skip cancelled runs because
+    # the screenshots job may not have had time to upload its artifacts.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+    # Download the "after" screenshots from the triggering PR run.
+    # We scope by run_id so we always get exactly this PR's artifacts.
+    - name: Download "after" screenshots
+      uses: dawidd6/action-download-artifact@v6
+      with:
+        run_id: ${{ github.event.workflow_run.id }}
+        name: webui-visual-snapshots
+        path: screenshots/after
+        if_no_artifact_found: warn
+
+    - name: Check for after screenshots and read PR number
+      id: setup
+      run: |
+        # Check that screenshots were uploaded
+        PNG_COUNT=$(find screenshots/after -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$PNG_COUNT" -eq 0 ]; then
+          echo "No screenshots found in artifact — skipping diff"
+          echo "skip=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "screenshots_found=true" >> $GITHUB_OUTPUT
+
+        # PR number: written by the screenshots job into the artifact.
+        # For non-fork PRs we can also fall back to the event payload.
+        if [ -f "screenshots/after/pr-number.txt" ]; then
+          PR_NUMBER=$(cat screenshots/after/pr-number.txt | tr -d '[:space:]')
+        else
+          PR_NUMBER="${PR_NUMBER_FROM_EVENT}"
+        fi
+        if [ -z "$PR_NUMBER" ]; then
+          echo "Could not determine PR number — skipping"
+          echo "skip=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        echo "skip=false" >> $GITHUB_OUTPUT
+      env:
+        PR_NUMBER_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+
+    - uses: actions/checkout@v7
+      if: steps.setup.outputs.skip != 'true'
+      with:
+        ref: master
+
+    - name: Use Node.js 20
+      if: steps.setup.outputs.skip != 'true'
+      uses: actions/setup-node@v7
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: webui/package-lock.json
+
+    - name: Install dependencies (master)
+      if: steps.setup.outputs.skip != 'true'
+      working-directory: webui
+      run: npm ci
+
+    - name: Install Playwright browsers
+      if: steps.setup.outputs.skip != 'true'
+      working-directory: webui
+      run: npx playwright install --with-deps chromium
+
+    - name: Take "before" screenshots (master branch)
+      id: before
+      if: steps.setup.outputs.skip != 'true'
+      working-directory: webui
+      env:
+        SCREENSHOTS_DIR: ${{ github.workspace }}/screenshots/before
+      run: |
+        # The snapshot spec may not exist in master when this is the very first
+        # PR that adds the screenshot infrastructure.  Skip gracefully so the
+        # PR itself is not blocked.
+        if [ ! -f "e2e/visual-snapshots.spec.ts" ]; then
+          echo "No baseline spec in master yet — skipping visual diff"
+          echo "skip=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        npx playwright test e2e/visual-snapshots.spec.ts --reporter=dot
+        echo "skip=false" >> $GITHUB_OUTPUT
+
+    - name: Diff screenshots
+      id: diff
+      if: >-
+        steps.setup.outputs.skip != 'true' &&
+        steps.before.outputs.skip != 'true'
+      run: |
+        bash .github/scripts/diff-screenshots.sh \
+          screenshots/before \
+          screenshots/after \
+          screenshots/diff
+        CHANGED=$(python3 -c "import json; d=json.load(open('screenshots/diff/summary.json')); print(d['changed'])")
+        TOTAL=$(python3  -c "import json; d=json.load(open('screenshots/diff/summary.json')); print(d['total'])")
+        echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+        echo "total=$TOTAL"     >> $GITHUB_OUTPUT
+
+    - name: Upload diff artifacts
+      if: steps.diff.outputs.changed > 0
+      uses: actions/upload-artifact@v7
+      with:
+        name: webui-visual-diff-pr-${{ steps.setup.outputs.pr_number }}
+        path: screenshots/diff/
+        retention-days: 14
+
+    - name: Build and post PR comment
+      if: steps.diff.outputs.changed > 0
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const changed = parseInt('${{ steps.diff.outputs.changed }}', 10);
+          const total   = parseInt('${{ steps.diff.outputs.total }}',   10);
+          const prNumber = parseInt('${{ steps.setup.outputs.pr_number }}', 10);
+          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          // Build the table rows from summary.json
+          const summary = JSON.parse(fs.readFileSync('screenshots/diff/summary.json', 'utf8'));
+          const icon = { changed: '⚠️', new: '🆕', same: '✅' };
+          const rows = summary.results.map(r =>
+            `| \`${r.name}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
+          ).join('\n');
+
+          const body = [
+            '## 🎨 WebUI Visual Changes Detected',
+            '',
+            `**${changed} of ${total} screenshots changed** on this PR.`,
+            '',
+            '| View | Status | Pixels changed |',
+            '|------|--------|----------------|',
+            rows,
+            '',
+            `📦 Download [before/after/diff images](${runUrl}) from the workflow artifacts (GitHub sign-in required).`,
+            '',
+            '> _This comment is posted automatically when webui screenshots differ from master. No comment means no visual changes._',
+          ].join('\n');
+
+          const marker = '## 🎨 WebUI Visual Changes Detected';
+
+          // Update existing comment if present, otherwise create one
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+          });
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+          }

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -11,6 +11,8 @@ on:
       - 'Makefile'
       - 'scripts/validate_release_package.py'
       - '.github/workflows/webui.yml'
+      - '.github/workflows/webui-visual-diff.yml'
+      - '.github/scripts/diff-screenshots.sh'
 
 defaults:
   run:
@@ -218,3 +220,46 @@ jobs:
         dev="${{ steps.e2e-dev.outcome }}"
         echo "stable: $stable  dev: $dev"
         [ "$stable" = "success" ] && [ "$dev" = "success" ]
+
+  # ── Visual snapshot capture (PRs only) ───────────────────────────────────────
+  # Takes UI screenshots of the PR branch so that webui-visual-diff.yml can
+  # compare them against a master baseline and post a before/after comment
+  # when visual changes are detected.  No gptme server is needed — the webui
+  # runs in demo mode via `npm run dev`.
+  screenshots:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Use Node.js 20
+      uses: actions/setup-node@v7
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: webui/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Take visual snapshots (PR branch — "after")
+      working-directory: webui
+      env:
+        SCREENSHOTS_DIR: ${{ github.workspace }}/visual-snapshots
+      run: npx playwright test e2e/visual-snapshots.spec.ts --reporter=dot
+
+    - name: Save PR number for downstream workflow
+      run: echo "${{ github.event.pull_request.number }}" > "${{ github.workspace }}/visual-snapshots/pr-number.txt"
+
+    - name: Upload visual snapshots
+      uses: actions/upload-artifact@v7
+      with:
+        # Fixed name: the downstream workflow_run job scopes the download by
+        # run_id, so we don't need the PR number in the artifact name here.
+        name: webui-visual-snapshots
+        path: visual-snapshots/
+        retention-days: 7

--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -252,9 +252,6 @@ jobs:
         SCREENSHOTS_DIR: ${{ github.workspace }}/visual-snapshots
       run: npx playwright test e2e/visual-snapshots.spec.ts --reporter=dot
 
-    - name: Save PR number for downstream workflow
-      run: echo "${{ github.event.pull_request.number }}" > "${{ github.workspace }}/visual-snapshots/pr-number.txt"
-
     - name: Upload visual snapshots
       uses: actions/upload-artifact@v7
       with:

--- a/webui/e2e/visual-snapshots.spec.ts
+++ b/webui/e2e/visual-snapshots.spec.ts
@@ -1,0 +1,36 @@
+import { test } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+// Visual snapshot tests for before/after PR comparison.
+//
+// These are NOT assertions — they capture the UI state so that
+// .github/workflows/webui-visual-diff.yml can compare PR branch vs master
+// and post a diff comment when visual changes are detected.
+//
+// Run via:
+//   SCREENSHOTS_DIR=/tmp/shots npx playwright test e2e/visual-snapshots.spec.ts
+
+const SCREENSHOTS_DIR = process.env.SCREENSHOTS_DIR
+  ? path.resolve(process.env.SCREENSHOTS_DIR)
+  : path.join(process.cwd(), 'visual-snapshots');
+
+test.beforeAll(() => {
+  fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+});
+
+test('01-home', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '01-home.png') });
+});
+
+test('02-demo-conversation', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.getByText('Introduction to gptme').click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1000);
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '02-demo-conversation.png') });
+});

--- a/webui/e2e/visual-snapshots.spec.ts
+++ b/webui/e2e/visual-snapshots.spec.ts
@@ -20,14 +20,14 @@ test.beforeAll(() => {
 });
 
 test('01-home', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?demo=1');
   await page.waitForLoadState('networkidle');
   await page.waitForTimeout(500);
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '01-home.png') });
 });
 
 test('02-demo-conversation', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?demo=1');
   await page.waitForLoadState('networkidle');
   await page.getByText('Introduction to gptme').click();
   await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

Implements the intelligent v2 screenshot diff system described in #3467.

**How it works:**

1. **`screenshots` job** (in `webui.yml`, PR-only): runs Playwright in demo mode against the PR branch, captures key UI views, uploads them as the `webui-visual-snapshots` artifact.

2. **`webui-visual-diff.yml`** (trusted `workflow_run`): downloads the "after" artifact, checks out master and captures "before" screenshots, diffs them pixel-by-pixel with ImageMagick, then posts (or updates) a PR comment **only when at least one view changed**.

No comment = no visual changes. Reviewers see exactly what changed, not a screenshot dump on every PR.

## Files changed

| File | Purpose |
|------|---------|
| `webui/e2e/visual-snapshots.spec.ts` | Playwright spec — captures home + demo conversation views to `$SCREENSHOTS_DIR` |
| `.github/scripts/diff-screenshots.sh` | ImageMagick comparison — writes `summary.json` with per-screenshot pixel diffs |
| `.github/workflows/webui.yml` | Adds `screenshots` job (PR-only) |
| `.github/workflows/webui-visual-diff.yml` | Trusted `workflow_run` job — diffs + posts comment |

## Security model

The `workflow_run` job runs in the base-repo context (not the fork), giving `github.token` PR write access even on fork PRs. Fork code is never executed in the trusted workflow — only pre-built artifacts are downloaded. See the [GitHub security note](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

## Bootstrap behaviour

If the snapshot spec doesn't exist in master yet (i.e. this is the first PR adding the infrastructure), the before-screenshot step exits cleanly with no diff posted. Subsequent PRs will get full before/after comparison.

## Test plan

- [ ] Open a PR that changes webui layout → comment appears with changed views listed
- [ ] Open a PR that only changes Python/logic → no comment (screenshots identical)
- [ ] Open a fork PR → comment still posts (trusted `workflow_run` context)
- [ ] Open a second PR after this merges → before screenshots taken from master baseline

<!-- gptme-id:v1:gai_LbUAskX7q3VSDXL6JML0vJtpawVzbSW0iogwZ38BEPb -->