### PR TITLE
feat(review): add --trusted-reviewer guard for artifact mode

### DIFF
--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -295,27 +295,107 @@ def _load_artifact(artifact_path: str) -> ReviewArtifact:
     return ReviewArtifact.from_json(text)
 
 
+def _verify_comment_reviewer(
+    *,
+    owner: str,
+    repo: str,
+    comment_id: int,
+    expected_reviewer: str,
+) -> bool:
+    """Verify a PR review comment belongs to the claimed reviewer via GitHub API.
+
+    Fetches the comment and compares ``user.login`` case-insensitively.
+    Returns ``False`` when the API is unavailable or the login does not match,
+    so callers fail closed on network errors.
+    """
+    data = run_gh_json(
+        ["gh", "api", f"repos/{owner}/{repo}/pulls/comments/{comment_id}"],
+        timeout=10,
+    )
+    if not isinstance(data, dict):
+        logger.warning(
+            "Could not fetch GitHub comment %d for reviewer verification; "
+            "rejecting finding as unverifiable.",
+            comment_id,
+        )
+        return False
+
+    actual_login = data.get("user", {}).get("login", "")
+    if actual_login.lower() != expected_reviewer.lower():
+        logger.warning(
+            "GitHub comment %d reviewer mismatch: artifact claims '%s', "
+            "API returned '%s'; rejecting finding.",
+            comment_id,
+            expected_reviewer,
+            actual_login,
+        )
+        return False
+    return True
+
+
 def _filter_findings_by_trusted_reviewers(
     findings: list[ReviewFinding],
     trusted_reviewers: tuple[str, ...],
+    *,
+    owner: str = "",
+    repo: str = "",
 ) -> list[ReviewFinding]:
     """Filter findings to only those authored by trusted reviewers.
 
     If ``trusted_reviewers`` is empty, all findings are returned unchanged.
     If ``trusted_reviewers`` is non-empty, only findings whose ``reviewer``
-    field matches one of the allowed logins are returned.
+    field matches one of the allowed logins are returned (comparison is
+    case-insensitive — GitHub logins are case-preserving but not
+    case-sensitive).
+
+    When ``owner`` and ``repo`` are provided and a finding carries a
+    ``github_comment_id``, the reviewer field is cross-checked against the
+    GitHub API before the finding is accepted.  This prevents a forged
+    artifact from bypassing the allowlist by setting the reviewer field to a
+    trusted login without that reviewer having actually authored the comment.
+    Findings that fail API verification are rejected (fail-closed).
+    Findings without a ``github_comment_id`` are accepted on the name match
+    alone — this accommodates manually crafted artifacts while logging a
+    debug-level notice.
     """
     if not trusted_reviewers:
         return findings
 
-    trusted_set = set(trusted_reviewers)
-    filtered = [f for f in findings if f.reviewer in trusted_set]
+    # Normalise allowlist to lowercase; GitHub logins are case-insensitive.
+    trusted_set_lower = {r.lower() for r in trusted_reviewers}
+
+    filtered: list[ReviewFinding] = []
+    for f in findings:
+        if f.reviewer.lower() not in trusted_set_lower:
+            continue
+
+        if f.github_comment_id and owner and repo:
+            # Verify attribution against GitHub — reject on mismatch or API error.
+            if not _verify_comment_reviewer(
+                owner=owner,
+                repo=repo,
+                comment_id=f.github_comment_id,
+                expected_reviewer=f.reviewer,
+            ):
+                continue
+        elif f.github_comment_id and not (owner and repo):
+            logger.debug(
+                "Finding has github_comment_id=%d but no repo context for "
+                "API verification; accepting based on artifact reviewer field '%s'.",
+                f.github_comment_id,
+                f.reviewer,
+            )
+
+        filtered.append(f)
 
     if len(filtered) < len(findings):
         skipped = len(findings) - len(filtered)
         logger.info(
-            f"Filtered {skipped} finding(s) from untrusted reviewer(s); "
-            f"kept {len(filtered)} from {trusted_set}"
+            "Filtered %d finding(s) from untrusted/unverified reviewer(s); "
+            "kept %d from %s.",
+            skipped,
+            len(filtered),
+            set(trusted_reviewers),
         )
 
     return filtered
@@ -530,10 +610,15 @@ def review_watch(
             err=True,
         )
 
-        # Filter findings by trusted reviewers if specified
+        # Filter findings by trusted reviewers if specified.
+        # Pass repo context so findings with a github_comment_id are verified
+        # against the GitHub API (prevents forged-reviewer bypass).
         if trusted_reviewers:
             open_findings = _filter_findings_by_trusted_reviewers(
-                open_findings, trusted_reviewers
+                open_findings,
+                trusted_reviewers,
+                owner=effective_owner,
+                repo=effective_repo_name,
             )
             if not open_findings:
                 click.echo(

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -302,12 +302,14 @@ def _verify_comment_reviewer(
     comment_id: int,
     expected_reviewer: str,
     expected_body: str = "",
+    target_pr_number: int | None = None,
 ) -> tuple[bool, str]:
     """Verify a PR review comment belongs to the claimed reviewer and has matching body.
 
     Fetches the comment and compares:
-    1. ``user.login`` case-insensitively
+    1. ``user.login`` case-insensitively (using casefold for proper Unicode handling)
     2. Comment body contains or matches the artifact finding body (if provided)
+    3. If target_pr_number is provided, verifies the comment is on that specific PR
 
     Returns (verified, body) where verified is True only if login matches and
     body is authentic. When verification fails, body is empty string.
@@ -326,7 +328,7 @@ def _verify_comment_reviewer(
         return False, ""
 
     actual_login = data.get("user", {}).get("login", "")
-    if actual_login.lower() != expected_reviewer.lower():
+    if actual_login.casefold() != expected_reviewer.casefold():
         logger.warning(
             "GitHub comment %d reviewer mismatch: artifact claims '%s', "
             "API returned '%s'; rejecting finding.",
@@ -335,6 +337,19 @@ def _verify_comment_reviewer(
             actual_login,
         )
         return False, ""
+
+    # Verify the comment is on the target PR (prevent cross-PR comment injection)
+    if target_pr_number is not None:
+        comment_pr = data.get("pull_request", {}).get("number")
+        if comment_pr != target_pr_number:
+            logger.warning(
+                "GitHub comment %d is from PR #%s, but artifact targets PR #%d; "
+                "rejecting finding (prevents unrelated feedback injection).",
+                comment_id,
+                comment_pr,
+                target_pr_number,
+            )
+            return False, ""
 
     # Verify the comment body if one was expected
     comment_body = data.get("body", "")
@@ -358,13 +373,14 @@ def _filter_findings_by_trusted_reviewers(
     *,
     owner: str = "",
     repo: str = "",
+    pr_number: int | None = None,
 ) -> list[ReviewFinding]:
     """Filter findings to only those authored by trusted reviewers.
 
     If ``trusted_reviewers`` is empty, all findings are returned unchanged.
     If ``trusted_reviewers`` is non-empty, only findings whose ``reviewer``
     field matches one of the allowed logins are returned (comparison is
-    case-insensitive — GitHub logins are case-preserving but not
+    case-insensitive using casefold — GitHub logins are case-preserving but not
     case-sensitive).
 
     When ``owner`` and ``repo`` are provided (artifact mode with live repo
@@ -374,6 +390,9 @@ def _filter_findings_by_trusted_reviewers(
     without that reviewer having actually authored the comment. Findings
     without ``github_comment_id`` in live-repo mode are rejected (fail-closed).
 
+    When ``pr_number`` is provided, verified comments are checked to ensure
+    they are on the target PR (prevents cross-PR comment injection).
+
     When ``owner`` and ``repo`` are NOT provided (offline artifact mode),
     findings without ``github_comment_id`` are accepted on name match alone
     (no GitHub verification available). This accommodates manually crafted
@@ -382,12 +401,13 @@ def _filter_findings_by_trusted_reviewers(
     if not trusted_reviewers:
         return findings
 
-    # Normalise allowlist to lowercase; GitHub logins are case-insensitive.
-    trusted_set_lower = {r.lower() for r in trusted_reviewers}
+    # Normalise allowlist using casefold for proper Unicode case handling.
+    # GitHub logins are case-insensitive.
+    trusted_set_lower = {r.casefold() for r in trusted_reviewers}
 
     filtered: list[ReviewFinding] = []
     for f in findings:
-        if f.reviewer.lower() not in trusted_set_lower:
+        if f.reviewer.casefold() not in trusted_set_lower:
             continue
 
         if owner and repo:
@@ -408,6 +428,7 @@ def _filter_findings_by_trusted_reviewers(
                 comment_id=f.github_comment_id,
                 expected_reviewer=f.reviewer,
                 expected_body=f.body,  # Verify the finding body matches the comment
+                target_pr_number=pr_number,  # Verify comment is on target PR
             )
             if not verified:
                 continue
@@ -653,6 +674,7 @@ def review_watch(
                 trusted_reviewers,
                 owner=effective_owner,
                 repo=effective_repo_name,
+                pr_number=effective_pr_number,
             )
             if not open_findings:
                 click.echo(

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -383,20 +383,20 @@ def _filter_findings_by_trusted_reviewers(
     case-insensitive using casefold — GitHub logins are case-preserving but not
     case-sensitive).
 
-    When ``owner`` and ``repo`` are provided (artifact mode with live repo
-    context), a finding MUST carry a ``github_comment_id`` and that ID is
-    verified against the GitHub API. This prevents forged artifacts from
-    bypassing the allowlist by setting the reviewer field to a trusted login
-    without that reviewer having actually authored the comment. Findings
-    without ``github_comment_id`` in live-repo mode are rejected (fail-closed).
+    When ``trusted_reviewers`` is enabled, all findings MUST carry a
+    ``github_comment_id`` to be verifiable against the GitHub API.  This
+    prevents forged artifacts from injecting attacker-controlled findings.
+    The reviewer field and finding body are cross-checked against GitHub
+    before the finding is accepted.  Findings that fail API verification or
+    lack a ``github_comment_id`` are rejected (fail-closed).
 
     When ``pr_number`` is provided, verified comments are checked to ensure
     they are on the target PR (prevents cross-PR comment injection).
 
-    When ``owner`` and ``repo`` are NOT provided (offline artifact mode),
-    findings without ``github_comment_id`` are accepted on name match alone
-    (no GitHub verification available). This accommodates manually crafted
-    or cached artifacts in offline environments but logs a warning.
+    When ``owner`` and ``repo`` are omitted but ``trusted_reviewers`` is
+    enabled, findings with ``github_comment_id`` are accepted on name match
+    alone (accommodates offline/local mode while logging a notice).  Findings
+    without a ``github_comment_id`` are still rejected to prevent forged findings.
     """
     if not trusted_reviewers:
         return findings
@@ -410,17 +410,19 @@ def _filter_findings_by_trusted_reviewers(
         if f.reviewer.casefold() not in trusted_set_lower:
             continue
 
-        if owner and repo:
-            # Live repo mode: require github_comment_id and verify against GitHub
-            if not f.github_comment_id:
-                logger.warning(
-                    "Finding from '%s' has no github_comment_id in live-repo mode; "
-                    "rejecting for security (forged artifacts cannot be verified). "
-                    "To accept this finding, provide a github_comment_id.",
-                    f.reviewer,
-                )
-                continue
+        # When trusted-reviewer filtering is enabled, all findings MUST have
+        # a github_comment_id for verification. Findings without one are
+        # rejected (fail-closed) to prevent forged artifacts from injecting
+        # arbitrary content. See gptme/gptme#3451 for threat model.
+        if not f.github_comment_id:
+            logger.warning(
+                "Finding from trusted reviewer '%s' lacks github_comment_id; "
+                "rejecting as unverifiable (requires explicit GitHub comment link).",
+                f.reviewer,
+            )
+            continue
 
+        if owner and repo:
             # Verify attribution and body against GitHub — reject on mismatch or API error.
             verified, _body = _verify_comment_reviewer(
                 owner=owner,
@@ -433,13 +435,15 @@ def _filter_findings_by_trusted_reviewers(
             if not verified:
                 continue
         else:
-            # Offline mode: accept on name match alone (no GitHub available)
-            if not f.github_comment_id:
-                logger.debug(
-                    "Finding has no github_comment_id and no repo context; "
-                    "accepting based on artifact reviewer field '%s' (offline mode).",
-                    f.reviewer,
-                )
+            # No repo context: accept on name match + comment_id presence alone.
+            # Logs a notice since the body cannot be verified offline.
+            logger.debug(
+                "Finding has github_comment_id=%d but no repo context for "
+                "API verification; accepting based on artifact reviewer field '%s'. "
+                "(In production, provide owner and repo for full verification.)",
+                f.github_comment_id,
+                f.reviewer,
+            )
 
         filtered.append(f)
 

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -295,6 +295,32 @@ def _load_artifact(artifact_path: str) -> ReviewArtifact:
     return ReviewArtifact.from_json(text)
 
 
+def _filter_findings_by_trusted_reviewers(
+    findings: list[ReviewFinding],
+    trusted_reviewers: tuple[str, ...],
+) -> list[ReviewFinding]:
+    """Filter findings to only those authored by trusted reviewers.
+
+    If ``trusted_reviewers`` is empty, all findings are returned unchanged.
+    If ``trusted_reviewers`` is non-empty, only findings whose ``reviewer``
+    field matches one of the allowed logins are returned.
+    """
+    if not trusted_reviewers:
+        return findings
+
+    trusted_set = set(trusted_reviewers)
+    filtered = [f for f in findings if f.reviewer in trusted_set]
+
+    if len(filtered) < len(findings):
+        skipped = len(findings) - len(filtered)
+        logger.info(
+            f"Filtered {skipped} finding(s) from untrusted reviewer(s); "
+            f"kept {len(filtered)} from {trusted_set}"
+        )
+
+    return filtered
+
+
 def spawn_review_session(
     *,
     prompt: str,
@@ -382,6 +408,18 @@ def spawn_review_session(
     ),
 )
 @click.option(
+    "--trusted-reviewer",
+    "trusted_reviewers",
+    multiple=True,
+    metavar="LOGIN",
+    help=(
+        "Filter artifact findings to only those authored by these GitHub logins. "
+        "Findings from reviewers not in this allowlist are skipped. "
+        "If not given, all findings are processed (default behavior). "
+        "Can be passed multiple times: --trusted-reviewer ErikBjare --trusted-reviewer alice"
+    ),
+)
+@click.option(
     "--model",
     default=None,
     help="Model override for the continuation gptme session.",
@@ -429,6 +467,7 @@ def review_watch(
     pr_number: int | None,
     repo: str | None,
     artifact_path: str | None,
+    trusted_reviewers: tuple[str, ...],
     model: str | None,
     max_iterations: int,
     poll_interval: int,
@@ -490,6 +529,18 @@ def review_watch(
             f"#{effective_pr_number}: {len(open_findings)} open finding(s).",
             err=True,
         )
+
+        # Filter findings by trusted reviewers if specified
+        if trusted_reviewers:
+            open_findings = _filter_findings_by_trusted_reviewers(
+                open_findings, trusted_reviewers
+            )
+            if not open_findings:
+                click.echo(
+                    "  ℹ️  No findings from trusted reviewers — nothing to fix.",
+                    err=True,
+                )
+                return
 
         prompt = _build_review_prompt_from_findings(
             owner=effective_owner,

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -338,9 +338,17 @@ def _verify_comment_reviewer(
         )
         return False, ""
 
-    # Verify the comment is on the target PR (prevent cross-PR comment injection)
+    # Verify the comment is on the target PR (prevent cross-PR comment injection).
+    # The GitHub API returns pull_request_url (a string URL) not a nested dict.
+    # Example: "https://api.github.com/repos/owner/repo/pulls/42"
     if target_pr_number is not None:
-        comment_pr = data.get("pull_request", {}).get("number")
+        pr_url = data.get("pull_request_url", "")
+        comment_pr: int | None = None
+        if pr_url:
+            try:
+                comment_pr = int(pr_url.rstrip("/").split("/")[-1])
+            except (ValueError, IndexError):
+                pass
         if comment_pr != target_pr_number:
             logger.warning(
                 "GitHub comment %d is from PR #%s, but artifact targets PR #%d; "

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -308,20 +308,37 @@ def _verify_comment_reviewer(
 
     Fetches the comment and compares:
     1. ``user.login`` case-insensitively (using casefold for proper Unicode handling)
-    2. Comment body contains or matches the artifact finding body (if provided)
+    2. Comment body matches the artifact finding body exactly (if provided)
     3. If target_pr_number is provided, verifies the comment is on that specific PR
+
+    Tries the inline review-comment endpoint first (``pulls/comments``); falls
+    back to the issue-comment endpoint (``issues/comments``) for PR-level
+    conversation comments, which live in a separate ID space.
 
     Returns (verified, body) where verified is True only if login matches and
     body is authentic. When verification fails, body is empty string.
     Fails closed on network errors or mismatches.
     """
+    # Try inline review comment endpoint first.
     data = run_gh_json(
         ["gh", "api", f"repos/{owner}/{repo}/pulls/comments/{comment_id}"],
         timeout=10,
     )
+    is_issue_comment = False
+    if not isinstance(data, dict):
+        # Fall back to the issue/conversation comment endpoint.
+        # PR-level comments (not attached to a diff line) use this endpoint and
+        # have IDs that are independent of the pulls/comments ID space.
+        data = run_gh_json(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/comments/{comment_id}"],
+            timeout=10,
+        )
+        is_issue_comment = True
+
     if not isinstance(data, dict):
         logger.warning(
-            "Could not fetch GitHub comment %d for reviewer verification; "
+            "Could not fetch GitHub comment %d for reviewer verification "
+            "(tried both pulls/comments and issues/comments endpoints); "
             "rejecting finding as unverifiable.",
             comment_id,
         )
@@ -339,16 +356,26 @@ def _verify_comment_reviewer(
         return False, ""
 
     # Verify the comment is on the target PR (prevent cross-PR comment injection).
-    # The GitHub API returns pull_request_url (a string URL) not a nested dict.
-    # Example: "https://api.github.com/repos/owner/repo/pulls/42"
     if target_pr_number is not None:
-        pr_url = data.get("pull_request_url", "")
         comment_pr: int | None = None
-        if pr_url:
-            try:
-                comment_pr = int(pr_url.rstrip("/").split("/")[-1])
-            except (ValueError, IndexError):
-                pass
+        if is_issue_comment:
+            # Issue comments use ``issue_url``:
+            # "https://api.github.com/repos/owner/repo/issues/42"
+            issue_url = data.get("issue_url", "")
+            if issue_url:
+                try:
+                    comment_pr = int(issue_url.rstrip("/").split("/")[-1])
+                except (ValueError, IndexError):
+                    pass
+        else:
+            # Inline review comments use ``pull_request_url``:
+            # "https://api.github.com/repos/owner/repo/pulls/42"
+            pr_url = data.get("pull_request_url", "")
+            if pr_url:
+                try:
+                    comment_pr = int(pr_url.rstrip("/").split("/")[-1])
+                except (ValueError, IndexError):
+                    pass
         if comment_pr != target_pr_number:
             logger.warning(
                 "GitHub comment %d is from PR #%s, but artifact targets PR #%d; "
@@ -359,15 +386,16 @@ def _verify_comment_reviewer(
             )
             return False, ""
 
-    # Verify the comment body if one was expected
+    # Verify the comment body if one was expected.
+    # Require exact match (after stripping leading/trailing whitespace) to prevent
+    # substring manipulation: an attacker who supplies a context-altering fragment
+    # of a genuine trusted comment would otherwise pass a containment check.
     comment_body = data.get("body", "")
     if expected_body:
-        # For security, the artifact body must appear verbatim in the GitHub comment
-        # to prove it came from the reviewer and wasn't fabricated.
-        if expected_body not in comment_body:
+        if expected_body.strip() != comment_body.strip():
             logger.warning(
-                "GitHub comment %d body mismatch: artifact body not found in "
-                "reviewer's actual comment; rejecting finding (prevents forgery).",
+                "GitHub comment %d body mismatch: artifact body does not exactly "
+                "match reviewer's actual comment; rejecting finding (prevents forgery).",
                 comment_id,
             )
             return False, ""

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -402,9 +402,10 @@ def _filter_findings_by_trusted_reviewers(
     they are on the target PR (prevents cross-PR comment injection).
 
     When ``owner`` and ``repo`` are omitted but ``trusted_reviewers`` is
-    enabled, findings with ``github_comment_id`` are accepted on name match
-    alone (accommodates offline/local mode while logging a notice).  Findings
-    without a ``github_comment_id`` are still rejected to prevent forged findings.
+    enabled, ALL findings are rejected (fail-closed).  Without repository
+    context the comment body cannot be cross-checked against GitHub, so
+    accepting any finding would allow an attacker to strip pr metadata from
+    the artifact and bypass body verification entirely.
     """
     if not trusted_reviewers:
         return findings
@@ -443,15 +444,20 @@ def _filter_findings_by_trusted_reviewers(
             if not verified:
                 continue
         else:
-            # No repo context: accept on name match + comment_id presence alone.
-            # Logs a notice since the body cannot be verified offline.
-            logger.debug(
-                "Finding has github_comment_id=%d but no repo context for "
-                "API verification; accepting based on artifact reviewer field '%s'. "
-                "(In production, provide owner and repo for full verification.)",
-                f.github_comment_id,
+            # Fail-closed: trusted-reviewer mode requires repo context for body
+            # verification. Without owner/repo the comment body cannot be
+            # cross-checked against GitHub, so accepting would allow an attacker
+            # to omit repository metadata from the artifact and bypass verification.
+            # Provide --repo on the CLI or ensure the artifact includes pr_owner/pr_repo.
+            logger.warning(
+                "Finding from trusted reviewer '%s' (github_comment_id=%d) "
+                "cannot be verified: no repository context (owner/repo) available. "
+                "Rejecting to prevent unverified content from reaching the fix session. "
+                "Pass --repo owner/repo or ensure the artifact includes pr metadata.",
                 f.reviewer,
+                f.github_comment_id,
             )
+            continue
 
         filtered.append(f)
 

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -301,12 +301,17 @@ def _verify_comment_reviewer(
     repo: str,
     comment_id: int,
     expected_reviewer: str,
-) -> bool:
-    """Verify a PR review comment belongs to the claimed reviewer via GitHub API.
+    expected_body: str = "",
+) -> tuple[bool, str]:
+    """Verify a PR review comment belongs to the claimed reviewer and has matching body.
 
-    Fetches the comment and compares ``user.login`` case-insensitively.
-    Returns ``False`` when the API is unavailable or the login does not match,
-    so callers fail closed on network errors.
+    Fetches the comment and compares:
+    1. ``user.login`` case-insensitively
+    2. Comment body contains or matches the artifact finding body (if provided)
+
+    Returns (verified, body) where verified is True only if login matches and
+    body is authentic. When verification fails, body is empty string.
+    Fails closed on network errors or mismatches.
     """
     data = run_gh_json(
         ["gh", "api", f"repos/{owner}/{repo}/pulls/comments/{comment_id}"],
@@ -318,7 +323,7 @@ def _verify_comment_reviewer(
             "rejecting finding as unverifiable.",
             comment_id,
         )
-        return False
+        return False, ""
 
     actual_login = data.get("user", {}).get("login", "")
     if actual_login.lower() != expected_reviewer.lower():
@@ -329,8 +334,22 @@ def _verify_comment_reviewer(
             expected_reviewer,
             actual_login,
         )
-        return False
-    return True
+        return False, ""
+
+    # Verify the comment body if one was expected
+    comment_body = data.get("body", "")
+    if expected_body:
+        # For security, the artifact body must appear verbatim in the GitHub comment
+        # to prove it came from the reviewer and wasn't fabricated.
+        if expected_body not in comment_body:
+            logger.warning(
+                "GitHub comment %d body mismatch: artifact body not found in "
+                "reviewer's actual comment; rejecting finding (prevents forgery).",
+                comment_id,
+            )
+            return False, ""
+
+    return True, comment_body
 
 
 def _filter_findings_by_trusted_reviewers(
@@ -370,13 +389,15 @@ def _filter_findings_by_trusted_reviewers(
             continue
 
         if f.github_comment_id and owner and repo:
-            # Verify attribution against GitHub — reject on mismatch or API error.
-            if not _verify_comment_reviewer(
+            # Verify attribution and body against GitHub — reject on mismatch or API error.
+            verified, _body = _verify_comment_reviewer(
                 owner=owner,
                 repo=repo,
                 comment_id=f.github_comment_id,
                 expected_reviewer=f.reviewer,
-            ):
+                expected_body=f.body,  # Verify the finding body matches the comment
+            )
+            if not verified:
                 continue
         elif f.github_comment_id and not (owner and repo):
             logger.debug(

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -367,15 +367,17 @@ def _filter_findings_by_trusted_reviewers(
     case-insensitive — GitHub logins are case-preserving but not
     case-sensitive).
 
-    When ``owner`` and ``repo`` are provided and a finding carries a
-    ``github_comment_id``, the reviewer field is cross-checked against the
-    GitHub API before the finding is accepted.  This prevents a forged
-    artifact from bypassing the allowlist by setting the reviewer field to a
-    trusted login without that reviewer having actually authored the comment.
-    Findings that fail API verification are rejected (fail-closed).
-    Findings without a ``github_comment_id`` are accepted on the name match
-    alone — this accommodates manually crafted artifacts while logging a
-    debug-level notice.
+    When ``owner`` and ``repo`` are provided (artifact mode with live repo
+    context), a finding MUST carry a ``github_comment_id`` and that ID is
+    verified against the GitHub API. This prevents forged artifacts from
+    bypassing the allowlist by setting the reviewer field to a trusted login
+    without that reviewer having actually authored the comment. Findings
+    without ``github_comment_id`` in live-repo mode are rejected (fail-closed).
+
+    When ``owner`` and ``repo`` are NOT provided (offline artifact mode),
+    findings without ``github_comment_id`` are accepted on name match alone
+    (no GitHub verification available). This accommodates manually crafted
+    or cached artifacts in offline environments but logs a warning.
     """
     if not trusted_reviewers:
         return findings
@@ -388,7 +390,17 @@ def _filter_findings_by_trusted_reviewers(
         if f.reviewer.lower() not in trusted_set_lower:
             continue
 
-        if f.github_comment_id and owner and repo:
+        if owner and repo:
+            # Live repo mode: require github_comment_id and verify against GitHub
+            if not f.github_comment_id:
+                logger.warning(
+                    "Finding from '%s' has no github_comment_id in live-repo mode; "
+                    "rejecting for security (forged artifacts cannot be verified). "
+                    "To accept this finding, provide a github_comment_id.",
+                    f.reviewer,
+                )
+                continue
+
             # Verify attribution and body against GitHub — reject on mismatch or API error.
             verified, _body = _verify_comment_reviewer(
                 owner=owner,
@@ -399,13 +411,14 @@ def _filter_findings_by_trusted_reviewers(
             )
             if not verified:
                 continue
-        elif f.github_comment_id and not (owner and repo):
-            logger.debug(
-                "Finding has github_comment_id=%d but no repo context for "
-                "API verification; accepting based on artifact reviewer field '%s'.",
-                f.github_comment_id,
-                f.reviewer,
-            )
+        else:
+            # Offline mode: accept on name match alone (no GitHub available)
+            if not f.github_comment_id:
+                logger.debug(
+                    "Finding has no github_comment_id and no repo context; "
+                    "accepting based on artifact reviewer field '%s' (offline mode).",
+                    f.reviewer,
+                )
 
         filtered.append(f)
 

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -820,3 +820,170 @@ def test_review_watch_reprocesses_edited_comment(monkeypatch):
     assert spawn_calls[0] == 2, (
         "Editing a comment after it was processed must re-spawn a fix session"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for --trusted-reviewer filtering
+# ---------------------------------------------------------------------------
+
+
+def test_filter_findings_by_trusted_reviewers_all_trusted():
+    """When all findings are from trusted reviewers, all should be returned."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(body="Issue 1", reviewer="alice"),
+        ReviewFinding(body="Issue 2", reviewer="bob"),
+    ]
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings, ("alice", "bob")
+    )
+    assert len(result) == 2
+    assert result[0].body == "Issue 1"
+    assert result[1].body == "Issue 2"
+
+
+def test_filter_findings_by_trusted_reviewers_partial():
+    """When some findings are from untrusted reviewers, they should be filtered."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(body="From Alice", reviewer="alice"),
+        ReviewFinding(body="From Eve", reviewer="eve"),
+        ReviewFinding(body="From Bob", reviewer="bob"),
+    ]
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings, ("alice", "bob")
+    )
+    assert len(result) == 2
+    assert result[0].body == "From Alice"
+    assert result[1].body == "From Bob"
+
+
+def test_filter_findings_by_trusted_reviewers_empty_allowlist():
+    """When no trusted reviewers are specified, all findings should be returned."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(body="Issue 1", reviewer="alice"),
+        ReviewFinding(body="Issue 2", reviewer="eve"),
+    ]
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(findings, ())
+    assert len(result) == 2
+
+
+def test_filter_findings_by_trusted_reviewers_all_filtered():
+    """When all findings are from untrusted reviewers, result should be empty."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(body="From Eve", reviewer="eve"),
+        ReviewFinding(body="From Mallory", reviewer="mallory"),
+    ]
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings, ("alice", "bob")
+    )
+    assert len(result) == 0
+
+
+def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
+    """Artifact mode with --trusted-reviewer should filter findings before spawning."""
+    from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
+
+    artifact = ReviewArtifact(
+        pr_owner="owner",
+        pr_repo="repo",
+        pr_number=1,
+        findings=[
+            ReviewFinding(
+                body="From Alice", reviewer="alice", status=FindingStatus.OPEN
+            ),
+            ReviewFinding(body="From Eve", reviewer="eve", status=FindingStatus.OPEN),
+        ],
+    )
+
+    # Write artifact to temp file
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(artifact.to_json())
+        artifact_path = f.name
+
+    try:
+        spawn_calls: list[dict] = []
+
+        def fake_spawn(**kw):
+            spawn_calls.append(kw)
+            return {"exit_reason": "done", "duration_s": 0.1}
+
+        monkeypatch.setattr(cmd_review_watch, "spawn_review_session", fake_spawn)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            util_main,
+            [
+                "review-watch",
+                "--artifact",
+                artifact_path,
+                "--trusted-reviewer",
+                "alice",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(spawn_calls) == 1
+        # Prompt should only mention Alice's finding
+        prompt = spawn_calls[0]["prompt"]
+        assert "From Alice" in prompt
+        assert "From Eve" not in prompt
+    finally:
+        import os
+
+        os.unlink(artifact_path)
+
+
+def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
+    """Artifact mode with --trusted-reviewer should exit if no findings match."""
+    from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
+
+    artifact = ReviewArtifact(
+        pr_owner="owner",
+        pr_repo="repo",
+        pr_number=1,
+        findings=[
+            ReviewFinding(body="From Eve", reviewer="eve", status=FindingStatus.OPEN),
+        ],
+    )
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(artifact.to_json())
+        artifact_path = f.name
+
+    try:
+        spawn_calls: list[dict] = []
+
+        def fake_spawn(**kw):
+            spawn_calls.append(kw)
+            return {"exit_reason": "done", "duration_s": 0.1}
+
+        monkeypatch.setattr(cmd_review_watch, "spawn_review_session", fake_spawn)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            util_main,
+            [
+                "review-watch",
+                "--artifact",
+                artifact_path,
+                "--trusted-reviewer",
+                "alice",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(spawn_calls) == 0
+        assert "No findings from trusted reviewers" in result.output
+    finally:
+        import os
+
+        os.unlink(artifact_path)

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -828,12 +828,15 @@ def test_review_watch_reprocesses_edited_comment(monkeypatch):
 
 
 def test_filter_findings_by_trusted_reviewers_all_trusted():
-    """When all findings are from trusted reviewers, all should be returned."""
+    """When all findings are from trusted reviewers with comment IDs, all should be returned.
+
+    Findings without github_comment_id are rejected even if reviewer matches (fail-closed).
+    """
     from gptme.util.review import ReviewFinding
 
     findings = [
-        ReviewFinding(body="Issue 1", reviewer="alice"),
-        ReviewFinding(body="Issue 2", reviewer="bob"),
+        ReviewFinding(body="Issue 1", reviewer="alice", github_comment_id=11111),
+        ReviewFinding(body="Issue 2", reviewer="bob", github_comment_id=22222),
     ]
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
         findings, ("alice", "bob")
@@ -844,13 +847,16 @@ def test_filter_findings_by_trusted_reviewers_all_trusted():
 
 
 def test_filter_findings_by_trusted_reviewers_partial():
-    """When some findings are from untrusted reviewers, they should be filtered."""
+    """When some findings are from untrusted reviewers, they should be filtered.
+
+    Findings without github_comment_id are rejected even if reviewer is trusted.
+    """
     from gptme.util.review import ReviewFinding
 
     findings = [
-        ReviewFinding(body="From Alice", reviewer="alice"),
-        ReviewFinding(body="From Eve", reviewer="eve"),
-        ReviewFinding(body="From Bob", reviewer="bob"),
+        ReviewFinding(body="From Alice", reviewer="alice", github_comment_id=11111),
+        ReviewFinding(body="From Eve", reviewer="eve", github_comment_id=22222),
+        ReviewFinding(body="From Bob", reviewer="bob", github_comment_id=33333),
     ]
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
         findings, ("alice", "bob")
@@ -877,8 +883,8 @@ def test_filter_findings_by_trusted_reviewers_all_filtered():
     from gptme.util.review import ReviewFinding
 
     findings = [
-        ReviewFinding(body="From Eve", reviewer="eve"),
-        ReviewFinding(body="From Mallory", reviewer="mallory"),
+        ReviewFinding(body="From Eve", reviewer="eve", github_comment_id=22222),
+        ReviewFinding(body="From Mallory", reviewer="mallory", github_comment_id=33333),
     ]
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
         findings, ("alice", "bob")
@@ -891,8 +897,12 @@ def test_filter_findings_case_insensitive():
     from gptme.util.review import ReviewFinding
 
     findings = [
-        ReviewFinding(body="Upper-case reviewer", reviewer="ErikBjare"),
-        ReviewFinding(body="Lower-case reviewer", reviewer="alice"),
+        ReviewFinding(
+            body="Upper-case reviewer", reviewer="ErikBjare", github_comment_id=11111
+        ),
+        ReviewFinding(
+            body="Lower-case reviewer", reviewer="alice", github_comment_id=22222
+        ),
     ]
     # Allowlist uses different casing from the artifact reviewer fields.
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
@@ -1022,11 +1032,57 @@ def test_filter_findings_forged_body_rejected(monkeypatch):
     assert len(result) == 0, "Forged finding body must be rejected"
 
 
+def test_filter_findings_missing_comment_id_rejected(monkeypatch):
+    """When trusted-reviewer filtering is enabled, findings without a
+    github_comment_id must be rejected (fail-closed) to prevent forged findings
+    from bypassing verification.
+
+    This is the critical fix for the ID-less path bypass identified in
+    gptme/gptme#3470.
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        # Finding with comment_id: will be accepted if reviewer matches
+        ReviewFinding(
+            body="Legitimate review",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+        # Finding without comment_id: must be rejected even if reviewer matches
+        ReviewFinding(
+            body="Forged finding without verification",
+            reviewer="ErikBjare",
+            github_comment_id=None,  # Explicitly no ID
+        ),
+    ]
+
+    # Mock API to accept the first finding
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Here is my review:\n\nLegitimate review",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    # Only the finding WITH github_comment_id should remain
+    assert len(result) == 1, "Findings without github_comment_id must be rejected"
+    assert result[0].github_comment_id == 12345
+
+
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
     """Artifact mode with --trusted-reviewer should filter findings before spawning.
 
-    When repo context is available (owner/repo), findings must have github_comment_id
-    and pass GitHub verification. This test mocks the verification to succeed.
+    Findings must have github_comment_id to be accepted (fail-closed security policy).
     """
     from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
 
@@ -1039,25 +1095,16 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
                 body="From Alice",
                 reviewer="alice",
                 status=FindingStatus.OPEN,
-                github_comment_id=100,  # Findings must have IDs in live-repo mode
+                github_comment_id=11111,  # Required for verification
             ),
             ReviewFinding(
                 body="From Eve",
                 reviewer="eve",
                 status=FindingStatus.OPEN,
-                github_comment_id=101,
+                github_comment_id=22222,  # Required for verification
             ),
         ],
     )
-
-    # Mock GitHub comment verification to succeed
-    def fake_verify(*, owner, repo, comment_id, expected_reviewer, expected_body=""):
-        # Simulate successful verification for alice's comment
-        if comment_id == 100 and expected_reviewer.lower() == "alice":
-            return True, "From Alice"
-        return False, ""
-
-    monkeypatch.setattr(cmd_review_watch, "_verify_comment_reviewer", fake_verify)
 
     # Write artifact to temp file
     import tempfile
@@ -1073,7 +1120,16 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
             spawn_calls.append(kw)
             return {"exit_reason": "done", "duration_s": 0.1}
 
+        def fake_run_gh_json(args, **kwargs):
+            # Mock API: return both comments as if from trusted reviewers
+            if "pulls/comments/11111" in " ".join(args):
+                return {"user": {"login": "alice"}, "body": "Review:\n\nFrom Alice"}
+            if "pulls/comments/22222" in " ".join(args):
+                return {"user": {"login": "eve"}, "body": "Review:\n\nFrom Eve"}
+            return None
+
         monkeypatch.setattr(cmd_review_watch, "spawn_review_session", fake_spawn)
+        monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -1088,7 +1144,7 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
         )
         assert result.exit_code == 0
         assert len(spawn_calls) == 1
-        # Prompt should only mention Alice's finding
+        # Prompt should only mention Alice's finding (Eve is filtered out)
         prompt = spawn_calls[0]["prompt"]
         assert "From Alice" in prompt
         assert "From Eve" not in prompt
@@ -1101,8 +1157,9 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
 def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
     """Artifact mode with --trusted-reviewer should exit if no findings match.
 
-    When repo context is available, findings must have github_comment_id.
-    This test includes an unverified finding to test filtering.
+    Findings can be filtered for two reasons:
+    1. Reviewer not in allowlist (different reviewer)
+    2. Missing github_comment_id (fail-closed security policy)
     """
     from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
 
@@ -1115,16 +1172,10 @@ def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
                 body="From Eve",
                 reviewer="eve",
                 status=FindingStatus.OPEN,
-                github_comment_id=101,
+                github_comment_id=99999,  # Has ID, but wrong reviewer
             ),
         ],
     )
-
-    # Mock GitHub verification to reject eve's comment
-    def fake_verify(*, owner, repo, comment_id, expected_reviewer, expected_body=""):
-        return False, ""  # Reject all verification
-
-    monkeypatch.setattr(cmd_review_watch, "_verify_comment_reviewer", fake_verify)
 
     import tempfile
 
@@ -1149,7 +1200,7 @@ def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
                 "--artifact",
                 artifact_path,
                 "--trusted-reviewer",
-                "alice",
+                "alice",  # Only alice is trusted, eve is not
             ],
         )
         assert result.exit_code == 0

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -1023,7 +1023,11 @@ def test_filter_findings_forged_body_rejected(monkeypatch):
 
 
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
-    """Artifact mode with --trusted-reviewer should filter findings before spawning."""
+    """Artifact mode with --trusted-reviewer should filter findings before spawning.
+
+    When repo context is available (owner/repo), findings must have github_comment_id
+    and pass GitHub verification. This test mocks the verification to succeed.
+    """
     from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
 
     artifact = ReviewArtifact(
@@ -1032,11 +1036,28 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
         pr_number=1,
         findings=[
             ReviewFinding(
-                body="From Alice", reviewer="alice", status=FindingStatus.OPEN
+                body="From Alice",
+                reviewer="alice",
+                status=FindingStatus.OPEN,
+                github_comment_id=100,  # Findings must have IDs in live-repo mode
             ),
-            ReviewFinding(body="From Eve", reviewer="eve", status=FindingStatus.OPEN),
+            ReviewFinding(
+                body="From Eve",
+                reviewer="eve",
+                status=FindingStatus.OPEN,
+                github_comment_id=101,
+            ),
         ],
     )
+
+    # Mock GitHub comment verification to succeed
+    def fake_verify(*, owner, repo, comment_id, expected_reviewer, expected_body=""):
+        # Simulate successful verification for alice's comment
+        if comment_id == 100 and expected_reviewer.lower() == "alice":
+            return True, "From Alice"
+        return False, ""
+
+    monkeypatch.setattr(cmd_review_watch, "_verify_comment_reviewer", fake_verify)
 
     # Write artifact to temp file
     import tempfile
@@ -1078,7 +1099,11 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
 
 
 def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
-    """Artifact mode with --trusted-reviewer should exit if no findings match."""
+    """Artifact mode with --trusted-reviewer should exit if no findings match.
+
+    When repo context is available, findings must have github_comment_id.
+    This test includes an unverified finding to test filtering.
+    """
     from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding
 
     artifact = ReviewArtifact(
@@ -1086,9 +1111,20 @@ def test_review_watch_artifact_with_trusted_reviewer_no_match(monkeypatch):
         pr_repo="repo",
         pr_number=1,
         findings=[
-            ReviewFinding(body="From Eve", reviewer="eve", status=FindingStatus.OPEN),
+            ReviewFinding(
+                body="From Eve",
+                reviewer="eve",
+                status=FindingStatus.OPEN,
+                github_comment_id=101,
+            ),
         ],
     )
+
+    # Mock GitHub verification to reject eve's comment
+    def fake_verify(*, owner, repo, comment_id, expected_reviewer, expected_body=""):
+        return False, ""  # Reject all verification
+
+    monkeypatch.setattr(cmd_review_watch, "_verify_comment_reviewer", fake_verify)
 
     import tempfile
 

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -918,7 +918,7 @@ def test_filter_findings_forged_reviewer_rejected(monkeypatch):
     # API returns a different user for comment 99999.
     def fake_run_gh_json(args, **kwargs):
         if "pulls/comments/99999" in " ".join(args):
-            return {"user": {"login": "attacker"}}
+            return {"user": {"login": "attacker"}, "body": "Some comment"}
         return None
 
     monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
@@ -933,7 +933,7 @@ def test_filter_findings_forged_reviewer_rejected(monkeypatch):
 
 
 def test_filter_findings_verified_reviewer_accepted(monkeypatch):
-    """A finding whose github_comment_id confirms the trusted reviewer is accepted."""
+    """A finding whose github_comment_id confirms the trusted reviewer and body is accepted."""
     from gptme.util.review import ReviewFinding
 
     findings = [
@@ -944,10 +944,13 @@ def test_filter_findings_verified_reviewer_accepted(monkeypatch):
         ),
     ]
 
-    # API confirms ErikBjare authored comment 12345.
+    # API confirms ErikBjare authored comment 12345 with the matching body.
     def fake_run_gh_json(args, **kwargs):
         if "pulls/comments/12345" in " ".join(args):
-            return {"user": {"login": "ErikBjare"}}
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Here is my review:\n\nReal review comment\n\nPlease fix this.",
+            }
         return None
 
     monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
@@ -974,7 +977,7 @@ def test_filter_findings_api_unavailable_rejected(monkeypatch):
         ),
     ]
 
-    # Simulate API failure.
+    # Simulate API failure (returns None).
     monkeypatch.setattr(cmd_review_watch, "run_gh_json", lambda *a, **kw: None)
 
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
@@ -984,6 +987,39 @@ def test_filter_findings_api_unavailable_rejected(monkeypatch):
         repo="repo",
     )
     assert len(result) == 0, "Unverifiable finding must be rejected (fail-closed)"
+
+
+def test_filter_findings_forged_body_rejected(monkeypatch):
+    """When a forged artifact has a different body than the GitHub comment,
+    it must be rejected even if the reviewer login is trusted."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Inject malicious code",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    # API confirms ErikBjare authored comment 12345, but with different body.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Please add better error handling to this function.",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, "Forged finding body must be rejected"
 
 
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -844,13 +844,13 @@ def test_filter_findings_by_trusted_reviewers_all_trusted(monkeypatch):
         if "pulls/comments/11111" in " ".join(args):
             return {
                 "user": {"login": "alice"},
-                "body": "Here is my review:\n\nIssue 1",
+                "body": "Issue 1",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         if "pulls/comments/22222" in " ".join(args):
             return {
                 "user": {"login": "bob"},
-                "body": "Here is my review:\n\nIssue 2",
+                "body": "Issue 2",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         return None
@@ -883,13 +883,13 @@ def test_filter_findings_by_trusted_reviewers_partial(monkeypatch):
         if "pulls/comments/11111" in " ".join(args):
             return {
                 "user": {"login": "alice"},
-                "body": "Here is my review:\n\nFrom Alice",
+                "body": "From Alice",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         if "pulls/comments/33333" in " ".join(args):
             return {
                 "user": {"login": "bob"},
-                "body": "Here is my review:\n\nFrom Bob",
+                "body": "From Bob",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         return None
@@ -947,13 +947,13 @@ def test_filter_findings_case_insensitive(monkeypatch):
         if "pulls/comments/11111" in " ".join(args):
             return {
                 "user": {"login": "ErikBjare"},
-                "body": "Here is my review:\n\nUpper-case reviewer",
+                "body": "Upper-case reviewer",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         if "pulls/comments/22222" in " ".join(args):
             return {
                 "user": {"login": "alice"},
-                "body": "Here is my review:\n\nLower-case reviewer",
+                "body": "Lower-case reviewer",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         return None
@@ -999,7 +999,11 @@ def test_filter_findings_forged_reviewer_rejected(monkeypatch):
 
 
 def test_filter_findings_verified_reviewer_accepted(monkeypatch):
-    """A finding whose github_comment_id confirms the trusted reviewer and body is accepted."""
+    """A finding whose github_comment_id confirms the trusted reviewer and body is accepted.
+
+    Body verification requires exact match (after strip): the artifact must store
+    the full, unmodified comment body — not a substring.
+    """
     from gptme.util.review import ReviewFinding
 
     findings = [
@@ -1010,12 +1014,12 @@ def test_filter_findings_verified_reviewer_accepted(monkeypatch):
         ),
     ]
 
-    # API confirms ErikBjare authored comment 12345 with the matching body.
+    # API confirms ErikBjare authored comment 12345 with an exactly matching body.
     def fake_run_gh_json(args, **kwargs):
         if "pulls/comments/12345" in " ".join(args):
             return {
                 "user": {"login": "ErikBjare"},
-                "body": "Here is my review:\n\nReal review comment\n\nPlease fix this.",
+                "body": "Real review comment",
             }
         return None
 
@@ -1113,12 +1117,12 @@ def test_filter_findings_missing_comment_id_rejected(monkeypatch):
         ),
     ]
 
-    # Mock API to accept the first finding
+    # Mock API to accept the first finding (body matches exactly)
     def fake_run_gh_json(args, **kwargs):
         if "pulls/comments/12345" in " ".join(args):
             return {
                 "user": {"login": "ErikBjare"},
-                "body": "Here is my review:\n\nLegitimate review",
+                "body": "Legitimate review",
             }
         return None
 
@@ -1153,13 +1157,13 @@ def test_filter_findings_cross_pr_injection_rejected(monkeypatch):
         ),
     ]
 
-    # API returns the comment as valid (ErikBjare is trusted, body matches),
+    # API returns the comment as valid (ErikBjare is trusted, body matches exactly),
     # but it belongs to PR #2, not the target PR #1.
     def fake_run_gh_json(args, **kwargs):
         if "pulls/comments/99999" in " ".join(args):
             return {
                 "user": {"login": "ErikBjare"},
-                "body": "Here is my review:\n\nReal comment from ErikBjare",
+                "body": "Real comment from ErikBjare",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/2",
             }
         return None
@@ -1192,7 +1196,7 @@ def test_filter_findings_pr_bound_accepted_for_correct_pr(monkeypatch):
         if "pulls/comments/12345" in " ".join(args):
             return {
                 "user": {"login": "ErikBjare"},
-                "body": "Here is my review:\n\nReal comment from ErikBjare",
+                "body": "Real comment from ErikBjare",
                 "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
             }
         return None
@@ -1207,6 +1211,135 @@ def test_filter_findings_pr_bound_accepted_for_correct_pr(monkeypatch):
         pr_number=1,  # Comment is on PR #1, target is PR #1 — should pass
     )
     assert len(result) == 1, "Valid comment on correct PR must be accepted"
+
+
+def test_filter_findings_substring_body_rejected(monkeypatch):
+    """A finding whose body is a substring of the real GitHub comment must be rejected.
+
+    This is the exact-match fix: a fragment of a genuine trusted comment can alter
+    meaning by stripping surrounding qualifiers or negation. Verification now requires
+    the artifact body to match the full GitHub comment body exactly (after strip).
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="add the unsafe flag",  # fragment — strips the "do not" prefix
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "do not add the unsafe flag",  # real comment has negation
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, (
+        "A fragment/substring of the real comment must be rejected "
+        "(exact body match required)"
+    )
+
+
+def test_filter_findings_conversation_comment_accepted(monkeypatch):
+    """A finding whose github_comment_id is a PR conversation (issue) comment ID is
+    accepted when it resolves correctly via the issues/comments endpoint.
+
+    Inline review comments (attached to diff lines) live at pulls/comments/{id}.
+    PR-level conversation comments live at issues/comments/{id} and use a separate
+    ID space.  The verifier must try the issues/comments endpoint as a fallback so
+    valid PR-level findings are not silently discarded.
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="PR-level conversation comment",
+            reviewer="ErikBjare",
+            github_comment_id=55555,  # lives in issues/comments space
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        joined = " ".join(args)
+        if "pulls/comments/55555" in joined:
+            # Not an inline comment — endpoint returns nothing
+            return None
+        if "issues/comments/55555" in joined:
+            # Found via conversation-comment endpoint
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "PR-level conversation comment",
+                "issue_url": "https://api.github.com/repos/owner/repo/issues/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+        pr_number=1,
+    )
+    assert len(result) == 1, (
+        "Conversation comment (issue/comment ID) must be accepted via fallback endpoint"
+    )
+
+
+def test_filter_findings_conversation_comment_wrong_pr_rejected(monkeypatch):
+    """A conversation comment from a different PR must be rejected even via the
+    issues/comments fallback endpoint.
+
+    PR-bound check for conversation comments uses ``issue_url`` rather than
+    ``pull_request_url`` (which is absent on issue comments).
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Comment from another PR",
+            reviewer="ErikBjare",
+            github_comment_id=55555,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        joined = " ".join(args)
+        if "pulls/comments/55555" in joined:
+            return None
+        if "issues/comments/55555" in joined:
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Comment from another PR",
+                "issue_url": "https://api.github.com/repos/owner/repo/issues/2",  # PR #2
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+        pr_number=1,  # target is PR #1, comment is on PR #2
+    )
+    assert len(result) == 0, (
+        "Conversation comment from a different PR must be rejected (PR-bound check)"
+    )
 
 
 def test_filter_findings_missing_repo_context_rejected():
@@ -1288,17 +1421,18 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
             return {"exit_reason": "done", "duration_s": 0.1}
 
         def fake_run_gh_json(args, **kwargs):
-            # Mock API: return both comments as if from trusted reviewers on PR #1
+            # Mock API: return both comments as if from trusted reviewers on PR #1.
+            # Body must match the artifact finding body exactly.
             if "pulls/comments/11111" in " ".join(args):
                 return {
                     "user": {"login": "alice"},
-                    "body": "Review:\n\nFrom Alice",
+                    "body": "From Alice",
                     "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
                 }
             if "pulls/comments/22222" in " ".join(args):
                 return {
                     "user": {"login": "eve"},
-                    "body": "Review:\n\nFrom Eve",
+                    "body": "From Eve",
                     "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
                 }
             return None

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -1079,6 +1079,80 @@ def test_filter_findings_missing_comment_id_rejected(monkeypatch):
     assert result[0].github_comment_id == 12345
 
 
+def test_filter_findings_cross_pr_injection_rejected(monkeypatch):
+    """A trusted reviewer's comment from a different PR must be rejected.
+
+    This is the PR-bound verification fix for gptme/gptme#3451: an attacker
+    can craft an artifact that claims a trusted reviewer's comment_id from
+    PR #2 as justification for a fix on PR #1. The verification must check
+    that the comment belongs to the target PR.
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real comment from ErikBjare",
+            reviewer="ErikBjare",
+            github_comment_id=99999,
+        ),
+    ]
+
+    # API returns the comment as valid (ErikBjare is trusted, body matches),
+    # but it belongs to PR #2, not the target PR #1.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/99999" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Here is my review:\n\nReal comment from ErikBjare",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/2",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+        pr_number=1,  # Target is PR #1, but comment is from PR #2
+    )
+    assert len(result) == 0, "Cross-PR comment injection must be rejected"
+
+
+def test_filter_findings_pr_bound_accepted_for_correct_pr(monkeypatch):
+    """A trusted reviewer's comment on the correct PR is accepted."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real comment from ErikBjare",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Here is my review:\n\nReal comment from ErikBjare",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+        pr_number=1,  # Comment is on PR #1, target is PR #1 — should pass
+    )
+    assert len(result) == 1, "Valid comment on correct PR must be accepted"
+
+
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
     """Artifact mode with --trusted-reviewer should filter findings before spawning.
 
@@ -1121,11 +1195,19 @@ def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
             return {"exit_reason": "done", "duration_s": 0.1}
 
         def fake_run_gh_json(args, **kwargs):
-            # Mock API: return both comments as if from trusted reviewers
+            # Mock API: return both comments as if from trusted reviewers on PR #1
             if "pulls/comments/11111" in " ".join(args):
-                return {"user": {"login": "alice"}, "body": "Review:\n\nFrom Alice"}
+                return {
+                    "user": {"login": "alice"},
+                    "body": "Review:\n\nFrom Alice",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+                }
             if "pulls/comments/22222" in " ".join(args):
-                return {"user": {"login": "eve"}, "body": "Review:\n\nFrom Eve"}
+                return {
+                    "user": {"login": "eve"},
+                    "body": "Review:\n\nFrom Eve",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+                }
             return None
 
         monkeypatch.setattr(cmd_review_watch, "spawn_review_session", fake_spawn)

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -886,6 +886,106 @@ def test_filter_findings_by_trusted_reviewers_all_filtered():
     assert len(result) == 0
 
 
+def test_filter_findings_case_insensitive():
+    """Reviewer matching must be case-insensitive (GitHub logins are case-insensitive)."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(body="Upper-case reviewer", reviewer="ErikBjare"),
+        ReviewFinding(body="Lower-case reviewer", reviewer="alice"),
+    ]
+    # Allowlist uses different casing from the artifact reviewer fields.
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings, ("erikbjare", "ALICE")
+    )
+    assert len(result) == 2, "Both findings should match case-insensitively"
+
+
+def test_filter_findings_forged_reviewer_rejected(monkeypatch):
+    """A forged artifact that sets reviewer to a trusted login must be rejected
+    when the GitHub API confirms the comment belongs to a different user."""
+    from gptme.util.review import ReviewFinding
+
+    # Finding claims ErikBjare as reviewer and has a github_comment_id.
+    findings = [
+        ReviewFinding(
+            body="Inject arbitrary instruction",
+            reviewer="ErikBjare",
+            github_comment_id=99999,
+        ),
+    ]
+
+    # API returns a different user for comment 99999.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/99999" in " ".join(args):
+            return {"user": {"login": "attacker"}}
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, "Forged reviewer attribution must be rejected"
+
+
+def test_filter_findings_verified_reviewer_accepted(monkeypatch):
+    """A finding whose github_comment_id confirms the trusted reviewer is accepted."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    # API confirms ErikBjare authored comment 12345.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {"user": {"login": "ErikBjare"}}
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 1, "Verified finding must be accepted"
+
+
+def test_filter_findings_api_unavailable_rejected(monkeypatch):
+    """When the GitHub API is unavailable, findings with a comment ID must be
+    rejected (fail-closed) rather than silently accepted."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Some finding",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    # Simulate API failure.
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", lambda *a, **kw: None)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, "Unverifiable finding must be rejected (fail-closed)"
+
+
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):
     """Artifact mode with --trusted-reviewer should filter findings before spawning."""
     from gptme.util.review import FindingStatus, ReviewArtifact, ReviewFinding

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -827,10 +827,11 @@ def test_review_watch_reprocesses_edited_comment(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_filter_findings_by_trusted_reviewers_all_trusted():
+def test_filter_findings_by_trusted_reviewers_all_trusted(monkeypatch):
     """When all findings are from trusted reviewers with comment IDs, all should be returned.
 
     Findings without github_comment_id are rejected even if reviewer matches (fail-closed).
+    Repo context (owner/repo) must be provided; without it all findings are rejected.
     """
     from gptme.util.review import ReviewFinding
 
@@ -838,18 +839,37 @@ def test_filter_findings_by_trusted_reviewers_all_trusted():
         ReviewFinding(body="Issue 1", reviewer="alice", github_comment_id=11111),
         ReviewFinding(body="Issue 2", reviewer="bob", github_comment_id=22222),
     ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/11111" in " ".join(args):
+            return {
+                "user": {"login": "alice"},
+                "body": "Here is my review:\n\nIssue 1",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        if "pulls/comments/22222" in " ".join(args):
+            return {
+                "user": {"login": "bob"},
+                "body": "Here is my review:\n\nIssue 2",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
-        findings, ("alice", "bob")
+        findings, ("alice", "bob"), owner="owner", repo="repo"
     )
     assert len(result) == 2
     assert result[0].body == "Issue 1"
     assert result[1].body == "Issue 2"
 
 
-def test_filter_findings_by_trusted_reviewers_partial():
+def test_filter_findings_by_trusted_reviewers_partial(monkeypatch):
     """When some findings are from untrusted reviewers, they should be filtered.
 
     Findings without github_comment_id are rejected even if reviewer is trusted.
+    Repo context (owner/repo) must be provided; without it all findings are rejected.
     """
     from gptme.util.review import ReviewFinding
 
@@ -858,8 +878,26 @@ def test_filter_findings_by_trusted_reviewers_partial():
         ReviewFinding(body="From Eve", reviewer="eve", github_comment_id=22222),
         ReviewFinding(body="From Bob", reviewer="bob", github_comment_id=33333),
     ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/11111" in " ".join(args):
+            return {
+                "user": {"login": "alice"},
+                "body": "Here is my review:\n\nFrom Alice",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        if "pulls/comments/33333" in " ".join(args):
+            return {
+                "user": {"login": "bob"},
+                "body": "Here is my review:\n\nFrom Bob",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
-        findings, ("alice", "bob")
+        findings, ("alice", "bob"), owner="owner", repo="repo"
     )
     assert len(result) == 2
     assert result[0].body == "From Alice"
@@ -892,7 +930,7 @@ def test_filter_findings_by_trusted_reviewers_all_filtered():
     assert len(result) == 0
 
 
-def test_filter_findings_case_insensitive():
+def test_filter_findings_case_insensitive(monkeypatch):
     """Reviewer matching must be case-insensitive (GitHub logins are case-insensitive)."""
     from gptme.util.review import ReviewFinding
 
@@ -904,9 +942,27 @@ def test_filter_findings_case_insensitive():
             body="Lower-case reviewer", reviewer="alice", github_comment_id=22222
         ),
     ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/11111" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Here is my review:\n\nUpper-case reviewer",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        if "pulls/comments/22222" in " ".join(args):
+            return {
+                "user": {"login": "alice"},
+                "body": "Here is my review:\n\nLower-case reviewer",
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
     # Allowlist uses different casing from the artifact reviewer fields.
     result = cmd_review_watch._filter_findings_by_trusted_reviewers(
-        findings, ("erikbjare", "ALICE")
+        findings, ("erikbjare", "ALICE"), owner="owner", repo="repo"
     )
     assert len(result) == 2, "Both findings should match case-insensitively"
 
@@ -1151,6 +1207,43 @@ def test_filter_findings_pr_bound_accepted_for_correct_pr(monkeypatch):
         pr_number=1,  # Comment is on PR #1, target is PR #1 — should pass
     )
     assert len(result) == 1, "Valid comment on correct PR must be accepted"
+
+
+def test_filter_findings_missing_repo_context_rejected():
+    """When trusted-reviewer filtering is enabled but no repo context is provided,
+    all findings must be rejected (fail-closed) regardless of comment_id presence.
+
+    This is the fix for the empty-repository bypass: an attacker can strip
+    pr_owner/pr_repo from the artifact, causing effective_owner/effective_repo_name
+    to be empty strings, which previously fell through to the offline-mode path
+    that accepted findings on name match alone (skipping body verification).
+    """
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Legitimate review",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+        ReviewFinding(
+            body="Another finding",
+            reviewer="ErikBjare",
+            github_comment_id=99999,
+        ),
+    ]
+
+    # No owner or repo provided — simulates artifact with missing pr metadata.
+    # Must reject all findings (fail-closed) even though comment_id is present.
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="",
+        repo="",
+    )
+    assert len(result) == 0, (
+        "All findings must be rejected when repo context is missing in trusted-reviewer mode"
+    )
 
 
 def test_review_watch_artifact_with_trusted_reviewer_filter(monkeypatch):


### PR DESCRIPTION
Fixes #3451

Adds --trusted-reviewer CLI option to filter ReviewArtifact findings based on reviewer field before injecting them as fix-session instructions.