### PR TITLE
fix(replay): read conversation.jsonl master log as explicit UTF-8

### DIFF
--- a/gptme/util/replay.py
+++ b/gptme/util/replay.py
@@ -88,7 +88,7 @@ def _read_master_messages(logfile: Path) -> list[dict]:
     """Read all messages from conversation.jsonl master log."""
     messages: list[dict] = []
     try:
-        with open(logfile) as f:
+        with open(logfile, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,13 +1,20 @@
 """Tests for evidence replay (BM25-based context recovery)."""
 
+import builtins
 import json
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from gptme.llm.models.resolution import _default_model_var
 from gptme.message import Message
-from gptme.util.replay import build_query, inject_relevant_evidence, score_messages_bm25
+from gptme.util.replay import (
+    _read_master_messages,
+    build_query,
+    inject_relevant_evidence,
+    score_messages_bm25,
+)
 
 # --- score_messages_bm25 ---
 
@@ -481,3 +488,87 @@ def test_inject_query_n_turns_1_matches_original_single_query():
 
         # At minimum: n_turns=1 still finds decorator-relevant evidence from the last msg
         assert injected_n1, "n_turns=1 should still inject relevant evidence"
+
+
+# --- _read_master_messages (encoding) ---
+
+# A codec that is the platform default on a stock Windows install but cannot
+# represent non-ASCII. Under the shim below, an `open()` that omits `encoding=`
+# reads the file as ascii and raises UnicodeDecodeError on any non-ASCII byte —
+# which is exactly the crash `_read_master_messages` suffered before the UTF-8
+# fix. CJK and the accented Latin together cover both the cp936 and cp1252
+# blind spots, though under ascii every non-ASCII byte is undecodable anyway.
+NON_ASCII_CONTENT = "我是一名开发者 — drinking café"
+
+
+@contextmanager
+def legacy_default_encoding(codec: str = "ascii"):
+    """Make encoding-less `open()` calls behave as they do under a legacy locale.
+
+    Monkeypatching `locale.getpreferredencoding` does not work: CPython reads the
+    locale encoding at the C level, so `open()` ignores the patched function. This
+    shim supplies a codec in exactly the position CPython would supply the
+    locale's — only when the caller passed no `encoding` — so the test fails on a
+    machine of any locale when `encoding=` is missing, and passes on a machine of
+    any locale when it is present. Mirrors tests/test_config_encoding.py.
+    """
+    real_open = builtins.open
+
+    def shim(file, mode="r", *args, **kwargs):
+        if "b" not in mode and kwargs.get("encoding") is None and len(args) < 2:
+            kwargs["encoding"] = codec
+        return real_open(file, mode, *args, **kwargs)
+
+    with patch.object(builtins, "open", shim):
+        yield
+
+
+def test_read_master_messages_non_ascii_under_legacy_locale(tmp_path: Path):
+    """A non-ASCII master log must read back intact under a legacy (ascii) locale.
+
+    The conversation.jsonl master log holds user text, pasted code and file
+    contents, so it routinely contains non-ASCII. Before the fix,
+    `_read_master_messages` opened it without `encoding=`, so under a non-UTF-8
+    locale CPython decoded with the platform code page and raised
+    UnicodeDecodeError — which escapes both the per-line `json.JSONDecodeError`
+    handler and the outer `FileNotFoundError` handler and propagates through
+    `inject_relevant_evidence` to its unwrapped caller, crashing the session
+    whenever GPTME_EVIDENCE_REPLAY=1.
+    """
+    logfile = tmp_path / "conversation.jsonl"
+    # Pin the bytes on disk to real UTF-8 (the JSON spec's encoding) so the read
+    # side is the only thing the legacy-locale shim stresses. ensure_ascii=False
+    # mirrors the canonical log writer (see gptme/checkpoint.py) and leaves the
+    # non-ASCII as raw bytes instead of \uXXXX escapes — which is what makes the
+    # legacy ascii decode raise on the unfixed open().
+    with open(logfile, "w", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {"role": "user", "content": NON_ASCII_CONTENT}, ensure_ascii=False
+            )
+            + "\n"
+        )
+
+    with legacy_default_encoding("ascii"):
+        messages = _read_master_messages(logfile)
+
+    assert len(messages) == 1
+    assert messages[0]["content"] == NON_ASCII_CONTENT
+
+
+def test_read_master_messages_ascii_log_under_legacy_locale(tmp_path: Path):
+    """Control: an ASCII-only master log still parses under the legacy locale."""
+    logfile = tmp_path / "conversation.jsonl"
+    with open(logfile, "w", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {"role": "user", "content": "Hello, developer!"}, ensure_ascii=False
+            )
+            + "\n"
+        )
+
+    with legacy_default_encoding("ascii"):
+        messages = _read_master_messages(logfile)
+
+    assert len(messages) == 1
+    assert messages[0]["content"] == "Hello, developer!"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -492,12 +492,12 @@ def test_inject_query_n_turns_1_matches_original_single_query():
 
 # --- _read_master_messages (encoding) ---
 
-# A codec that is the platform default on a stock Windows install but cannot
-# represent non-ASCII. Under the shim below, an `open()` that omits `encoding=`
-# reads the file as ascii and raises UnicodeDecodeError on any non-ASCII byte —
-# which is exactly the crash `_read_master_messages` suffered before the UTF-8
-# fix. CJK and the accented Latin together cover both the cp936 and cp1252
-# blind spots, though under ascii every non-ASCII byte is undecodable anyway.
+# A codec that cannot represent non-ASCII and is the family of a stock-Windows
+# locale. Under the shim below, an `open()` that omits `encoding=` reads the
+# file as ascii and raises UnicodeDecodeError on any non-ASCII byte — which
+# reproduces the mechanism by which `_read_master_messages` would fail on a
+# raw-UTF-8 master log before the fix. The string spans CJK and accented Latin,
+# though under ascii every non-ASCII byte is undecodable regardless.
 NON_ASCII_CONTENT = "我是一名开发者 — drinking café"
 
 
@@ -524,23 +524,33 @@ def legacy_default_encoding(codec: str = "ascii"):
 
 
 def test_read_master_messages_non_ascii_under_legacy_locale(tmp_path: Path):
-    """A non-ASCII master log must read back intact under a legacy (ascii) locale.
+    """A raw-UTF-8 master log must read back intact under a legacy (ascii) locale.
 
-    The conversation.jsonl master log holds user text, pasted code and file
-    contents, so it routinely contains non-ASCII. Before the fix,
-    `_read_master_messages` opened it without `encoding=`, so under a non-UTF-8
-    locale CPython decoded with the platform code page and raised
-    UnicodeDecodeError — which escapes both the per-line `json.JSONDecodeError`
-    handler and the outer `FileNotFoundError` handler and propagates through
-    `inject_relevant_evidence` to its unwrapped caller, crashing the session
-    whenever GPTME_EVIDENCE_REPLAY=1.
+    JSON is defined to be UTF-8, so conversation.jsonl must be read as UTF-8
+    regardless of host locale. Before the fix, `_read_master_messages` opened it
+    with a bare `open(logfile)` (no `encoding=`), so CPython decoded with the
+    platform's preferred code page; under a legacy locale a raw-UTF-8 log raised
+    UnicodeDecodeError on the first non-ASCII byte. That escapes both the
+    per-line `json.JSONDecodeError` handler and the outer `FileNotFoundError`
+    handler and propagates through `inject_relevant_evidence` to its unwrapped
+    caller (logmanager/manager.py:970).
+
+    The fixture is written with `ensure_ascii=False`, which is deliberately NOT
+    gptme's current behaviour: the sole writer of conversation.jsonl,
+    `Log.write_jsonl` (gptme/logmanager/manager.py:108-110), serializes with
+    `json.dumps` at its default `ensure_ascii=True`, so production logs are pure
+    ASCII today and the decode crash is not reachable via gptme's own writer.
+    This test provokes the raw-UTF-8 on-disk form a manual edit, an external
+    tool, or a future writer change could introduce, and so pins the read to be
+    locale-independent — the same discipline as #3399 and #2051. See the
+    ASCII-only companion below for today's canonical case.
     """
     logfile = tmp_path / "conversation.jsonl"
-    # Pin the bytes on disk to real UTF-8 (the JSON spec's encoding) so the read
-    # side is the only thing the legacy-locale shim stresses. ensure_ascii=False
-    # mirrors the canonical log writer (see gptme/checkpoint.py) and leaves the
-    # non-ASCII as raw bytes instead of \uXXXX escapes — which is what makes the
-    # legacy ascii decode raise on the unfixed open().
+    # Pin the bytes on disk to raw UTF-8 (the JSON spec's encoding) so the read
+    # side is what the legacy-locale shim stresses. ensure_ascii=False leaves the
+    # non-ASCII as raw bytes instead of \uXXXX escapes, which is what makes the
+    # legacy ascii decode raise on the unfixed open(). gptme does not write this
+    # form today (see the docstring); the fixture deliberately stages it.
     with open(logfile, "w", encoding="utf-8") as f:
         f.write(
             json.dumps(
@@ -557,7 +567,14 @@ def test_read_master_messages_non_ascii_under_legacy_locale(tmp_path: Path):
 
 
 def test_read_master_messages_ascii_log_under_legacy_locale(tmp_path: Path):
-    """Control: an ASCII-only master log still parses under the legacy locale."""
+    """Control: today's canonical master log (pure ASCII) parses under any locale.
+
+    `Log.write_jsonl` serializes with the default `ensure_ascii=True`, so the
+    conversation.jsonl gptme writes today is pure ASCII and decodes under every
+    locale — including the legacy one this shim simulates. This is the
+    no-regression guard for the common case the non-ASCII test deliberately
+    steps outside.
+    """
     logfile = tmp_path / "conversation.jsonl"
     with open(logfile, "w", encoding="utf-8") as f:
         f.write(


### PR DESCRIPTION
## Summary
`_read_master_messages` in `gptme/util/replay.py` now reads the conversation master log with an explicit `encoding="utf-8"`, instead of relying on `locale.getpreferredencoding()`.

## Motivation
JSON is defined (RFC 8259) to be UTF-8. The previous bare `open(logfile)` decoded with `locale.getpreferredencoding(False)`, making the read **locale-dependent**: under a legacy code page (cp1252/cp936 on stock Windows, `ascii`/`C` elsewhere) a non-ASCII byte raised an unhandled `UnicodeDecodeError` that escaped both the per-line `json.JSONDecodeError` handler and the outer `FileNotFoundError` handler and propagated through `inject_relevant_evidence` to its unwrapped caller in `logmanager/manager.py`, breaking context preparation whenever `GPTME_EVIDENCE_REPLAY=1`.

This aligns the replay reader with the established UTF-8 discipline from #2051 (tools sweep) and #3399 (config read-side fix) — `replay.py` landed in #3146 **after** both and escaped them. This is the **read-side** counterpart for the evidence-replay module.

**Honest framing:** gptme's own `Log.write_jsonl` currently writes with the default `ensure_ascii=True`, so today's on-disk logs are pure-ASCII and the bug is not reachable through gptme's own writer. This PR is **canonical hardening** — it removes the platform-dependent behaviour and future-proofs against a writer change, an externally-edited log, or a log produced by another tool, matching the JSON spec and the #3399/#2051 precedent. The write side lives in `gptme/logmanager/` and is intentionally not touched here (one concern per PR).

## Change
One line in `gptme/util/replay.py`:
`with open(logfile) as f:` → `with open(logfile, encoding="utf-8") as f:`
The per-line `except json.JSONDecodeError` tolerance is unchanged. No `errors="replace"` (would change semantics).

## Tests
Adds a regression test to `tests/test_replay.py` mirroring `tests/test_config_encoding.py`: under a `legacy_default_encoding("ascii")` shim (monkeypatches `builtins.open` to inject the codec only when no `encoding` is passed — faithfully simulating a legacy locale on a machine of **any** locale), a master log written as raw UTF-8 (`ensure_ascii=False`, e.g. `我是一名开发者 — café`) reads back intact without raising, and an ASCII-only log still parses. The non-ASCII case fails on master with `UnicodeDecodeError` and passes after the fix.

`make lint` clean. `replay.py`/`test_replay.py` typecheck clean (the 21 mypy `import-not-found` errors are pre-existing, from optional deps not installed in the default env — none reference this change).
