### PR TITLE
fix(logmanager): use explicit UTF-8 for JSONL conversation I/O

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -106,7 +106,7 @@ class Log:
         return Log(list(gen))
 
     def write_jsonl(self, path: PathLike) -> None:
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             file.writelines(json.dumps(msg.to_dict()) + "\n" for msg in self.messages)
 
     def print(self, show_hidden: bool = False) -> int:
@@ -1008,7 +1008,7 @@ def _gen_read_jsonl(path: PathLike) -> Generator[Message, None, None]:
     # Pre-compute file mtime as fallback for messages without timestamps
     _file_mtime = datetime.fromtimestamp(Path(path).stat().st_mtime, tz=timezone.utc)
 
-    with open(path) as file:
+    with open(path, encoding="utf-8") as file:
         for line in file:
             line = line.strip()
             if not line:

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -1,4 +1,8 @@
+import builtins
+import json
+from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -499,3 +503,141 @@ def test_read_jsonl_unknown_field(tmp_path):
     assert len(log.messages) == 2
     assert log.messages[0].content == "hello"
     assert log.messages[1].content == "world"
+
+
+# ── JSONL conversation I/O must be explicit UTF-8 ─────────────────────
+#
+# conversation.jsonl is the durability substrate: read on every startup,
+# written on every turn, across machines and locales. gptme's own writers emit
+# pure ASCII today (json.dumps defaults to ensure_ascii=True), but a log edited
+# by hand, produced by an older/newer build, or written under any future
+# ensure_ascii=False change puts real non-ASCII UTF-8 bytes on disk. Reading or
+# writing those bytes without naming an encoding falls back to the platform's
+# *preferred* encoding -- a legacy codepage on a stock Windows install -- so a
+# conversation written on one machine can break on another. These tests pin the
+# explicit UTF-8 discipline established for config (#3399) and tools (#2051) to
+# the conversation-persistence layer, and mirror tests/test_config_encoding.py.
+
+
+@contextmanager
+def _legacy_default_encoding(codec: str):
+    """Make encoding-less ``open()`` calls behave as under a legacy locale.
+
+    Monkeypatching ``locale.getpreferredencoding`` does not work: CPython reads
+    the locale encoding at the C level, so ``open()`` ignores the patched
+    function. This shim instead supplies ``codec`` in exactly the position
+    CPython would supply the locale's -- only when the caller passed no
+    ``encoding`` -- so these tests fail on a machine of any locale when
+    ``encoding=`` is missing, and pass on a machine of any locale when present.
+    Mirrors the helper of the same name in tests/test_config_encoding.py.
+    """
+    real_open = builtins.open
+
+    def shim(file, mode="r", *args, **kwargs):
+        if "b" not in mode and kwargs.get("encoding") is None and len(args) < 2:
+            kwargs["encoding"] = codec
+        return real_open(file, mode, *args, **kwargs)
+
+    with patch.object(builtins, "open", shim):
+        yield
+
+
+@contextmanager
+def _record_open_calls():
+    """Record every ``builtins.open`` call's file/mode/encoding for spy tests."""
+    real_open = builtins.open
+    calls: list[dict] = []
+
+    def shim(file, mode="r", *args, **kwargs):
+        calls.append(
+            {"file": str(file), "mode": mode, "encoding": kwargs.get("encoding")}
+        )
+        return real_open(file, mode, *args, **kwargs)
+
+    with patch.object(builtins, "open", shim):
+        yield calls
+
+
+def test_read_jsonl_round_trips_non_ascii_with_explicit_encoding(tmp_path: Path):
+    """A conversation.jsonl line holding raw non-ASCII UTF-8 must round-trip.
+
+    Today ``Log.write_jsonl`` emits pure ASCII (``json.dumps`` defaults to
+    ``ensure_ascii=True``), but a log edited by hand, written by an older or
+    newer build, or produced by any future ``ensure_ascii=False`` change puts
+    real UTF-8 bytes on disk. Reading those bytes must not depend on the
+    platform's preferred encoding.
+
+    The fixture writes non-ASCII bytes with ``ensure_ascii=False`` (test-only,
+    to put real bytes on disk) and reads them back under a legacy single-byte
+    codec shimmed into the position CPython would otherwise fill with the locale
+    encoding -- so this fails on a machine of any locale if the ``encoding=`` is
+    removed from ``_gen_read_jsonl``.
+    """
+    non_ascii = "café — 中文 — 🎉"
+    jsonl_file = tmp_path / "conversation.jsonl"
+    line = json.dumps(
+        {
+            "role": "user",
+            "content": non_ascii,
+            "timestamp": "2025-01-01T00:00:00+00:00",
+        },
+        ensure_ascii=False,
+    )
+    jsonl_file.write_text(line + "\n", encoding="utf-8")
+    # Real multi-byte UTF-8 on disk, not "\uXXXX" ASCII escapes.
+    assert b"\xc3\xa9" in jsonl_file.read_bytes()
+
+    with _legacy_default_encoding("latin-1"):
+        log = Log.read_jsonl(jsonl_file)
+
+    assert log.messages[0].content == non_ascii
+
+
+def test_write_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):
+    """``write_jsonl`` must open conversation.jsonl with ``encoding="utf-8"``.
+
+    A direct spy on ``builtins.open`` proves the encoding kwarg is passed
+    regardless of the machine's locale -- the locale-independent complement to
+    the round-trip test. ``write_jsonl`` makes exactly one ``open()`` call, so
+    that call is the one under test.
+    """
+    log = Log([Message("user", "hello")])
+    jsonl_file = tmp_path / "conversation.jsonl"
+
+    with _record_open_calls() as calls:
+        log.write_jsonl(jsonl_file)
+
+    assert len(calls) == 1, f"expected one open() call, got {calls}"
+    assert "w" in calls[0]["mode"]
+    assert calls[0]["encoding"] == "utf-8", (
+        f"write_jsonl must pass encoding='utf-8', got encoding={calls[0]['encoding']!r}"
+    )
+
+
+def test_read_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):
+    """``read_jsonl`` must open conversation.jsonl with ``encoding="utf-8"``.
+
+    Symmetric to the write-side spy. ``_gen_read_jsonl`` makes exactly one
+    ``open()`` call (the ``Path.stat`` for the mtime fallback is not an open), so
+    that call is the one under test.
+    """
+    jsonl_file = tmp_path / "conversation.jsonl"
+    jsonl_file.write_text(
+        json.dumps(
+            {
+                "role": "user",
+                "content": "hello",
+                "timestamp": "2025-01-01T00:00:00+00:00",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with _record_open_calls() as calls:
+        Log.read_jsonl(jsonl_file)
+
+    assert len(calls) == 1, f"expected one open() call, got {calls}"
+    assert calls[0]["encoding"] == "utf-8", (
+        f"read_jsonl must pass encoding='utf-8', got encoding={calls[0]['encoding']!r}"
+    )


### PR DESCRIPTION
## Summary
Make `conversation.jsonl` reads and writes name their codec explicitly. Adds `encoding="utf-8"` to the two `open()` calls in `gptme/logmanager/manager.py` that touch JSONL conversation logs — `Log.write_jsonl` (the single writer, used by every persistence path) and `_gen_read_jsonl` (the single reader behind `Log.read_jsonl`).

## Motivation
`conversation.jsonl` is gptme's durability substrate — read on every startup, written on every turn, across machines and locales. Without an explicit `encoding=`, `open()` falls back to the platform's *preferred* encoding, which is a legacy codepage on a stock Windows install (cp936, cp1252, …). gptme's own writers emit pure ASCII today (`json.dumps` defaults to `ensure_ascii=True`), so this is not a literal production crash — but a log edited by hand, produced by an older/newer build, or written under any future `ensure_ascii=False` change puts real non-ASCII UTF-8 bytes on disk, and those bytes decode to mojibake (or raise) under a legacy locale.

This is the **write-side counterpart to #3474** (which made the replay read-side explicit UTF-8), completing the `conversation.jsonl` read/write UTF-8 pair, and aligning the persistence layer with the explicit-UTF-8 discipline already established for config (#3399) and tools (#2051). Canonical hardening, not a bug fix.

## Change
- `gptme/logmanager/manager.py` — `Log.write_jsonl`: `open(path, "w")` → `open(path, "w", encoding="utf-8")`; `_gen_read_jsonl`: `open(path)` → `open(path, encoding="utf-8")`.
- No other modules touched. `json.dumps` defaults unchanged. `gptme/util/replay.py` belongs to #3474. `conv_checkpoints.py` and `eventlog.py` were already explicit UTF-8. Lockfile / binary / `os.open` / `config.toml` opens are intentionally out of scope.

## Tests
Adds three regression tests to `tests/test_logmanager.py` (all selected by `-k encoding`): a round-trip test that puts real non-ASCII UTF-8 bytes on disk (`ensure_ascii=False` in the fixture only) and asserts `Log.read_jsonl` recovers them under a legacy-codec locale shim; and two `open()`-spy tests asserting `write_jsonl` / `read_jsonl` invoke `open()` with `encoding="utf-8"`. The helpers mirror `tests/test_config_encoding.py`. Verified red-before-green: all three fail with the `encoding=` additions reverted.

Refs #3474, #3399. (No `Closes` — proactive hardening.)
