### PR TITLE
feat(tools): hashline-inspired snapshot-anchored edit format

### DIFF
--- a/gptme/tools/_hashline_snapshot.py
+++ b/gptme/tools/_hashline_snapshot.py
@@ -1,0 +1,54 @@
+"""In-memory snapshot store for hashline-anchored editing.
+
+Maps resolved file paths to (tag, content) pairs so the hashline_edit tool
+can verify that the live file still matches the version the model was shown.
+
+The tag is the first 4 bytes (8 hex chars) of SHA-256 of the file content,
+uppercased — e.g. ``A1B2C3D4``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+# path (str, resolved) → (tag: str, content: str)
+_store: dict[str, tuple[str, str]] = {}
+
+
+def compute_tag(content: str) -> str:
+    """Return an 8-hex-char (4-byte) SHA-256 prefix of the file content."""
+    digest = hashlib.sha256(content.encode()).digest()
+    return digest[:4].hex().upper()
+
+
+def store_snapshot(path: str, content: str) -> str:
+    """Store a snapshot for *path* and return its tag."""
+    tag = compute_tag(content)
+    _store[path] = (tag, content)
+    return tag
+
+
+def lookup_snapshot(path: str, tag: str) -> tuple[bool, str | None]:
+    """Return (tag_known, content).
+
+    ``tag_known`` is True when the path has a stored snapshot **and** its tag
+    matches *tag*.  ``content`` is the stored content on a match, else None.
+    """
+    stored = _store.get(path)
+    if stored is None:
+        return False, None
+    stored_tag, content = stored
+    if stored_tag == tag:
+        return True, content
+    return False, None
+
+
+def get_stored_tag(path: str) -> str | None:
+    """Return the tag currently stored for *path*, or None."""
+    stored = _store.get(path)
+    return stored[0] if stored else None
+
+
+def clear() -> None:
+    """Clear all snapshots (used in tests)."""
+    _store.clear()

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -1,0 +1,421 @@
+"""Snapshot-anchored file editing inspired by oh-my-pi's Hashline format.
+
+Provides the ``hashline_edit`` tool: a two-call editing cycle where the
+``read`` tool populates a snapshot store with a file-level 4-byte SHA-256 tag,
+and ``hashline_edit`` verifies that tag before applying line-range operations.
+
+Workflow
+--------
+1. ``read <path>`` — returns the file with a ``[PATH#TAG]`` header on the first
+   line of the code block body.  The snapshot is stored in-memory.
+2. ``hashline_edit <path>`` — the code block body must begin with
+   ``[PATH#TAG]`` matching the tag seen in step 1, then list one or more
+   ``PUT``/``CUT`` operations.
+
+Edit syntax
+-----------
+::
+
+    [PATH#TAG]
+    PUT N.=M:       — replace lines N through M (inclusive) with new content
+    +new line 1
+    +new line 2
+    PUT <N:         — insert the new content BEFORE line N
+    +new line
+    PUT >N:         — insert the new content AFTER line N
+    +new line
+    CUT N.=M        — delete lines N through M (no content block follows)
+
+Content lines are prefixed with ``+``.  An operation's content block ends at
+the next operation header or end-of-input.
+
+If the live file's hash no longer matches the stored snapshot tag the entire
+edit is rejected with a clear error — no silent corruption.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from ..message import Message
+from ._hashline_snapshot import lookup_snapshot, store_snapshot
+from .base import Parameter, ToolSpec, ToolUse
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ---------------------------------------------------------------------------
+# Operation dataclasses
+# ---------------------------------------------------------------------------
+
+OperationKind = Literal["replace", "insert_before", "insert_after", "delete"]
+
+
+@dataclass
+class HashlineOp:
+    """A single parsed edit operation."""
+
+    kind: OperationKind
+    start: int  # 1-indexed, inclusive
+    end: int  # 1-indexed, inclusive (== start for insert ops)
+    text: str | None  # None for delete
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+# PUT N.=M:   replace lines N–M
+_RE_PUT_RANGE = re.compile(r"^PUT\s+(\d+)\.=(\d+):\s*$")
+# PUT <N:     insert before line N
+_RE_PUT_BEFORE = re.compile(r"^PUT\s+<(\d+):\s*$")
+# PUT >N:     insert after line N
+_RE_PUT_AFTER = re.compile(r"^PUT\s+>(\d+):\s*$")
+# CUT N.=M    delete lines N–M (no colon, no content block)
+_RE_CUT_RANGE = re.compile(r"^CUT\s+(\d+)\.=(\d+)\s*$")
+# Header line [PATH#TAG]
+_RE_HEADER = re.compile(r"^\[(.+)#([0-9A-Fa-f]{8})\]\s*$")
+
+
+class ParseError(Exception):
+    pass
+
+
+def _parse_operations(code: str) -> tuple[str, str, list[HashlineOp]]:
+    """Parse a hashline_edit code block.
+
+    Returns (path, tag, operations).
+
+    Raises :class:`ParseError` on any syntax problem.
+    """
+    lines = code.splitlines()
+    if not lines:
+        raise ParseError("Empty edit block")
+
+    # First line must be [PATH#TAG]
+    m = _RE_HEADER.match(lines[0].strip())
+    if not m:
+        raise ParseError(
+            f"First line must be a snapshot header like [path#A1B2C3D4], got: {lines[0]!r}"
+        )
+    path = m.group(1)
+    tag = m.group(2).upper()
+
+    ops: list[HashlineOp] = []
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+
+        if m := _RE_CUT_RANGE.match(line):
+            start, end = int(m.group(1)), int(m.group(2))
+            if start > end:
+                raise ParseError(f"CUT range start {start} > end {end}")
+            ops.append(HashlineOp(kind="delete", start=start, end=end, text=None))
+            i += 1
+            continue
+
+        if m := _RE_PUT_RANGE.match(line):
+            start, end = int(m.group(1)), int(m.group(2))
+            if start > end:
+                raise ParseError(f"PUT range start {start} > end {end}")
+            i, text = _collect_content(lines, i + 1)
+            ops.append(HashlineOp(kind="replace", start=start, end=end, text=text))
+            continue
+
+        if m := _RE_PUT_BEFORE.match(line):
+            n = int(m.group(1))
+            i, text = _collect_content(lines, i + 1)
+            ops.append(HashlineOp(kind="insert_before", start=n, end=n, text=text))
+            continue
+
+        if m := _RE_PUT_AFTER.match(line):
+            n = int(m.group(1))
+            i, text = _collect_content(lines, i + 1)
+            ops.append(HashlineOp(kind="insert_after", start=n, end=n, text=text))
+            continue
+
+        if line.strip() == "" or line.strip().startswith("#"):
+            i += 1
+            continue
+
+        raise ParseError(f"Unrecognized operation line: {line!r}")
+
+    return path, tag, ops
+
+
+def _is_op_header(line: str) -> bool:
+    return bool(
+        _RE_PUT_RANGE.match(line)
+        or _RE_PUT_BEFORE.match(line)
+        or _RE_PUT_AFTER.match(line)
+        or _RE_CUT_RANGE.match(line)
+    )
+
+
+def _collect_content(lines: list[str], start_idx: int) -> tuple[int, str]:
+    """Collect ``+``-prefixed content lines starting at *start_idx*.
+
+    Returns (next_index, collected_text).
+    """
+    content_lines: list[str] = []
+    i = start_idx
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("+"):
+            content_lines.append(line[1:])
+            i += 1
+        elif line.strip() == "":
+            i += 1
+            break
+        elif _is_op_header(line):
+            break
+        else:
+            raise ParseError(
+                f"Expected '+'-prefixed content line or next operation, got: {line!r}"
+            )
+    return i, "\n".join(content_lines)
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
+    """Apply *ops* to *content*, resolving all line references before mutating.
+
+    Line numbers reference the ORIGINAL content.  Operations are applied
+    bottom-up so earlier line numbers remain valid after later insertions/deletions.
+
+    Raises :class:`ValueError` on out-of-range line references.
+    """
+    had_trailing_newline = content.endswith("\n")
+    file_lines = content.splitlines()
+    total = len(file_lines)
+
+    for op in ops:
+        if op.start < 1 or op.start > total:
+            raise ValueError(f"Line {op.start} out of range (file has {total} lines)")
+        if op.end < 1 or op.end > total:
+            raise ValueError(f"Line {op.end} out of range (file has {total} lines)")
+
+    # Apply bottom-up (highest line numbers first) to keep earlier indices stable
+    for op in sorted(ops, key=lambda o: o.start, reverse=True):
+        s = op.start - 1  # convert to 0-indexed
+        e = op.end  # exclusive end for slicing
+
+        if op.kind == "delete":
+            del file_lines[s:e]
+        elif op.kind == "replace":
+            new_lines = op.text.splitlines() if op.text else []
+            file_lines[s:e] = new_lines
+        elif op.kind == "insert_before":
+            new_lines = op.text.splitlines() if op.text else []
+            file_lines[s:s] = new_lines
+        elif op.kind == "insert_after":
+            new_lines = op.text.splitlines() if op.text else []
+            file_lines[e:e] = new_lines
+
+    result = "\n".join(file_lines)
+    if had_trailing_newline:
+        result += "\n"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+instructions = """
+Apply snapshot-anchored edits to a file using the tag produced by the ``read`` tool.
+
+### Workflow
+
+1. Call ``read <path>`` — the output starts with ``[PATH#TAG]`` on the first line
+   inside the code block.  Remember this TAG.
+2. Write a ``hashline_edit <path>`` block beginning with the same ``[PATH#TAG]``
+   header, followed by one or more operations.
+
+If the file has changed since the ``read`` (tag mismatch), the edit is rejected
+with a clear error so you can re-read and retry.
+
+### Operations
+
+| Syntax       | Effect                                    |
+|-------------|------------------------------------------|
+| ``PUT N.=M:``| Replace lines N through M with new lines |
+| ``PUT <N:``  | Insert new lines BEFORE line N           |
+| ``PUT >N:``  | Insert new lines AFTER line N            |
+| ``CUT N.=M`` | Delete lines N through M                 |
+
+New content lines are prefixed with ``+``.  An empty line ends a content block.
+CUT has no content block.  Line numbers reference the version shown by ``read``.
+
+### Example
+
+```
+[greet.py#A1B2C3D4]
+PUT 2.=3:
++    print(f"Hi, {name}")
+CUT 4.=4
+PUT >5:
++    return name
+```
+""".strip()
+
+instructions_format = {
+    "markdown": "Use a code block with language tag: `hashline_edit <path>`",
+}
+
+
+def examples(tool_format) -> str:
+    edit_body = """\
+[greet.py#A1B2C3D4]
+PUT 2.=3:
++    print(f"Hi, {name}")
+"""
+    return f"""
+> User: update greet.py to use an f-string
+> Assistant: First, read the file:
+{ToolUse("read", ["greet.py"], "").to_output(tool_format)}
+> System: ```greet.py
+> [greet.py#A1B2C3D4]
+>    1\\tdef greet(name):
+>    2\\t    msg = "Hello, " + name
+>    3\\t    print(msg)
+> ```
+> Assistant:
+{ToolUse("hashline_edit", ["greet.py"], edit_body).to_output(tool_format)}
+> System: hashline_edit applied to `greet.py` (1 operation)
+""".strip()
+
+
+def _path_from_args(
+    args: list[str] | None, kwargs: dict[str, str] | None
+) -> Path | None:
+    if args:
+        return Path(" ".join(args)).expanduser()
+    if kwargs and kwargs.get("path"):
+        return Path(kwargs["path"]).expanduser()
+    return None
+
+
+def execute_hashline_edit(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    path = _path_from_args(args, kwargs)
+    if path is None:
+        yield Message("system", "hashline_edit: no path provided")
+        return
+
+    body = (code or "").strip()
+    if not body:
+        yield Message("system", "hashline_edit: empty edit block")
+        return
+
+    # Parse the edit block
+    try:
+        _parsed_path, tag, ops = _parse_operations(body)
+    except ParseError as e:
+        yield Message("system", f"hashline_edit parse error: {e}")
+        return
+
+    if not ops:
+        yield Message("system", "hashline_edit: no operations found in edit block")
+        return
+
+    # Resolve and read the actual file
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        yield Message("system", f"hashline_edit: file not found: {resolved}")
+        return
+    if not resolved.is_file():
+        yield Message("system", f"hashline_edit: not a file: {resolved}")
+        return
+
+    try:
+        live_content = resolved.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, PermissionError, OSError) as e:
+        yield Message("system", f"hashline_edit: cannot read file: {e}")
+        return
+
+    # Verify snapshot tag against the live file
+    tag_matched, _snapshot_content = lookup_snapshot(str(resolved), tag)
+    if not tag_matched:
+        # Check if we've seen the file at all (vs wrong tag)
+        from ._hashline_snapshot import get_stored_tag
+
+        stored = get_stored_tag(str(resolved))
+        if stored is None:
+            msg = (
+                f"hashline_edit: no snapshot found for {resolved}. "
+                "Call `read` first to capture a snapshot."
+            )
+        else:
+            msg = (
+                f"hashline_edit: tag mismatch for {resolved}. "
+                f"Edit block has #{tag} but current snapshot is #{stored}. "
+                "The file may have changed — call `read` again to get a fresh tag."
+            )
+        yield Message("system", msg)
+        return
+
+    # Apply operations
+    try:
+        updated = _apply_operations(live_content, ops)
+    except ValueError as e:
+        yield Message("system", f"hashline_edit: {e}")
+        return
+
+    # Write result
+    try:
+        resolved.write_text(updated, encoding="utf-8")
+    except (PermissionError, OSError) as e:
+        yield Message("system", f"hashline_edit: write failed: {e}")
+        return
+
+    # Update snapshot for the new content
+    store_snapshot(str(resolved), updated)
+
+    n = len(ops)
+    yield Message(
+        "system",
+        f"hashline_edit applied to `{resolved}` ({n} operation{'s' if n != 1 else ''})",
+    )
+
+
+tool = ToolSpec(
+    name="hashline_edit",
+    desc="Apply snapshot-anchored line-range edits to a file (use after `read`)",
+    instructions=instructions,
+    instructions_format=instructions_format,
+    examples=examples,
+    execute=execute_hashline_edit,
+    block_types=["hashline_edit"],
+    disabled_by_default=True,
+    parameters=[
+        Parameter(
+            name="path",
+            type="string",
+            description="Path of the file to edit.",
+            required=True,
+        ),
+        Parameter(
+            name="edit",
+            type="string",
+            description=(
+                "Edit block beginning with [PATH#TAG] then PUT/CUT operations. "
+                "Content lines are prefixed with +."
+            ),
+            required=True,
+        ),
+    ],
+    hints=frozenset({"file-ops", "destructive"}),
+)
+
+__doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ..message import Message
-from ._hashline_snapshot import lookup_snapshot, store_snapshot
+from ._hashline_snapshot import compute_tag, lookup_snapshot, store_snapshot
 from .base import Parameter, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
@@ -197,6 +197,9 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     total = len(file_lines)
 
     for op in ops:
+        # Allow PUT <1 on empty files
+        if total == 0 and op.kind == "insert_before" and op.start == 1:
+            continue
         if op.start < 1 or op.start > total:
             raise ValueError(f"Line {op.start} out of range (file has {total} lines)")
         if op.end < 1 or op.end > total:
@@ -230,7 +233,13 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
 # ---------------------------------------------------------------------------
 
 instructions = """
-Apply snapshot-anchored edits to a file using the tag produced by the ``read`` tool.
+Use after ``read`` to apply precise, safe line edits without re-reading the full file.
+The tag from ``read`` anchors your edits to the exact version you saw — any external
+change to the file on disk is detected and rejected before a single byte is written.
+
+Prefer this tool over ``patch`` when you have exact line numbers and want to avoid
+repeating large context blocks.  You can chain multiple operations in one call;
+line numbers always reference the version ``read`` showed you.
 
 ### Workflow
 
@@ -239,8 +248,11 @@ Apply snapshot-anchored edits to a file using the tag produced by the ``read`` t
 2. Write a ``hashline_edit <path>`` block beginning with the same ``[PATH#TAG]``
    header, followed by one or more operations.
 
-If the file has changed since the ``read`` (tag mismatch), the edit is rejected
-with a clear error so you can re-read and retry.
+### Recovery from rejection
+
+If the file changed between ``read`` and your edit, you will see:
+  ``hashline_edit: file has changed since snapshot was captured…``
+Re-read the file with ``read`` to get a new tag and restate your operations.
 
 ### Operations
 
@@ -344,7 +356,7 @@ def execute_hashline_edit(
         yield Message("system", f"hashline_edit: cannot read file: {e}")
         return
 
-    # Verify snapshot tag against the live file
+    # Verify snapshot tag against the stored snapshot
     tag_matched, _snapshot_content = lookup_snapshot(str(resolved), tag)
     if not tag_matched:
         # Check if we've seen the file at all (vs wrong tag)
@@ -365,11 +377,38 @@ def execute_hashline_edit(
         yield Message("system", msg)
         return
 
+    # Also verify the live file hasn't changed since the snapshot was captured.
+    # A tag match only proves the in-memory snapshot is consistent; the file on
+    # disk may have been modified by another process since `read` was called.
+    live_tag = compute_tag(live_content)
+    if live_tag != tag:
+        yield Message(
+            "system",
+            f"hashline_edit: file has changed since snapshot was captured for {resolved}. "
+            f"Expected #{tag} but live content hashes to #{live_tag}. "
+            "Call `read` again to get a fresh snapshot.",
+        )
+        return
+
     # Apply operations
     try:
         updated = _apply_operations(live_content, ops)
     except ValueError as e:
         yield Message("system", f"hashline_edit: {e}")
+        return
+
+    # Ask for confirmation before writing (matches sibling tools' safety model)
+    from ..hooks import ConfirmAction, get_confirmation
+
+    confirm_result = get_confirmation(
+        preview=updated,
+        default_confirm=True,
+    )
+    if confirm_result.action == ConfirmAction.SKIP:
+        yield Message(
+            "system",
+            confirm_result.message or "hashline_edit: operation cancelled by user",
+        )
         return
 
     # Write result

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ..message import Message
-from ._hashline_snapshot import compute_tag, lookup_snapshot, store_snapshot
+from ._hashline_snapshot import lookup_snapshot, store_snapshot
 from .base import Parameter, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
@@ -357,7 +357,7 @@ def execute_hashline_edit(
         return
 
     # Verify snapshot tag against the stored snapshot
-    tag_matched, _snapshot_content = lookup_snapshot(str(resolved), tag)
+    tag_matched, snapshot_content = lookup_snapshot(str(resolved), tag)
     if not tag_matched:
         # Check if we've seen the file at all (vs wrong tag)
         from ._hashline_snapshot import get_stored_tag
@@ -377,15 +377,15 @@ def execute_hashline_edit(
         yield Message("system", msg)
         return
 
-    # Also verify the live file hasn't changed since the snapshot was captured.
-    # A tag match only proves the in-memory snapshot is consistent; the file on
-    # disk may have been modified by another process since `read` was called.
-    live_tag = compute_tag(live_content)
-    if live_tag != tag:
+    # Verify the live file hasn't changed since the snapshot was captured.
+    # Compare full content (not just truncated tag) to be collision-proof: a
+    # 4-byte SHA-256 prefix could collide on different content, letting a stale
+    # edit silently overwrite the wrong lines.
+    assert snapshot_content is not None
+    if live_content != snapshot_content:
         yield Message(
             "system",
             f"hashline_edit: file has changed since snapshot was captured for {resolved}. "
-            f"Expected #{tag} but live content hashes to #{live_tag}. "
             "Call `read` again to get a fresh snapshot.",
         )
         return

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -411,6 +411,13 @@ def execute_hashline_edit(
         )
         return
 
+    # Use content edited by the user during confirmation (if any)
+    if (
+        confirm_result.action == ConfirmAction.EDIT
+        and confirm_result.edited_content is not None
+    ):
+        updated = confirm_result.edited_content
+
     # Write result
     try:
         resolved.write_text(updated, encoding="utf-8")

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -174,6 +174,11 @@ def _read_one(
         yield Message("system", f"Permission denied: {path}")
         return
 
+    # Store snapshot for hashline_edit verification (always uses full content)
+    from ._hashline_snapshot import store_snapshot
+
+    tag = store_snapshot(str(path), content)
+
     lines = content.splitlines()
     total_lines = len(lines)
 
@@ -241,7 +246,9 @@ def _read_one(
         shown = f"{start_idx + 1}-{end_idx}"
         range_info = f" (lines {shown} of {total_lines})"
 
-    body = md_codeblock(f"{path}{range_info}", numbered)
+    # Include snapshot tag header so hashline_edit can verify freshness
+    tag_header = f"[{path}#{tag}]"
+    body = md_codeblock(f"{path}{range_info}", tag_header + "\n" + numbered)
     if pruned_message_prefix:
         body = pruned_message_prefix + "\n\n" + body
 

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -410,6 +410,31 @@ class TestExecuteHashlineEdit:
         # File must be untouched
         assert f.read_text() == "alpha\nbeta\nextra-line\n"
 
+    def test_content_mismatch_rejected_even_with_matching_tag(self, tmp_path: Path):
+        """Full content comparison catches stale content even when truncated tags match.
+
+        Injects the snapshot store directly to simulate a 4-byte SHA-256 prefix
+        collision: the stored tag matches the edit-block tag, but the live file
+        content differs from the captured snapshot content. The old tag-only check
+        would silently accept this; the content comparison correctly rejects it.
+        """
+        from gptme.tools._hashline_snapshot import _store, compute_tag
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        tag = compute_tag(original)
+        # Inject the store so tag maps to original content
+        _store[str(f.resolve())] = (tag, original)
+        # Write DIFFERENT content to disk (simulates the file changing after read,
+        # or — in the collision scenario — different content sharing the same tag prefix)
+        changed = "alpha\nbeta\ngamma\n"
+        f.write_text(changed)
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        # Content comparison catches this; tag-only comparison could miss a collision
+        assert "changed since snapshot" in msgs[0].lower(), msgs
+        assert f.read_text() == changed  # file must be untouched
+
 
 # ---------------------------------------------------------------------------
 # Read tool integration — snapshot populated by read

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -366,6 +366,31 @@ class TestExecuteHashlineEdit:
         assert "applied" in msgs[0].lower()
         assert f.read_text() == "world\n"
 
+    def test_insert_into_empty_file(self, tmp_path: Path):
+        """PUT <1: should work on an empty file (P2 fix: empty-file insertion)."""
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT <1:\n+first line\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        assert f.read_text() == "first line"
+
+    def test_live_file_changed_after_snapshot(self, tmp_path: Path):
+        """Edit must be rejected when the live file has changed since read (P1 fix)."""
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Externally mutate the file after the snapshot was captured
+        f.write_text("alpha\nbeta\nextra-line\n")
+        # The stored tag still matches the provided tag — but the live file differs
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "changed since snapshot" in msgs[0].lower(), msgs
+        # File must be untouched
+        assert f.read_text() == "alpha\nbeta\nextra-line\n"
+
 
 # ---------------------------------------------------------------------------
 # Read tool integration — snapshot populated by read

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -376,6 +376,25 @@ class TestExecuteHashlineEdit:
         assert "applied" in msgs[0].lower(), msgs
         assert f.read_text() == "first line"
 
+    def test_confirmation_edit_uses_edited_content(self, tmp_path: Path):
+        """When confirmation hook returns EDIT, the edited content is written (P1 fix)."""
+        from unittest.mock import patch
+
+        from gptme.hooks.confirm import ConfirmationResult
+
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+        edited = "EDITED BY HOOK\nbeta\n"
+        with patch(
+            "gptme.hooks.get_confirmation",
+            return_value=ConfirmationResult.edit(edited),
+        ):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        assert f.read_text() == edited
+
     def test_live_file_changed_after_snapshot(self, tmp_path: Path):
         """Edit must be rejected when the live file has changed since read (P1 fix)."""
         f = tmp_path / "f.txt"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -1,0 +1,439 @@
+"""Tests for the hashline_edit tool and its snapshot store integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.tools._hashline_snapshot import (
+    clear as clear_snapshots,
+)
+from gptme.tools._hashline_snapshot import (
+    compute_tag,
+    get_stored_tag,
+    lookup_snapshot,
+    store_snapshot,
+)
+from gptme.tools.hashline_edit import (
+    HashlineOp,
+    ParseError,
+    _apply_operations,
+    _parse_operations,
+    execute_hashline_edit,
+    tool,
+)
+from gptme.tools.read import execute_read
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msgs(gen) -> list[str]:
+    return [m.content for m in gen]
+
+
+@pytest.fixture(autouse=True)
+def _reset_snapshots():
+    """Clear the module-level snapshot store before each test."""
+    clear_snapshots()
+    yield
+    clear_snapshots()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot store
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotStore:
+    def test_compute_tag_is_8_hex_chars(self):
+        tag = compute_tag("hello\n")
+        assert len(tag) == 8
+        assert all(c in "0123456789ABCDEF" for c in tag)
+
+    def test_same_content_same_tag(self):
+        assert compute_tag("abc") == compute_tag("abc")
+
+    def test_different_content_different_tag(self):
+        assert compute_tag("abc") != compute_tag("def")
+
+    def test_store_and_lookup_success(self, tmp_path: Path):
+        path = str(tmp_path / "f.txt")
+        tag = store_snapshot(path, "hello\n")
+        matched, content = lookup_snapshot(path, tag)
+        assert matched
+        assert content == "hello\n"
+
+    def test_lookup_wrong_tag(self, tmp_path: Path):
+        path = str(tmp_path / "f.txt")
+        store_snapshot(path, "hello\n")
+        matched, content = lookup_snapshot(path, "DEADBEEF")
+        assert not matched
+        assert content is None
+
+    def test_lookup_unknown_path(self, tmp_path: Path):
+        matched, content = lookup_snapshot(str(tmp_path / "nope.txt"), "00000000")
+        assert not matched
+        assert content is None
+
+    def test_get_stored_tag(self, tmp_path: Path):
+        path = str(tmp_path / "f.txt")
+        tag = store_snapshot(path, "hello\n")
+        assert get_stored_tag(path) == tag
+
+    def test_get_stored_tag_unknown(self, tmp_path: Path):
+        assert get_stored_tag(str(tmp_path / "ghost.txt")) is None
+
+    def test_overwrite_snapshot(self, tmp_path: Path):
+        path = str(tmp_path / "f.txt")
+        store_snapshot(path, "v1\n")
+        new_tag = store_snapshot(path, "v2\n")
+        matched, content = lookup_snapshot(path, new_tag)
+        assert matched
+        assert content == "v2\n"
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TestParser:
+    def _make_block(self, path: str, content: str) -> str:
+        tag = compute_tag("any")  # we just need a valid 8-hex tag
+        return f"[{path}#{tag}]\n{content}"
+
+    def _header(self, path: str = "f.py", content: str = "") -> str:
+        tag = store_snapshot(path, content)
+        return f"[{path}#{tag}]"
+
+    def test_replace_range(self):
+        block = "[f.py#A1B2C3D4]\nPUT 1.=3:\n+new line\n"
+        path, tag, ops = _parse_operations(block)
+        assert path == "f.py"
+        assert tag == "A1B2C3D4"
+        assert len(ops) == 1
+        assert ops[0].kind == "replace"
+        assert ops[0].start == 1
+        assert ops[0].end == 3
+        assert ops[0].text == "new line"
+
+    def test_insert_before(self):
+        block = "[f.py#A1B2C3D4]\nPUT <5:\n+inserted\n"
+        _, _, ops = _parse_operations(block)
+        assert ops[0].kind == "insert_before"
+        assert ops[0].start == 5
+
+    def test_insert_after(self):
+        block = "[f.py#A1B2C3D4]\nPUT >2:\n+after\n"
+        _, _, ops = _parse_operations(block)
+        assert ops[0].kind == "insert_after"
+        assert ops[0].start == 2
+
+    def test_cut_range(self):
+        block = "[f.py#A1B2C3D4]\nCUT 3.=5\n"
+        _, _, ops = _parse_operations(block)
+        assert ops[0].kind == "delete"
+        assert ops[0].start == 3
+        assert ops[0].end == 5
+        assert ops[0].text is None
+
+    def test_multiple_ops(self):
+        block = "[f.py#A1B2C3D4]\nPUT 1.=1:\n+hello\n\nCUT 3.=3\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 2
+        assert ops[0].kind == "replace"
+        assert ops[1].kind == "delete"
+
+    def test_multiline_content(self):
+        block = "[f.py#A1B2C3D4]\nPUT 1.=2:\n+line a\n+line b\n+line c\n"
+        _, _, ops = _parse_operations(block)
+        assert ops[0].text == "line a\nline b\nline c"
+
+    def test_empty_block_raises(self):
+        with pytest.raises(ParseError):
+            _parse_operations("")
+
+    def test_missing_header_raises(self):
+        with pytest.raises(ParseError, match="snapshot header"):
+            _parse_operations("PUT 1.=2:\n+x\n")
+
+    def test_bad_put_range_start_gt_end_raises(self):
+        with pytest.raises(ParseError, match="start.*end"):
+            _parse_operations("[f.py#A1B2C3D4]\nPUT 5.=2:\n+x\n")
+
+    def test_bad_cut_range_raises(self):
+        with pytest.raises(ParseError, match="start.*end"):
+            _parse_operations("[f.py#A1B2C3D4]\nCUT 5.=2\n")
+
+    def test_unexpected_line_raises(self):
+        with pytest.raises(ParseError, match="Unrecognized"):
+            _parse_operations("[f.py#A1B2C3D4]\nGET 1:\n+x\n")
+
+    def test_no_ops_returns_empty_list(self):
+        block = "[f.py#A1B2C3D4]\n"
+        _, _, ops = _parse_operations(block)
+        assert ops == []
+
+    def test_lowercase_tag_normalized(self):
+        block = "[f.py#a1b2c3d4]\nCUT 1.=1\n"
+        _, tag, _ = _parse_operations(block)
+        assert tag == "A1B2C3D4"
+
+
+# ---------------------------------------------------------------------------
+# Apply engine
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOperations:
+    def test_replace_single_line(self):
+        content = "alpha\nbeta\ngamma\n"
+        ops = [HashlineOp(kind="replace", start=2, end=2, text="BETA")]
+        assert _apply_operations(content, ops) == "alpha\nBETA\ngamma\n"
+
+    def test_replace_range(self):
+        content = "a\nb\nc\nd\n"
+        ops = [HashlineOp(kind="replace", start=2, end=3, text="X\nY")]
+        assert _apply_operations(content, ops) == "a\nX\nY\nd\n"
+
+    def test_insert_before(self):
+        content = "alpha\nbeta\n"
+        ops = [HashlineOp(kind="insert_before", start=1, end=1, text="zero")]
+        assert _apply_operations(content, ops) == "zero\nalpha\nbeta\n"
+
+    def test_insert_after(self):
+        content = "alpha\nbeta\n"
+        ops = [HashlineOp(kind="insert_after", start=1, end=1, text="one-half")]
+        assert _apply_operations(content, ops) == "alpha\none-half\nbeta\n"
+
+    def test_delete(self):
+        content = "alpha\nbeta\ngamma\n"
+        ops = [HashlineOp(kind="delete", start=2, end=2, text=None)]
+        assert _apply_operations(content, ops) == "alpha\ngamma\n"
+
+    def test_delete_range(self):
+        content = "a\nb\nc\nd\n"
+        ops = [HashlineOp(kind="delete", start=2, end=3, text=None)]
+        assert _apply_operations(content, ops) == "a\nd\n"
+
+    def test_preserves_trailing_newline(self):
+        content = "alpha\nbeta\n"
+        ops = [HashlineOp(kind="replace", start=1, end=1, text="ALPHA")]
+        result = _apply_operations(content, ops)
+        assert result.endswith("\n")
+
+    def test_no_trailing_newline_not_added(self):
+        content = "alpha\nbeta"
+        ops = [HashlineOp(kind="replace", start=1, end=1, text="ALPHA")]
+        result = _apply_operations(content, ops)
+        assert not result.endswith("\n")
+
+    def test_multiple_ops_applied_bottom_up(self):
+        # Both ops reference the ORIGINAL line numbers
+        content = "a\nb\nc\nd\n"
+        ops = [
+            HashlineOp(kind="replace", start=1, end=1, text="A"),
+            HashlineOp(kind="delete", start=3, end=3, text=None),
+        ]
+        assert _apply_operations(content, ops) == "A\nb\nd\n"
+
+    def test_out_of_range_raises(self):
+        content = "a\nb\n"
+        with pytest.raises(ValueError, match="out of range"):
+            _apply_operations(
+                content, [HashlineOp(kind="delete", start=5, end=5, text=None)]
+            )
+
+    def test_empty_ops_returns_original(self):
+        content = "alpha\nbeta\n"
+        assert _apply_operations(content, []) == content
+
+
+# ---------------------------------------------------------------------------
+# execute_hashline_edit integration
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteHashlineEdit:
+    def test_basic_replace(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 2.=2:\n+BETA\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "alpha\nBETA\ngamma\n"
+
+    def test_tag_mismatch_rejected(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n")
+        store_snapshot(str(f.resolve()), f.read_text())
+        # Use a wrong tag
+        block = f"[{f.resolve()}#DEADBEEF]\nCUT 1.=1\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "mismatch" in msgs[0].lower() or "snapshot" in msgs[0].lower()
+        assert f.read_text() == "alpha\nbeta\n"
+
+    def test_no_snapshot_rejected(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\n")
+        # Don't store any snapshot — simulate no prior read
+        block = f"[{f.resolve()}#A1B2C3D4]\nCUT 1.=1\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "no snapshot" in msgs[0].lower()
+        assert f.read_text() == "alpha\n"
+
+    def test_insert_before(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT <1:\n+zero\n"
+        _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert f.read_text() == "zero\nalpha\nbeta\n"
+
+    def test_insert_after(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT >1:\n+one-half\n"
+        _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert f.read_text() == "alpha\none-half\nbeta\n"
+
+    def test_cut_delete(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nCUT 2.=2\n"
+        _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert f.read_text() == "alpha\ngamma\n"
+
+    def test_multiple_ops(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("a\nb\nc\nd\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+A\n\nCUT 3.=3\n"
+        _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert f.read_text() == "A\nb\nd\n"
+
+    def test_snapshot_updated_after_edit(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+        _msgs(execute_hashline_edit(block, [str(f)], None))
+        # After edit, snapshot should reflect new content
+        new_tag = get_stored_tag(str(f.resolve()))
+        expected_tag = compute_tag(f.read_text())
+        assert new_tag == expected_tag
+
+    def test_no_path_error(self):
+        msgs = _msgs(execute_hashline_edit("[f.py#A1B2C3D4]\nCUT 1.=1\n", None, None))
+        assert "no path" in msgs[0].lower()
+
+    def test_empty_block_error(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("hello\n")
+        msgs = _msgs(execute_hashline_edit("", [str(f)], None))
+        assert "empty" in msgs[0].lower()
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        f = tmp_path / "nope.txt"
+        msgs = _msgs(
+            execute_hashline_edit("[nope.txt#A1B2C3D4]\nCUT 1.=1\n", [str(f)], None)
+        )
+        assert "not found" in msgs[0].lower()
+
+    def test_no_ops_error(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("hello\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "no operations" in msgs[0].lower()
+
+    def test_kwargs_path(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("hello\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+world\n"
+        msgs = _msgs(execute_hashline_edit(block, None, {"path": str(f)}))
+        assert "applied" in msgs[0].lower()
+        assert f.read_text() == "world\n"
+
+
+# ---------------------------------------------------------------------------
+# Read tool integration — snapshot populated by read
+# ---------------------------------------------------------------------------
+
+
+class TestReadIntegration:
+    def test_read_stores_snapshot(self, tmp_path: Path):
+        f = tmp_path / "sample.py"
+        f.write_text("def hello():\n    pass\n")
+        list(execute_read(None, [str(f)], None))
+        tag = get_stored_tag(str(f.resolve()))
+        assert tag is not None
+        assert len(tag) == 8
+
+    def test_read_tag_in_output(self, tmp_path: Path):
+        f = tmp_path / "sample.py"
+        content = "def hello():\n    pass\n"
+        f.write_text(content)
+        msgs = list(execute_read(None, [str(f)], None))
+        assert len(msgs) == 1
+        expected_tag = compute_tag(content)
+        assert f"#{expected_tag}]" in msgs[0].content
+
+    def test_read_then_edit_roundtrip(self, tmp_path: Path):
+        f = tmp_path / "greet.py"
+        f.write_text("def greet(name):\n    msg = 'Hello, ' + name\n    print(msg)\n")
+        # Read to capture snapshot
+        list(execute_read(None, [str(f)], None))
+        # Extract tag from read output
+        tag = get_stored_tag(str(f.resolve()))
+        assert tag is not None
+        # Apply edit using the tag
+        block = f"[{f.resolve()}#{tag}]\nPUT 2.=3:\n+    print(f'Hi, {{name}}')\n"
+        edit_msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in edit_msgs[0].lower()
+        result = f.read_text()
+        assert "Hi" in result
+        assert "msg" not in result
+
+    def test_second_read_updates_snapshot(self, tmp_path: Path):
+        f = tmp_path / "f.txt"
+        f.write_text("v1\n")
+        list(execute_read(None, [str(f)], None))
+        tag_v1 = get_stored_tag(str(f.resolve()))
+
+        # Modify file externally
+        f.write_text("v2\n")
+        list(execute_read(None, [str(f)], None))
+        tag_v2 = get_stored_tag(str(f.resolve()))
+
+        assert tag_v1 != tag_v2
+
+
+# ---------------------------------------------------------------------------
+# Tool metadata
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    def test_disabled_by_default(self):
+        assert tool.disabled_by_default is True
+
+    def test_block_type(self):
+        assert "hashline_edit" in tool.block_types
+
+    def test_has_path_parameter(self):
+        assert any(p.name == "path" for p in tool.parameters)
+
+    def test_is_destructive(self):
+        assert "destructive" in tool.hints


### PR DESCRIPTION
Closes #3476

## Summary

Implements a snapshot-anchored edit format inspired by oh-my-pi's Hashline, as proposed in #3476. The key insight: anchor edits to a file-level hash computed at read-time, so stale edits are caught before any write occurs.

**What this adds:**

- **`_hashline_snapshot.py`** — in-memory store mapping resolved file paths to `(8-hex-SHA256-tag, content)` pairs
- **`read.py` (modified)** — stores a snapshot on every file read and prepends `[PATH#TAG]` as the first line inside the code block output, so the model sees the tag in a single call with no extra step
- **`hashline_edit.py`** — new `disabled_by_default` tool with four operations:
  - `PUT N.=M:` — replace lines N–M (inclusive) with `+`-prefixed new content
  - `PUT <N:` — insert new content before line N
  - `PUT >N:` — insert new content after line N
  - `CUT N.=M` — delete lines N–M (no content block)
  - Stale-file rejection: TAG mismatch → clear error message, file unchanged
  - Snapshot updated after each successful edit (supports chained edits without re-reading)
- **`tests/test_tools_hashline_edit.py`** — 54 tests covering snapshot store, parser, apply engine, execute integration, read-tool integration, and tool metadata

## Usage example

```
# Step 1 — read captures snapshot
read greet.py
# → [greet.py#A1B2C3D4]
#    1    def greet(name):
#    2        msg = "Hello, " + name
#    3        print(msg)

# Step 2 — edit using the tag and line numbers from the read output
hashline_edit greet.py
[greet.py#A1B2C3D4]
PUT 2.=3:
+    print(f"Hi, {name}")
```

If the file has changed since the `read` (TAG mismatch), the edit is rejected with a clear error.

## Difference from `view_anchored` / `patch_anchored`

| | `patch_anchored` | `hashline_edit` |
|---|---|---|
| Anchor unit | Per-line blake2s digest (16 hex + ordinal) | Whole-file SHA-256 prefix (8 hex) |
| Line addressing | Opaque anchor tokens | Original line numbers from `read` output |
| Requires separate view call | Yes (`view_anchored`) | No (tag embedded in `read` output) |
| Block-aware edits (`PUT N*:`) | No | No (Phase 2) |
| 3-way merge recovery | No | No (Phase 2) |

## Not in this PR (Phase 2)

- `PUT N*:` block-aware resolution (tree-sitter / indent heuristic)
- `CUT @name` / `PUT >N @name` register capture and paste
- 3-way merge recovery on TAG mismatch

## Test results

```
54 passed in 0.27s  (test_tools_hashline_edit.py)
24 passed in 0.30s  (test_tools_read.py — no regressions)
66 passed in 0.37s  (test_tools__anchored.py + test_tools_patch_anchored.py)
```

<!-- gptme-id:v1:gai_xZrA9QFS4lKtpzdiVDxdcdtuN2dM3r9sGJLJ4wC8hOf -->