### PR TITLE
feat(tools/hashline_edit): add PUT N*: block-aware replace (#3476 Phase 1 remainder)

### DIFF
--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -210,7 +210,11 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     A same-indentation continuation clause (``elif``/``else``/``except``/
     ``finally``) is treated as part of the same compound statement: its header
     and body are absorbed too, so the resolved range covers the whole
-    ``if``/``try`` statement rather than stopping at the first clause.
+    ``if``/``try`` statement rather than stopping at the first clause. A
+    comment line does not end the block by itself — it is skipped while
+    scanning for a following continuation clause, so a comment placed between
+    e.g. an ``if`` body and its ``else`` doesn't strand the ``else`` outside
+    the resolved range.
 
     Raises :class:`ValueError` when *start* is out of range.
     """
@@ -234,6 +238,8 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
         if indent > header_indent:
             end = i + 1  # 1-indexed
             i += 1
+        elif line.lstrip().startswith("#"):
+            i += 1  # comments may separate continuation clauses
         elif indent == header_indent and _RE_CONTINUATION_CLAUSE.match(line.lstrip()):
             end = i + 1  # absorb the continuation clause header itself
             i += 1

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -197,6 +197,49 @@ def _collect_content(lines: list[str], start_idx: int) -> tuple[int, str]:
 
 
 _RE_CONTINUATION_CLAUSE = re.compile(r"^(elif|else|except|finally)\b")
+_RE_PYTHON_COMPOUND_HEADER = re.compile(
+    r"^(?:async\s+)?(?:def|class|if|for|while|with|try)\b"
+)
+
+
+def _bracket_depth(line: str) -> int:
+    """Return the net bracket depth for a line, ignoring comments/strings."""
+    depth = 0
+    quote: str | None = None
+    triple_quote = False
+    escaped = False
+    i = 0
+    while i < len(line):
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if quote is not None:
+            if line[i] == "\\":
+                escaped = True
+            elif triple_quote and line.startswith(quote * 3, i):
+                quote = None
+                triple_quote = False
+                i += 3
+                continue
+            elif not triple_quote and line[i] == quote:
+                quote = None
+            i += 1
+            continue
+        if line[i] == "#":
+            break
+        if line[i] in {"'", '"'}:
+            quote = line[i]
+            triple_quote = line.startswith(line[i] * 3, i)
+            if triple_quote:
+                i += 3
+                continue
+        elif line[i] in "([{":
+            depth += 1
+        elif line[i] in ")]}":
+            depth -= 1
+        i += 1
+    return depth
 
 
 def _resolve_block_end(file_lines: list[str], start: int) -> int:
@@ -207,8 +250,9 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     indentation.  The block ends at the last such line (blank lines inside the body
     are absorbed).  If no body follows, the block is just the header line itself.
 
-    A same-indentation continuation clause (``elif``/``else``/``except``/
-    ``finally``) is treated as part of the same compound statement: its header
+    A multi-line header delimited by brackets is consumed before indentation
+    scanning begins. A same-indentation continuation clause
+    (``elif``/``else``/``except``/``finally``) is treated as part of the same compound statement: its header
     and body are absorbed too, so the resolved range covers the whole
     ``if``/``try`` statement rather than stopping at the first clause. A
     comment line does not end the block by itself — it is skipped while
@@ -226,11 +270,18 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
 
     header = file_lines[start - 1]
     header_indent = len(header) - len(header.lstrip())
+    python_compound = bool(_RE_PYTHON_COMPOUND_HEADER.match(header.lstrip()))
+    bracket_depth = _bracket_depth(header)
 
     end = start
     i = start  # file_lines[start] is the line AFTER the header (0-indexed)
     while i < total:
         line = file_lines[i]
+        if bracket_depth > 0:
+            bracket_depth += _bracket_depth(line)
+            end = i + 1
+            i += 1
+            continue
         if not line.strip():
             i += 1
             continue  # blank lines are absorbed; decide at the next non-blank line
@@ -240,7 +291,11 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
             i += 1
         elif line.lstrip().startswith("#"):
             i += 1  # comments may separate continuation clauses
-        elif indent == header_indent and _RE_CONTINUATION_CLAUSE.match(line.lstrip()):
+        elif (
+            python_compound
+            and indent == header_indent
+            and _RE_CONTINUATION_CLAUSE.match(line.lstrip())
+        ):
             end = i + 1  # absorb the continuation clause header itself
             i += 1
         else:

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -196,6 +196,9 @@ def _collect_content(lines: list[str], start_idx: int) -> tuple[int, str]:
 # ---------------------------------------------------------------------------
 
 
+_RE_CONTINUATION_CLAUSE = re.compile(r"^(elif|else|except|finally)\b")
+
+
 def _resolve_block_end(file_lines: list[str], start: int) -> int:
     """Return the 1-indexed last line of the syntactic block starting at *start*.
 
@@ -203,6 +206,11 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     body is the contiguous sequence of non-blank lines with strictly greater
     indentation.  The block ends at the last such line (blank lines inside the body
     are absorbed).  If no body follows, the block is just the header line itself.
+
+    A same-indentation continuation clause (``elif``/``else``/``except``/
+    ``finally``) is treated as part of the same compound statement: its header
+    and body are absorbed too, so the resolved range covers the whole
+    ``if``/``try`` statement rather than stopping at the first clause.
 
     Raises :class:`ValueError` when *start* is out of range.
     """
@@ -216,19 +224,22 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     header_indent = len(header) - len(header.lstrip())
 
     end = start
-    in_body = False
-    for i in range(start, total):  # file_lines[start] is the line AFTER the header
+    i = start  # file_lines[start] is the line AFTER the header (0-indexed)
+    while i < total:
         line = file_lines[i]
         if not line.strip():
+            i += 1
             continue  # blank lines are absorbed; decide at the next non-blank line
         indent = len(line) - len(line.lstrip())
         if indent > header_indent:
-            in_body = True
             end = i + 1  # 1-indexed
+            i += 1
+        elif indent == header_indent and _RE_CONTINUATION_CLAUSE.match(line.lstrip()):
+            end = i + 1  # absorb the continuation clause header itself
+            i += 1
         else:
-            break  # same or lower indent: block is complete
+            break  # same or lower indent, not a continuation clause: block is complete
 
-    _ = in_body  # used implicitly: if we never set it, end == start (single-line block)
     return end
 
 
@@ -329,11 +340,19 @@ Re-read the file with ``read`` to get a new tag and restate your operations.
 | ``PUT >N:``  | Insert new lines AFTER line N            |
 | ``CUT N.=M`` | Delete lines N through M                 |
 
-``PUT N*:`` uses an indent-tracking heuristic: the block starts at line N and
-ends at the last line with indentation greater than line N's indentation.  This
-works for Python functions, classes, if/for/while blocks, and similar indented
-constructs.  Point the model at the ``def``/``class`` line and the system finds
-the closing line automatically.
+``PUT N*:`` replaces a whole indented construct — point it at the ``def``,
+``class``, ``if``, ``for``, ``while``, or ``try`` line and the system finds the
+closing line for you, including any ``elif``/``else``/``except``/``finally``
+clauses attached to that same statement.  Use it instead of ``PUT N.=M:`` when
+you want to replace an entire function/block and don't want to count lines by
+hand.
+
+Point N at the actual header line (e.g. the ``def`` line, not a decorator or a
+comment above it) — the block is resolved from that line's indentation.
+Constructs the heuristic can't reliably reproduce: blocks that mix tabs and
+spaces, or a header followed by a same-indentation line that is *not* a
+continuation clause (e.g. a one-line ``if x: y`` body) — for those, fall back to
+``PUT N.=M:`` with an explicit line range.
 
 New content lines are prefixed with ``+``.  An empty line ends a content block.
 CUT has no content block.  Line numbers reference the version shown by ``read``.

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -202,44 +202,60 @@ _RE_PYTHON_COMPOUND_HEADER = re.compile(
 )
 
 
-def _bracket_depth(line: str) -> int:
-    """Return the net bracket depth for a line, ignoring comments/strings."""
+def _scan_line(line: str, open_quote: str | None = None) -> tuple[int, str | None]:
+    """Scan *line*, returning ``(net bracket depth, triple-quote left open)``.
+
+    *open_quote* is the triple-quote delimiter (``'''`` or ``\"\"\"``) left open by
+    a previous line, or ``None`` when the line starts outside a string.  The
+    returned delimiter is the one still open at end of line, so callers can carry
+    multi-line string state across lines instead of re-deciding per line.
+    Brackets and ``#`` comments inside strings are ignored.
+    """
     depth = 0
-    quote: str | None = None
-    triple_quote = False
+    triple: str | None = open_quote  # multi-line string; persists across lines
+    single: str | None = None  # single-quoted string; cannot span lines
     escaped = False
     i = 0
-    while i < len(line):
+    n = len(line)
+    while i < n:
+        ch = line[i]
         if escaped:
             escaped = False
             i += 1
             continue
-        if quote is not None:
-            if line[i] == "\\":
+        if triple is not None:
+            if ch == "\\":
                 escaped = True
-            elif triple_quote and line.startswith(quote * 3, i):
-                quote = None
-                triple_quote = False
+                i += 1
+            elif line.startswith(triple, i):
+                triple = None
                 i += 3
-                continue
-            elif not triple_quote and line[i] == quote:
-                quote = None
+            else:
+                i += 1
+            continue
+        if single is not None:
+            if ch == "\\":
+                escaped = True
+            elif ch == single:
+                single = None
             i += 1
             continue
-        if line[i] == "#":
+        if ch == "#":
             break
-        if line[i] in {"'", '"'}:
-            quote = line[i]
-            triple_quote = line.startswith(line[i] * 3, i)
-            if triple_quote:
+        if ch in {"'", '"'}:
+            if line.startswith(ch * 3, i):
+                triple = ch * 3
                 i += 3
-                continue
-        elif line[i] in "([{":
+            else:
+                single = ch
+                i += 1
+            continue
+        if ch in "([{":
             depth += 1
-        elif line[i] in ")]}":
+        elif ch in ")]}":
             depth -= 1
         i += 1
-    return depth
+    return depth, triple
 
 
 def _resolve_block_end(file_lines: list[str], start: int) -> int:
@@ -250,8 +266,10 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     indentation.  The block ends at the last such line (blank lines inside the body
     are absorbed).  If no body follows, the block is just the header line itself.
 
-    A multi-line header delimited by brackets is consumed before indentation
-    scanning begins. A same-indentation continuation clause
+    A multi-line header delimited by brackets or by a triple-quoted string is
+    consumed before indentation scanning begins, and triple-quoted string state
+    is carried across body lines so a left-aligned string body doesn't terminate
+    the block early. A same-indentation continuation clause
     (``elif``/``else``/``except``/``finally``) is treated as part of the same compound statement: its header
     and body are absorbed too, so the resolved range covers the whole
     ``if``/``try`` statement rather than stopping at the first clause. A
@@ -260,7 +278,9 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     e.g. an ``if`` body and its ``else`` doesn't strand the ``else`` outside
     the resolved range.
 
-    Raises :class:`ValueError` when *start* is out of range.
+    Raises :class:`ValueError` when *start* is out of range, or when the block
+    cannot be delimited because a bracket or triple-quoted string opened by the
+    block is never closed before end of file.
     """
     total = len(file_lines)
     if start < 1 or start > total:
@@ -271,14 +291,17 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
     header = file_lines[start - 1]
     header_indent = len(header) - len(header.lstrip())
     python_compound = bool(_RE_PYTHON_COMPOUND_HEADER.match(header.lstrip()))
-    bracket_depth = _bracket_depth(header)
+    bracket_depth, open_quote = _scan_line(header)
 
     end = start
     i = start  # file_lines[start] is the line AFTER the header (0-indexed)
     while i < total:
         line = file_lines[i]
-        if bracket_depth > 0:
-            bracket_depth += _bracket_depth(line)
+        if bracket_depth > 0 or open_quote is not None:
+            # Inside a multi-line header or a multi-line string: consume the line
+            # verbatim, indentation carries no meaning here.
+            delta, open_quote = _scan_line(line, open_quote)
+            bracket_depth += delta
             end = i + 1
             i += 1
             continue
@@ -288,6 +311,9 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
         indent = len(line) - len(line.lstrip())
         if indent > header_indent:
             end = i + 1  # 1-indexed
+            # A body line may open a triple-quoted string whose content is
+            # left-aligned; track it so those lines stay inside the block.
+            _, open_quote = _scan_line(line)
             i += 1
         elif line.lstrip().startswith("#"):
             i += 1  # comments may separate continuation clauses
@@ -300,6 +326,15 @@ def _resolve_block_end(file_lines: list[str], start: int) -> int:
             i += 1
         else:
             break  # same or lower indent, not a continuation clause: block is complete
+
+    if bracket_depth > 0 or open_quote is not None:
+        # Never closed before EOF — without this guard the scan absorbs the rest
+        # of the file and the replace would silently truncate it.
+        unterminated = "bracket" if bracket_depth > 0 else "string"
+        raise ValueError(
+            f"Block at line {start} has an unterminated {unterminated} — cannot "
+            "determine where it ends; use an explicit range (PUT N.=M:) instead"
+        )
 
     return end
 

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -51,7 +51,9 @@ if TYPE_CHECKING:
 # Operation dataclasses
 # ---------------------------------------------------------------------------
 
-OperationKind = Literal["replace", "insert_before", "insert_after", "delete"]
+OperationKind = Literal[
+    "replace", "insert_before", "insert_after", "delete", "block_replace"
+]
 
 
 @dataclass
@@ -70,6 +72,8 @@ class HashlineOp:
 
 # PUT N.=M:   replace lines N–M
 _RE_PUT_RANGE = re.compile(r"^PUT\s+(\d+)\.=(\d+):\s*$")
+# PUT N*:     replace the syntactic block starting at line N
+_RE_PUT_BLOCK = re.compile(r"^PUT\s+(\d+)\*:\s*$")
 # PUT <N:     insert before line N
 _RE_PUT_BEFORE = re.compile(r"^PUT\s+<(\d+):\s*$")
 # PUT >N:     insert after line N
@@ -137,6 +141,13 @@ def _parse_operations(code: str) -> tuple[str, str, list[HashlineOp]]:
             ops.append(HashlineOp(kind="insert_after", start=n, end=n, text=text))
             continue
 
+        if m := _RE_PUT_BLOCK.match(line):
+            n = int(m.group(1))
+            i, text = _collect_content(lines, i + 1)
+            # end=-1 is a sentinel; resolved against live file in _apply_operations
+            ops.append(HashlineOp(kind="block_replace", start=n, end=-1, text=text))
+            continue
+
         if line.strip() == "" or line.strip().startswith("#"):
             i += 1
             continue
@@ -149,6 +160,7 @@ def _parse_operations(code: str) -> tuple[str, str, list[HashlineOp]]:
 def _is_op_header(line: str) -> bool:
     return bool(
         _RE_PUT_RANGE.match(line)
+        or _RE_PUT_BLOCK.match(line)
         or _RE_PUT_BEFORE.match(line)
         or _RE_PUT_AFTER.match(line)
         or _RE_CUT_RANGE.match(line)
@@ -180,6 +192,47 @@ def _collect_content(lines: list[str], start_idx: int) -> tuple[int, str]:
 
 
 # ---------------------------------------------------------------------------
+# Block resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_block_end(file_lines: list[str], start: int) -> int:
+    """Return the 1-indexed last line of the syntactic block starting at *start*.
+
+    Uses an indent-tracking heuristic: the block header is at *start*; the block
+    body is the contiguous sequence of non-blank lines with strictly greater
+    indentation.  The block ends at the last such line (blank lines inside the body
+    are absorbed).  If no body follows, the block is just the header line itself.
+
+    Raises :class:`ValueError` when *start* is out of range.
+    """
+    total = len(file_lines)
+    if start < 1 or start > total:
+        raise ValueError(
+            f"Block start line {start} out of range (file has {total} lines)"
+        )
+
+    header = file_lines[start - 1]
+    header_indent = len(header) - len(header.lstrip())
+
+    end = start
+    in_body = False
+    for i in range(start, total):  # file_lines[start] is the line AFTER the header
+        line = file_lines[i]
+        if not line.strip():
+            continue  # blank lines are absorbed; decide at the next non-blank line
+        indent = len(line) - len(line.lstrip())
+        if indent > header_indent:
+            in_body = True
+            end = i + 1  # 1-indexed
+        else:
+            break  # same or lower indent: block is complete
+
+    _ = in_body  # used implicitly: if we never set it, end == start (single-line block)
+    return end
+
+
+# ---------------------------------------------------------------------------
 # Apply
 # ---------------------------------------------------------------------------
 
@@ -195,6 +248,18 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     had_trailing_newline = content.endswith("\n")
     file_lines = content.splitlines()
     total = len(file_lines)
+
+    # Resolve block_replace ops to concrete replace ranges before validation/sorting
+    resolved: list[HashlineOp] = []
+    for op in ops:
+        if op.kind == "block_replace":
+            end = _resolve_block_end(file_lines, op.start)
+            resolved.append(
+                HashlineOp(kind="replace", start=op.start, end=end, text=op.text)
+            )
+        else:
+            resolved.append(op)
+    ops = resolved
 
     for op in ops:
         # Allow PUT <1 on empty files
@@ -259,9 +324,16 @@ Re-read the file with ``read`` to get a new tag and restate your operations.
 | Syntax       | Effect                                    |
 |-------------|------------------------------------------|
 | ``PUT N.=M:``| Replace lines N through M with new lines |
+| ``PUT N*:``  | Replace the syntactic block at line N    |
 | ``PUT <N:``  | Insert new lines BEFORE line N           |
 | ``PUT >N:``  | Insert new lines AFTER line N            |
 | ``CUT N.=M`` | Delete lines N through M                 |
+
+``PUT N*:`` uses an indent-tracking heuristic: the block starts at line N and
+ends at the last line with indentation greater than line N's indentation.  This
+works for Python functions, classes, if/for/while blocks, and similar indented
+constructs.  Point the model at the ``def``/``class`` line and the system finds
+the closing line automatically.
 
 New content lines are prefixed with ``+``.  An empty line ends a content block.
 CUT has no content block.  Line numbers reference the version shown by ``read``.

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -613,6 +613,48 @@ class TestResolveBlockEnd:
         lines = content.splitlines()
         assert _resolve_block_end(lines, 1) == 2
 
+    def test_unclosed_bracket_header_raises_instead_of_eating_file(self):
+        # A header whose bracket never closes must NOT absorb to EOF — that
+        # would make PUT N*: silently truncate the rest of the file.
+        content = "def foo(\n    x,\nunrelated = 1\nmore = 2\n"
+        with pytest.raises(ValueError, match="unterminated bracket"):
+            _resolve_block_end(content.splitlines(), 1)
+
+    def test_unmatched_paren_in_prose_raises(self):
+        # hashline_edit edits any file, not just Python: an unmatched paren in
+        # plain text must not swallow the remainder of the document.
+        content = "- item (see note\n- item two\n- item three\n"
+        with pytest.raises(ValueError, match="unterminated bracket"):
+            _resolve_block_end(content.splitlines(), 1)
+
+    def test_unterminated_triple_quote_raises(self):
+        content = 'x = """\nline a\nline b\n'
+        with pytest.raises(ValueError, match="unterminated string"):
+            _resolve_block_end(content.splitlines(), 1)
+
+    def test_multiline_string_header_absorbs_string_body(self):
+        # The header opens a triple-quoted string: the block runs to its close,
+        # not just the opening line.
+        content = 'x = """\nline a\nline b\n"""\ny = 2\n'
+        assert _resolve_block_end(content.splitlines(), 1) == 4
+
+    def test_dedented_string_body_does_not_end_block(self):
+        # A left-aligned line inside a triple-quoted string in the body has
+        # indent <= header indent, but is still part of the block.
+        content = (
+            'def foo():\n    x = """\ntext at column 0\n"""\n    return 1\nafter()\n'
+        )
+        assert _resolve_block_end(content.splitlines(), 1) == 5
+
+    def test_indented_docstring_still_resolves(self):
+        content = 'def foo():\n    """Doc\n    more\n    """\n    return 1\nafter()\n'
+        assert _resolve_block_end(content.splitlines(), 1) == 5
+
+    def test_brace_delimited_block_resolves(self):
+        # C-style braces close the header scan at the matching brace.
+        content = "if (x) {\n    foo();\n}\nafter();\n"
+        assert _resolve_block_end(content.splitlines(), 1) == 3
+
 
 # ---------------------------------------------------------------------------
 # PUT N*: block-aware replace
@@ -638,6 +680,26 @@ class TestBlockReplace:
         result = _apply_operations(content, ops)
         assert "def foo():\n    return 42\n\ndef bar():" in result
         assert "x = 1" not in result
+
+    def test_apply_block_replace_unclosed_bracket_is_rejected(self):
+        # Regression: PUT N*: on a header with an unclosed bracket used to
+        # resolve to EOF and delete the remainder of the file.
+        content = "def foo(\n    x,\nkeep_me = 1\nkeep_me_too = 2\n"
+        ops = [HashlineOp(kind="block_replace", start=1, end=-1, text="def foo(x):")]
+        with pytest.raises(ValueError, match="unterminated bracket"):
+            _apply_operations(content, ops)
+
+    def test_execute_put_block_unclosed_bracket_leaves_file_intact(
+        self, tmp_path: Path
+    ):
+        f = tmp_path / "broken.py"
+        original = "def foo(\n    x,\nkeep_me = 1\nkeep_me_too = 2\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1*:\n+def foo(x):\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "unterminated bracket" in msgs[0]
+        assert f.read_text() == original  # nothing truncated
 
     def test_apply_block_replace_single_line(self):
         content = "x = 1\ny = 2\n"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -537,6 +537,32 @@ class TestResolveBlockEnd:
         with pytest.raises(ValueError, match="out of range"):
             _resolve_block_end(lines, 5)
 
+    def test_if_elif_else_absorbed(self):
+        content = "if x:\n    do_a()\nelif y:\n    do_b()\nelse:\n    do_c()\ndo_d()\n"
+        lines = content.splitlines()
+        # Block at line 1 (if x) must absorb elif/else through line 6
+        assert _resolve_block_end(lines, 1) == 6
+
+    def test_try_except_finally_absorbed(self):
+        content = (
+            "try:\n"
+            "    risky()\n"
+            "except ValueError as e:\n"
+            "    handle(e)\n"
+            "finally:\n"
+            "    cleanup()\n"
+            "after()\n"
+        )
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 6
+
+    def test_same_indent_non_continuation_not_absorbed(self):
+        # A same-indentation line that is not elif/else/except/finally still
+        # terminates the block (e.g. an unrelated statement after an if).
+        content = "if x:\n    do_a()\nelifish_var = 1\n"
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 2
+
 
 # ---------------------------------------------------------------------------
 # PUT N*: block-aware replace
@@ -585,6 +611,16 @@ class TestBlockReplace:
 
     def test_put_block_in_instructions(self):
         assert "PUT N*:" in tool.instructions
+
+    def test_apply_block_replace_if_elif_else(self):
+        content = "if x:\n    do_a()\nelif y:\n    do_b()\nelse:\n    do_c()\ndo_d()\n"
+        ops = [
+            HashlineOp(kind="block_replace", start=1, end=-1, text="if z:\n    do_z()")
+        ]
+        result = _apply_operations(content, ops)
+        assert result == "if z:\n    do_z()\ndo_d()\n"
+        assert "elif" not in result
+        assert "else" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -563,6 +563,29 @@ class TestResolveBlockEnd:
         lines = content.splitlines()
         assert _resolve_block_end(lines, 1) == 2
 
+    def test_multiline_function_header(self):
+        content = (
+            "def foo(\n"
+            "    first: tuple[int, str],\n"
+            "    second: str = 'ignore ) in strings',\n"
+            "):\n"
+            "    return first\n"
+            "after()\n"
+        )
+        assert _resolve_block_end(content.splitlines(), 1) == 5
+
+    def test_multiline_if_header(self):
+        content = "if (\n    first\n    and second\n):\n    act()\nafter()\n"
+        assert _resolve_block_end(content.splitlines(), 1) == 5
+
+    def test_comment_bracket_does_not_hold_header_open(self):
+        content = "def foo(  # unmatched ]\n    value,\n):\n    return value\nafter()\n"
+        assert _resolve_block_end(content.splitlines(), 1) == 4
+
+    def test_non_python_else_section_not_absorbed(self):
+        content = "commands:\n  - run\nelse:\n  - cleanup\n"
+        assert _resolve_block_end(content.splitlines(), 1) == 2
+
     def test_comment_between_clauses_does_not_strand_else(self):
         # A same-indentation comment before else/except/etc. must not end the
         # block early — the else clause is still part of the same statement.
@@ -648,6 +671,27 @@ class TestBlockReplace:
         assert result == "if z:\n    do_z()\ndo_d()\n"
         assert "elif" not in result
         assert "else" not in result
+
+    def test_apply_block_replace_multiline_header_with_adjacent_cut(self):
+        content = (
+            "before = True\n"
+            "def foo(\n"
+            "    first,\n"
+            "    second,\n"
+            "):\n"
+            "    return first + second\n"
+            "obsolete = True\n"
+            "after = True\n"
+        )
+        ops = [
+            HashlineOp(
+                kind="block_replace", start=2, end=-1, text="def foo():\n    return 42"
+            ),
+            HashlineOp(kind="delete", start=7, end=7, text=None),
+        ]
+        assert _apply_operations(content, ops) == (
+            "before = True\ndef foo():\n    return 42\nafter = True\n"
+        )
 
     def test_apply_block_replace_comment_between_clauses(self):
         content = "if x:\n    do_a()\n# comment\nelse:\n    do_b()\ndo_c()\n"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -563,6 +563,33 @@ class TestResolveBlockEnd:
         lines = content.splitlines()
         assert _resolve_block_end(lines, 1) == 2
 
+    def test_comment_between_clauses_does_not_strand_else(self):
+        # A same-indentation comment before else/except/etc. must not end the
+        # block early — the else clause is still part of the same statement.
+        content = "if x:\n    do_a()\n# comment\nelse:\n    do_b()\ndo_c()\n"
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 5
+
+    def test_multiple_comments_between_clauses_absorbed(self):
+        content = (
+            "try:\n"
+            "    risky()\n"
+            "# note 1\n"
+            "# note 2\n"
+            "except ValueError:\n"
+            "    handle()\n"
+            "after()\n"
+        )
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 6
+
+    def test_comment_with_no_following_continuation_not_absorbed(self):
+        # A trailing same-indentation comment with no continuation clause after
+        # it must not be pulled into the block, nor extend past it.
+        content = "if x:\n    do_a()\n# trailing comment\nprint('done')\n"
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 2
+
 
 # ---------------------------------------------------------------------------
 # PUT N*: block-aware replace
@@ -620,6 +647,16 @@ class TestBlockReplace:
         result = _apply_operations(content, ops)
         assert result == "if z:\n    do_z()\ndo_d()\n"
         assert "elif" not in result
+        assert "else" not in result
+
+    def test_apply_block_replace_comment_between_clauses(self):
+        content = "if x:\n    do_a()\n# comment\nelse:\n    do_b()\ndo_c()\n"
+        ops = [
+            HashlineOp(kind="block_replace", start=1, end=-1, text="if z:\n    do_z()")
+        ]
+        result = _apply_operations(content, ops)
+        assert result == "if z:\n    do_z()\ndo_c()\n"
+        assert "# comment" not in result
         assert "else" not in result
 
 

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -23,6 +23,7 @@ from gptme.tools.hashline_edit import (
     ParseError,
     _apply_operations,
     _parse_operations,
+    _resolve_block_end,
     execute_hashline_edit,
     tool,
 )
@@ -487,6 +488,103 @@ class TestReadIntegration:
         tag_v2 = get_stored_tag(str(f.resolve()))
 
         assert tag_v1 != tag_v2
+
+
+# ---------------------------------------------------------------------------
+# Block resolution (_resolve_block_end)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBlockEnd:
+    def test_python_function(self):
+        content = "def foo():\n    x = 1\n    return x\n\ndef bar():\n    pass\n"
+        lines = content.splitlines()
+        # Block at line 1 (def foo) should end at line 3 (return x)
+        assert _resolve_block_end(lines, 1) == 3
+
+    def test_single_line_block(self):
+        content = "x = 1\ny = 2\n"
+        lines = content.splitlines()
+        # Line 1 has no indented body — block is just line 1
+        assert _resolve_block_end(lines, 1) == 1
+
+    def test_nested_blocks(self):
+        content = "class Foo:\n    def method(self):\n        return 1\n\n    def other(self):\n        return 2\n"
+        lines = content.splitlines()
+        # Block at line 1 (class Foo) ends at line 6 (last method body)
+        assert _resolve_block_end(lines, 1) == 6
+
+    def test_blank_lines_inside_body_absorbed(self):
+        content = (
+            "def foo():\n    x = 1\n\n    y = 2\n    return y\n\ndef bar():\n    pass\n"
+        )
+        lines = content.splitlines()
+        # Blank line (line 3) is inside the body; block ends at line 5
+        assert _resolve_block_end(lines, 1) == 5
+
+    def test_if_block(self):
+        content = "if x:\n    do_a()\n    do_b()\ndo_c()\n"
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 3
+
+    def test_last_function_in_file(self):
+        content = "def foo():\n    return 1\n"
+        lines = content.splitlines()
+        assert _resolve_block_end(lines, 1) == 2
+
+    def test_out_of_range_raises(self):
+        lines = ["a", "b"]
+        with pytest.raises(ValueError, match="out of range"):
+            _resolve_block_end(lines, 5)
+
+
+# ---------------------------------------------------------------------------
+# PUT N*: block-aware replace
+# ---------------------------------------------------------------------------
+
+
+class TestBlockReplace:
+    def test_parse_put_block_op(self):
+        code = "[foo.py#A1B2C3D4]\nPUT 1*:\n+def foo():\n+    pass\n"
+        _, _, ops = _parse_operations(code)
+        assert len(ops) == 1
+        assert ops[0].kind == "block_replace"
+        assert ops[0].start == 1
+        assert ops[0].end == -1  # sentinel; resolved at apply time
+
+    def test_apply_block_replace_function(self):
+        content = "def foo():\n    x = 1\n    return x\n\ndef bar():\n    pass\n"
+        ops = [
+            HashlineOp(
+                kind="block_replace", start=1, end=-1, text="def foo():\n    return 42"
+            )
+        ]
+        result = _apply_operations(content, ops)
+        assert "def foo():\n    return 42\n\ndef bar():" in result
+        assert "x = 1" not in result
+
+    def test_apply_block_replace_single_line(self):
+        content = "x = 1\ny = 2\n"
+        ops = [HashlineOp(kind="block_replace", start=1, end=-1, text="x = 99")]
+        result = _apply_operations(content, ops)
+        assert result == "x = 99\ny = 2\n"
+
+    def test_execute_put_block(self, tmp_path: Path):
+        f = tmp_path / "example.py"
+        f.write_text(
+            "def greet(name):\n    print('Hello')\n    return name\n\ndef bye():\n    pass\n"
+        )
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1*:\n+def greet(name):\n+    print(f'Hi, {{name}}')\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower()
+        result = f.read_text()
+        assert "Hi, {name}" in result or "Hi," in result
+        assert "Hello" not in result
+        assert "def bye" in result  # other function untouched
+
+    def test_put_block_in_instructions(self):
+        assert "PUT N*:" in tool.instructions
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the `PUT N*:` (block-aware replace) operation from issue #3476's Phase 1 specification that was deferred to Phase 2 in the initial implementation (#3477).

- `PUT N*:` resolves the end of the syntactic block at line N using an indent-tracking heuristic: the block ends at the last non-blank line with indentation strictly greater than the header line's indentation
- Works for Python functions, classes, if/for/while/with blocks, and any indented construct
- Block resolution happens before the existing bottom-up apply pass, so all existing snapshot-verification and ordering guarantees are unchanged
- Adds `_resolve_block_end()` as a public function (tested independently)

**Example usage:**

```
[greet.py#A1B2C3D4]
PUT 1*:
+def greet(name):
+    print(f"Hi, {name}")
```

The model points at `def greet` (line 1); the system automatically finds the closing line of that function and replaces the whole block.

## Changes

- `gptme/tools/hashline_edit.py`: adds `_RE_PUT_BLOCK` regex, `block_replace` op kind, `_resolve_block_end()`, and resolves `block_replace` → `replace` in `_apply_operations`; updates instructions table
- `tests/test_tools_hashline_edit.py`: 12 new tests for `_resolve_block_end` and `PUT N*:` parse/apply/execute paths

## Test plan

- [x] All 70 tests pass (`PYTHONPATH=tests .venv/bin/python -m pytest tests/test_tools_hashline_edit.py -q`)
- [x] Pre-commit hooks pass (ruff format, mypy)
- [x] Python function block resolution verified
- [x] Nested class/method resolution verified
- [x] Blank-line-inside-body absorption verified
- [x] Single-line (no body) fallback verified

Closes #3476

<!-- gptme-id:v1:gai_h7UJzedHaf1zTx2TVTzNAZqmJHlDzb2uHjGbmyT7Gq8 -->