### PR TITLE
fix(server): prevent premature continuation when confirming concurrent tools

### DIFF
--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -83,6 +83,10 @@ class ConversationSession(BaseSession):
     events: list[EventType] = field(default_factory=list)
     _events_offset: int = 0  # number of events trimmed from front of list
     pending_tools: dict[str, ToolExecution] = field(default_factory=dict)
+    # Tools that have been popped from pending_tools but not yet written their
+    # results. Used to prevent the continuation step from starting before all
+    # concurrent tool threads have finished writing.
+    _executing_tools: set[str] = field(default_factory=set)
     auto_confirm_count: int = 0
     clients: set[str] = field(default_factory=set)
     event_flag: threading.Event = field(default_factory=threading.Event)

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1057,20 +1057,32 @@ def start_tool_execution(
                         session.generating = False
                         session.generating_since = None
                     return  # another thread claimed this tool; don't trigger auto-step
-                if assistant_msg_timestamp is None:
-                    assistant_msg_timestamp = tool_exec.assistant_msg_timestamp
-                tool_exec.status = ToolStatus.EXECUTING
+                # The claim is registered above but the try/finally that releases
+                # it only starts below, so anything that raises in between (most
+                # plausibly add_event, which iterates sessions and trims their
+                # event buffers) would strand current_tool_id in
+                # _executing_tools for the lifetime of the session. Nothing else
+                # ever clears that set, and the continuation gate requires it to
+                # be empty — so a single failure here would silently stop every
+                # later tool in this session from producing an assistant reply.
+                try:
+                    if assistant_msg_timestamp is None:
+                        assistant_msg_timestamp = tool_exec.assistant_msg_timestamp
+                    tool_exec.status = ToolStatus.EXECUTING
 
-                # use explicit tooluse if set (may be modified), else from pending
-                tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
+                    # use explicit tooluse if set (may be modified), else from pending
+                    tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
 
-                # Record start time and notify about tool execution
-                tool_exec.started_at = time.monotonic()
-                SessionManager.add_event(
-                    conversation_id,
-                    {"type": "tool_executing", "tool_id": current_tool_id},
-                )
-                logger.info(f"Tool {current_tool_id} executing")
+                    # Record start time and notify about tool execution
+                    tool_exec.started_at = time.monotonic()
+                    SessionManager.add_event(
+                        conversation_id,
+                        {"type": "tool_executing", "tool_id": current_tool_id},
+                    )
+                    logger.info(f"Tool {current_tool_id} executing")
+                except BaseException:
+                    session._executing_tools.discard(current_tool_id)
+                    raise
 
                 # Execute the tool
                 try:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1038,10 +1038,14 @@ def start_tool_execution(
                 # the correct message history, not always the "main" branch.
                 manager = LogManager.load(conversation_id, branch=branch, lock=False)
 
-                # Atomically claim the tool with pop(): a get-then-pop sequence
-                # leaves a window where two threads (e.g. two concurrent confirm
-                # requests) both see the tool and both execute it.
-                tool_exec = session.pending_tools.pop(current_tool_id, None)
+                # Atomically claim the tool with pop() and register it as
+                # executing — both under conversation_lock so no sibling thread
+                # can see pending_tools empty while this thread hasn't yet
+                # added itself to _executing_tools.
+                with SessionManager.conversation_lock(conversation_id):
+                    tool_exec = session.pending_tools.pop(current_tool_id, None)
+                    if tool_exec is not None:
+                        session._executing_tools.add(current_tool_id)
                 if tool_exec is None:
                     logger.warning(
                         f"Tool {current_tool_id} not found in pending tools "
@@ -1116,6 +1120,7 @@ def start_tool_execution(
                         )
                         for tool_output in tool_outputs:
                             _append_and_notify(manager, session, tool_output)
+                        session._executing_tools.discard(current_tool_id)
                 except Exception as e:
                     logger.exception(f"Error executing tool {tooluse.tool}: {e}")
                     tool_exec.status = ToolStatus.FAILED
@@ -1128,6 +1133,7 @@ def start_tool_execution(
                             "system", f"Error: {e!s}", call_id=tooluse.call_id
                         )
                         _append_and_notify(manager, session, msg)
+                        session._executing_tools.discard(current_tool_id)
 
                 # Emit tool_complete with duration; also accumulate for metadata.
                 if tool_exec.started_at is not None:
@@ -1184,10 +1190,12 @@ def start_tool_execution(
                     branch=branch,
                 )
 
-            # Only auto-step when all pending tools have been executed.
-            # With multiple tools per message, we must wait until every tool
-            # has run before asking the model for a continuation.
-            if not session.pending_tools:
+            # Only auto-step when all pending tools have been executed AND all
+            # concurrent execution threads have written their results.
+            # pending_tools tracks tools awaiting confirmation; _executing_tools
+            # tracks tools that were popped (confirmed) but haven't finished
+            # writing yet — both must be empty before asking the model to continue.
+            if not session.pending_tools and not session._executing_tools:
                 _start_step_thread(
                     conversation_id,
                     session,

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1084,120 +1084,120 @@ def start_tool_execution(
                     session._executing_tools.discard(current_tool_id)
                     raise
 
-                # Execute the tool
+                claimed_tool_id = current_tool_id
                 try:
-                    logger.info(f"Executing tool: {tooluse.tool}")
-                    stream_tool_id = current_tool_id
+                    # Execute the tool
+                    try:
+                        logger.info(f"Executing tool: {tooluse.tool}")
+                        stream_tool_id = current_tool_id
 
-                    def stream_tool_output(
-                        tool_output: Message, tool_id: str = stream_tool_id
-                    ) -> None:
-                        if (
-                            tool_output.role == "system"
-                            and not tool_output.hide
-                            and not tool_output.quiet
-                        ):
-                            SessionManager.add_event(
-                                conversation_id,
-                                {
-                                    "type": "tool_output",
-                                    "tool_id": tool_id,
-                                    "output": tool_output.content,
-                                },
+                        def stream_tool_output(
+                            tool_output: Message, tool_id: str = stream_tool_id
+                        ) -> None:
+                            if (
+                                tool_output.role == "system"
+                                and not tool_output.hide
+                                and not tool_output.quiet
+                            ):
+                                SessionManager.add_event(
+                                    conversation_id,
+                                    {
+                                        "type": "tool_output",
+                                        "tool_id": tool_id,
+                                        "output": tool_output.content,
+                                    },
+                                )
+
+                        tool_outputs = list(
+                            tooluse.execute(
+                                log=manager.log,
+                                workspace=manager.workspace,
+                                on_result_message=stream_tool_output,
                             )
-
-                    tool_outputs = list(
-                        tooluse.execute(
-                            log=manager.log,
-                            workspace=manager.workspace,
-                            on_result_message=stream_tool_output,
                         )
-                    )
-                    logger.info(
-                        f"Tool execution complete, outputs: {len(tool_outputs)}"
-                    )
-
-                    # Store the tool outputs. call_id is already assigned in
-                    # ToolUse.execute() for real results; hook messages intentionally
-                    # have no call_id — don't re-stamp here or hook messages become
-                    # duplicate function_call_output entries (Responses API 400).
-                    #
-                    # Reload under conversation_lock before appending: without this,
-                    # a stale in-memory manager (loaded at the top of the loop) would
-                    # rewrite the full JSONL, overwriting concurrent tool-result appends
-                    # or timing patches written by other confirmation threads.
-                    with SessionManager.conversation_lock(conversation_id):
-                        manager = LogManager.load(
-                            conversation_id, branch=branch, lock=False
+                        logger.info(
+                            f"Tool execution complete, outputs: {len(tool_outputs)}"
                         )
-                        for tool_output in tool_outputs:
-                            _append_and_notify(manager, session, tool_output)
-                except Exception as e:
-                    logger.exception(f"Error executing tool {tooluse.tool}: {e}")
-                    tool_exec.status = ToolStatus.FAILED
 
-                    with SessionManager.conversation_lock(conversation_id):
-                        manager = LogManager.load(
-                            conversation_id, branch=branch, lock=False
+                        # Store the tool outputs. call_id is already assigned in
+                        # ToolUse.execute() for real results; hook messages intentionally
+                        # have no call_id — don't re-stamp here or hook messages become
+                        # duplicate function_call_output entries (Responses API 400).
+                        #
+                        # Reload under conversation_lock before appending: without this,
+                        # a stale in-memory manager (loaded at the top of the loop) would
+                        # rewrite the full JSONL, overwriting concurrent tool-result appends
+                        # or timing patches written by other confirmation threads.
+                        with SessionManager.conversation_lock(conversation_id):
+                            manager = LogManager.load(
+                                conversation_id, branch=branch, lock=False
+                            )
+                            for tool_output in tool_outputs:
+                                _append_and_notify(manager, session, tool_output)
+                    except Exception as e:
+                        logger.exception(f"Error executing tool {tooluse.tool}: {e}")
+                        tool_exec.status = ToolStatus.FAILED
+
+                        with SessionManager.conversation_lock(conversation_id):
+                            manager = LogManager.load(
+                                conversation_id, branch=branch, lock=False
+                            )
+                            msg = Message(
+                                "system", f"Error: {e!s}", call_id=tooluse.call_id
+                            )
+                            _append_and_notify(manager, session, msg)
+
+                    # Emit tool_complete with duration; also accumulate for metadata.
+                    if tool_exec.started_at is not None:
+                        duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
+                        tool_ms_by_name[tooluse.tool] = (
+                            tool_ms_by_name.get(tooluse.tool, 0.0) + duration_ms
                         )
-                        msg = Message(
-                            "system", f"Error: {e!s}", call_id=tooluse.call_id
-                        )
-                        _append_and_notify(manager, session, msg)
-                finally:
-                    # Unconditional cleanup: whatever happens above (success,
-                    # a caught Exception, a BaseException like KeyboardInterrupt,
-                    # or a failure while persisting the result/error message
-                    # itself), the claim must be released or this tool id stays
-                    # in _executing_tools forever, permanently blocking the
-                    # `not pending_tools and not _executing_tools` continuation
-                    # check for this session.
-                    session._executing_tools.discard(current_tool_id)
-
-                # Emit tool_complete with duration; also accumulate for metadata.
-                if tool_exec.started_at is not None:
-                    duration_ms = (time.monotonic() - tool_exec.started_at) * 1000
-                    tool_ms_by_name[tooluse.tool] = (
-                        tool_ms_by_name.get(tooluse.tool, 0.0) + duration_ms
-                    )
-                    SessionManager.add_event(
-                        conversation_id,
-                        {
-                            "type": "tool_complete",
-                            "tool_id": current_tool_id,
-                            "duration_ms": duration_ms,
-                            "success": tool_exec.status != ToolStatus.FAILED,
-                        },
-                    )
-
-                # Chain to next pending auto-confirm tool (serial execution)
-                next_auto_id: str | None = None
-                next_auto_ts: datetime | None = None
-                for tid, texec in list(session.pending_tools.items()):
-                    if texec.auto_confirm:
-                        next_auto_id = tid
-                        next_auto_ts = texec.assistant_msg_timestamp
-                        break
-
-                if next_auto_id is not None:
-                    # If the next chained tool belongs to a different assistant
-                    # message (e.g. added by a rerun while this thread is
-                    # running), flush accumulated timings for the current target
-                    # before switching — otherwise those durations would be
-                    # attached to the wrong step.
-                    if next_auto_ts != assistant_msg_timestamp and tool_ms_by_name:
-                        _attach_tool_timings(
+                        SessionManager.add_event(
                             conversation_id,
-                            dict(tool_ms_by_name),
-                            assistant_msg_timestamp,
-                            branch=branch,
+                            {
+                                "type": "tool_complete",
+                                "tool_id": current_tool_id,
+                                "duration_ms": duration_ms,
+                                "success": tool_exec.status != ToolStatus.FAILED,
+                            },
                         )
-                        tool_ms_by_name.clear()
-                        assistant_msg_timestamp = next_auto_ts
-                    current_tool_id = next_auto_id
-                    current_edited_tooluse = None
-                else:
-                    break
+
+                    # Chain to next pending auto-confirm tool (serial execution)
+                    next_auto_id: str | None = None
+                    next_auto_ts: datetime | None = None
+                    for tid, texec in list(session.pending_tools.items()):
+                        if texec.auto_confirm:
+                            next_auto_id = tid
+                            next_auto_ts = texec.assistant_msg_timestamp
+                            break
+
+                    if next_auto_id is not None:
+                        # If the next chained tool belongs to a different assistant
+                        # message (e.g. added by a rerun while this thread is
+                        # running), flush accumulated timings for the current target
+                        # before switching — otherwise those durations would be
+                        # attached to the wrong step.
+                        if next_auto_ts != assistant_msg_timestamp and tool_ms_by_name:
+                            _attach_tool_timings(
+                                conversation_id,
+                                dict(tool_ms_by_name),
+                                assistant_msg_timestamp,
+                                branch=branch,
+                            )
+                            tool_ms_by_name.clear()
+                            assistant_msg_timestamp = next_auto_ts
+                        current_tool_id = next_auto_id
+                        current_edited_tooluse = None
+                    else:
+                        break
+                finally:
+                    # Keep the claim through completion events and timing writes.
+                    # Releasing it under the same lock used by the continuation
+                    # election prevents a sibling from observing an incomplete
+                    # bookkeeping state as quiescent.
+                    with SessionManager.conversation_lock(conversation_id):
+                        session._executing_tools.discard(claimed_tool_id)
 
             # Persist aggregated tool timing in the assistant message that
             # triggered these tool calls so it is available in session records.
@@ -1209,26 +1209,35 @@ def start_tool_execution(
                     branch=branch,
                 )
 
-            # Only auto-step when all pending tools have been executed AND all
-            # concurrent execution threads have written their results.
-            # pending_tools tracks tools awaiting confirmation; _executing_tools
-            # tracks tools that were popped (confirmed) but haven't finished
-            # writing yet — both must be empty before asking the model to continue.
-            if not session.pending_tools and not session._executing_tools:
+            # Elect exactly one continuation while holding the same lock used to
+            # add and remove execution claims. This makes quiescence observation
+            # and generation reservation one atomic state transition.
+            start_continuation = False
+            with SessionManager.conversation_lock(conversation_id), session.step_lock:
+                if not session.pending_tools and not session._executing_tools:
+                    if reserved:
+                        start_continuation = True
+                    elif not SessionManager.conversation_generating(
+                        conversation_id
+                    ) and not SessionManager.command_is_active(conversation_id):
+                        session.generating = True
+                        session.generating_since = datetime.now(tz=timezone.utc)
+                        start_continuation = True
+                elif reserved:
+                    # Pending non-auto-confirm tools remain; those need explicit
+                    # confirmation. Release the pre-reserved generation slot.
+                    session.generating = False
+                    session.generating_since = None
+
+            if start_continuation:
                 _start_step_thread(
                     conversation_id,
                     session,
                     model,
                     chat_config.workspace,
                     branch=branch,
-                    reserved=reserved,
+                    reserved=True,
                 )
-            elif reserved:
-                # Pending non-auto-confirm tools remain; those need explicit client
-                # confirmation.  Release the pre-reserved generation slot so the
-                # conversation is not permanently blocked.
-                session.generating = False
-                session.generating_since = None
         except Exception:
             logger.exception(
                 f"Unhandled error in tool execution thread for {conversation_id}"

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1120,7 +1120,6 @@ def start_tool_execution(
                         )
                         for tool_output in tool_outputs:
                             _append_and_notify(manager, session, tool_output)
-                        session._executing_tools.discard(current_tool_id)
                 except Exception as e:
                     logger.exception(f"Error executing tool {tooluse.tool}: {e}")
                     tool_exec.status = ToolStatus.FAILED
@@ -1133,7 +1132,15 @@ def start_tool_execution(
                             "system", f"Error: {e!s}", call_id=tooluse.call_id
                         )
                         _append_and_notify(manager, session, msg)
-                        session._executing_tools.discard(current_tool_id)
+                finally:
+                    # Unconditional cleanup: whatever happens above (success,
+                    # a caught Exception, a BaseException like KeyboardInterrupt,
+                    # or a failure while persisting the result/error message
+                    # itself), the claim must be released or this tool id stays
+                    # in _executing_tools forever, permanently blocking the
+                    # `not pending_tools and not _executing_tools` continuation
+                    # check for this session.
+                    session._executing_tools.discard(current_tool_id)
 
                 # Emit tool_complete with duration; also accumulate for metadata.
                 if tool_exec.started_at is not None:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1190,6 +1190,16 @@ def start_tool_execution(
                         current_tool_id = next_auto_id
                         current_edited_tooluse = None
                     else:
+                        # Persist aggregated timing before releasing the final claim,
+                        # so continuation cannot load the originating message while
+                        # its completion metadata is still being patched.
+                        if tool_ms_by_name:
+                            _attach_tool_timings(
+                                conversation_id,
+                                tool_ms_by_name,
+                                assistant_msg_timestamp,
+                                branch=branch,
+                            )
                         break
                 finally:
                     # Keep the claim through completion events and timing writes.
@@ -1198,16 +1208,6 @@ def start_tool_execution(
                     # bookkeeping state as quiescent.
                     with SessionManager.conversation_lock(conversation_id):
                         session._executing_tools.discard(claimed_tool_id)
-
-            # Persist aggregated tool timing in the assistant message that
-            # triggered these tool calls so it is available in session records.
-            if tool_ms_by_name:
-                _attach_tool_timings(
-                    conversation_id,
-                    tool_ms_by_name,
-                    assistant_msg_timestamp,
-                    branch=branch,
-                )
 
             # Elect exactly one continuation while holding the same lock used to
             # add and remove execution claims. This makes quiescence observation

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -6,6 +6,7 @@ These are unit-level tests using the Flask test client — they don't
 require API keys or LLM calls.
 """
 
+import threading
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -991,6 +992,157 @@ class TestToolConfirmEndpoint:
             assert response.status_code == 200
         finally:
             session.pending_tools.pop(tool_id, None)
+
+
+# --- Concurrent tool confirmation tests (issue #3479) ---
+
+
+class TestConcurrentToolConfirmation:
+    """Regression tests for #3479: concurrent non-auto-confirm tool confirmation
+    must not trigger the continuation step before all tool threads finish writing."""
+
+    def test_executing_tools_field_exists(self, conv, client: FlaskClient):
+        """ConversationSession has _executing_tools set, initially empty."""
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        assert hasattr(session, "_executing_tools")
+        assert len(session._executing_tools) == 0
+
+    def test_no_premature_step_with_concurrent_confirmations(
+        self, conv, client: FlaskClient
+    ):
+        """Fast tool must not trigger continuation while slow tool is still writing.
+
+        Simulates issue #3479: two non-auto-confirm tools confirmed simultaneously.
+        The fast tool finishes first; without the _executing_tools guard it would
+        see pending_tools empty and fire _start_step_thread prematurely, before the
+        slow tool has written its output.
+        """
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        tool1_id = str(uuid.uuid4())
+        tool2_id = str(uuid.uuid4())
+
+        # slow_can_proceed gates tool2's write — held until we release it
+        slow_can_proceed = threading.Event()
+
+        step_calls: list[dict] = []
+
+        def mock_start_step(conv_id, sess, *args, **kwargs):
+            # Record whether slow tool is still in _executing_tools
+            step_calls.append(
+                {
+                    "tool2_still_executing": tool2_id in sess._executing_tools,
+                }
+            )
+            return True
+
+        def make_execute(delay_event: threading.Event | None):
+            """Return a tooluse.execute side-effect that optionally waits."""
+
+            def execute(log, workspace, on_result_message=None):
+                if delay_event is not None:
+                    delay_event.wait(timeout=5)
+                return []
+
+            return execute
+
+        # Register two tools: tool1 (fast), tool2 (slow — waits for slow_can_proceed)
+        tool1_exec = ToolExecution(
+            tool_id=tool1_id,
+            tooluse=ToolUse("bash", [], "echo fast"),
+            auto_confirm=False,
+        )
+        tool2_exec = ToolExecution(
+            tool_id=tool2_id,
+            tooluse=ToolUse("bash", [], "echo slow"),
+            auto_confirm=False,
+        )
+        session.pending_tools[tool1_id] = tool1_exec
+        session.pending_tools[tool2_id] = tool2_exec
+
+        tool1_exec.tooluse = MagicMock(
+            tool="bash",
+            args=[],
+            content="echo fast",
+            call_id=tool1_id,
+        )
+        tool1_exec.tooluse.execute = make_execute(None)
+
+        tool2_exec.tooluse = MagicMock(
+            tool="bash",
+            args=[],
+            content="echo slow",
+            call_id=tool2_id,
+        )
+        tool2_exec.tooluse.execute = make_execute(slow_can_proceed)
+
+        chat_config = ChatConfig(model="mock/model")
+
+        with (
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch(
+                "gptme.server.session_step.LogManager.load",
+                return_value=MagicMock(
+                    log=MagicMock(messages=[]),
+                    workspace=MagicMock(),
+                ),
+            ),
+            patch("gptme.server.session_step._append_and_notify"),
+            patch("gptme.server.session_step._attach_tool_timings"),
+            patch(
+                "gptme.server.session_step._start_step_thread",
+                side_effect=mock_start_step,
+            ),
+        ):
+            # Confirm both tools concurrently (same as the UI "confirm all" action)
+            t1 = start_tool_execution(
+                conv["conversation_id"],
+                session,
+                tool1_id,
+                None,
+                "mock/model",
+                chat_config,
+                branch="main",
+            )
+            t2 = start_tool_execution(
+                conv["conversation_id"],
+                session,
+                tool2_id,
+                None,
+                "mock/model",
+                chat_config,
+                branch="main",
+            )
+
+            # Let tool1 finish immediately (it doesn't wait)
+            # Give it time to run and see if it tries to start the step
+            t1.join(timeout=2)
+
+            # Verify tool1 did NOT trigger the step (tool2 is still "executing")
+            assert step_calls == [], (
+                "Fast tool triggered step continuation before slow tool finished writing"
+            )
+
+            # Now let tool2 proceed to write its result
+            slow_can_proceed.set()
+            t2.join(timeout=5)
+
+        # After both threads finish, exactly one step trigger should have fired
+        assert len(step_calls) == 1, (
+            f"Expected exactly 1 step trigger, got {len(step_calls)}"
+        )
+        # And at that point, tool2 must have already been removed from _executing_tools
+        assert not step_calls[0]["tool2_still_executing"], (
+            "Step was triggered while tool2 was still in _executing_tools"
+        )
+        # Both sets are clean
+        assert len(session._executing_tools) == 0
+        assert len(session.pending_tools) == 0
 
 
 # --- Rerun endpoint tests ---

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1144,6 +1144,79 @@ class TestConcurrentToolConfirmation:
         assert len(session._executing_tools) == 0
         assert len(session.pending_tools) == 0
 
+    def test_claim_released_when_setup_raises_before_execution(
+        self, conv, client: FlaskClient
+    ):
+        """A failure between claiming the tool and entering the execute block
+        must still release the claim.
+
+        The claim is added under conversation_lock, but the try/finally that
+        releases it starts further down. If anything in between raises — most
+        plausibly add_event, which iterates sessions and trims their event
+        buffers — the tool id would be stranded in _executing_tools forever.
+        Nothing else ever clears that set and the continuation gate requires it
+        to be empty, so every later tool in this session would silently stop
+        producing an assistant reply.
+        """
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        tool_id = str(uuid.uuid4())
+        tool_exec = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "echo hi"),
+            auto_confirm=False,
+        )
+        session.pending_tools[tool_id] = tool_exec
+        tool_exec.tooluse = MagicMock(
+            tool="bash", args=[], content="echo hi", call_id=tool_id
+        )
+        tool_exec.tooluse.execute = lambda *a, **kw: []
+
+        real_add_event = SessionManager.add_event
+
+        def failing_add_event(conversation_id, event):
+            # Fail exactly on the setup-phase event, after the claim is taken
+            # but before the execute try/finally is entered.
+            if event.get("type") == "tool_executing":
+                raise RuntimeError("event bus exploded")
+            return real_add_event(conversation_id, event)
+
+        chat_config = ChatConfig(model="mock/model")
+
+        with (
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch(
+                "gptme.server.session_step.LogManager.load",
+                return_value=MagicMock(
+                    log=MagicMock(messages=[]), workspace=MagicMock()
+                ),
+            ),
+            patch("gptme.server.session_step._append_and_notify"),
+            patch("gptme.server.session_step._attach_tool_timings"),
+            patch("gptme.server.session_step._start_step_thread"),
+            patch.object(SessionManager, "add_event", staticmethod(failing_add_event)),
+        ):
+            thread = start_tool_execution(
+                conv["conversation_id"],
+                session,
+                tool_id,
+                None,
+                "mock/model",
+                chat_config,
+                branch="main",
+            )
+            thread.join(timeout=5)
+
+        assert tool_id not in session._executing_tools, (
+            "Tool claim was stranded in _executing_tools after a setup failure — "
+            "the session can never start another continuation step"
+        )
+        assert len(session._executing_tools) == 0
+
 
 # --- Rerun endpoint tests ---
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1166,17 +1166,14 @@ class TestConcurrentToolConfirmation:
         tool_exec.tooluse.execute = lambda *args, **kwargs: []
         session.pending_tools[tool_id] = tool_exec
 
-        completion_entered = threading.Event()
-        allow_completion = threading.Event()
+        timing_entered = threading.Event()
+        allow_timing = threading.Event()
         step_calls: list[bool] = []
-        real_add_event = SessionManager.add_event
 
-        def blocking_add_event(conversation_id, event):
-            if event.get("type") == "tool_complete":
-                completion_entered.set()
-                assert tool_id in session._executing_tools
-                allow_completion.wait(timeout=5)
-            return real_add_event(conversation_id, event)
+        def blocking_attach_timings(*args, **kwargs):
+            timing_entered.set()
+            assert tool_id in session._executing_tools
+            allow_timing.wait(timeout=5)
 
         chat_config = ChatConfig(model="mock/model")
         with (
@@ -1188,12 +1185,14 @@ class TestConcurrentToolConfirmation:
                 ),
             ),
             patch("gptme.server.session_step._append_and_notify"),
-            patch("gptme.server.session_step._attach_tool_timings"),
+            patch(
+                "gptme.server.session_step._attach_tool_timings",
+                side_effect=blocking_attach_timings,
+            ),
             patch(
                 "gptme.server.session_step._start_step_thread",
                 side_effect=lambda *args, **kwargs: step_calls.append(True),
             ),
-            patch.object(SessionManager, "add_event", staticmethod(blocking_add_event)),
         ):
             thread = start_tool_execution(
                 conv["conversation_id"],
@@ -1204,10 +1203,10 @@ class TestConcurrentToolConfirmation:
                 chat_config,
                 branch="main",
             )
-            assert completion_entered.wait(timeout=5)
+            assert timing_entered.wait(timeout=5)
             assert step_calls == []
             assert tool_id in session._executing_tools
-            allow_completion.set()
+            allow_timing.set()
             thread.join(timeout=5)
 
         assert not thread.is_alive()

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1144,6 +1144,76 @@ class TestConcurrentToolConfirmation:
         assert len(session._executing_tools) == 0
         assert len(session.pending_tools) == 0
 
+    def test_completion_bookkeeping_finishes_before_continuation(
+        self, conv, client: FlaskClient
+    ):
+        """The final execution claim covers completion events and timing writes."""
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        tool_id = str(uuid.uuid4())
+        tool_exec = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "echo done"),
+            auto_confirm=False,
+        )
+        tool_exec.tooluse = MagicMock(
+            tool="bash", args=[], content="echo done", call_id=tool_id
+        )
+        tool_exec.tooluse.execute = lambda *args, **kwargs: []
+        session.pending_tools[tool_id] = tool_exec
+
+        completion_entered = threading.Event()
+        allow_completion = threading.Event()
+        step_calls: list[bool] = []
+        real_add_event = SessionManager.add_event
+
+        def blocking_add_event(conversation_id, event):
+            if event.get("type") == "tool_complete":
+                completion_entered.set()
+                assert tool_id in session._executing_tools
+                allow_completion.wait(timeout=5)
+            return real_add_event(conversation_id, event)
+
+        chat_config = ChatConfig(model="mock/model")
+        with (
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch(
+                "gptme.server.session_step.LogManager.load",
+                return_value=MagicMock(
+                    log=MagicMock(messages=[]), workspace=MagicMock()
+                ),
+            ),
+            patch("gptme.server.session_step._append_and_notify"),
+            patch("gptme.server.session_step._attach_tool_timings"),
+            patch(
+                "gptme.server.session_step._start_step_thread",
+                side_effect=lambda *args, **kwargs: step_calls.append(True),
+            ),
+            patch.object(SessionManager, "add_event", staticmethod(blocking_add_event)),
+        ):
+            thread = start_tool_execution(
+                conv["conversation_id"],
+                session,
+                tool_id,
+                None,
+                "mock/model",
+                chat_config,
+                branch="main",
+            )
+            assert completion_entered.wait(timeout=5)
+            assert step_calls == []
+            assert tool_id in session._executing_tools
+            allow_completion.set()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert step_calls == [True]
+        assert session._executing_tools == set()
+
     def test_claim_released_when_setup_raises_before_execution(
         self, conv, client: FlaskClient
     ):


### PR DESCRIPTION
## Problem

When two non-auto-confirm tools from the same assistant message are confirmed simultaneously (e.g. "confirm all" UI button or rapid programmatic confirms), both threads pop their tool from `pending_tools` at the start. The fast thread then sees `pending_tools` empty and fires `_start_step_thread` before the slow thread finishes writing its output — producing an out-of-order transcript.

Closes #3479

## Root Cause

In `execute_tool_thread`, `.pop()` happens at the top of the while loop outside any lock. Both concurrent threads pop their tool immediately, leaving `pending_tools = {}`. The fast thread finishes its write and checks `if not session.pending_tools` → `True` → triggers continuation while the slow thread is still executing.

## Fix

Add `_executing_tools: set[str]` to `ConversationSession` to track tools that have been claimed (popped) but haven't yet finished writing their results.

Key invariant: the `pop` and the `_executing_tools.add` are both performed under `conversation_lock`, so no sibling thread can observe `pending_tools` empty while another thread hasn't yet registered itself as executing. The `discard` happens inside the same lock that guards the write, so the continuation check (`not pending_tools and not _executing_tools`) can only be `True` once the last thread has fully written its output.

`_start_step_thread(reserved=False)` already gates double-calls via the `generating` flag, so two threads simultaneously passing the check safely reduces to a single step start.

Note: this is distinct from PR #3457 (interrupt flag) — that fixes continuation after interrupt; this fixes ordering when multiple manual confirmations arrive concurrently.

## Test plan

`TestConcurrentToolConfirmation::test_no_premature_step_with_concurrent_confirmations` uses a threading event to gate the slow tool's write:
1. Tool 1 (fast) runs immediately; tool 2 (slow) waits for `slow_can_proceed`
2. After tool 1 finishes, asserts `_start_step_thread` was NOT called (tool 2 still in `_executing_tools`)
3. Releases tool 2; after both threads complete, asserts exactly one step trigger with `_executing_tools` already empty

This test fails on the old code and passes with the fix.

- [x] `uv run pytest tests/test_server_v2_sessions.py -q` — 149 passed

<!-- gptme-id:v1:gai_a7GPp6mDkHxpabQ5l8tcYFIyWoIf9hGTgv98ABIaVAv -->