### PR TITLE
ci(webui): embed before/after images inline in visual-diff PR comments (#3467)

### DIFF
--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+      contents: write  # CML needs write access to create draft release assets for image hosting
 
     steps:
     # Download the "after" screenshots from the triggering PR run.
@@ -139,72 +139,62 @@ jobs:
         path: screenshots/diff/
         retention-days: 14
 
-    - name: Build and post PR comment
+    - name: Setup CML
       if: steps.diff.outputs.changed > 0
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          const changed = parseInt('${{ steps.diff.outputs.changed }}', 10);
-          const total   = parseInt('${{ steps.diff.outputs.total }}',   10);
-          const prNumber = parseInt('${{ steps.setup.outputs.pr_number }}', 10);
-          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+      uses: iterative/setup-cml@v2
 
-          // Build the table rows from summary.json
-          const summary = JSON.parse(fs.readFileSync('screenshots/diff/summary.json', 'utf8'));
-          const icon = { changed: '⚠️', new: '🆕', removed: '🗑️', same: '✅' };
-          // Sanitize fork-controlled filenames for Markdown table rows.
-          // Backslash-escaping backticks does NOT work inside CommonMark code spans
-          // (the spec renders code-span content verbatim), so we replace backticks
-          // with their HTML entity instead. CR/LF would break the table row, so we
-          // collapse them to space. Pipes are backslash-escaped.
-          const sanitizeMd = s => s
-            .replace(/\r?\n|\r/g, ' ')  // newlines → space (prevent row-break injection)
-            .replace(/`/g, '&#96;')     // backtick → HTML entity (code-span safe)
-            .replace(/\|/g, '\\|');     // pipe → escaped (prevent cell injection)
-          const rows = summary.results.map(r =>
-            `| \`${sanitizeMd(r.name)}\` | ${icon[r.status] ?? '❓'} ${r.status} | ${r.pixels.toLocaleString()} |`
-          ).join('\n');
+    - name: Build and post PR comment with inline images
+      # CML uploads the local image references to a public host (GitHub draft
+      # release assets) so reviewers see before/after screenshots directly in
+      # the PR comment without needing to download artifacts.
+      if: steps.diff.outputs.changed > 0
+      env:
+        REPO_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ steps.setup.outputs.pr_number }}
+        CHANGED: ${{ steps.diff.outputs.changed }}
+        TOTAL: ${{ steps.diff.outputs.total }}
+      run: |
+        python3 - << 'PYEOF'
+        import json, os, re
 
-          const body = [
+        summary = json.load(open('screenshots/diff/summary.json'))
+        changed = os.environ['CHANGED']
+        total   = os.environ['TOTAL']
+
+        ICON = {'changed': '⚠️', 'new': '🆕', 'removed': '🗑️'}
+
+        def label(name):
+            """Escape filename for a Markdown table cell label (no injection vectors)."""
+            return '`' + re.sub(r'[`|\[\]]', lambda m: '&#' + str(ord(m.group())) + ';', name) + '`'
+
+        lines = [
             '## 🎨 WebUI Visual Changes Detected',
             '',
-            `**${changed} of ${total} screenshots changed** on this PR.`,
+            f'**{changed} of {total} screenshots changed** on this PR.',
             '',
-            '| View | Status | Pixels changed |',
-            '|------|--------|----------------|',
-            rows,
+            '| View | Before | After |',
+            '|------|--------|-------|',
+        ]
+        for r in summary['results']:
+            if r['status'] not in ('changed', 'new', 'removed'):
+                continue
+            name   = r['name']
+            status = r['status']
+            icon   = ICON.get(status, '❓') + ' ' + status
+            before = f'![before](screenshots/diff/before-{name})' if status in ('changed', 'removed') else f'_{icon}_'
+            after  = f'![after](screenshots/diff/after-{name})'   if status in ('changed', 'new')     else f'_{icon}_'
+            lines.append(f'| {label(name)} | {before} | {after} |')
+
+        lines += [
             '',
-            `📦 Download [before/after/diff images](${runUrl}) from the workflow artifacts (GitHub sign-in required).`,
-            '',
-            '> _This comment is posted automatically when webui screenshots differ from master. No comment means no visual changes._',
-          ].join('\n');
+            '> _Posted automatically when webui screenshots differ from master. '
+            'No comment = no visual changes._',
+        ]
 
-          const marker = '## 🎨 WebUI Visual Changes Detected';
+        with open('comment.md', 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        PYEOF
 
-          // Update existing comment if present, otherwise create one
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-          });
-          const existing = comments.find(c =>
-            c.user.login === 'github-actions[bot]' &&
-            c.body && c.body.includes(marker)
-          );
-
-          if (existing) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existing.id,
-              body,
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
-          }
+        cml comment create comment.md \
+          --pr-url "https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" \
+          --update

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -221,13 +221,15 @@ jobs:
         repo   = os.environ['GITHUB_REPOSITORY']
         pr     = os.environ['PR_NUMBER']
         marker = '## 🎨 WebUI Visual Changes Detected'
-        jq     = '[.[] | select(.user.login=="github-actions[bot]") | select(.body | startswith("' + marker + '")) | {id,body}]'
+        # No array wrapper: `--paginate --jq` outputs one result per matching item
+        # across all pages (NDJSON), not one JSON array per page.
+        jq     = '.[] | select(.user.login=="github-actions[bot]") | select(.body | startswith("' + marker + '")) | {id,body}'
 
         out = subprocess.run(
             ['gh', 'api', f'repos/{repo}/issues/{pr}/comments', '--paginate', '--jq', jq],
             capture_output=True, text=True, check=True,
         ).stdout
-        comments = json.loads(out)
+        comments = [json.loads(line) for line in out.strip().split('\n') if line.strip()]
 
         def run_id(c):
             m = re.search(r'visual-diff-run-id:\s*(\d+)', c['body'])

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -204,13 +204,42 @@ jobs:
             f.write('\n'.join(lines) + '\n')
         PYEOF
 
+        # Stamp the run ID so overlapping runs are ordered by workflow run, not
+        # by comment creation time (which can differ from run completion order).
+        printf '<!-- visual-diff-run-id: %s -->\n' "$GITHUB_RUN_ID" >> comment.md
+
         # Post new comment FIRST — a comment is always visible even if pruning fails.
         cml comment create comment.md --target "pr/${PR_NUMBER}"
 
-        # Prune earlier visual-diff comments; keep only the newest (just created).
-        COMMENT_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-          --paginate \
-          --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("## 🎨 WebUI Visual Changes Detected")) | .id] | sort | .[:-1][]')
-        for id in $COMMENT_IDS; do
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
-        done
+        # Prune stale visual-diff comments; keep the one from the newest workflow
+        # run (highest GITHUB_RUN_ID) so out-of-order completions never replace
+        # newer screenshots with older ones.  Falls back to highest comment ID
+        # for comments that pre-date the run-ID stamp.
+        python3 - << 'PRUNE_EOF'
+        import json, os, re, subprocess
+
+        repo   = os.environ['GITHUB_REPOSITORY']
+        pr     = os.environ['PR_NUMBER']
+        marker = '## 🎨 WebUI Visual Changes Detected'
+        jq     = '[.[] | select(.user.login=="github-actions[bot]") | select(.body | startswith("' + marker + '")) | {id,body}]'
+
+        out = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/issues/{pr}/comments', '--paginate', '--jq', jq],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        comments = json.loads(out)
+
+        def run_id(c):
+            m = re.search(r'visual-diff-run-id:\s*(\d+)', c['body'])
+            return int(m.group(1)) if m else 0
+
+        if comments:
+            keep = max(comments, key=lambda c: (run_id(c), c['id']))
+            for c in comments:
+                if c['id'] != keep['id']:
+                    subprocess.run(
+                        ['gh', 'api', '-X', 'DELETE',
+                         f'repos/{repo}/issues/comments/{c["id"]}'],
+                        check=True,
+                    )
+        PRUNE_EOF

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -146,32 +146,19 @@ jobs:
       # review on gptme/gptme#3482.
       uses: iterative/setup-cml@e5f9f4673e0a8f275c45cc66dbbfd29c8469fb4e # v2.1.0
 
-    - name: Delete previous visual-diff comment
-      # `cml comment update` PATCHes via CML's own comment lookup, which
-      # requires a user-supplied PAT — the default github.token gets rejected
-      # with "commit_id has been locked" (https://cml.dev/doc/ref/comment#github).
-      # Delete-then-create keeps a single comment using only APIs github.token
-      # already has for issue/PR comments (list + delete), avoiding CML's
-      # update path entirely.
-      if: steps.diff.outputs.changed > 0
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ steps.setup.outputs.pr_number }}
-      run: |
-        MARKER='## 🎨 WebUI Visual Changes Detected'
-        gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"${MARKER}\")) | .id" |
-        while read -r id; do
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
-        done
-
     - name: Build and post PR comment with inline images
       # CML uploads the local image references to a public host (GitHub draft
       # release assets) so reviewers see before/after screenshots directly in
       # the PR comment without needing to download artifacts.
+      #
+      # Replacement is create-then-prune: the new comment is posted FIRST so
+      # reviewers always have a live visual-diff comment even if the cleanup
+      # step fails.  The prune step deletes older copies by keeping only the
+      # comment with the highest (newest) ID.
       if: steps.diff.outputs.changed > 0
       env:
         REPO_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ steps.setup.outputs.pr_number }}
         CHANGED: ${{ steps.diff.outputs.changed }}
         TOTAL: ${{ steps.diff.outputs.total }}
@@ -217,4 +204,13 @@ jobs:
             f.write('\n'.join(lines) + '\n')
         PYEOF
 
+        # Post new comment FIRST — a comment is always visible even if pruning fails.
         cml comment create comment.md --target "pr/${PR_NUMBER}"
+
+        # Prune earlier visual-diff comments; keep only the newest (just created).
+        COMMENT_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          --paginate \
+          --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("## 🎨 WebUI Visual Changes Detected")) | .id] | sort | .[:-1][]')
+        for id in $COMMENT_IDS; do
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
+        done

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -146,6 +146,25 @@ jobs:
       # review on gptme/gptme#3482.
       uses: iterative/setup-cml@e5f9f4673e0a8f275c45cc66dbbfd29c8469fb4e # v2.1.0
 
+    - name: Delete previous visual-diff comment
+      # `cml comment update` PATCHes via CML's own comment lookup, which
+      # requires a user-supplied PAT — the default github.token gets rejected
+      # with "commit_id has been locked" (https://cml.dev/doc/ref/comment#github).
+      # Delete-then-create keeps a single comment using only APIs github.token
+      # already has for issue/PR comments (list + delete), avoiding CML's
+      # update path entirely.
+      if: steps.diff.outputs.changed > 0
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ steps.setup.outputs.pr_number }}
+      run: |
+        MARKER='## 🎨 WebUI Visual Changes Detected'
+        gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"${MARKER}\")) | .id" |
+        while read -r id; do
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
+        done
+
     - name: Build and post PR comment with inline images
       # CML uploads the local image references to a public host (GitHub draft
       # release assets) so reviewers see before/after screenshots directly in
@@ -198,4 +217,4 @@ jobs:
             f.write('\n'.join(lines) + '\n')
         PYEOF
 
-        cml comment update comment.md --target "pr/${PR_NUMBER}"
+        cml comment create comment.md --target "pr/${PR_NUMBER}"

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -165,6 +165,7 @@ jobs:
       run: |
         python3 - << 'PYEOF'
         import json, os, re
+        from urllib.parse import quote
 
         summary = json.load(open('screenshots/diff/summary.json'))
         changed = os.environ['CHANGED']
@@ -174,6 +175,7 @@ jobs:
 
         def label(name):
             """Escape filename for a Markdown table cell label (no injection vectors)."""
+            name = re.sub(r'\r?\n|\r', ' ', name)  # newlines would break the table row
             return '`' + re.sub(r'[`|\[\]]', lambda m: '&#' + str(ord(m.group())) + ';', name) + '`'
 
         lines = [
@@ -190,8 +192,11 @@ jobs:
             name   = r['name']
             status = r['status']
             icon   = ICON.get(status, '❓') + ' ' + status
-            before = f'![before](screenshots/diff/before-{name})' if status in ('changed', 'removed') else f'_{icon}_'
-            after  = f'![after](screenshots/diff/after-{name})'   if status in ('changed', 'new')     else f'_{icon}_'
+            # URL-encode the filename: an unescaped `)` or newline in a fork-controlled
+            # screenshot name could terminate the image URL early and inject markdown.
+            url_name = quote(name)
+            before = f'![before](screenshots/diff/before-{url_name})' if status in ('changed', 'removed') else f'_{icon}_'
+            after  = f'![after](screenshots/diff/after-{url_name})'   if status in ('changed', 'new')     else f'_{icon}_'
             lines.append(f'| {label(name)} | {before} | {after} |')
 
         lines += [
@@ -239,9 +244,13 @@ jobs:
             keep = max(comments, key=lambda c: (run_id(c), c['id']))
             for c in comments:
                 if c['id'] != keep['id']:
-                    subprocess.run(
+                    # A concurrent run may have already deleted this comment (404) —
+                    # the final state (only `keep` surviving) is still correct, so
+                    # don't fail the step over a race.
+                    result = subprocess.run(
                         ['gh', 'api', '-X', 'DELETE',
                          f'repos/{repo}/issues/comments/{c["id"]}'],
-                        check=True,
                     )
+                    if result.returncode != 0:
+                        print(f'note: could not delete comment {c["id"]} (likely already removed by a concurrent run)')
         PRUNE_EOF

--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -141,7 +141,10 @@ jobs:
 
     - name: Setup CML
       if: steps.diff.outputs.changed > 0
-      uses: iterative/setup-cml@v2
+      # Pinned to a full commit SHA (not the mutable `v2` tag) because this
+      # job holds `contents: write` + `pull-requests: write` — see Greptile
+      # review on gptme/gptme#3482.
+      uses: iterative/setup-cml@e5f9f4673e0a8f275c45cc66dbbfd29c8469fb4e # v2.1.0
 
     - name: Build and post PR comment with inline images
       # CML uploads the local image references to a public host (GitHub draft
@@ -195,6 +198,4 @@ jobs:
             f.write('\n'.join(lines) + '\n')
         PYEOF
 
-        cml comment create comment.md \
-          --pr-url "https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" \
-          --update
+        cml comment update comment.md --target "pr/${PR_NUMBER}"


### PR DESCRIPTION
## Problem

The prior implementation (#3469) posts a stats table with a "download artifacts" link. GitHub artifact URLs require authentication — reviewers can't see the screenshots inline. This defeats the issue's core requirement:

> "Show the changed views side-by-side so reviewers can see what changed at a glance."

## Fix

Replace the `actions/github-script` comment step with [CML](https://github.com/iterative/cml) (`iterative/setup-cml@v2`), which uploads the before/after PNG files to **public** GitHub draft-release assets and rewrites local image references to the hosted URLs.

Reviewers now see screenshots **embedded directly** in the PR comment — no download required:

| View | Before | After |
|------|--------|-------|
| `01-home.png` | ![before] | ![after] |

(Actual images rendered by CML at runtime)

## Changes

- **`.github/workflows/webui-visual-diff.yml`**: Replace `actions/github-script` comment step with CML-based step; add `iterative/setup-cml@v2`; add `contents: write` permission for CML draft-release asset creation; Python script generates markdown with inline image references; filename label column remains injection-safe.

## Security

- `contents: write` is needed only for CML to create draft release assets — we never execute fork code, only download artifact PNGs.
- Filename labels in the table use HTML entity escaping (backtick, pipe, bracket) to prevent cell injection.

## Test plan

- [ ] Open a webui PR that makes a visible layout change (e.g. color, size tweak)
- [ ] Confirm the `screenshots` job uploads `webui-visual-snapshots` artifacts
- [ ] Confirm `webui-visual-diff` triggers and posts a comment with embedded before/after images visible without login

Closes #3467

<!-- gptme-id:v1:gai_2j5yAWkokstI3kc6dvvvcQDUzL1ipYdPbLbT50geESx -->