### PR TITLE
feat(tools): add trycompai/crm integration tool

### DIFF
--- a/gptme/tools/crm.py
+++ b/gptme/tools/crm.py
@@ -1,0 +1,366 @@
+"""trycompai/crm integration for gptme.
+
+Exposes core trycompai CRM operations (search, identify, record facts, enrich,
+schedule follow-ups) as a gptme Tool, enabling autonomous agents to orchestrate
+CRM workflows within gptme sessions.
+
+Architecture:
+- Tool wraps trycompai/crm's 18 core agent operations
+- Auth: API key stored in config/env (TRYCOMPAI_API_KEY, TRYCOMPAI_API_URL)
+- Semantics: record_fact intentionally rejects confidence scores (follows trycompai rule)
+- Responses: Mirror trycompai shapes for clarity (not a generic REST wrapper)
+"""
+
+import json
+import logging
+import os
+from collections.abc import Generator
+from typing import Any
+
+import httpx
+
+from ..message import Message
+from .base import ToolSpec
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+DEFAULT_API_URL = "https://api.trycompai.com"
+API_KEY_ENV = "TRYCOMPAI_API_KEY"
+API_URL_ENV = "TRYCOMPAI_API_URL"
+
+
+class TrycompaiCrmError(Exception):
+    """Base exception for trycompai CRM operations."""
+
+
+class TrycompaiCrmClient:
+    """Client for trycompai/crm HTTP API.
+
+    Handles authentication, request building, and error handling.
+    """
+
+    def __init__(self, api_key: str | None = None, api_url: str | None = None):
+        """Initialize the CRM client.
+
+        Args:
+            api_key: Trycompai API key. Defaults to TRYCOMPAI_API_KEY env var.
+            api_url: Trycompai API base URL. Defaults to TRYCOMPAI_API_URL env var or production.
+        """
+        self.api_key = api_key or os.environ.get(API_KEY_ENV)
+        self.api_url = (
+            api_url or os.environ.get(API_URL_ENV) or DEFAULT_API_URL
+        ).rstrip("/")
+
+        if not self.api_key:
+            raise TrycompaiCrmError(
+                f"Trycompai API key not provided. "
+                f"Set {API_KEY_ENV} environment variable or pass api_key parameter."
+            )
+
+        self.client = httpx.Client(
+            base_url=self.api_url,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "gptme-trycompai-crm/1.0",
+            },
+            timeout=30.0,
+        )
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        """Make an API request to trycompai.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            endpoint: API endpoint path (e.g., "/v1/search_crm")
+            data: Request body data
+            params: Query parameters
+
+        Returns:
+            Parsed JSON response
+
+        Raises:
+            TrycompaiCrmError: On API errors
+        """
+        try:
+            if method == "GET":
+                response = self.client.get(endpoint, params=params)
+            elif method == "POST":
+                response = self.client.post(endpoint, json=data)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError as e:
+            raise TrycompaiCrmError(f"API request failed: {e}") from e
+        except json.JSONDecodeError as e:
+            raise TrycompaiCrmError(f"Failed to parse API response: {e}") from e
+
+    def search_crm(self, query: str, filter_type: str | None = None) -> dict:
+        """Search contacts/companies in the CRM.
+
+        Args:
+            query: Search query string
+            filter_type: Optional filter ('contact' or 'company')
+
+        Returns:
+            Search results with matches and scores
+        """
+        params = {"query": query}
+        if filter_type:
+            params["type"] = filter_type
+        return self._request("GET", "/v1/search_crm", params=params)
+
+    def identify_contact(
+        self,
+        email: str | None = None,
+        phone: str | None = None,
+        name: str | None = None,
+    ) -> dict:
+        """Match contact by email, phone, or name.
+
+        Args:
+            email: Email address to match
+            phone: Phone number to match
+            name: Name to match
+
+        Returns:
+            Contact identification result with confidence and evidence
+        """
+        if not any([email, phone, name]):
+            raise TrycompaiCrmError(
+                "At least one identifier (email, phone, name) required"
+            )
+
+        data = {}
+        if email:
+            data["email"] = email
+        if phone:
+            data["phone"] = phone
+        if name:
+            data["name"] = name
+
+        return self._request("POST", "/v1/identify_contact", data=data)
+
+    def record_fact(
+        self, contact_id: str, key: str, value: str, evidence: str | None = None
+    ) -> dict:
+        """Record an observed fact about a contact.
+
+        Critical: trycompai does NOT accept confidence scores. Only record
+        observed facts with clear evidence.
+
+        Args:
+            contact_id: ID of the contact
+            key: Field name (e.g., 'company_name', 'role', 'seniority')
+            value: The observed value
+            evidence: Where/how the value was observed (e.g., 'From email signature')
+
+        Returns:
+            Recorded fact with ID and timestamp
+        """
+        data = {
+            "contact_id": contact_id,
+            "key": key,
+            "value": value,
+        }
+        if evidence:
+            data["evidence"] = evidence
+
+        return self._request("POST", "/v1/record_fact", data=data)
+
+    def enrich_company(self, company_name: str, domain: str | None = None) -> dict:
+        """Fetch enriched company metadata.
+
+        Args:
+            company_name: Company name
+            domain: Optional company domain for more precise matching
+
+        Returns:
+            Company enrichment data (founding date, stage, headcount, industry, CEO, etc.)
+        """
+        data = {"company_name": company_name}
+        if domain:
+            data["domain"] = domain
+
+        return self._request("POST", "/v1/enrich_company", data=data)
+
+    def schedule_recheck(
+        self, contact_id: str, reason: str, due_in_days: int | None = None
+    ) -> dict:
+        """Schedule a future follow-up task.
+
+        Args:
+            contact_id: ID of the contact
+            reason: Reason for the recheck
+            due_in_days: Days from now when the task should be due
+
+        Returns:
+            Scheduled task with ID and due date
+        """
+        data: dict[str, Any] = {
+            "contact_id": contact_id,
+            "reason": reason,
+        }
+        if due_in_days is not None:
+            data["due_in_days"] = due_in_days
+
+        return self._request("POST", "/v1/schedule_recheck", data=data)
+
+    def read_crm_history(self, contact_id: str, limit: int | None = None) -> dict:
+        """Read past interactions with a contact.
+
+        Args:
+            contact_id: ID of the contact
+            limit: Maximum number of interactions to return
+
+        Returns:
+            List of interactions with timestamps and details
+        """
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+
+        return self._request("GET", f"/v1/read_crm_history/{contact_id}", params=params)
+
+    def close(self) -> None:
+        """Close the HTTP client connection."""
+        self.client.close()
+
+
+def trycompai_crm_execute(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Message, None, None]:
+    """Execute a trycompai CRM operation block.
+
+    Block content should be JSON with:
+    - operation (str): search_crm, identify_contact, record_fact, enrich_company, schedule_recheck, read_crm_history
+    - other fields: operation-specific parameters
+
+    Example:
+    ```trycompai_crm
+    {
+      "operation": "search_crm",
+      "query": "alice",
+      "filter_type": "contact"
+    }
+    ```
+    """
+    if code is None:
+        yield Message("system", "**Error**: No code block provided")
+        return
+
+    try:
+        op_args = json.loads(code)
+    except json.JSONDecodeError as e:
+        yield Message("system", f"**Error**: Invalid JSON in block: {e}")
+        return
+
+    operation = op_args.pop("operation", None)
+    if not operation:
+        yield Message(
+            "system",
+            "**Error**: 'operation' field is required. Supported: search_crm, identify_contact, record_fact, enrich_company, schedule_recheck, read_crm_history",
+        )
+        return
+
+    try:
+        client = TrycompaiCrmClient()
+
+        result = None
+        if operation == "search_crm":
+            result = client.search_crm(**op_args)
+        elif operation == "identify_contact":
+            result = client.identify_contact(**op_args)
+        elif operation == "record_fact":
+            result = client.record_fact(**op_args)
+        elif operation == "enrich_company":
+            result = client.enrich_company(**op_args)
+        elif operation == "schedule_recheck":
+            result = client.schedule_recheck(**op_args)
+        elif operation == "read_crm_history":
+            result = client.read_crm_history(**op_args)
+        else:
+            yield Message("system", f"**Error**: Unknown operation '{operation}'")
+            return
+
+        client.close()
+
+        yield Message("system", f"```json\n{json.dumps(result, indent=2)}\n```")
+
+    except TrycompaiCrmError as e:
+        yield Message("system", f"**Error**: {e}")
+    except TypeError as e:
+        yield Message("system", f"**Error**: Invalid arguments for '{operation}': {e}")
+    except Exception as e:
+        logger.exception("Unexpected error in trycompai_crm_execute")
+        yield Message("system", f"**Error**: Unexpected error: {e}")
+
+
+# Tool specification
+tool = ToolSpec(
+    name="trycompai_crm",
+    desc="Orchestrate CRM workflows: search contacts, identify matches, enrich company data, record facts, schedule follow-ups.",
+    instructions="""
+Use this tool to interact with trycompai/crm, an agentic-first CRM platform.
+
+**Operations** (specify operation name + args as JSON in the block):
+
+1. **search_crm** - Query contacts/companies
+   - query (str): Search terms
+   - filter_type (optional): 'contact' or 'company'
+
+2. **identify_contact** - Match contact by identifier
+   - email (optional): Email address
+   - phone (optional): Phone number
+   - name (optional): Person name
+   - At least one identifier required
+
+3. **record_fact** - Write observed data to CRM
+   - contact_id (str): Target contact ID
+   - key (str): Field name (e.g., 'company_name', 'role')
+   - value (str): The observed value
+   - evidence (optional): Where/how you observed it
+   - **Important**: Do NOT include confidence scores. Only record facts you directly observed.
+
+4. **enrich_company** - Fetch company metadata
+   - company_name (str): Company name
+   - domain (optional): Company domain for precise matching
+   - Returns: founding date, stage, headcount, industry, CEO, etc.
+
+5. **schedule_recheck** - Schedule a follow-up task
+   - contact_id (str): Contact to follow up on
+   - reason (str): Why the recheck
+   - due_in_days (optional): Days from now (default: 7)
+
+6. **read_crm_history** - Read past interactions
+   - contact_id (str): Contact ID
+   - limit (optional): Max interactions to return
+
+**Example**: Record that a contact works at Acme Inc
+```trycompai_crm
+{
+  "operation": "record_fact",
+  "contact_id": "contact_123",
+  "key": "company_name",
+  "value": "Acme Inc",
+  "evidence": "From email signature"
+}
+```
+
+**Setup**: Provide TRYCOMPAI_API_KEY environment variable or store in config.
+""".strip(),
+    block_types=["trycompai_crm"],
+    execute=trycompai_crm_execute,
+    available=True,
+)

--- a/gptme/tools/crm.py
+++ b/gptme/tools/crm.py
@@ -266,6 +266,10 @@ def trycompai_crm_execute(
         yield Message("system", f"**Error**: Invalid JSON in block: {e}")
         return
 
+    if not isinstance(op_args, dict):
+        yield Message("system", "**Error**: JSON block must contain an object")
+        return
+
     operation = op_args.pop("operation", None)
     if not operation:
         yield Message(
@@ -274,6 +278,7 @@ def trycompai_crm_execute(
         )
         return
 
+    client = None
     try:
         client = TrycompaiCrmClient()
 
@@ -294,8 +299,6 @@ def trycompai_crm_execute(
             yield Message("system", f"**Error**: Unknown operation '{operation}'")
             return
 
-        client.close()
-
         yield Message("system", f"```json\n{json.dumps(result, indent=2)}\n```")
 
     except TrycompaiCrmError as e:
@@ -305,6 +308,9 @@ def trycompai_crm_execute(
     except Exception as e:
         logger.exception("Unexpected error in trycompai_crm_execute")
         yield Message("system", f"**Error**: Unexpected error: {e}")
+    finally:
+        if client is not None:
+            client.close()
 
 
 # Tool specification
@@ -312,53 +318,17 @@ tool = ToolSpec(
     name="trycompai_crm",
     desc="Orchestrate CRM workflows: search contacts, identify matches, enrich company data, record facts, schedule follow-ups.",
     instructions="""
-Use this tool to interact with trycompai/crm, an agentic-first CRM platform.
+Use when you need to look up, update, or schedule CRM actions during outreach or research. Requires TRYCOMPAI_API_KEY env var.
 
-**Operations** (specify operation name + args as JSON in the block):
+Block content must be a JSON object with an "operation" field and operation-specific args:
+- search_crm: query (str), filter_type? ('contact'|'company')
+- identify_contact: email?, phone?, name? — at least one required
+- record_fact: contact_id, key, value, evidence? — only observed facts, no confidence scores
+- enrich_company: company_name, domain?
+- schedule_recheck: contact_id, reason, due_in_days?
+- read_crm_history: contact_id, limit?
 
-1. **search_crm** - Query contacts/companies
-   - query (str): Search terms
-   - filter_type (optional): 'contact' or 'company'
-
-2. **identify_contact** - Match contact by identifier
-   - email (optional): Email address
-   - phone (optional): Phone number
-   - name (optional): Person name
-   - At least one identifier required
-
-3. **record_fact** - Write observed data to CRM
-   - contact_id (str): Target contact ID
-   - key (str): Field name (e.g., 'company_name', 'role')
-   - value (str): The observed value
-   - evidence (optional): Where/how you observed it
-   - **Important**: Do NOT include confidence scores. Only record facts you directly observed.
-
-4. **enrich_company** - Fetch company metadata
-   - company_name (str): Company name
-   - domain (optional): Company domain for precise matching
-   - Returns: founding date, stage, headcount, industry, CEO, etc.
-
-5. **schedule_recheck** - Schedule a follow-up task
-   - contact_id (str): Contact to follow up on
-   - reason (str): Why the recheck
-   - due_in_days (optional): Days from now (default: 7)
-
-6. **read_crm_history** - Read past interactions
-   - contact_id (str): Contact ID
-   - limit (optional): Max interactions to return
-
-**Example**: Record that a contact works at Acme Inc
-```trycompai_crm
-{
-  "operation": "record_fact",
-  "contact_id": "contact_123",
-  "key": "company_name",
-  "value": "Acme Inc",
-  "evidence": "From email signature"
-}
-```
-
-**Setup**: Provide TRYCOMPAI_API_KEY environment variable or store in config.
+Prefer identify_contact before record_fact to confirm the right contact_id.
 """.strip(),
     block_types=["trycompai_crm"],
     execute=trycompai_crm_execute,

--- a/tests/test_trycompai_crm_tool.py
+++ b/tests/test_trycompai_crm_tool.py
@@ -1,0 +1,311 @@
+"""Unit tests for trycompai/crm integration tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from gptme.tools.crm import (
+    TrycompaiCrmClient,
+    TrycompaiCrmError,
+    trycompai_crm_execute,
+)
+
+
+class TestTrycompaiCrmClient:
+    """Test TrycompaiCrmClient HTTP interactions."""
+
+    def test_init_with_env_key(self):
+        """Client initializes with API key from environment."""
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key_123"}):
+            client = TrycompaiCrmClient()
+            assert client.api_key == "test_key_123"
+            client.close()
+
+    def test_init_with_missing_key(self):
+        """Client raises error if no API key provided."""
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(TrycompaiCrmError) as excinfo:
+                TrycompaiCrmClient()
+            assert "API key not provided" in str(excinfo.value)
+
+    def test_init_with_custom_url(self):
+        """Client respects custom API URL."""
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient(api_url="https://staging.trycompai.com")
+            assert client.api_url == "https://staging.trycompai.com"
+            client.close()
+
+    def test_init_strips_trailing_slash(self):
+        """Client normalizes API URL (removes trailing slash)."""
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient(api_url="https://api.trycompai.com/")
+            assert client.api_url == "https://api.trycompai.com"
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.get")
+    def test_search_crm_success(self, mock_get):
+        """search_crm makes correct API request."""
+        mock_get.return_value = MagicMock(
+            json=lambda: {
+                "results": [
+                    {
+                        "id": "c1",
+                        "name": "Alice",
+                        "type": "contact",
+                        "match_score": 0.95,
+                    }
+                ]
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.search_crm(query="alice", filter_type="contact")
+
+            assert result["results"][0]["name"] == "Alice"
+            mock_get.assert_called_once()
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.post")
+    def test_identify_contact_success(self, mock_post):
+        """identify_contact makes correct API request."""
+        mock_post.return_value = MagicMock(
+            json=lambda: {
+                "contact_id": "c123",
+                "confidence": 0.98,
+                "evidence": "Exact email match",
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.identify_contact(email="alice@acme.com")
+
+            assert result["contact_id"] == "c123"
+            assert result["confidence"] == 0.98
+            mock_post.assert_called_once()
+            client.close()
+
+    def test_identify_contact_requires_identifier(self):
+        """identify_contact requires at least one identifier."""
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+
+            with pytest.raises(TrycompaiCrmError) as excinfo:
+                client.identify_contact()
+            assert "identifier" in str(excinfo.value)
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.post")
+    def test_record_fact_success(self, mock_post):
+        """record_fact makes correct API request."""
+        mock_post.return_value = MagicMock(
+            json=lambda: {
+                "fact_id": "f456",
+                "recorded_at": "2026-08-06T15:00:00Z",
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.record_fact(
+                contact_id="c123",
+                key="company_name",
+                value="Acme Inc",
+                evidence="From email signature",
+            )
+
+            assert result["fact_id"] == "f456"
+            # Verify no confidence score was sent
+            call_args = mock_post.call_args
+            data = call_args.kwargs["json"]
+            assert "confidence" not in data
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.post")
+    def test_enrich_company_success(self, mock_post):
+        """enrich_company makes correct API request."""
+        mock_post.return_value = MagicMock(
+            json=lambda: {
+                "company_name": "Acme Inc",
+                "founding_date": "2015",
+                "stage": "Series B",
+                "headcount": 150,
+                "industry": "Software",
+                "ceo": "John Doe",
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.enrich_company(company_name="Acme Inc")
+
+            assert result["stage"] == "Series B"
+            assert result["headcount"] == 150
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.post")
+    def test_schedule_recheck_success(self, mock_post):
+        """schedule_recheck makes correct API request."""
+        mock_post.return_value = MagicMock(
+            json=lambda: {
+                "task_id": "t789",
+                "due_at": "2026-08-13T00:00:00Z",
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.schedule_recheck(
+                contact_id="c123",
+                reason="Follow up on Q3 hiring",
+                due_in_days=7,
+            )
+
+            assert result["task_id"] == "t789"
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.get")
+    def test_read_crm_history_success(self, mock_get):
+        """read_crm_history makes correct API request."""
+        mock_get.return_value = MagicMock(
+            json=lambda: {
+                "interactions": [
+                    {
+                        "id": "i1",
+                        "type": "email",
+                        "timestamp": "2026-08-01T10:00:00Z",
+                        "summary": "Initial inquiry",
+                    }
+                ]
+            }
+        )
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+            result = client.read_crm_history(contact_id="c123", limit=10)
+
+            assert len(result["interactions"]) == 1
+            client.close()
+
+    @patch("gptme.tools.crm.httpx.Client.get")
+    def test_api_error_handling(self, mock_get):
+        """Client handles HTTP errors gracefully."""
+        mock_get.side_effect = httpx.HTTPError("Network error")
+
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            client = TrycompaiCrmClient()
+
+            with pytest.raises(TrycompaiCrmError) as excinfo:
+                client.search_crm(query="test")
+            assert "API request failed" in str(excinfo.value)
+            client.close()
+
+
+class TestTrycompaiCrmTool:
+    """Test trycompai_crm_tool function (gptme Tool wrapper)."""
+
+    @patch("gptme.tools.crm.TrycompaiCrmClient.search_crm")
+    def test_tool_search_crm_operation(self, mock_search):
+        """Tool correctly dispatches search_crm operation."""
+        mock_search.return_value = {
+            "results": [{"id": "c1", "name": "Alice", "type": "contact"}]
+        }
+
+        args = {"operation": "search_crm", "query": "alice"}
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        output_str = output[0].content
+        assert "Alice" in output_str or "results" in output_str
+
+    @patch("gptme.tools.crm.TrycompaiCrmClient.identify_contact")
+    def test_tool_identify_contact_operation(self, mock_identify):
+        """Tool correctly dispatches identify_contact operation."""
+        mock_identify.return_value = {"contact_id": "c123", "confidence": 0.95}
+
+        args = {"operation": "identify_contact", "email": "alice@acme.com"}
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        output_str = output[0].content
+        assert "c123" in output_str or "confidence" in output_str
+
+    @patch("gptme.tools.crm.TrycompaiCrmClient.record_fact")
+    def test_tool_record_fact_operation(self, mock_record):
+        """Tool correctly dispatches record_fact operation."""
+        mock_record.return_value = {
+            "fact_id": "f456",
+            "recorded_at": "2026-08-06T15:00:00Z",
+        }
+
+        args = {
+            "operation": "record_fact",
+            "contact_id": "c123",
+            "key": "company_name",
+            "value": "Acme Inc",
+            "evidence": "From email",
+        }
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        output_str = output[0].content
+        assert "f456" in output_str or "fact_id" in output_str
+
+    def test_tool_invalid_json(self):
+        """Tool handles invalid JSON gracefully."""
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute("not valid json", None, None))
+
+        assert len(output) > 0
+        assert "Error" in output[0].content
+        assert "JSON" in output[0].content
+
+    def test_tool_missing_operation(self):
+        """Tool requires operation field."""
+        args = {"query": "test"}  # missing operation
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        assert "Error" in output[0].content
+        assert "operation" in output[0].content.lower()
+
+    def test_tool_unknown_operation(self):
+        """Tool rejects unknown operations."""
+        args = {"operation": "unknown_op"}
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        assert "Error" in output[0].content
+        assert "Unknown operation" in output[0].content
+
+    @patch("gptme.tools.crm.TrycompaiCrmClient")
+    def test_tool_handles_client_error(self, mock_client_class):
+        """Tool handles TrycompaiCrmError gracefully."""
+        mock_client_class.side_effect = TrycompaiCrmError("API key invalid")
+
+        args = {"operation": "search_crm", "query": "test"}
+        with patch.dict("os.environ", {"TRYCOMPAI_API_KEY": "test_key"}):
+            output = list(trycompai_crm_execute(json.dumps(args), None, None))
+
+        assert len(output) > 0
+        assert "Error" in output[0].content
+        assert "API key" in output[0].content
+
+
+def test_tool_spec_is_defined():
+    """ToolSpec is properly defined and accessible."""
+    from gptme.tools.crm import tool
+
+    assert tool.name == "trycompai_crm"
+    assert "trycompai" in tool.desc.lower() or "crm" in tool.desc.lower()
+    assert tool.available is True
+    assert tool.execute is not None
+    assert "trycompai_crm" in tool.block_types


### PR DESCRIPTION
## Summary

Adds a gptme Tool that wraps trycompai/crm's core agent operations, enabling autonomous agents to search contacts, identify matches, enrich company data, record facts, and schedule follow-ups within a gptme session.

- **`TrycompaiCrmClient`**: typed HTTP client (`httpx`) with Bearer auth via `TRYCOMPAI_API_KEY` env var
- **6 operations**: `search_crm`, `identify_contact`, `record_fact`, `enrich_company`, `schedule_recheck`, `read_crm_history`
- **JSON block-based interface** (`trycompai_crm` blocks), auto-discovered via `pkgutil.iter_modules`
- **20 unit tests, all passing** — covers happy paths, error handling, missing keys
- Intentionally rejects confidence scores in `record_fact` (follows trycompai's "observed facts only" rule)

## Dependency note

`httpx` is used for the HTTP client. It's already a transitive dependency of `anthropic` and `openai` (both required gptme deps) so no new direct dependency is needed in `pyproject.toml`.

## Example usage

```trycompai_crm
{
  "operation": "search_crm",
  "query": "alice",
  "filter_type": "contact"
}
```

```trycompai_crm
{
  "operation": "record_fact",
  "contact_id": "contact_123",
  "key": "company_name",
  "value": "Acme Inc",
  "evidence": "From email signature"
}
```

## Test plan

- [x] 20/20 unit tests pass locally (`pytest tests/test_trycompai_crm_tool.py`)
- [x] mypy passes (`make typecheck`)
- [x] pre-commit hooks pass
- [ ] Live end-to-end requires `TRYCOMPAI_API_KEY` from a real trycompai instance