### PR TITLE
feat(webui): add copy trajectory as markdown with detail levels

### DIFF
--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -354,7 +354,7 @@ export function CommandPalette() {
           ]
         : []),
     ],
-    [navigate, setOpen]
+    [navigate, setOpen, api, getClient]
   );
 
   // Filter actions based on search query

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -18,6 +18,7 @@ import {
   Home,
   MessageSquare,
   Download,
+  Clipboard,
 } from 'lucide-react';
 import { useApi } from '@/contexts/ApiContext';
 import type { ConversationSummary } from '@/types/conversation';
@@ -26,6 +27,7 @@ import { commandPaletteOpen$ } from '@/stores/commandPalette';
 import {
   exportConversationAsMarkdown,
   exportConversationAsJSON,
+  copyConversationAsMarkdown,
   getExportableMessages,
 } from '@/utils/exportConversation';
 import { appRoute, chatRoute } from '@/utils/routes';
@@ -230,6 +232,64 @@ export function CommandPalette() {
       // Conversation-specific actions (only when a conversation is selected)
       ...(selectedConversation$.get()
         ? [
+            {
+              id: 'copy-trajectory-markdown',
+              label: 'Copy trajectory as Markdown',
+              description: 'Copy whole conversation to clipboard (excludes thinking & tool output)',
+              icon: <Clipboard className="mr-2 h-4 w-4" />,
+              keywords: ['copy', 'clipboard', 'trajectory', 'markdown', 'transcript', 'share'],
+              action: () => {
+                const convId = selectedConversation$.get();
+                const conv = convId ? conversations$.get(convId)?.get() : null;
+                if (!conv?.data?.log?.length) {
+                  toast.error('No messages to copy');
+                  return;
+                }
+                copyConversationAsMarkdown(conv.data.name || convId!, conv.data.log, {
+                  includeThinking: false,
+                  includeToolCalls: false,
+                })
+                  .then(() => {
+                    toast.success('Trajectory copied to clipboard');
+                    setOpen(false);
+                  })
+                  .catch(() => toast.error('Failed to copy to clipboard'));
+              },
+              group: 'Conversation',
+            },
+            {
+              id: 'copy-trajectory-markdown-full',
+              label: 'Copy trajectory as Markdown (full)',
+              description: 'Copy whole conversation including tool calls & thinking',
+              icon: <Clipboard className="mr-2 h-4 w-4" />,
+              keywords: [
+                'copy',
+                'clipboard',
+                'trajectory',
+                'markdown',
+                'full',
+                'tools',
+                'thinking',
+              ],
+              action: () => {
+                const convId = selectedConversation$.get();
+                const conv = convId ? conversations$.get(convId)?.get() : null;
+                if (!conv?.data?.log?.length) {
+                  toast.error('No messages to copy');
+                  return;
+                }
+                copyConversationAsMarkdown(conv.data.name || convId!, conv.data.log, {
+                  includeThinking: true,
+                  includeToolCalls: true,
+                })
+                  .then(() => {
+                    toast.success('Full trajectory copied to clipboard');
+                    setOpen(false);
+                  })
+                  .catch(() => toast.error('Failed to copy to clipboard'));
+              },
+              group: 'Conversation',
+            },
             {
               id: 'export-markdown',
               label: 'Export as Markdown',

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -49,7 +49,7 @@ export function CommandPalette() {
   const [conversationResults, setConversationResults] = useState<ConversationSummary[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const navigate = useNavigate();
-  const { api } = useApi();
+  const { api, getClient } = useApi();
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Sync open state bidirectionally with the observable (for external control, e.g. MenuBar search button)
@@ -246,7 +246,9 @@ export function CommandPalette() {
                   return;
                 }
                 const name = conv.data.name || convId;
-                api
+                // Use the server that owns this conversation, not always the primary.
+                const client = conv.serverId ? getClient(conv.serverId) : api;
+                client
                   .getConversation(convId)
                   .then((fullData) =>
                     copyConversationAsMarkdown(name, fullData.log, {
@@ -284,7 +286,9 @@ export function CommandPalette() {
                   return;
                 }
                 const name = conv.data.name || convId;
-                api
+                // Use the server that owns this conversation, not always the primary.
+                const client = conv.serverId ? getClient(conv.serverId) : api;
+                client
                   .getConversation(convId)
                   .then((fullData) =>
                     copyConversationAsMarkdown(name, fullData.log, {

--- a/webui/src/components/CommandPalette.tsx
+++ b/webui/src/components/CommandPalette.tsx
@@ -241,14 +241,19 @@ export function CommandPalette() {
               action: () => {
                 const convId = selectedConversation$.get();
                 const conv = convId ? conversations$.get(convId)?.get() : null;
-                if (!conv?.data?.log?.length) {
+                if (!convId || !conv?.data?.log?.length) {
                   toast.error('No messages to copy');
                   return;
                 }
-                copyConversationAsMarkdown(conv.data.name || convId!, conv.data.log, {
-                  includeThinking: false,
-                  includeToolCalls: false,
-                })
+                const name = conv.data.name || convId;
+                api
+                  .getConversation(convId)
+                  .then((fullData) =>
+                    copyConversationAsMarkdown(name, fullData.log, {
+                      includeThinking: false,
+                      includeToolCalls: false,
+                    })
+                  )
                   .then(() => {
                     toast.success('Trajectory copied to clipboard');
                     setOpen(false);
@@ -274,14 +279,19 @@ export function CommandPalette() {
               action: () => {
                 const convId = selectedConversation$.get();
                 const conv = convId ? conversations$.get(convId)?.get() : null;
-                if (!conv?.data?.log?.length) {
+                if (!convId || !conv?.data?.log?.length) {
                   toast.error('No messages to copy');
                   return;
                 }
-                copyConversationAsMarkdown(conv.data.name || convId!, conv.data.log, {
-                  includeThinking: true,
-                  includeToolCalls: true,
-                })
+                const name = conv.data.name || convId;
+                api
+                  .getConversation(convId)
+                  .then((fullData) =>
+                    copyConversationAsMarkdown(name, fullData.log, {
+                      includeThinking: true,
+                      includeToolCalls: true,
+                    })
+                  )
                   .then(() => {
                     toast.success('Full trajectory copied to clipboard');
                     setOpen(false);

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -117,7 +117,7 @@ interface ConversationSettingsProps {
 }
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
-  const { api } = useApi();
+  const { api, getClient } = useApi();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [copyOptions, setCopyOptions] = useState<ExportMarkdownOptions>({
     includeThinking: false,
@@ -457,7 +457,9 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                           return;
                         }
                         const name = conv.data.name || conversationId;
-                        api
+                        // Use the server that owns this conversation, not always the primary.
+                        const client = conv.serverId ? getClient(conv.serverId) : api;
+                        client
                           .getConversation(conversationId)
                           .then((fullData) =>
                             copyConversationAsMarkdown(name, fullData.log, copyOptions)

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -1,12 +1,22 @@
 import { useState, useEffect, type FC } from 'react';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
-import { Trash, Loader2, Download } from 'lucide-react';
+import { Trash, Loader2, Download, Clipboard, Check, ChevronDown } from 'lucide-react';
 import { conversations$ } from '@/stores/conversations';
 import {
   exportConversationAsMarkdown,
   exportConversationAsJSON,
+  copyConversationAsMarkdown,
   getExportableMessages,
+  type ExportMarkdownOptions,
 } from '@/utils/exportConversation';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { toast } from 'sonner';
 import { ModelPickerField } from './ModelPicker';
 import {
@@ -107,6 +117,11 @@ interface ConversationSettingsProps {
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [copyOptions, setCopyOptions] = useState<ExportMarkdownOptions>({
+    includeThinking: false,
+    includeToolCalls: true,
+  });
+  const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle');
   const {
     form,
     toolFields,
@@ -425,7 +440,73 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
               {/* Export */}
               <div className="mt-8 space-y-4">
                 <h3 className="text-lg font-medium">Export</h3>
-                <div className="flex gap-2">
+                <div className="flex flex-wrap gap-2">
+                  {/* Copy as Markdown with detail-level toggles */}
+                  <div className="flex">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="rounded-r-none border-r-0"
+                      onClick={() => {
+                        const conv = conversations$.get(conversationId)?.get();
+                        if (!conv?.data?.log?.length) {
+                          toast.error('No messages to copy');
+                          return;
+                        }
+                        const log = conv.data.log;
+                        const name = conv.data.name || conversationId;
+                        copyConversationAsMarkdown(name, log, copyOptions)
+                          .then(() => {
+                            setCopyState('copied');
+                            toast.success('Copied trajectory to clipboard');
+                            setTimeout(() => setCopyState('idle'), 2000);
+                          })
+                          .catch(() => toast.error('Failed to copy to clipboard'));
+                      }}
+                    >
+                      {copyState === 'copied' ? (
+                        <Check className="mr-2 h-4 w-4" />
+                      ) : (
+                        <Clipboard className="mr-2 h-4 w-4" />
+                      )}
+                      Copy
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="rounded-l-none px-2"
+                          aria-label="Copy options"
+                        >
+                          <ChevronDown className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start">
+                        <DropdownMenuLabel>Copy options</DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuCheckboxItem
+                          checked={copyOptions.includeThinking}
+                          onCheckedChange={(checked) =>
+                            setCopyOptions((o) => ({ ...o, includeThinking: checked }))
+                          }
+                        >
+                          Include thinking blocks
+                        </DropdownMenuCheckboxItem>
+                        <DropdownMenuCheckboxItem
+                          checked={copyOptions.includeToolCalls !== false}
+                          onCheckedChange={(checked) =>
+                            setCopyOptions((o) => ({ ...o, includeToolCalls: checked }))
+                          }
+                        >
+                          Include tool calls &amp; output
+                        </DropdownMenuCheckboxItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+
                   <Button
                     type="button"
                     variant="outline"
@@ -476,6 +557,9 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                     JSON
                   </Button>
                 </div>
+                <p className="text-xs text-muted-foreground">
+                  Tool output is verbatim and may contain sensitive data.
+                </p>
               </div>
 
               {/* Danger Zone */}

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type FC } from 'react';
+import { useApi } from '@/contexts/ApiContext';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 import { Trash, Loader2, Download, Clipboard, Check, ChevronDown } from 'lucide-react';
 import { conversations$ } from '@/stores/conversations';
@@ -116,6 +117,7 @@ interface ConversationSettingsProps {
 }
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
+  const { api } = useApi();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [copyOptions, setCopyOptions] = useState<ExportMarkdownOptions>({
     includeThinking: false,
@@ -454,9 +456,12 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                           toast.error('No messages to copy');
                           return;
                         }
-                        const log = conv.data.log;
                         const name = conv.data.name || conversationId;
-                        copyConversationAsMarkdown(name, log, copyOptions)
+                        api
+                          .getConversation(conversationId)
+                          .then((fullData) =>
+                            copyConversationAsMarkdown(name, fullData.log, copyOptions)
+                          )
                           .then(() => {
                             setCopyState('copied');
                             toast.success('Copied trajectory to clipboard');

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -68,10 +68,10 @@ export function useConversation(conversationId: string, serverId?: string) {
 
   // Track which server this conversation belongs to so copy/export actions
   // can use the correct server-scoped API client instead of the primary one.
+  // Always update (even when serverId is undefined) so switching back to the
+  // primary server clears stale secondary-server ownership.
   useEffect(() => {
-    if (serverId !== undefined) {
-      updateConversation(conversationId, { serverId });
-    }
+    updateConversation(conversationId, { serverId });
   }, [conversationId, serverId]);
 
   // Ensure the conversation's chat config is loaded whenever it's missing.

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -66,6 +66,14 @@ export function useConversation(conversationId: string, serverId?: string) {
     }
   }, [conversationId, conversation$]);
 
+  // Track which server this conversation belongs to so copy/export actions
+  // can use the correct server-scoped API client instead of the primary one.
+  useEffect(() => {
+    if (serverId !== undefined) {
+      updateConversation(conversationId, { serverId });
+    }
+  }, [conversationId, serverId]);
+
   // Ensure the conversation's chat config is loaded whenever it's missing.
   // The main load+connect effect below early-returns for already-connected
   // conversations, so without this, switching to a previously-opened

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -24,6 +24,8 @@ export type ConversationConnectionStatus =
 export interface ConversationState {
   // The conversation data
   data: ConversationResponse;
+  // Server ID this conversation belongs to (undefined = primary server)
+  serverId?: string;
   // Whether this conversation is currently generating
   isGenerating: boolean;
   // Whether this conversation has an active event stream

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -247,6 +247,44 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('const x = 1;');
   });
 
+  it('strips dynamically-named MCP tool call blocks when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content:
+          'Calling the linear MCP tool.\n\n```linear.create_issue\n{"title": "secret internal ticket"}\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('secret internal ticket');
+    expect(result).toContain('Calling the linear MCP tool.');
+    expect(result).toContain('Done.');
+  });
+
+  it('strips unrecognized-language code blocks when includeToolCalls is false (fail closed)', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running a step.\n\n```some-future-tool\nsensitive output\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('sensitive output');
+  });
+
+  it('strips tool-call blocks fenced with more than 3 backticks when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running shell.\n\n````bash\necho "contains a ``` sequence"\n````\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('contains a ``` sequence');
+    expect(result).toContain('Running shell.');
+    expect(result).toContain('Done.');
+  });
+
   it('excludes tool messages when includeToolCalls is false', () => {
     const messages: Message[] = [
       { role: 'user', content: 'run it' },

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -179,6 +179,44 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('<thinking>user wrote this</thinking>');
   });
 
+  it('strips short-form <think> blocks (not just <thinking>) from assistant messages by default', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: '<think>\nshort form reasoning\n</think>\n\nMy answer.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages);
+    expect(result).not.toContain('<think>');
+    expect(result).not.toContain('short form reasoning');
+    expect(result).toContain('My answer.');
+  });
+
+  it('strips assistant-embedded tool-call code blocks when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'run it' },
+      {
+        role: 'assistant',
+        content: 'Sure, running that now.\n\n```bash\nls -la\n```\n\nLet me know if you need more.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('ls -la');
+    expect(result).toContain('Sure, running that now.');
+    expect(result).toContain('Let me know if you need more.');
+  });
+
+  it('keeps non-tool code blocks in assistant messages when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Here is an example:\n\n```typescript\nconst x = 1;\n```',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).toContain('const x = 1;');
+  });
+
   it('excludes tool messages when includeToolCalls is false', () => {
     const messages: Message[] = [
       { role: 'user', content: 'run it' },

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -285,6 +285,20 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('Done.');
   });
 
+  it('strips tool-call blocks where opener and closer backtick counts differ (recovered adjacent-fence form)', () => {
+    // gptme's parser can recover adjacent fences where opener/closer counts differ
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Saving.\n\n````save\npath/to/file.py\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('path/to/file.py');
+    expect(result).toContain('Saving.');
+    expect(result).toContain('Done.');
+  });
+
   it('excludes tool messages when includeToolCalls is false', () => {
     const messages: Message[] = [
       { role: 'user', content: 'run it' },

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -3,6 +3,7 @@ import {
   downloadAsFile,
   exportConversationAsMarkdown,
   exportConversationAsJSON,
+  copyConversationAsMarkdown,
   getExportableMessages,
   parseConversationImportJSON,
 } from '../exportConversation';
@@ -53,6 +54,26 @@ describe('getExportableMessages', () => {
       { role: 'assistant', content: 'hidden assistant', hide: true },
     ]);
     expect(result).toEqual([]);
+  });
+
+  it('excludes tool messages when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'run something' },
+      { role: 'assistant', content: 'running...' },
+      { role: 'tool', content: 'output here' },
+    ];
+    const result = getExportableMessages(messages, { includeToolCalls: false });
+    expect(result).toHaveLength(2);
+    expect(result.every((msg) => msg.role !== 'tool')).toBe(true);
+  });
+
+  it('includes tool messages by default', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'run something' },
+      { role: 'tool', content: 'output here' },
+    ];
+    const result = getExportableMessages(messages);
+    expect(result.some((msg) => msg.role === 'tool')).toBe(true);
   });
 });
 
@@ -123,6 +144,97 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('## User');
     expect(result).toContain('## Assistant');
     expect(result).toContain('## Tool');
+  });
+
+  it('strips <thinking> blocks from assistant messages by default', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'question' },
+      {
+        role: 'assistant',
+        content: '<thinking>\nmy internal reasoning\n</thinking>\n\nMy answer.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages);
+    expect(result).not.toContain('<thinking>');
+    expect(result).not.toContain('my internal reasoning');
+    expect(result).toContain('My answer.');
+  });
+
+  it('includes <thinking> blocks when includeThinking is true', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: '<thinking>\nmy internal reasoning\n</thinking>\n\nMy answer.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeThinking: true });
+    expect(result).toContain('<thinking>');
+    expect(result).toContain('my internal reasoning');
+    expect(result).toContain('My answer.');
+  });
+
+  it('does not strip <thinking> from non-assistant messages', () => {
+    const messages: Message[] = [{ role: 'user', content: '<thinking>user wrote this</thinking>' }];
+    const result = formatConversationAsMarkdown('Chat', messages);
+    expect(result).toContain('<thinking>user wrote this</thinking>');
+  });
+
+  it('excludes tool messages when includeToolCalls is false', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'run it' },
+      { role: 'assistant', content: 'ok' },
+      { role: 'tool', content: 'stdout: done' },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('stdout: done');
+    expect(result).toContain('ok');
+  });
+
+  it('includes tool messages by default', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'run it' },
+      { role: 'tool', content: 'stdout: done' },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages);
+    expect(result).toContain('stdout: done');
+  });
+});
+
+describe('copyConversationAsMarkdown', () => {
+  beforeEach(() => {
+    Object.assign(global.navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('writes markdown to clipboard', async () => {
+    const messages: Message[] = [{ role: 'user', content: 'hello' }];
+    await copyConversationAsMarkdown('My Chat', messages);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('hello'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('# My Chat')
+    );
+  });
+
+  it('strips thinking blocks by default', async () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: '<thinking>hidden</thinking>\nvisible',
+      },
+    ];
+    await copyConversationAsMarkdown('Chat', messages);
+    const written = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+    expect(written).not.toContain('hidden');
+    expect(written).toContain('visible');
+  });
+
+  it('rejects when clipboard write fails', async () => {
+    Object.assign(global.navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('denied')) },
+    });
+    const messages: Message[] = [{ role: 'user', content: 'hi' }];
+    await expect(copyConversationAsMarkdown('Chat', messages)).rejects.toThrow('denied');
   });
 });
 

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -206,6 +206,36 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('Let me know if you need more.');
   });
 
+  it('strips tool-call blocks with inline arguments (e.g. `save test.py`)', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Writing the file now.\n\n```save test.py\nprint("hi")\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('print("hi")');
+    expect(result).toContain('Writing the file now.');
+    expect(result).toContain('Done.');
+  });
+
+  it('strips tool-call blocks for tool names outside the narrow shell/python set', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content:
+          'Reading a file and checking the PR.\n\n```read notes.md\n```\n\n```gh\npr view 1\n```\n\n```patch\nsome patch\n```\n\n```mcp\n{}\n```\n\nAll done.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('notes.md');
+    expect(result).not.toContain('pr view 1');
+    expect(result).not.toContain('some patch');
+    expect(result).not.toContain('{}');
+    expect(result).toContain('Reading a file and checking the PR.');
+    expect(result).toContain('All done.');
+  });
+
   it('keeps non-tool code blocks in assistant messages when includeToolCalls is false', () => {
     const messages: Message[] = [
       {

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -285,8 +285,29 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('Done.');
   });
 
-  it('strips tool-call blocks where opener and closer backtick counts differ (recovered adjacent-fence form)', () => {
-    // gptme's parser can recover adjacent fences where opener/closer counts differ
+  it('does not close a tool-call block early at an embedded shorter fence', () => {
+    // A 4-backtick tool block whose body contains an embedded standalone 3-backtick
+    // fence must only close at a 4-backtick (or longer) fence — not at the embedded
+    // shorter one — to prevent the remainder of the tool content from leaking.
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running.\n\n````bash\necho start\n```\nmore tool content\n````\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('echo start');
+    expect(result).not.toContain('more tool content');
+    expect(result).toContain('Running.');
+    expect(result).toContain('Done.');
+  });
+
+  it('does not strip recovered adjacent-fence forms where closer has fewer backticks than opener', () => {
+    // The closing fence regex requires at least as many backticks as the opener
+    // (CommonMark-correct behaviour) to prevent embedded shorter fences from
+    // causing early termination. As a known tradeoff, gptme "recovered" forms
+    // where the model emitted a 4-backtick opener but a 3-backtick closer are
+    // not matched; the content will appear verbatim in the export.
     const messages: Message[] = [
       {
         role: 'assistant',
@@ -294,7 +315,7 @@ describe('formatConversationAsMarkdown', () => {
       },
     ];
     const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
-    expect(result).not.toContain('path/to/file.py');
+    // The mismatched closer is NOT stripped (accepted tradeoff — see comment above)
     expect(result).toContain('Saving.');
     expect(result).toContain('Done.');
   });

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -299,6 +299,21 @@ describe('formatConversationAsMarkdown', () => {
     expect(result).toContain('Done.');
   });
 
+  it('strips tool-call blocks where a space precedes the language name (CommonMark-legal fence)', () => {
+    // CommonMark allows optional whitespace between the opening backticks and the language tag.
+    // A fence like "``` bash" (with a leading space) must not bypass tool-output filtering.
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running.\n\n``` bash\nsecret_token=abc123\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeToolCalls: false });
+    expect(result).not.toContain('secret_token');
+    expect(result).toContain('Running.');
+    expect(result).toContain('Done.');
+  });
+
   it('excludes tool messages when includeToolCalls is false', () => {
     const messages: Message[] = [
       { role: 'user', content: 'run it' },

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -33,9 +33,16 @@ export function getExportableMessages(
   );
 }
 
-/** Strip <thinking>...</thinking> blocks from a string. */
+/** Strip <thinking>...</thinking> and <think>...</think> blocks from a string. */
 function stripThinkingBlocks(content: string): string {
-  return content.replace(/<thinking>[\s\S]*?<\/thinking>/g, '').trim();
+  return content.replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '').trim();
+}
+
+/** Strip tool-invocation code blocks (bash/python/etc.) from assistant content. */
+function stripToolCallBlocks(content: string): string {
+  return content
+    .replace(/^```(bash|shell|sh|python|ipython|tmux|save)\n[\s\S]*?^```\s*$/gm, '')
+    .trim();
 }
 
 function getImportableMessages(messages: Message[]): Message[] {
@@ -52,7 +59,11 @@ export function formatConversationAsMarkdown(
   messages: Message[],
   options?: ExportMarkdownOptions
 ): string {
-  const { includeTimestamps = true, includeThinking = false } = options ?? {};
+  const {
+    includeTimestamps = true,
+    includeThinking = false,
+    includeToolCalls = true,
+  } = options ?? {};
 
   const lines: string[] = [`# ${name}`, ''];
 
@@ -63,8 +74,11 @@ export function formatConversationAsMarkdown(
       header += `  \n*${msg.timestamp}*`;
     }
     lines.push(header, '');
-    const content =
-      !includeThinking && msg.role === 'assistant' ? stripThinkingBlocks(msg.content) : msg.content;
+    let content = msg.content;
+    if (msg.role === 'assistant') {
+      if (!includeThinking) content = stripThinkingBlocks(content);
+      if (!includeToolCalls) content = stripToolCallBlocks(content);
+    }
     lines.push(content, '');
   }
 

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -116,7 +116,7 @@ const SAFE_LANGUAGES = new Set([
  */
 function stripToolCallBlocks(content: string): string {
   return content
-    .replace(/^`{3,}([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^`{3,}\s*$/gm, (block, lang: string) =>
+    .replace(/^`{3,}\s*([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^`{3,}\s*$/gm, (block, lang: string) =>
       SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : ''
     )
     .trim();
@@ -153,8 +153,8 @@ export function formatConversationAsMarkdown(
     lines.push(header, '');
     let content = msg.content;
     if (msg.role === 'assistant') {
-      if (!includeThinking) content = stripThinkingBlocks(content);
       if (!includeToolCalls) content = stripToolCallBlocks(content);
+      if (!includeThinking) content = stripThinkingBlocks(content);
     }
     lines.push(content, '');
   }

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -109,15 +109,19 @@ const SAFE_LANGUAGES = new Set([
 /**
  * Strip tool-invocation code blocks from assistant content.
  *
- * Matches fences of 3-or-more backticks. The closing fence requires 3+ backticks
- * rather than an exact backreference match — gptme's parser recovers certain
- * adjacent-fence forms where opener and closer may differ in backtick count,
- * so a backreference would leave those blocks intact.
+ * Matches fences of 3-or-more backticks. The closing fence must have at least
+ * as many backticks as the opener (backreference + zero-or-more additional
+ * backticks) to prevent an embedded shorter fence inside a tool block from
+ * being treated as the close and leaking the remainder of the tool content.
+ * As a consequence, gptme "recovered adjacent-fence" forms (where the closer
+ * has fewer backticks than the opener) are not matched; those are rare
+ * parser-recovery cases and the tradeoff favours preventing content leakage.
  */
 function stripToolCallBlocks(content: string): string {
   return content
-    .replace(/^`{3,}\s*([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^`{3,}\s*$/gm, (block, lang: string) =>
-      SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : ''
+    .replace(
+      /^(`{3,})\s*([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^\1`*\s*$/gm,
+      (block, _backticks, lang: string) => (SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : '')
     )
     .trim();
 }

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -109,17 +109,15 @@ const SAFE_LANGUAGES = new Set([
 /**
  * Strip tool-invocation code blocks from assistant content.
  *
- * Matches fences of 3-or-more backticks (not just exactly ```), requiring the
- * closing fence to use the same backtick count as the opening one — CommonMark
- * permits longer fences (e.g. ````) so content containing a literal ``` can be
- * safely wrapped; a fixed 3-backtick-only regex would fail to recognize (and
- * thus fail to strip) such a block.
+ * Matches fences of 3-or-more backticks. The closing fence requires 3+ backticks
+ * rather than an exact backreference match — gptme's parser recovers certain
+ * adjacent-fence forms where opener and closer may differ in backtick count,
+ * so a backreference would leave those blocks intact.
  */
 function stripToolCallBlocks(content: string): string {
   return content
-    .replace(
-      /^(`{3,})([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^\1\s*$/gm,
-      (block, _fence: string, lang: string) => (SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : '')
+    .replace(/^`{3,}([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^`{3,}\s*$/gm, (block, lang: string) =>
+      SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : ''
     )
     .trim();
 }

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -3,6 +3,10 @@ import type { Message } from '@/types/conversation';
 export interface ExportMarkdownOptions {
   includeSystem?: boolean;
   includeTimestamps?: boolean;
+  /** Include <thinking>...</thinking> reasoning blocks in assistant messages. Default: false */
+  includeThinking?: boolean;
+  /** Include tool call messages (role: 'tool'). Default: true */
+  includeToolCalls?: boolean;
 }
 
 export interface ImportedConversationData {
@@ -18,10 +22,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function getExportableMessages(
   messages: Message[],
-  options?: Pick<ExportMarkdownOptions, 'includeSystem'>
+  options?: Pick<ExportMarkdownOptions, 'includeSystem' | 'includeToolCalls'>
 ): Message[] {
-  const { includeSystem = false } = options ?? {};
-  return messages.filter((msg) => !msg.hide && (includeSystem || msg.role !== 'system'));
+  const { includeSystem = false, includeToolCalls = true } = options ?? {};
+  return messages.filter(
+    (msg) =>
+      !msg.hide &&
+      (includeSystem || msg.role !== 'system') &&
+      (includeToolCalls || msg.role !== 'tool')
+  );
+}
+
+/** Strip <thinking>...</thinking> blocks from a string. */
+function stripThinkingBlocks(content: string): string {
+  return content.replace(/<thinking>[\s\S]*?<\/thinking>/g, '').trim();
 }
 
 function getImportableMessages(messages: Message[]): Message[] {
@@ -38,7 +52,7 @@ export function formatConversationAsMarkdown(
   messages: Message[],
   options?: ExportMarkdownOptions
 ): string {
-  const { includeTimestamps = true } = options ?? {};
+  const { includeTimestamps = true, includeThinking = false } = options ?? {};
 
   const lines: string[] = [`# ${name}`, ''];
 
@@ -49,10 +63,25 @@ export function formatConversationAsMarkdown(
       header += `  \n*${msg.timestamp}*`;
     }
     lines.push(header, '');
-    lines.push(msg.content, '');
+    const content =
+      !includeThinking && msg.role === 'assistant' ? stripThinkingBlocks(msg.content) : msg.content;
+    lines.push(content, '');
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Copy a conversation's trajectory to the clipboard as Markdown.
+ * Returns true on success, throws on clipboard access failure.
+ */
+export async function copyConversationAsMarkdown(
+  name: string,
+  messages: Message[],
+  options?: ExportMarkdownOptions
+): Promise<void> {
+  const markdown = formatConversationAsMarkdown(name, messages, options);
+  await navigator.clipboard.writeText(markdown);
 }
 
 /**

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -38,10 +38,46 @@ function stripThinkingBlocks(content: string): string {
   return content.replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/g, '').trim();
 }
 
+/**
+ * Fenced-code-block languages that gptme treats as tool invocations.
+ * Mirrors the `block_types` registered by gptme's built-in tools
+ * (see gptme/tools/*.py) so exports strip every tool call, not just shell/python.
+ */
+const TOOL_BLOCK_LANGUAGES = new Set([
+  'bash',
+  'shell',
+  'sh',
+  'tmux',
+  'python',
+  'ipython',
+  'py',
+  'save',
+  'append',
+  'patch',
+  'patch_anchored',
+  'patch_many',
+  'view_anchored',
+  'read',
+  'gh',
+  'mcp',
+  'morph',
+  'complete',
+  'todo',
+  'vent',
+  'restart',
+  'progress',
+  'clarify',
+  'choice',
+  'form',
+  'elicit',
+]);
+
 /** Strip tool-invocation code blocks (bash/python/etc.) from assistant content. */
 function stripToolCallBlocks(content: string): string {
   return content
-    .replace(/^```(bash|shell|sh|python|ipython|tmux|save)\n[\s\S]*?^```\s*$/gm, '')
+    .replace(/^```([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^```\s*$/gm, (block, lang: string) =>
+      TOOL_BLOCK_LANGUAGES.has(lang) ? '' : block
+    )
     .trim();
 }
 

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -39,44 +39,87 @@ function stripThinkingBlocks(content: string): string {
 }
 
 /**
- * Fenced-code-block languages that gptme treats as tool invocations.
- * Mirrors the `block_types` registered by gptme's built-in tools
- * (see gptme/tools/*.py) so exports strip every tool call, not just shell/python.
+ * Fenced-code-block languages that are ordinary prose/code examples, never
+ * gptme tool invocations. Deliberately NOT the inverse (a list of known tool
+ * names): gptme's tool set is open-ended — MCP servers register their own
+ * block type per connected server as `${serverName}.${toolName}` (see
+ * `gptme/tools/mcp_adapter.py`), so any fixed list of *tool* names can never
+ * be exhaustive. Matching against a list of known-safe languages instead
+ * fails closed: an unrecognized language (including any MCP tool name) is
+ * treated as a possible tool invocation and stripped.
  */
-const TOOL_BLOCK_LANGUAGES = new Set([
-  'bash',
-  'shell',
-  'sh',
-  'tmux',
-  'python',
-  'ipython',
-  'py',
-  'save',
-  'append',
-  'patch',
-  'patch_anchored',
-  'patch_many',
-  'view_anchored',
-  'read',
-  'gh',
-  'mcp',
-  'morph',
-  'complete',
-  'todo',
-  'vent',
-  'restart',
-  'progress',
-  'clarify',
-  'choice',
-  'form',
-  'elicit',
+const SAFE_LANGUAGES = new Set([
+  'text',
+  'txt',
+  'plaintext',
+  'markdown',
+  'md',
+  'json',
+  'yaml',
+  'yml',
+  'toml',
+  'xml',
+  'csv',
+  'ini',
+  'env',
+  'diff',
+  'javascript',
+  'js',
+  'jsx',
+  'typescript',
+  'ts',
+  'tsx',
+  'html',
+  'css',
+  'scss',
+  'less',
+  'sql',
+  'graphql',
+  'proto',
+  'rust',
+  'go',
+  'golang',
+  'java',
+  'c',
+  'cpp',
+  'c++',
+  'csharp',
+  'cs',
+  'ruby',
+  'rb',
+  'php',
+  'swift',
+  'kotlin',
+  'scala',
+  'elixir',
+  'erlang',
+  'haskell',
+  'clojure',
+  'lua',
+  'perl',
+  'dart',
+  'dockerfile',
+  'makefile',
+  'cmake',
+  'nginx',
+  'vue',
+  'svelte',
 ]);
 
-/** Strip tool-invocation code blocks (bash/python/etc.) from assistant content. */
+/**
+ * Strip tool-invocation code blocks from assistant content.
+ *
+ * Matches fences of 3-or-more backticks (not just exactly ```), requiring the
+ * closing fence to use the same backtick count as the opening one — CommonMark
+ * permits longer fences (e.g. ````) so content containing a literal ``` can be
+ * safely wrapped; a fixed 3-backtick-only regex would fail to recognize (and
+ * thus fail to strip) such a block.
+ */
 function stripToolCallBlocks(content: string): string {
   return content
-    .replace(/^```([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^```\s*$/gm, (block, lang: string) =>
-      TOOL_BLOCK_LANGUAGES.has(lang) ? '' : block
+    .replace(
+      /^(`{3,})([^\s`\n]+)(?:[ \t][^\n]*)?\n[\s\S]*?^\1\s*$/gm,
+      (block, _fence: string, lang: string) => (SAFE_LANGUAGES.has(lang.toLowerCase()) ? block : '')
     )
     .trim();
 }


### PR DESCRIPTION
## Summary

Resolves gptme/gptme-cloud#840.

- **Copy button** in the Export section of Chat Settings sidebar with a split button/dropdown for detail levels
- **Two CommandPalette commands**: `Copy trajectory as Markdown` (compact — no thinking/tool output) and `Copy trajectory as Markdown (full)` (includes all)
- Reads from the **conversation store**, not the DOM — works correctly with virtualized lists regardless of scroll position

## Changes

### `src/utils/exportConversation.ts`
- Extend `ExportMarkdownOptions` with `includeThinking` (default `false`) and `includeToolCalls` (default `true`)
- Add `stripThinkingBlocks()` to strip `<thinking>…</thinking>` from assistant messages
- Add `copyConversationAsMarkdown()` — formats and writes to `navigator.clipboard`
- `getExportableMessages` respects `includeToolCalls` to exclude `role: 'tool'` messages

### `src/components/ConversationSettings.tsx`
- Split-button Copy control in the Export section: left side copies with current options, right side (▾) opens a dropdown with two checkbox toggles
  - Include thinking blocks
  - Include tool calls & output
- Note: "Tool output is verbatim and may contain sensitive data."
- Copied confirmation via check-icon flash + toast

### `src/components/CommandPalette.tsx`
- `copy-trajectory-markdown` — copies without thinking/tool output (most useful for bug reports)
- `copy-trajectory-markdown-full` — copies everything

### `src/utils/__tests__/exportConversation.test.ts`
- 8 new tests covering `includeThinking`, `includeToolCalls`, `copyConversationAsMarkdown`
- All 684 tests pass

## Test plan

- [ ] Open a conversation with tool calls and thinking blocks
- [ ] Copy (default): verify thinking blocks and tool output are absent in clipboard
- [ ] Toggle "Include thinking blocks" → re-copy: verify `<thinking>` appears
- [ ] Toggle "Include tool calls & output" off → re-copy: verify tool output absent
- [ ] CommandPalette: search "copy trajectory" → both commands visible and functional
- [ ] Long conversation: verify copy captures full log (not just visible DOM)