### PR TITLE
feat(webui): add copy trajectory as markdown with detail level toggles

### DIFF
--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, type FC } from 'react';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
-import { Trash, Loader2, Download } from 'lucide-react';
+import { Trash, Loader2, Download, Copy, Check } from 'lucide-react';
 import { conversations$ } from '@/stores/conversations';
 import {
   exportConversationAsMarkdown,
   exportConversationAsJSON,
+  copyConversationToClipboard,
   getExportableMessages,
 } from '@/utils/exportConversation';
 import { toast } from 'sonner';
@@ -107,6 +108,9 @@ interface ConversationSettingsProps {
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [includeThinking, setIncludeThinking] = useState(false);
+  const [includeTools, setIncludeTools] = useState(true);
   const {
     form,
     toolFields,
@@ -425,7 +429,63 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
               {/* Export */}
               <div className="mt-8 space-y-4">
                 <h3 className="text-lg font-medium">Export</h3>
-                <div className="flex gap-2">
+
+                {/* Detail level toggles */}
+                <div className="space-y-2 rounded-lg border px-3 py-2 shadow-sm">
+                  <p className="text-sm font-medium text-muted-foreground">Detail level</p>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm">Include thinking blocks</span>
+                    <Switch checked={includeThinking} onCheckedChange={setIncludeThinking} />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm">Include tool calls &amp; results</span>
+                    <Switch checked={includeTools} onCheckedChange={setIncludeTools} />
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {/* Copy to clipboard */}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={async () => {
+                      const conv = conversations$.get(conversationId)?.get();
+                      if (!conv?.data?.log?.length) {
+                        toast.error('No messages to copy');
+                        return;
+                      }
+                      const exportOptions = { includeThinking, includeTools };
+                      const exportableMessages = getExportableMessages(
+                        conv.data.log,
+                        exportOptions
+                      );
+                      if (!exportableMessages.length) {
+                        toast.error('No visible messages to copy');
+                        return;
+                      }
+                      try {
+                        await copyConversationToClipboard(
+                          conv.data.name || conversationId,
+                          exportableMessages,
+                          exportOptions
+                        );
+                        setCopied(true);
+                        setTimeout(() => setCopied(false), 2000);
+                      } catch {
+                        toast.error('Failed to copy to clipboard');
+                      }
+                    }}
+                  >
+                    {copied ? (
+                      <Check className="mr-2 h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="mr-2 h-4 w-4" />
+                    )}
+                    {copied ? 'Copied!' : 'Copy'}
+                  </Button>
+
+                  {/* Download Markdown */}
                   <Button
                     type="button"
                     variant="outline"
@@ -437,7 +497,11 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                         return;
                       }
 
-                      const exportableMessages = getExportableMessages(conv.data.log);
+                      const exportOptions = { includeThinking, includeTools };
+                      const exportableMessages = getExportableMessages(
+                        conv.data.log,
+                        exportOptions
+                      );
                       if (!exportableMessages.length) {
                         toast.error('No visible messages to export');
                         return;
@@ -446,14 +510,17 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                       exportConversationAsMarkdown(
                         conversationId,
                         conv.data.name || conversationId,
-                        exportableMessages
+                        exportableMessages,
+                        exportOptions
                       );
-                      toast.success('Exported as Markdown');
+                      toast.success('Downloaded as Markdown');
                     }}
                   >
                     <Download className="mr-2 h-4 w-4" />
-                    Markdown
+                    Download .md
                   </Button>
+
+                  {/* Download JSON */}
                   <Button
                     type="button"
                     variant="outline"
@@ -469,13 +536,16 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                         conv.data.name || conversationId,
                         conv.data.log
                       );
-                      toast.success('Exported as JSON');
+                      toast.success('Downloaded as JSON');
                     }}
                   >
                     <Download className="mr-2 h-4 w-4" />
-                    JSON
+                    Download .json
                   </Button>
                 </div>
+                <p className="text-xs text-muted-foreground">
+                  Note: tool output is included verbatim and may contain sensitive data.
+                </p>
               </div>
 
               {/* Danger Zone */}

--- a/webui/src/components/ConversationSettings.tsx
+++ b/webui/src/components/ConversationSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FC } from 'react';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 import { Trash, Loader2, Download, Copy, Check } from 'lucide-react';
+import { useApi } from '@/contexts/ApiContext';
 import { conversations$ } from '@/stores/conversations';
 import {
   exportConversationAsMarkdown,
@@ -107,6 +108,7 @@ interface ConversationSettingsProps {
 }
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
+  const { api } = useApi();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [includeThinking, setIncludeThinking] = useState(false);
@@ -455,11 +457,21 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                         toast.error('No messages to copy');
                         return;
                       }
+                      // The store may only hold the currently-loaded window of a
+                      // long conversation (virtualized pagination). Fetch the
+                      // full history from the server rather than silently
+                      // copying a partial slice.
+                      let fullLog = conv.data.log;
+                      if (!isDemo && conv.hasMoreBefore) {
+                        try {
+                          fullLog = (await api.getConversation(conversationId)).log;
+                        } catch {
+                          toast.error('Failed to load full conversation history');
+                          return;
+                        }
+                      }
                       const exportOptions = { includeThinking, includeTools };
-                      const exportableMessages = getExportableMessages(
-                        conv.data.log,
-                        exportOptions
-                      );
+                      const exportableMessages = getExportableMessages(fullLog, exportOptions);
                       if (!exportableMessages.length) {
                         toast.error('No visible messages to copy');
                         return;
@@ -490,18 +502,27 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() => {
+                    onClick={async () => {
                       const conv = conversations$.get(conversationId)?.get();
                       if (!conv?.data?.log?.length) {
                         toast.error('No messages to export');
                         return;
                       }
 
+                      // See the Copy handler above: don't silently export a
+                      // partial window of a long, paginated conversation.
+                      let fullLog = conv.data.log;
+                      if (!isDemo && conv.hasMoreBefore) {
+                        try {
+                          fullLog = (await api.getConversation(conversationId)).log;
+                        } catch {
+                          toast.error('Failed to load full conversation history');
+                          return;
+                        }
+                      }
+
                       const exportOptions = { includeThinking, includeTools };
-                      const exportableMessages = getExportableMessages(
-                        conv.data.log,
-                        exportOptions
-                      );
+                      const exportableMessages = getExportableMessages(fullLog, exportOptions);
                       if (!exportableMessages.length) {
                         toast.error('No visible messages to export');
                         return;

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -443,6 +443,32 @@ describe('formatConversationAsMarkdown - tool invocation stripping', () => {
     expect(result).toContain('Checking.');
     expect(result).toContain('Done.');
   });
+
+  it('preserves non-JSON @-prefixed lines when includeTools is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Note: @shell: this is just a note, not a call\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).toContain('@shell: this is just a note');
+    expect(result).toContain('Done.');
+  });
+
+  it('preserves trailing text after closing brace of an @tool call when includeTools is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running it.\n@shell(call_1): {"command": "ls"} and more\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).not.toContain('"command"');
+    expect(result).toContain('and more');
+    expect(result).toContain('Running it.');
+    expect(result).toContain('Done.');
+  });
 });
 
 describe('getExportableMessages - includeTools option', () => {

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -366,6 +366,18 @@ describe('stripThinkingBlocks', () => {
     expect(result).toBe('Visible text');
     expect(result).not.toContain('opaque payload');
   });
+
+  it('removes an unclosed trailing <think> block (generation interrupted mid-thinking)', () => {
+    const result = stripThinkingBlocks('Visible text\n<think>\nreasoning that never closed');
+    expect(result).toBe('Visible text');
+    expect(result).not.toContain('reasoning that never closed');
+  });
+
+  it('removes an unclosed trailing <thinking> block with no preceding text', () => {
+    const result = stripThinkingBlocks('<thinking>\ninterrupted reasoning');
+    expect(result).toBe('');
+    expect(result).not.toContain('interrupted reasoning');
+  });
 });
 
 describe('formatConversationAsMarkdown - tool invocation stripping', () => {
@@ -401,6 +413,19 @@ describe('formatConversationAsMarkdown - tool invocation stripping', () => {
     const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
     expect(result).not.toContain('/secret');
     expect(result).toContain('Running it.');
+    expect(result).toContain('Done.');
+  });
+
+  it('strips dynamically named MCP fenced invocations when includeTools is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Checking.\n\n```github.create_issue\n{"title": "secret bug"}\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).not.toContain('secret bug');
+    expect(result).toContain('Checking.');
     expect(result).toContain('Done.');
   });
 });

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -358,6 +358,51 @@ describe('stripThinkingBlocks', () => {
     );
     expect(result).toBe('middle');
   });
+
+  it('removes <think redacted> blocks (Anthropic RedactedThinkingBlock)', () => {
+    const result = stripThinkingBlocks(
+      '<think redacted>\nopaque payload\n</think redacted>\n\nVisible text'
+    );
+    expect(result).toBe('Visible text');
+    expect(result).not.toContain('opaque payload');
+  });
+});
+
+describe('formatConversationAsMarkdown - tool invocation stripping', () => {
+  it('strips fenced tool codeblocks embedded in assistant content when includeTools is false', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'List files' },
+      {
+        role: 'assistant',
+        content: 'Sure, checking now.\n\n```shell\nls -la /secret/path\n```\n\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).not.toContain('/secret/path');
+    expect(result).toContain('Sure, checking now.');
+    expect(result).toContain('Done.');
+  });
+
+  it('keeps fenced codeblocks with non-tool langtags when includeTools is false', () => {
+    const messages: Message[] = [
+      { role: 'assistant', content: 'Example:\n\n```python\nprint("hi")\n```' },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).toContain('print("hi")');
+  });
+
+  it('strips @tool: {...} invocation lines when includeTools is false', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: 'Running it.\n@shell(call_1): {\n  "command": "rm -rf /secret"\n}\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).not.toContain('/secret');
+    expect(result).toContain('Running it.');
+    expect(result).toContain('Done.');
+  });
 });
 
 describe('getExportableMessages - includeTools option', () => {

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -5,6 +5,8 @@ import {
   exportConversationAsJSON,
   getExportableMessages,
   parseConversationImportJSON,
+  stripThinkingBlocks,
+  copyConversationToClipboard,
 } from '../exportConversation';
 import type { Message } from '@/types/conversation';
 
@@ -325,5 +327,134 @@ describe('parseConversationImportJSON', () => {
     );
 
     expect(result.name).toBe('');
+  });
+});
+
+describe('stripThinkingBlocks', () => {
+  it('removes <thinking> blocks', () => {
+    const result = stripThinkingBlocks('Before\n<thinking>hidden</thinking>\nAfter');
+    expect(result).toBe('Before\nAfter');
+    expect(result).not.toContain('hidden');
+  });
+
+  it('removes <think> blocks', () => {
+    const result = stripThinkingBlocks('<think>hidden</think>\nVisible text');
+    expect(result).toBe('Visible text');
+    expect(result).not.toContain('hidden');
+  });
+
+  it('removes multi-line thinking blocks', () => {
+    const result = stripThinkingBlocks('Start\n<thinking>\nline 1\nline 2\n</thinking>\nEnd');
+    expect(result).toBe('Start\nEnd');
+  });
+
+  it('handles content with no thinking blocks', () => {
+    expect(stripThinkingBlocks('Just regular text')).toBe('Just regular text');
+  });
+
+  it('removes multiple thinking blocks', () => {
+    const result = stripThinkingBlocks(
+      '<thinking>first</thinking>middle<thinking>second</thinking>'
+    );
+    expect(result).toBe('middle');
+  });
+});
+
+describe('getExportableMessages - includeTools option', () => {
+  const messagesWithTools: Message[] = [
+    { role: 'user', content: 'Run a command' },
+    { role: 'assistant', content: 'Sure' },
+    { role: 'tool', content: 'tool output' },
+  ];
+
+  it('includes tool messages by default', () => {
+    const result = getExportableMessages(messagesWithTools);
+    expect(result.some((m) => m.role === 'tool')).toBe(true);
+  });
+
+  it('excludes tool messages when includeTools is false', () => {
+    const result = getExportableMessages(messagesWithTools, { includeTools: false });
+    expect(result.some((m) => m.role === 'tool')).toBe(false);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('formatConversationAsMarkdown - thinking and tools options', () => {
+  const messagesWithThinkingAndTools: Message[] = [
+    { role: 'user', content: 'Question' },
+    {
+      role: 'assistant',
+      content: '<thinking>internal reasoning</thinking>\nThe answer is 42.',
+    },
+    { role: 'tool', content: 'tool result' },
+  ];
+
+  it('strips thinking blocks when includeThinking is false', () => {
+    const result = formatConversationAsMarkdown('Chat', messagesWithThinkingAndTools, {
+      includeThinking: false,
+    });
+    expect(result).not.toContain('internal reasoning');
+    expect(result).toContain('The answer is 42.');
+  });
+
+  it('includes thinking blocks when includeThinking is true', () => {
+    const result = formatConversationAsMarkdown('Chat', messagesWithThinkingAndTools, {
+      includeThinking: true,
+    });
+    expect(result).toContain('internal reasoning');
+    expect(result).toContain('The answer is 42.');
+  });
+
+  it('excludes tool messages when includeTools is false', () => {
+    const result = formatConversationAsMarkdown('Chat', messagesWithThinkingAndTools, {
+      includeTools: false,
+    });
+    expect(result).not.toContain('tool result');
+    expect(result).toContain('The answer is 42.');
+  });
+
+  it('includes tool messages when includeTools is true', () => {
+    const result = formatConversationAsMarkdown('Chat', messagesWithThinkingAndTools, {
+      includeTools: true,
+    });
+    expect(result).toContain('tool result');
+  });
+});
+
+describe('copyConversationToClipboard', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes markdown to the clipboard', async () => {
+    await copyConversationToClipboard('Test Chat', sampleMessages);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    const written = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+    expect(written).toContain('# Test Chat');
+    expect(written).toContain('## User');
+    expect(written).toContain('Hello, how are you?');
+  });
+
+  it('applies thinking and tools options', async () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Q' },
+      { role: 'assistant', content: '<thinking>hidden</thinking>\nAnswer' },
+      { role: 'tool', content: 'tool output' },
+    ];
+    await copyConversationToClipboard('Chat', messages, {
+      includeThinking: false,
+      includeTools: false,
+    });
+    const written = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+    expect(written).not.toContain('hidden');
+    expect(written).not.toContain('tool output');
+    expect(written).toContain('Answer');
   });
 });

--- a/webui/src/utils/__tests__/exportConversation.test.ts
+++ b/webui/src/utils/__tests__/exportConversation.test.ts
@@ -416,6 +416,21 @@ describe('formatConversationAsMarkdown - tool invocation stripping', () => {
     expect(result).toContain('Done.');
   });
 
+  it('strips @tool: {...} invocations containing a closing brace inside a quoted string', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content:
+          'Running it.\n@shell(call_1): {\n  "command": "echo \\"}\\" && cat /etc/shadow",\n  "cwd": "/secret-path"\n}\nDone.',
+      },
+    ];
+    const result = formatConversationAsMarkdown('Chat', messages, { includeTools: false });
+    expect(result).not.toContain('/etc/shadow');
+    expect(result).not.toContain('/secret-path');
+    expect(result).toContain('Running it.');
+    expect(result).toContain('Done.');
+  });
+
   it('strips dynamically named MCP fenced invocations when includeTools is false', () => {
     const messages: Message[] = [
       {

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -20,13 +20,109 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /**
  * Strip thinking/reasoning blocks from assistant message content.
- * Handles both <thinking>...</thinking> and <think>...</think> tags.
+ * Handles <thinking>/<think> tags as well as the `<think redacted>` variant
+ * gptme emits for Anthropic's RedactedThinkingBlock (see llm_anthropic.py).
  */
 export function stripThinkingBlocks(content: string): string {
   return content
-    .replace(/<thinking>[\s\S]*?<\/thinking>\n?/g, '')
-    .replace(/<think>[\s\S]*?<\/think>\n?/g, '')
+    .replace(/<think(?:ing)?(?: redacted)?>[\s\S]*?<\/think(?:ing)?(?: redacted)?>\n?/g, '')
     .trim();
+}
+
+// Built-in gptme tool block types (markdown codeblock langtags that represent
+// a tool invocation rather than example code). Mirrors block_types across
+// gptme/tools/*.py. MCP server tools register dynamically and aren't covered.
+const TOOL_BLOCK_TYPES = new Set([
+  'clarify',
+  'complete',
+  'choice',
+  'gh',
+  'elicit',
+  'form',
+  'patch',
+  'patch_many',
+  'morph',
+  'view_anchored',
+  'patch_anchored',
+  'progress',
+  'hashline_edit',
+  'ipython',
+  'py',
+  'mcp',
+  'todo',
+  'save',
+  'append',
+  'vent',
+  'shell',
+  'tmux',
+  'read',
+  'restart',
+]);
+
+/**
+ * Strip fenced tool-invocation codeblocks (```shell, ```save path, etc.) from
+ * assistant message content.
+ */
+function stripFencedToolBlocks(content: string): string {
+  return content.replace(/```([^\n`]*)\n[\s\S]*?```/g, (block, langLine: string) => {
+    const tag = langLine.trim().split(/\s+/)[0]?.toLowerCase();
+    return tag && TOOL_BLOCK_TYPES.has(tag) ? '' : block;
+  });
+}
+
+/**
+ * Strip `@tool(id): {...}` / `@tool: {...}` invocation lines (the non-markdown
+ * "tool" format, and the live-streaming shape) from assistant message content.
+ * Scans braces rather than regex-matching JSON so pretty-printed or compact
+ * argument objects are both handled correctly.
+ */
+function stripAtFormatToolCalls(content: string): string {
+  const lines = content.split('\n');
+  const callPrefix = /^@[\w.-]+(?:\([^)\n]*\))?:\s*/;
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const match = lines[i].match(callPrefix);
+    if (!match) {
+      out.push(lines[i]);
+      i++;
+      continue;
+    }
+    const rest = lines[i].slice(match[0].length);
+    if (!rest.startsWith('{')) {
+      i++;
+      continue;
+    }
+    let depth = 0;
+    let sawOpen = false;
+    let j = i;
+    for (; j < lines.length; j++) {
+      const scanLine = j === i ? rest : lines[j];
+      for (const ch of scanLine) {
+        if (ch === '{') {
+          depth++;
+          sawOpen = true;
+        } else if (ch === '}') {
+          depth--;
+        }
+      }
+      if (sawOpen && depth <= 0) {
+        j++;
+        break;
+      }
+    }
+    i = j;
+  }
+  return out.join('\n');
+}
+
+/**
+ * Strip tool invocations embedded directly in assistant message content
+ * (fenced tool codeblocks and `@tool: {...}` calls). Distinct from filtering
+ * `role: 'tool'` result messages, which getExportableMessages handles.
+ */
+function stripToolInvocations(content: string): string {
+  return stripAtFormatToolCalls(stripFencedToolBlocks(content));
 }
 
 export function getExportableMessages(
@@ -54,7 +150,7 @@ export function formatConversationAsMarkdown(
   messages: Message[],
   options?: ExportMarkdownOptions
 ): string {
-  const { includeTimestamps = true, includeThinking = true } = options ?? {};
+  const { includeTimestamps = true, includeThinking = true, includeTools = true } = options ?? {};
 
   const lines: string[] = [`# ${name}`, ''];
 
@@ -65,8 +161,11 @@ export function formatConversationAsMarkdown(
       header += `  \n*${msg.timestamp}*`;
     }
     lines.push(header, '');
-    const content =
-      !includeThinking && msg.role === 'assistant' ? stripThinkingBlocks(msg.content) : msg.content;
+    let content = msg.content;
+    if (msg.role === 'assistant') {
+      if (!includeThinking) content = stripThinkingBlocks(content);
+      if (!includeTools) content = stripToolInvocations(content);
+    }
     lines.push(content, '');
   }
 

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -22,16 +22,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Strip thinking/reasoning blocks from assistant message content.
  * Handles <thinking>/<think> tags as well as the `<think redacted>` variant
  * gptme emits for Anthropic's RedactedThinkingBlock (see llm_anthropic.py).
+ * Also strips a trailing *unclosed* thinking tag: if generation is
+ * interrupted mid-thinking, gptme never streams the closing `</think>`, so
+ * the reasoning would otherwise leak into the exported "response" content.
  */
 export function stripThinkingBlocks(content: string): string {
   return content
     .replace(/<think(?:ing)?(?: redacted)?>[\s\S]*?<\/think(?:ing)?(?: redacted)?>\n?/g, '')
+    .replace(/<think(?:ing)?(?: redacted)?>[\s\S]*$/, '')
     .trim();
 }
 
 // Built-in gptme tool block types (markdown codeblock langtags that represent
 // a tool invocation rather than example code). Mirrors block_types across
-// gptme/tools/*.py. MCP server tools register dynamically and aren't covered.
+// gptme/tools/*.py.
 const TOOL_BLOCK_TYPES = new Set([
   'clarify',
   'complete',
@@ -59,14 +63,23 @@ const TOOL_BLOCK_TYPES = new Set([
   'restart',
 ]);
 
+// MCP server tools register block types dynamically as `{server}.{tool}`
+// (see gptme/tools/mcp_adapter.py: `block_types=[f"{server_config.name}.{mcp_tool.name}"]`),
+// so they can't be enumerated in TOOL_BLOCK_TYPES ahead of time.
+const MCP_BLOCK_TYPE_RE = /^[\w-]+\.[\w-]+$/;
+
+function isToolBlockTag(tag: string): boolean {
+  return TOOL_BLOCK_TYPES.has(tag) || MCP_BLOCK_TYPE_RE.test(tag);
+}
+
 /**
- * Strip fenced tool-invocation codeblocks (```shell, ```save path, etc.) from
- * assistant message content.
+ * Strip fenced tool-invocation codeblocks (```shell, ```save path, ```server.tool, etc.)
+ * from assistant message content.
  */
 function stripFencedToolBlocks(content: string): string {
   return content.replace(/```([^\n`]*)\n[\s\S]*?```/g, (block, langLine: string) => {
     const tag = langLine.trim().split(/\s+/)[0]?.toLowerCase();
-    return tag && TOOL_BLOCK_TYPES.has(tag) ? '' : block;
+    return tag && isToolBlockTag(tag) ? '' : block;
   });
 }
 

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -108,10 +108,25 @@ function stripAtFormatToolCalls(content: string): string {
     }
     let depth = 0;
     let sawOpen = false;
+    let inString = false;
+    let escapeNext = false;
     let j = i;
     for (; j < lines.length; j++) {
       const scanLine = j === i ? rest : lines[j];
       for (const ch of scanLine) {
+        if (escapeNext) {
+          escapeNext = false;
+          continue;
+        }
+        if (ch === '\\' && inString) {
+          escapeNext = true;
+          continue;
+        }
+        if (ch === '"') {
+          inString = !inString;
+          continue;
+        }
+        if (inString) continue;
         if (ch === '{') {
           depth++;
           sawOpen = true;

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -3,6 +3,8 @@ import type { Message } from '@/types/conversation';
 export interface ExportMarkdownOptions {
   includeSystem?: boolean;
   includeTimestamps?: boolean;
+  includeThinking?: boolean;
+  includeTools?: boolean;
 }
 
 export interface ImportedConversationData {
@@ -16,12 +18,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Strip thinking/reasoning blocks from assistant message content.
+ * Handles both <thinking>...</thinking> and <think>...</think> tags.
+ */
+export function stripThinkingBlocks(content: string): string {
+  return content
+    .replace(/<thinking>[\s\S]*?<\/thinking>\n?/g, '')
+    .replace(/<think>[\s\S]*?<\/think>\n?/g, '')
+    .trim();
+}
+
 export function getExportableMessages(
   messages: Message[],
-  options?: Pick<ExportMarkdownOptions, 'includeSystem'>
+  options?: Pick<ExportMarkdownOptions, 'includeSystem' | 'includeTools'>
 ): Message[] {
-  const { includeSystem = false } = options ?? {};
-  return messages.filter((msg) => !msg.hide && (includeSystem || msg.role !== 'system'));
+  const { includeSystem = false, includeTools = true } = options ?? {};
+  return messages.filter(
+    (msg) =>
+      !msg.hide && (includeSystem || msg.role !== 'system') && (includeTools || msg.role !== 'tool')
+  );
 }
 
 function getImportableMessages(messages: Message[]): Message[] {
@@ -38,7 +54,7 @@ export function formatConversationAsMarkdown(
   messages: Message[],
   options?: ExportMarkdownOptions
 ): string {
-  const { includeTimestamps = true } = options ?? {};
+  const { includeTimestamps = true, includeThinking = true } = options ?? {};
 
   const lines: string[] = [`# ${name}`, ''];
 
@@ -49,10 +65,25 @@ export function formatConversationAsMarkdown(
       header += `  \n*${msg.timestamp}*`;
     }
     lines.push(header, '');
-    lines.push(msg.content, '');
+    const content =
+      !includeThinking && msg.role === 'assistant' ? stripThinkingBlocks(msg.content) : msg.content;
+    lines.push(content, '');
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Copy the full conversation to the clipboard as Markdown.
+ * Reads from the conversation store, not the DOM, so virtualized messages are included.
+ */
+export async function copyConversationToClipboard(
+  name: string,
+  messages: Message[],
+  options?: ExportMarkdownOptions
+): Promise<void> {
+  const markdown = formatConversationAsMarkdown(name, messages, options);
+  await navigator.clipboard.writeText(markdown);
 }
 
 /**

--- a/webui/src/utils/exportConversation.ts
+++ b/webui/src/utils/exportConversation.ts
@@ -103,6 +103,8 @@ function stripAtFormatToolCalls(content: string): string {
     }
     const rest = lines[i].slice(match[0].length);
     if (!rest.startsWith('{')) {
+      // Not a JSON tool call — preserve the line as-is.
+      out.push(lines[i]);
       i++;
       continue;
     }
@@ -111,9 +113,11 @@ function stripAtFormatToolCalls(content: string): string {
     let inString = false;
     let escapeNext = false;
     let j = i;
-    for (; j < lines.length; j++) {
+    let trailingText = '';
+    outer: for (; j < lines.length; j++) {
       const scanLine = j === i ? rest : lines[j];
-      for (const ch of scanLine) {
+      for (let k = 0; k < scanLine.length; k++) {
+        const ch = scanLine[k];
         if (escapeNext) {
           escapeNext = false;
           continue;
@@ -133,11 +137,15 @@ function stripAtFormatToolCalls(content: string): string {
         } else if (ch === '}') {
           depth--;
         }
+        if (sawOpen && depth <= 0) {
+          trailingText = scanLine.slice(k + 1).trim();
+          j++;
+          break outer;
+        }
       }
-      if (sawOpen && depth <= 0) {
-        j++;
-        break;
-      }
+    }
+    if (trailingText) {
+      out.push(trailingText);
     }
     i = j;
   }


### PR DESCRIPTION
## Summary

Implements gptme/gptme-cloud#840: adds a **Copy** button to the conversation export panel (Chat Settings → Export) that writes the full conversation to the clipboard as Markdown.

This directly solves the bug Erik reported: manual select-all fails because the virtualized message list unmounts older elements as you scroll, so the clipboard only gets the currently-rendered slice. The copy reads from the **conversation store**, not the DOM, so the entire trajectory is always captured.

### New UI

- **Copy button** with checkmark (✓) feedback for 2 seconds after copying
- **Include thinking blocks** toggle (default: off) — strips `<thinking>`/`<think>` reasoning blocks for cleaner output
- **Include tool calls & results** toggle (default: on) — drops tool messages when off
- **Download .md** / **Download .json** buttons (renamed from "Markdown" / "JSON")
- Secrets note under the export section

Both toggles apply to the Copy button and the Download .md button. The JSON export is unchanged (it's for re-import, not sharing).

### Changes

- `webui/src/utils/exportConversation.ts`: added `includeThinking` and `includeTools` options to `ExportMarkdownOptions`; new `copyConversationToClipboard()` async function; `stripThinkingBlocks()` helper
- `webui/src/components/ConversationSettings.tsx`: Copy button + checkmark feedback, detail-level toggle switches, renamed download buttons, secrets note
- `webui/src/utils/__tests__/exportConversation.test.ts`: 37 tests (25 existing + 12 new covering thinking/tool filtering and clipboard copy)

## Related

- Closes gptme/gptme-cloud#840
- Supersedes gptme/gptme#3465 (prior attempt with unrelated changes bundled in)