### PR TITLE
fix(server): prevent spurious LLM continuation when interrupt races tool execution

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -405,6 +405,7 @@ def api_conversation_step(conversation_id: str):
             start_acp_health_monitor()
         session.generating = True
         session.generating_since = datetime.now(tz=timezone.utc)
+        session.step_seq += 1
 
     # Wrap setup in try/finally so any unexpected exception (get_default_model,
     # config I/O, etc.) resets the flag rather than leaving the session
@@ -716,6 +717,7 @@ def api_conversation_tool_confirm(conversation_id: str):
 
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            session.step_seq += 1
             try:
                 current_tool.status = ToolStatus.SKIPPED
                 session.pending_tools.pop(tool_id)
@@ -910,6 +912,7 @@ def api_conversation_rerun(conversation_id: str):
         if first_auto_id is not None:
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            session.step_seq += 1
             start_tool_execution(
                 conversation_id,
                 session,
@@ -1143,7 +1146,8 @@ def api_conversation_interrupt(conversation_id: str):
             with sess.step_lock:
                 if sess.generating or sess.pending_tools:
                     interrupted = True
-                # Mark session as not generating and clear pending tools
+                # Revoke in-flight tool and step workers before clearing state.
+                sess.step_seq += 1
                 sess.generating = False
                 sess.generating_since = None
                 sess.pending_tools.clear()

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -87,6 +87,9 @@ class ConversationSession(BaseSession):
     # results. Used to prevent the continuation step from starting before all
     # concurrent tool threads have finished writing.
     _executing_tools: set[str] = field(default_factory=set)
+    # Monotonic generation-reservation token. Interrupts and successors advance
+    # it so delayed workers cannot act on a reservation they no longer own.
+    step_seq: int = 0
     auto_confirm_count: int = 0
     clients: set[str] = field(default_factory=set)
     event_flag: threading.Event = field(default_factory=threading.Event)

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -638,6 +638,8 @@ def step(
     branch: str = "main",
     auto_confirm: bool = False,
     stream: bool = True,
+    *,
+    reservation_seq: int | None = None,
 ) -> None:
     """
     Generate a response and detect tools.
@@ -657,7 +659,29 @@ def step(
         branch: Branch to use (default: "main")
         auto_confirm: Whether to auto-confirm tools (default: False)
         stream: Whether to stream the response (default: True)
+        reservation_seq: Sequence token captured by the spawning thread. Direct
+            synchronous callers may omit it to snapshot the current reservation.
     """
+
+    my_step_seq = session.step_seq if reservation_seq is None else reservation_seq
+
+    def release_generation() -> None:
+        """Release this worker's reservation without clobbering a successor."""
+        with session.step_lock:
+            if session.step_seq == my_step_seq:
+                session.generating = False
+                session.generating_since = None
+
+    # Check the spawning reservation before hooks, writes, events, or LLM calls.
+    with session.step_lock:
+        if session.step_seq != my_step_seq or not session.generating:
+            logger.debug(
+                "step(): aborting setup — session %s reservation was revoked",
+                session.id,
+            )
+            if session.step_seq == my_step_seq:
+                session.generating_since = None
+            return
 
     # Load chat config and prepare execution environment
     logdir = get_logs_dir() / conversation_id
@@ -687,8 +711,7 @@ def step(
         _persist_generation_error(manager, session, str(e))
         SessionManager.add_event(conversation_id, ws_error_event)
         session.last_error = str(e)
-        session.generating = False
-        session.generating_since = None
+        release_generation()
         return
 
     # Set the model as default before triggering hooks
@@ -771,8 +794,7 @@ def step(
             "error": "No messages to process",
         }
         SessionManager.add_event(conversation_id, error_event)
-        session.generating = False
-        session.generating_since = None
+        release_generation()
         return
 
     # Notify clients about generation status
@@ -970,8 +992,7 @@ def step(
             conversation_id, {"type": "error", "error": error_message}
         )
     finally:
-        session.generating = False
-        session.generating_since = None
+        release_generation()
 
 
 def start_tool_execution(
@@ -999,10 +1020,16 @@ def start_tool_execution(
     branch.  Defaults to ``"main"`` to match the default in ``step()``.
     """
 
+    # Capture ownership before the worker starts. Interrupt + a successor step
+    # must not let this worker inherit the successor's reservation.
+    my_step_seq = session.step_seq
+
     # This function would ideally run asynchronously to not block the request
     # For simplicity, we'll run it in a thread
     @trace_function("api_v2.execute_tool", attributes={"component": "api_v2"})
     def execute_tool_thread() -> None:
+        continuation_seq: int | None = None
+
         # Set context vars for hook-based confirmation
         from ..hooks import current_conversation_id, current_session_id
 
@@ -1214,18 +1241,26 @@ def start_tool_execution(
             # and generation reservation one atomic state transition.
             start_continuation = False
             with SessionManager.conversation_lock(conversation_id), session.step_lock:
-                if not session.pending_tools and not session._executing_tools:
-                    if reserved:
-                        start_continuation = True
-                    elif not SessionManager.conversation_generating(
-                        conversation_id
-                    ) and not SessionManager.command_is_active(conversation_id):
+                if session.step_seq != my_step_seq:
+                    logger.debug(
+                        "Not starting continuation step for %s: reservation revoked",
+                        conversation_id,
+                    )
+                elif not session.pending_tools and not session._executing_tools:
+                    if reserved and not session.generating:
+                        logger.debug(
+                            "Not starting continuation step for %s: interrupted",
+                            conversation_id,
+                        )
+                    else:
+                        session.step_seq += 1
+                        continuation_seq = session.step_seq
                         session.generating = True
                         session.generating_since = datetime.now(tz=timezone.utc)
                         start_continuation = True
                 elif reserved:
                     # Pending non-auto-confirm tools remain; those need explicit
-                    # confirmation. Release the pre-reserved generation slot.
+                    # confirmation. Release only this worker's reservation.
                     session.generating = False
                     session.generating_since = None
 
@@ -1242,12 +1277,11 @@ def start_tool_execution(
             logger.exception(
                 f"Unhandled error in tool execution thread for {conversation_id}"
             )
-            if reserved:
-                # A crash anywhere before the reservation is transferred to
-                # _start_step_thread (or explicitly released above) must not
-                # permanently strand the conversation in a generating state.
-                session.generating = False
-                session.generating_since = None
+            if continuation_seq is None:
+                with session.step_lock:
+                    if session.step_seq == my_step_seq:
+                        session.generating = False
+                        session.generating_since = None
             raise
 
     # Propagate ContextVars from the request context into the execution thread.
@@ -1282,6 +1316,9 @@ def _start_step_thread(
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            session.step_seq += 1
+
+    reservation_seq = session.step_seq
     session.last_error = None
 
     def step_thread() -> None:
@@ -1300,6 +1337,7 @@ def _start_step_thread(
             branch=branch,
             auto_confirm=auto_confirm,
             stream=stream,
+            reservation_seq=reservation_seq,
         )
 
     # Propagate ContextVars (model, config) from the caller into the step thread.

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1078,11 +1078,13 @@ def start_tool_execution(
                         f"Tool {current_tool_id} not found in pending tools "
                         "(may have been handled by another thread)"
                     )
-                    # Release any pre-reserved generation slot so the conversation
-                    # is not permanently blocked.
+                    # Release only this worker's pre-reserved slot. Interrupt or
+                    # another worker may already have transferred ownership.
                     if reserved:
-                        session.generating = False
-                        session.generating_since = None
+                        with session.step_lock:
+                            if session.step_seq == my_step_seq:
+                                session.generating = False
+                                session.generating_since = None
                     return  # another thread claimed this tool; don't trigger auto-step
                 # The claim is registered above but the try/finally that releases
                 # it only starts below, so anything that raises in between (most

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1265,14 +1265,23 @@ def start_tool_execution(
                     session.generating_since = None
 
             if start_continuation:
-                _start_step_thread(
-                    conversation_id,
-                    session,
-                    model,
-                    chat_config.workspace,
-                    branch=branch,
-                    reserved=True,
-                )
+                try:
+                    _start_step_thread(
+                        conversation_id,
+                        session,
+                        model,
+                        chat_config.workspace,
+                        branch=branch,
+                        reserved=True,
+                    )
+                except BaseException:
+                    # Thread creation/start failed before the continuation could
+                    # assume ownership. Release exactly the transferred token.
+                    with session.step_lock:
+                        if session.step_seq == continuation_seq:
+                            session.generating = False
+                            session.generating_since = None
+                    raise
         except Exception:
             logger.exception(
                 f"Unhandled error in tool execution thread for {conversation_id}"

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1752,3 +1752,118 @@ class TestTranscriptEndpointInputValidation:
         data = response.get_json()
         assert data is not None
         assert "call_sid" in data["error"]
+
+
+# --- Interrupt reservation ownership tests ---
+
+
+class TestInterruptReservationOwnership:
+    """Interrupted workers cannot continue under a successor's reservation."""
+
+    def test_stale_worker_does_not_adopt_successor_reservation(
+        self, conv, client: FlaskClient
+    ):
+        """A delayed step keeps the token captured by its spawning thread."""
+        from pathlib import Path
+
+        from gptme.server.session_step import _start_step_thread
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        session.generating = True
+        session.step_seq += 1
+        stale_seq = session.step_seq
+
+        worker_started = threading.Event()
+        release_worker = threading.Event()
+        worker_finished = threading.Event()
+
+        def delayed_context_run(callback):
+            worker_started.set()
+            release_worker.wait(timeout=5)
+            try:
+                callback()
+            finally:
+                worker_finished.set()
+
+        with (
+            patch("gptme.server.session_step.contextvars.copy_context") as copy_context,
+            patch("gptme.server.session_step.ChatConfig.load_or_create") as config,
+            patch("gptme.server.session_step.trigger_hook") as trigger_hook,
+            patch("gptme.server.session_step.SessionManager.add_event") as add_event,
+            patch("gptme.server.session_step._stream") as stream,
+        ):
+            copy_context.return_value.run.side_effect = delayed_context_run
+            assert _start_step_thread(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                model="mock/model",
+                workspace=Path("/tmp"),
+                reserved=True,
+            )
+            assert worker_started.wait(timeout=5)
+
+            # Match interrupt followed by a fresh /step reservation.
+            with session.step_lock:
+                session.step_seq += 1
+                session.generating = False
+                session.step_seq += 1
+                successor_seq = session.step_seq
+                session.generating = True
+            release_worker.set()
+            assert worker_finished.wait(timeout=5)
+
+        assert stale_seq != successor_seq
+        assert session.step_seq == successor_seq
+        assert session.generating is True
+        config.assert_not_called()
+        trigger_hook.assert_not_called()
+        add_event.assert_not_called()
+        stream.assert_not_called()
+
+    def test_unreserved_interrupt_does_not_dispatch_continuation(
+        self, conv, client: FlaskClient
+    ):
+        """Interrupt revocation blocks the auto-confirm tool continuation path."""
+        from pathlib import Path
+
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        session.generating = True
+        tool_id = "test-interrupted-unreserved-tool"
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id, tooluse=ToolUse("shell", [], "echo ok")
+        )
+        chat_config = ChatConfig()
+        chat_config.workspace = Path("/tmp")
+
+        def fake_execute(**kwargs):
+            with session.step_lock:
+                session.step_seq += 1
+                session.generating = False
+                session.generating_since = None
+                session.pending_tools.clear()
+            return []
+
+        with (
+            patch("gptme.server.session_step._start_step_thread") as start_step,
+            patch.object(ToolUse, "execute", side_effect=fake_execute),
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch("gptme.server.session_step.SessionManager.add_event"),
+        ):
+            thread = start_tool_execution(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                tool_id=tool_id,
+                edited_tooluse=None,
+                model="mock/model",
+                chat_config=chat_config,
+            )
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        start_step.assert_not_called()
+        assert session.generating is False

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1867,3 +1867,45 @@ class TestInterruptReservationOwnership:
         assert not thread.is_alive()
         start_step.assert_not_called()
         assert session.generating is False
+
+    def test_failed_continuation_dispatch_releases_transferred_reservation(
+        self, conv, client: FlaskClient
+    ):
+        """A thread-start failure cannot strand the successor reservation."""
+        from pathlib import Path
+
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        session.generating = True
+        tool_id = "test-failed-continuation-dispatch"
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id, tooluse=ToolUse("shell", [], "echo ok")
+        )
+        chat_config = ChatConfig()
+        chat_config.workspace = Path("/tmp")
+
+        with (
+            patch(
+                "gptme.server.session_step._start_step_thread",
+                side_effect=RuntimeError("thread start failed"),
+            ),
+            patch.object(ToolUse, "execute", return_value=[]),
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch("gptme.server.session_step.SessionManager.add_event"),
+        ):
+            thread = start_tool_execution(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                tool_id=tool_id,
+                edited_tooluse=None,
+                model="mock/model",
+                chat_config=chat_config,
+            )
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert session.generating is False
+        assert session.generating_since is None

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1909,3 +1909,57 @@ class TestInterruptReservationOwnership:
         assert not thread.is_alive()
         assert session.generating is False
         assert session.generating_since is None
+
+    def test_stale_missing_tool_worker_preserves_successor_reservation(
+        self, conv, client: FlaskClient
+    ):
+        """A stale reserved worker cannot clear a newer step's reservation."""
+        from pathlib import Path
+
+        from gptme.config import ChatConfig
+        from gptme.server.session_step import start_tool_execution
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        session.generating = True
+        session.step_seq += 1
+        worker_seq = session.step_seq
+        tool_id = "test-missing-tool-after-successor"
+        session.pending_tools[tool_id] = ToolExecution(
+            tool_id=tool_id, tooluse=ToolUse("shell", [], "echo ok")
+        )
+        chat_config = ChatConfig()
+        chat_config.workspace = Path("/tmp")
+        release_prepare = threading.Event()
+        prepare_entered = threading.Event()
+
+        def delayed_prepare(**kwargs):
+            prepare_entered.set()
+            release_prepare.wait(timeout=5)
+
+        with patch(
+            "gptme.server.session_step.prepare_execution_environment",
+            side_effect=delayed_prepare,
+        ):
+            thread = start_tool_execution(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                tool_id=tool_id,
+                edited_tooluse=None,
+                model="mock/model",
+                chat_config=chat_config,
+                reserved=True,
+            )
+            assert prepare_entered.wait(timeout=5)
+            with session.step_lock:
+                session.pending_tools.clear()
+                session.step_seq += 1
+                successor_seq = session.step_seq
+                session.generating = True
+            release_prepare.set()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert worker_seq != successor_seq
+        assert session.step_seq == successor_seq
+        assert session.generating is True


### PR DESCRIPTION
## Problem

When a user interrupts while an auto-confirm tool is still executing, the tool worker can finish after `/interrupt` clears generation state and incorrectly start a new LLM continuation. A bare `generating` boolean cannot distinguish normal tool completion from interruption, and a delayed step worker can otherwise observe a newer request's reservation and act as if it owns it.

The result is an unwanted LLM API call, a spurious `[INTERRUPTED]` assistant message, or duplicate generation side effects under a successor request. This is the auto-confirm sibling of the concurrent manual-confirm race fixed in #3481.

## Fix

Generation reservations now carry a monotonic `step_seq` ownership token:

- `/step`, skip/rerun continuations, and tool handoffs advance the token when they reserve generation.
- `/interrupt` advances it before clearing generation state, revoking every in-flight worker.
- `_start_step_thread` captures the token in the spawning thread and passes it into `step()`, so a delayed worker cannot adopt a successor reservation.
- `step()` checks ownership before hooks, persistence, lifecycle events, or LLM calls, and only releases the token it owns.
- Tool completion checks the same token before dispatching a continuation, including the unreserved auto-confirm path.
- If continuation thread dispatch itself fails, the transferred token is released instead of stranding `generating=True`.

## Tests

Focused reservation regressions cover:

- interrupt before a delayed step worker enters `step()`;
- interrupt followed by a successor `/step` reservation before the stale worker starts;
- interrupt during an unreserved auto-confirm tool;
- failed continuation-thread dispatch cleanup;
- uninterrupted continuation and fast-tool ownership transfer.

The existing concurrent-confirmation suite from #3481 also remains green after the rebase.

## Related

- #3479 — concurrent tool-confirm race (separate bug, same area)

