### PR TITLE
fix(llm): flatten array tool-result content for DeepSeek via OpenRouter

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1770,6 +1770,11 @@ def _transform_msgs_for_special_provider(
     if (model.provider == "openrouter" and model.supports_reasoning) or (
         preserve_all_reasoning
     ):
+        # DeepSeek models routed through OpenRouter also require string (not
+        # array) content on tool-result messages — same strictness as direct
+        # deepseek provider.  Detected by the OpenRouter model namespace prefix.
+        needs_string_tool_content = model.model.startswith("deepseek/")
+
         openrouter_result: list[MessageDict] = []
         for msg in messages_dicts:
             if (
@@ -1803,6 +1808,31 @@ def _transform_msgs_for_special_provider(
                     # rejects messages with empty text content)
                     openrouter_msg.pop("content", None)
                 openrouter_result.append(cast(MessageDict, openrouter_msg))
+            elif (
+                needs_string_tool_content
+                and msg.get("role") == "tool"
+                and isinstance(msg.get("content"), list)
+            ):
+                # Flatten array tool-result content to string.
+                # _merge_tool_results_with_same_call_id emits list-form content
+                # when a tool call yields multiple messages (e.g. stdout + stderr).
+                # DeepSeek rejects this with invalid_request; flatten to a plain
+                # string here, consistent with how the direct deepseek provider
+                # branch handles it above.
+                content_list: list[Any] = msg["content"]
+                text_parts_tool = [
+                    part["text"]
+                    for part in content_list
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ]
+                flattened = (
+                    "\n\n".join(text_parts_tool)
+                    if text_parts_tool
+                    else "[non-text content]"
+                )
+                openrouter_result.append(
+                    cast(MessageDict, {**msg, "content": flattened})
+                )
             else:
                 openrouter_result.append(cast(MessageDict, msg))
         return openrouter_result

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1497,6 +1497,85 @@ def test_transform_msgs_for_deepseek_tool_results():
     assert result[0] == messages[0]
 
 
+def test_transform_msgs_for_openrouter_deepseek_array_tool_content():
+    """Test that array-form tool result content is flattened for DeepSeek via OpenRouter.
+
+    When _merge_tool_results_with_same_call_id merges multiple tool messages
+    (e.g. stdout + stderr from pip install) it produces list-form content:
+        {"role": "tool", "content": [{"type": "text", "text": "..."}, ...]}
+
+    Direct deepseek provider handles this in the groq/deepseek branch.
+    But deepseek-v4-flash arrives as provider="openrouter", so that branch is
+    skipped and the array reaches DeepSeek, which rejects it with invalid_request.
+
+    Regression test: gptme/gptme#3459 (6 invalid_request failures in 14 days).
+    """
+    from typing import Any
+
+    from gptme.llm.llm_openai import _transform_msgs_for_special_provider
+    from gptme.llm.models import ModelMeta
+
+    # deepseek/deepseek-v4-flash is registered under provider="openrouter" in data.py
+    openrouter_deepseek = ModelMeta(
+        provider="openrouter",
+        model="deepseek/deepseek-v4-flash",
+        context=1_000_000,
+        supports_reasoning=True,
+    )
+
+    # Array-form tool content as produced by _merge_tool_results_with_same_call_id
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_abc",
+            "content": [
+                {"type": "text", "text": "stdout: installing numpy"},
+                {"type": "text", "text": "stderr: WARNING: running as root"},
+            ],
+        },
+    ]
+
+    result = list(_transform_msgs_for_special_provider(messages, openrouter_deepseek))
+
+    # Array content must be flattened to a string — DeepSeek rejects list form
+    assert result[0]["role"] == "tool"
+    assert result[0]["tool_call_id"] == "call_abc"
+    assert isinstance(result[0]["content"], str)
+    assert "stdout: installing numpy" in result[0]["content"]
+    assert "stderr: WARNING: running as root" in result[0]["content"]
+
+
+def test_transform_msgs_for_openrouter_non_deepseek_array_tool_content_unchanged():
+    """Non-DeepSeek OpenRouter models (e.g. Kimi) pass array tool content through unchanged."""
+    from typing import Any
+
+    from gptme.llm.llm_openai import _transform_msgs_for_special_provider
+    from gptme.llm.models import ModelMeta
+
+    # A non-DeepSeek OpenRouter model that also has supports_reasoning=True
+    openrouter_kimi = ModelMeta(
+        provider="openrouter",
+        model="moonshot/moonshot-v1-8k",
+        context=8192,
+        supports_reasoning=True,
+    )
+
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_xyz",
+            "content": [
+                {"type": "text", "text": "result text"},
+            ],
+        },
+    ]
+
+    result = list(_transform_msgs_for_special_provider(messages, openrouter_kimi))
+
+    # Non-DeepSeek OpenRouter models: array content passes through unchanged
+    assert result[0]["content"] == messages[0]["content"]
+
+
 def test_transform_msgs_for_deepseek_reasoner_think_content_string():
     """Test that deepseek-reasoner assistant messages with <think> content and tool_calls
     get <think> extracted into reasoning_content, not embedded in content.


### PR DESCRIPTION
## Problem

`_merge_tool_results_with_same_call_id` produces list-form `content` when a single tool call yields multiple messages (e.g. stdout + stderr from `pip install`):

```python
{"role": "tool", "content": [{"type": "text", "text": "..."}, {"type": "text", "text": "..."}]}
```

The existing `groq`/`deepseek` branch in `_transform_msgs_for_special_provider` flattens this to a string. But `deepseek/deepseek-v4-flash` is registered under `provider="openrouter"` in `models/data.py`, so that branch never fires. DeepSeek rejects the array form with `invalid_request`.

Harness diagnostic confirms: 6 `invalid_request` failures in 14 days for `gptme:deepseek-v4-flash` across code/content/cross-repo sessions.

## Fix

Inside the OpenRouter reasoning handler, detect DeepSeek-namespace models (`model.model.startswith("deepseek/")`) and flatten array tool-result content to a plain string — consistent with what the direct deepseek provider branch already does.

## Tests

Two new unit tests in `test_llm_openai.py`:
- `test_transform_msgs_for_openrouter_deepseek_array_tool_content`: confirms array → string for `openrouter` + `deepseek/*` model
- `test_transform_msgs_for_openrouter_non_deepseek_array_tool_content_unchanged`: confirms non-DeepSeek OpenRouter models are unaffected

All 123 existing `test_llm_openai.py` tests pass.

Closes #3459