### PR TITLE
fix(gh): substitute owner/repo in per-job log-fetch fallback so run-view logs are reachable

### DIFF
--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -1204,12 +1204,22 @@ def get_github_run_logs(
 
                 output += f"\n```\n{extracted}\n```\n"
             else:
-                # Fallback: try per-job log via API
+                # Fallback: try per-job log via API.
+                # Derive owner/repo from the run URL (e.g.
+                # https://github.com/owner/repo/actions/runs/12345) so the
+                # jobs-logs endpoint is reachable; the URL needs the real
+                # values, not {owner}/{repo} placeholders.
+                owner, repo = "", ""
+                if url:
+                    parts = urllib.parse.urlparse(url).path.strip("/").split("/")
+                    if len(parts) >= 2:
+                        owner, repo = parts[0], parts[1]
+
                 api_result = subprocess.run(
                     [
                         "gh",
                         "api",
-                        f"/repos/{{owner}}/{{repo}}/actions/jobs/{job_id}/logs",
+                        f"/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
                     ],
                     capture_output=True,
                     text=True,

--- a/tests/test_util_gh.py
+++ b/tests/test_util_gh.py
@@ -746,6 +746,66 @@ class TestGetGithubRunLogs:
 
     @patch("gptme.util.gh.shutil.which", return_value="/usr/bin/gh")
     @patch("gptme.util.gh.subprocess.run")
+    def test_per_job_api_fallback_substitutes_owner_repo(self, mock_run, _mock_which):
+        """Per-job API fallback substitutes real owner/repo into the path.
+
+        Regression: the fallback built the gh api path with an f-string that
+        had literal ``{owner}``/``{repo}`` braces (``{{owner}}``), so the call
+        always 404'd and the user saw "Could not fetch logs" instead of the
+        real per-job logs. owner/repo must be derived from the run URL.
+        """
+        jobs = [self._make_job("test", "failure", 200)]
+        run_json = self._make_run_json("failure", jobs)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["gh", "run"] and "--json" in cmd:
+                return MagicMock(stdout=run_json, returncode=0)
+            if cmd[:2] == ["gh", "run"] and "--log-failed" in cmd:
+                # Empty -> triggers the per-job API fallback.
+                return MagicMock(stdout="", returncode=1)
+            if cmd[:2] == ["gh", "api"]:
+                path = cmd[2]
+                # The fix must substitute real owner/repo — no literal braces.
+                assert "{owner}" not in path, f"literal {{owner}} in path: {path}"
+                assert "{repo}" not in path, f"literal {{repo}} in path: {path}"
+                if path == "/repos/owner/repo/actions/jobs/200/logs":
+                    return MagicMock(stdout="ERROR: real per-job log\n", returncode=0)
+                return MagicMock(stdout="", returncode=1)
+            return MagicMock(stdout="", returncode=1)
+
+        mock_run.side_effect = fake_run
+
+        result = get_github_run_logs("12345")
+        assert result is not None
+        assert "real per-job log" in result
+        assert "Could not fetch logs" not in result
+
+    @patch("gptme.util.gh.shutil.which", return_value="/usr/bin/gh")
+    @patch("gptme.util.gh.subprocess.run")
+    def test_per_job_api_fallback_missing_url_degrades(self, mock_run, _mock_which):
+        """Fallback degrades to 'Could not fetch logs' when the run URL is empty.
+
+        Guards the owner/repo extraction: a missing ``url`` leaves owner/repo
+        blank, the gh api call 404s, and the existing failure message is shown
+        (no crash — same outcome as the pre-fix always-404 behaviour).
+        """
+        jobs = [self._make_job("test", "failure", 200)]
+        run_data = json.loads(self._make_run_json("failure", jobs))
+        run_data["url"] = ""
+        run_json = json.dumps(run_data)
+
+        mock_run.side_effect = [
+            MagicMock(stdout=run_json, returncode=0),  # gh run view --json
+            MagicMock(stdout="", returncode=1),  # gh run view --log-failed (empty)
+            MagicMock(stdout="", returncode=1),  # gh api fallback 404s
+        ]
+
+        result = get_github_run_logs("12345")
+        assert result is not None
+        assert "Could not fetch logs" in result
+
+    @patch("gptme.util.gh.shutil.which", return_value="/usr/bin/gh")
+    @patch("gptme.util.gh.subprocess.run")
     def test_no_jobs_available(self, mock_run, _mock_which):
         """Run with empty jobs list."""
         mock_run.return_value = MagicMock(


### PR DESCRIPTION
## 1. Root cause

In `get_github_run_logs`, the per-job fallback (fires when `gh run view --log-failed`
returns empty for a failed job) built the `gh api` path as an f-string with escaped
double braces:

```python
f"/repos/{{owner}}/{{repo}}/actions/jobs/{job_id}/logs"
```

In an f-string `{{owner}}` renders to the **literal** `{owner}` (the braces are
escaped, not a substitution), and there were no `owner`/`repo` variables in scope
anyway. So the runtime call was always:

```
gh api "/repos/{owner}/{repo}/actions/jobs/<job_id>/logs"
```

→ GitHub returns **404** for every run → the user always sees

> `Could not fetch logs. Try: gh run view <run_id> --log-failed`

instead of the real per-job logs. The run URL needed to recover `owner`/`repo`
was already in scope (`url = run_data.get("url", "")` at `gh.py:1101`, format
`https://github.com/<owner>/<repo>/actions/runs/<id>`), but never used.

Latent since PR #1837 introduced `gh run view`. The existing test
`test_failed_run_log_fetch_fails` masked the bug: it mocked the fallback to
`returncode=1` unconditionally and never inspected the URL it was called with.

## 2. The fix

`gptme/util/gh.py`, per-job `else` fallback (~line 1206): derive `owner`/`repo`
from the in-scope run `url` using the module's existing `urlparse` idiom (same
pattern already used by `_get_repo_from_git_remote:269` and `parse_github_url:347`),
then build the path with the real values. Control flow otherwise unchanged; when
the URL is missing/malformed, `owner`/`repo` stay `""` → path 404s → falls through
to the existing `else` → unchanged "Could not fetch logs" message (graceful
degradation, equivalent to the old always-404 outcome).

```diff
             else:
-                # Fallback: try per-job log via API
+                # Fallback: try per-job log via API.
+                # Derive owner/repo from the run URL (e.g.
+                # https://github.com/owner/repo/actions/runs/12345) so the
+                # jobs-logs endpoint is reachable; the URL needs the real
+                # values, not {owner}/{repo} placeholders.
+                owner, repo = "", ""
+                if url:
+                    parts = urllib.parse.urlparse(url).path.strip("/").split("/")
+                    if len(parts) >= 2:
+                        owner, repo = parts[0], parts[1]
+
                 api_result = subprocess.run(
                     [
                         "gh",
                         "api",
-                        f"/repos/{{owner}}/{{repo}}/actions/jobs/{job_id}/logs",
+                        f"/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
                     ],
                     capture_output=True,
                     text=True,
                     check=False,
                     timeout=60,
                 )
```

`urllib.parse` is already imported (`gh.py:12`); no new imports.

## 3. Red-before-green evidence

### RED — new test on unmodified `master` code

Command:

```
poetry run pytest tests/test_util_gh.py::TestGetGithubRunLogs::test_per_job_api_fallback_substitutes_owner_repo -v
```

Captured failure (the test's `assert "{owner}" not in path` trips on the literal
braces the buggy f-string produced):

```
cmd = ['gh', 'api', '/repos/{owner}/{repo}/actions/jobs/200/logs']
kwargs = {'capture_output': True, 'text': True, 'check': False, 'timeout': 60}

    def fake_run(cmd, **kwargs):
        ...
        if cmd[:2] == ["gh", "api"]:
            path = cmd[2]
>           assert "{owner}" not in path, f"literal {{owner}} in path: {path}"
E           AssertionError: literal {owner} in path: /repos/{owner}/{repo}/actions/jobs/200/logs
E           assert '{owner}' not in '/repos/{own...obs/200/logs'

tests/test_util_gh.py:769: AssertionError
========================= 1 failed in 1.49s =========================
```

### GREEN — full class after fix

Command:

```
poetry run pytest tests/test_util_gh.py::TestGetGithubRunLogs -v
```

```
collected 9 items

tests/test_util_gh.py::TestGetGithubRunLogs::test_no_gh_returns_none PASSED [ 11%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_success_run_no_failures PASSED [ 22%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_failed_run_with_logs PASSED [ 33%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_multiple_failed_jobs_fetch_logs_once PASSED [ 44%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_failed_run_log_fetch_fails PASSED [ 55%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_per_job_api_fallback_substitutes_owner_repo PASSED [ 66%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_per_job_api_fallback_missing_url_degrades PASSED [ 77%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_no_jobs_available PASSED [ 88%]
tests/test_util_gh.py::TestGetGithubRunLogs::test_run_header_fields PASSED [100%]

============================== 9 passed in 0.21s ==============================
```

Two new tests added:
- `test_per_job_api_fallback_substitutes_owner_repo` (the required regression
  guard): `side_effect` asserts `{owner}`/`{repo}` are absent from the API path,
  returns `stdout="ERROR: real per-job log\n"` **only** when the path equals
  `/repos/owner/repo/actions/jobs/200/logs`, and asserts the result contains
  "real per-job log" (and does NOT contain "Could not fetch logs"). Fails on
  master (literal braces), passes after the fix.
- `test_per_job_api_fallback_missing_url_degrades` (locks in the new
  `if url:`/`len(parts) >= 2` guard): empty run `url` → owner/repo blank →
  `gh api` 404 → existing "Could not fetch logs" message, no crash.

## 4. Gate

Per `projects/gptme.md`: GATE = `make test`; companions `make lint` (ruff) and
`make typecheck` (mypy).

**Touched files (ruff check + ruff format + mypy):**

```
$ poetry run ruff check gptme/util/gh.py tests/test_util_gh.py
All checks passed!
$ poetry run ruff format --check gptme/util/gh.py tests/test_util_gh.py
2 files already formatted
$ poetry run mypy gptme/util/gh.py tests/test_util_gh.py --ignore-missing-imports
Success: no issues found in 2 source files
```

> Note: this worktree was bootstrapped with a minimal `poetry install` (no `-E all`),
> so repo-wide `make typecheck` reports pre-existing `import-not-found` errors for
> optional extras (`textual`, `torch`, `prometheus_client`, `flask_compress`,
> `werkzeug.exceptions`, `sentence_transformers`) and 2 type errors in
> `gptme/tui/app.py` — **none** in `gptme/util/gh.py` or `tests/test_util_gh.py`
> (confirmed: `make typecheck 2>&1 | grep -E "gh\.py|test_util_gh\.py"` → no
> matches). Likewise `make lint` pylint R0801 duplicate-code findings are all in
> `gptme/eval/` and `gptme/acp/`, not the touched files. These are environmental,
> not introduced by this change.

## 5. Adversarial review (3-lens swarm, all green)

Three independent fresh-context lenses reviewed the diff; all returned a clean
pass with **zero confirmed defects**:

- **Logic / edge-cases / security** — APPROVE. Empirically traced standard URL
  extraction, trailing slash, empty/missing `url`, single-segment/garbage URL,
  and `..`-style paths. Empty `url` → `/repos///...` → 404 → existing
  "Could not fetch logs" branch (no regression vs. old always-404). No shell
  injection (list-form `subprocess.run`, segments can't contain `/`). Happy path
  untouched. Non-defect note: no `netloc == "github.com"` guard, which is
  actually fine here since `url` is trusted `gh run view --json` output with a
  fixed shape (and more correct for GitHub Enterprise path shape).
- **Behavior-equivalence** — PASS. Enumerated all 6 paths (happy path, valid-url
  fallback = the single intended delta, empty-url fallback ≡ old always-404,
  unchanged message text, unchanged truncation, unchanged loop). Strict 1:1
  scoped change, no leak into any other path.
- **Test-coverage** — ship as-is. New test is a genuine red-on-buggy /
  green-on-fixed guard (triple barrier: two in-mock `{owner}`/`{repo}` asserts +
  exact path match + negative "Could not fetch logs" assert — cannot pass for the
  wrong reason). `test_failed_run_log_fetch_fails` remains correct (not a
  regression guard, but not incorrect). No must-add gaps; the empty-url
  degradation test was added as a nice-to-have.

Independent empirical re-check (the author's) over 4 url shapes — all degrade
safely, no crash:

```
[empty url]                api_path='/repos///actions/jobs/200/logs'      -> "Could not fetch logs"
[normal url, api fails]    api_path='/repos/owner/repo/actions/jobs/200/logs' -> "Could not fetch logs"
[garbage single-segment]   api_path='/repos///actions/jobs/200/logs'      -> "Could not fetch logs"
[no runs suffix]           api_path='/repos/owner/repo/actions/jobs/200/logs' -> "Could not fetch logs"
```

## 6. PR body

```
## Summary
Fixes the per-job log-fetch fallback in `get_github_run_logs` so run-view logs are
actually reachable instead of always 404'ing.

## Motivation / Root cause
When `gh run view --log-failed` returns empty for a failed job, `get_github_run_logs`
falls back to fetching the per-job log via `gh api`. That fallback built the API path
as `f"/repos/{{owner}}/{{repo}}/actions/jobs/{job_id}/logs"`. The escaped double
braces render to the literal `{owner}`/`{repo}`, and those names were never
variables in scope — so every fallback call hit
`/repos/{owner}/{repo}/actions/jobs/<id>/logs` and 404'd. The user therefore always
saw "Could not fetch logs. Try: `gh run view <run_id> --log-failed`" instead of the
real per-job logs. The `owner`/`repo` were recoverable from the run `url` already in
scope (`https://github.com/<owner>/<repo>/actions/runs/<id>`), but unused. Latent
since #1837 introduced `gh run view`.

## Change
- `gptme/util/gh.py`: in the per-job fallback, derive `owner`/`repo` from the run
  `url` via the module's existing `urllib.parse.urlparse(...).path` idiom (same as
  `_get_repo_from_git_remote` and `parse_github_url`) and build the path with the
  real values. Control flow is otherwise unchanged; if the URL is missing/malformed,
  `owner`/`repo` stay empty, the path 404's, and the existing "Could not fetch logs"
  branch fires (graceful, equivalent to the old always-404 outcome). Happy path and
  all other functions untouched.
- `tests/test_util_gh.py`: add `test_per_job_api_fallback_substitutes_owner_repo`
  (the regression guard — mocks `gh run view --json` with a run whose `url` is
  `https://github.com/owner/repo/actions/runs/12345`, mocks `--log-failed` empty to
  force the fallback, and asserts via a `side_effect` that the `gh api` path contains
  no literal `{owner}`/`{repo}` and equals
  `/repos/owner/repo/actions/jobs/200/logs`, returning the per-job log only for that
  path; fails on master, passes after the fix) and
  `test_per_job_api_fallback_missing_url_degrades` (empty run `url` → graceful
  "Could not fetch logs", no crash).

## Tests
`poetry run pytest tests/test_util_gh.py::TestGetGithubRunLogs -v` → 9 passed
(2 new: the substitution guard + the missing-url degradation path; existing
`test_failed_run_log_fetch_fails` still green). ruff check + ruff format + mypy
clean on the touched files.

## Verification
Red-before-green: on unmodified master the new test fails with
`AssertionError: literal {owner} in path: /repos/{owner}/{repo}/actions/jobs/200/logs`;
after the fix the full class passes.
```

Sign-off: no DCO / `Signed-off-by` required for this repo (see `projects/gptme.md`:
"None (no CLA, no DCO, commits not GPG-signed)"). Squash-merge; PR title becomes the
commit subject with `(#NNNN)` appended.