### PR TITLE
fix(ci): use official download-artifact for cross-run artifacts; add more visual snapshots (#3467)

### DIFF
--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -27,28 +27,40 @@ jobs:
     permissions:
       pull-requests: write
       contents: write  # CML needs write access to create draft release assets for image hosting
+      actions: read    # needed to download artifacts from the triggering workflow run
 
     steps:
     # Download the "after" screenshots from the triggering PR run.
-    # We scope by run_id so we always get exactly this PR's artifacts.
+    # We use actions/download-artifact (official) rather than dawidd6/action-download-artifact
+    # because the official action guarantees files land directly in `path` (no artifact-name
+    # subdirectory), which is what diff-screenshots.sh expects with its non-recursive glob.
     - name: Download "after" screenshots
-      uses: dawidd6/action-download-artifact@v6
+      id: download
+      uses: actions/download-artifact@v7
       with:
-        run_id: ${{ github.event.workflow_run.id }}
+        run-id: ${{ github.event.workflow_run.id }}
         name: webui-visual-snapshots
         path: screenshots/after
-        if_no_artifact_found: warn
+        github-token: ${{ github.token }}
+      continue-on-error: true  # warn rather than fail when screenshots weren't uploaded
 
     - name: Check for after screenshots and read PR number
       id: setup
       run: |
-        # Check that screenshots were uploaded
-        PNG_COUNT=$(find screenshots/after -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+        # Log the downloaded structure to aid future debugging.
+        echo "=== screenshots/after contents ==="
+        find screenshots/after -maxdepth 2 2>/dev/null | sort || echo "(empty or not found)"
+        echo "==================================="
+
+        # Use -maxdepth 1 (same non-recursive scope as diff-screenshots.sh's glob)
+        # to avoid a false-positive proceed when files landed in a subdirectory.
+        PNG_COUNT=$(find screenshots/after -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
         if [ "$PNG_COUNT" -eq 0 ]; then
-          echo "No screenshots found in artifact — skipping diff"
+          echo "No screenshots found directly in screenshots/after — skipping diff"
           echo "skip=true" >> $GITHUB_OUTPUT
           exit 0
         fi
+        echo "Found $PNG_COUNT after-screenshot(s)"
         echo "screenshots_found=true" >> $GITHUB_OUTPUT
 
         # Derive PR number from trusted event data.

--- a/webui/e2e/visual-snapshots.spec.ts
+++ b/webui/e2e/visual-snapshots.spec.ts
@@ -34,3 +34,19 @@ test('02-demo-conversation', async ({ page }) => {
   await page.waitForTimeout(1000);
   await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '02-demo-conversation.png') });
 });
+
+test('03-home-mobile', async ({ page }) => {
+  // Capture the mobile (narrow) layout to catch responsive CSS regressions.
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto('/?demo=1');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '03-home-mobile.png') });
+});
+
+test('04-settings', async ({ page }) => {
+  await page.goto('/settings?demo=1');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: path.join(SCREENSHOTS_DIR, '04-settings.png') });
+});


### PR DESCRIPTION
## Problem

The `dawidd6/action-download-artifact@v6` action creates a subdirectory named after the artifact inside the specified `path` (e.g. `screenshots/after/webui-visual-snapshots/01-home.png`). The `diff-screenshots.sh` script uses a non-recursive glob (`$AFTER_DIR/*.png`) that only looks at the top level of the after directory. This mismatch meant the after-screenshots were always empty from the diff script's perspective, causing all before-screenshots to be reported as removed — even when the PR had real visual changes.

The `find screenshots/after -name '*.png'` check in the setup step found the files (it's recursive) and let the diff proceed, but the diff script then found 0 after-files and marked all before-files as removed.

This showed up in the visual-diff comment on PR #3491 as:
```
| 01-home.png | 🗑️ removed | 0 |
| 02-demo-conversation.png | 🗑️ removed | 0 |
```

## Fix

- **Switch from `dawidd6/action-download-artifact@v6` to `actions/download-artifact@v7`** with the `run-id` parameter. The official action guarantees artifact files land directly in `path` without an artifact-name subdirectory — exactly what `diff-screenshots.sh` expects.
- **Add `actions: read` permission** (required for cross-workflow-run artifact download).
- **Fix the PNG count check to use `find -maxdepth 1`** to be consistent with the non-recursive glob in `diff-screenshots.sh` — prevents a false-positive proceed when files landed in a subdirectory.
- **Add `continue-on-error: true`** to the download step so missing artifacts are handled gracefully by the check step (`skip=true`) rather than failing the job.
- **Add structured debug logging** after download to show the actual directory structure — makes future issues easy to diagnose from CI logs.

## Additional: more visual snapshot views

Two new views added to `visual-snapshots.spec.ts`:
- `03-home-mobile`: home view at 375×812px (catches responsive CSS regressions)
- `04-settings`: settings page view

## Verification

- CI green on this PR
- After merge: the next PR that touches `webui/`` should get a visual-diff comment with correctly-compared screenshots (no more false removed status)

Closes #3467

<!-- gptme-id:v1:gai_rC3jKXwGVzDUvk7ppWEYhvgh0eKLgxGSqZDwpmaPdoS -->