### PR TITLE
fix(read): reject inverted line range instead of silently returning empty

### DIFF
--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -290,6 +290,18 @@ def execute_read(
         )
         start_line, end_line = 1, None
 
+    # Reject an inverted line range instead of silently yielding an empty
+    # codeblock mislabeled with the requested range (e.g. lines[7:3] == []).
+    # Checked after the multi-path reset so an inverted range on a batch read
+    # is still treated as "ignored" (ranges don't apply to multi-path reads).
+    if end_line is not None and start_line > end_line:
+        yield Message(
+            "system",
+            f"Invalid line range: start_line ({start_line}) is greater than "
+            f"end_line ({end_line}).",
+        )
+        return
+
     for path in paths:
         yield from _read_one(path, start_line=start_line, end_line=end_line)
 

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -271,6 +271,59 @@ def test_read_invalid_end_line(tmp_path: Path):
     assert "Invalid end_line" in messages[0].content
 
 
+def test_read_invalid_line_range(tmp_path: Path):
+    """Test that an inverted range (start_line > end_line) returns an error."""
+    path = tmp_path / "test.txt"
+    path.write_text("\n".join(f"line {i}" for i in range(1, 11)) + "\n")
+
+    messages = list(
+        execute_read(
+            None,
+            None,
+            {"path": str(path), "start_line": "8", "end_line": "3"},
+        )
+    )
+    assert len(messages) == 1
+    # Value-anchored substrings pin the diagnostic: the bare digits "8"/"3"
+    # also appear in the broken-master label "(lines 8-3 of 10)".
+    assert "Invalid line range" in messages[0].content
+    assert "start_line (8)" in messages[0].content
+    assert "end_line (3)" in messages[0].content
+
+
+def test_read_line_range_start_equals_end(tmp_path: Path):
+    """A single-line range (start_line == end_line) is valid, not inverted."""
+    path = tmp_path / "test.txt"
+    path.write_text("\n".join(f"line {i}" for i in range(1, 11)) + "\n")
+
+    messages = list(
+        execute_read(
+            None,
+            None,
+            {"path": str(path), "start_line": "3", "end_line": "3"},
+        )
+    )
+    assert len(messages) == 1
+    assert "line 3" in messages[0].content
+    assert "lines 3-3 of 10" in messages[0].content
+
+
+def test_read_invalid_line_range_before_file_check(tmp_path: Path):
+    """The inverted-range check runs before the file is read/existence-checked."""
+    missing = tmp_path / "does-not-exist.txt"
+    messages = list(
+        execute_read(
+            None,
+            None,
+            {"path": str(missing), "start_line": "8", "end_line": "3"},
+        )
+    )
+    assert len(messages) == 1
+    # The malformed request is rejected before any filesystem access, so the
+    # range error wins over the usual "File not found" message.
+    assert "Invalid line range" in messages[0].content
+
+
 def test_read_path_traversal(tmp_path: Path, monkeypatch):
     """Test that relative paths traversing outside cwd are blocked."""
     external = tmp_path / "external.txt"


### PR DESCRIPTION
## Summary
Follow-up to #2130. The `read` tool now rejects an inverted line range
(`start_line > end_line`) with a clear error instead of silently returning an
empty codeblock mislabeled with the requested range.

## Motivation
#2130 taught `execute_read` to validate that `start_line`/`end_line` are
integers, but it never sanity-checked the range itself. For an inverted range
(e.g. `start_line=8, end_line=3`), `_read_one` computes `lines[7:3]`, which is
empty, so the tool returned an **empty codeblock labeled `(lines 8-3 of 10)`** —
no error, with a header that implies lines were returned. The LLM/user is left
staring at an empty result with no indication the request was malformed.

## Change
- In `gptme/tools/read.py` `execute_read`, after the multi-path reset, add a
  guard: when both bounds are set and `start_line > end_line`, yield
  `Invalid line range: start_line (N) is greater than end_line (M).` and return.
  - Strict `>` (a single-line `start==end` read stays valid).
  - Placed after the multi-path reset so an inverted range on a batch read is
    still treated as "ignored" (the existing multi-path contract is unchanged).
  - Runs before file IO, so a malformed request fails fast.

## Tests
New tests in `tests/test_tools_read.py`:
- `test_read_invalid_line_range` — `start_line=8, end_line=3` on a 10-line file
  yields one message with `Invalid line range`, `start_line (8)`, `end_line (3)`
  (assertions are value-anchored so they fail on master).
- `test_read_line_range_start_equals_end` — `start=3, end=3` still reads line 3
  (`lines 3-3 of 10`); guards against a future `>=` regression.
- `test_read_invalid_line_range_before_file_check` — inverted range on a missing
  file reports `Invalid line range` before any filesystem access.

`poetry run pytest tests/test_tools_read.py -v` → **27 passed** (was 24).
`make lint` → clean. `mypy gptme/tools/read.py` → clean.

Closes gptme/gptme#2130 (follow-up: inverted-range case missed by the integer validation).
