### PR TITLE
fix(ci): download after-screenshots to /tmp to survive checkout workspace wipe (#3467)

### DIFF
--- a/.github/workflows/webui-visual-diff.yml
+++ b/.github/workflows/webui-visual-diff.yml
@@ -34,13 +34,18 @@ jobs:
     # We use actions/download-artifact (official) rather than dawidd6/action-download-artifact
     # because the official action guarantees files land directly in `path` (no artifact-name
     # subdirectory), which is what diff-screenshots.sh expects with its non-recursive glob.
+    #
+    # IMPORTANT: download to /tmp/screenshots-after, NOT a path inside $GITHUB_WORKSPACE.
+    # actions/checkout@v7 runs "Deleting the contents of '$GITHUB_WORKSPACE'" before cloning,
+    # which wipes any files already downloaded there — including these screenshots.
+    # Storing them in /tmp survives the checkout step.
     - name: Download "after" screenshots
       id: download
       uses: actions/download-artifact@v7
       with:
         run-id: ${{ github.event.workflow_run.id }}
         name: webui-visual-snapshots
-        path: screenshots/after
+        path: /tmp/screenshots-after
         github-token: ${{ github.token }}
       continue-on-error: true  # warn rather than fail when screenshots weren't uploaded
 
@@ -48,15 +53,15 @@ jobs:
       id: setup
       run: |
         # Log the downloaded structure to aid future debugging.
-        echo "=== screenshots/after contents ==="
-        find screenshots/after -maxdepth 2 2>/dev/null | sort || echo "(empty or not found)"
-        echo "==================================="
+        echo "=== /tmp/screenshots-after contents ==="
+        find /tmp/screenshots-after -maxdepth 2 2>/dev/null | sort || echo "(empty or not found)"
+        echo "======================================="
 
         # Use -maxdepth 1 (same non-recursive scope as diff-screenshots.sh's glob)
         # to avoid a false-positive proceed when files landed in a subdirectory.
-        PNG_COUNT=$(find screenshots/after -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+        PNG_COUNT=$(find /tmp/screenshots-after -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
         if [ "$PNG_COUNT" -eq 0 ]; then
-          echo "No screenshots found directly in screenshots/after — skipping diff"
+          echo "No screenshots found directly in /tmp/screenshots-after — skipping diff"
           echo "skip=true" >> $GITHUB_OUTPUT
           exit 0
         fi
@@ -136,7 +141,7 @@ jobs:
       run: |
         bash .github/scripts/diff-screenshots.sh \
           screenshots/before \
-          screenshots/after \
+          /tmp/screenshots-after \
           screenshots/diff
         CHANGED=$(python3 -c "import json; d=json.load(open('screenshots/diff/summary.json')); print(d['changed'])")
         TOTAL=$(python3  -c "import json; d=json.load(open('screenshots/diff/summary.json')); print(d['total'])")


### PR DESCRIPTION
## Root cause

`actions/checkout@v7` logs **"Deleting the contents of '$GITHUB_WORKSPACE'"** before cloning the repo. This wipes every file in the workspace — including the `screenshots/after/` directory downloaded by the previous step. As a result, the diff script finds 0 after-screenshots and marks every before-screenshot as "removed".

This is visible in the CI log for run 31270488055 (the visual-diff run that posted the broken comment on #3491):

```
Download step: Found 2 after-screenshot(s)  ← download succeeded
Checkout step: Deleting the contents of '/home/runner/work/gptme/gptme'  ← WIPE
Diff step:     REMOVED: 01-home.png
               REMOVED: 02-demo-conversation.png
               REMOVED: 03-home-mobile.png
               REMOVED: 04-settings.png
               Result: 4/4 screenshots changed  ← all false-positives
```

So every visual-diff comment since the feature landed has been wrong — all "after" screenshots appear missing, all "before" screenshots appear as "removed".

## Fix

Download the artifact to `/tmp/screenshots-after` (outside `$GITHUB_WORKSPACE`) instead of `screenshots/after` (inside it). `/tmp` is not touched by `actions/checkout`, so the files survive the checkout step.

Update all three places that referenced `screenshots/after`:
1. `Download "after" screenshots` step: `path: /tmp/screenshots-after`
2. `Check for after screenshots` step: `find /tmp/screenshots-after ...`
3. `Diff screenshots` step: pass `/tmp/screenshots-after` as the after-dir argument

Closes #3467

<!-- gptme-id:v1:gai_Yvk3Rg8r95JDNszVcStwQ14VgO7UGnp86rVW7ckHlc2 -->