### PR TITLE
feat(tools/hashline_edit): add register operations (CUT @name / PUT @name)

### DIFF
--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -24,10 +24,17 @@ Edit syntax
     +new line
     PUT >N:         — insert the new content AFTER line N
     +new line
+    PUT N*:         — replace the syntactic block starting at line N
+    +new content
     CUT N.=M        — delete lines N through M (no content block follows)
+    CUT N.=M @r    — delete and save to named register r
+    PUT >N @r       — paste register r content AFTER line N (no content block)
+    PUT <N @r       — paste register r content BEFORE line N (no content block)
+    PUT N.=M: @r    — replace lines N–M with register r content (no content block)
 
 Content lines are prefixed with ``+``.  An operation's content block ends at
-the next operation header or end-of-input.
+the next operation header or end-of-input.  Register-paste operations have no
+content block.
 
 If the live file's hash no longer matches the stored snapshot tag the entire
 edit is rejected with a clear error — no silent corruption.
@@ -63,7 +70,8 @@ class HashlineOp:
     kind: OperationKind
     start: int  # 1-indexed, inclusive
     end: int  # 1-indexed, inclusive (== start for insert ops)
-    text: str | None  # None for delete
+    text: str | None  # None for delete or for register-read ops (resolved before apply)
+    register_name: str | None = None  # for CUT @name (capture) or PUT @name (paste)
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +88,14 @@ _RE_PUT_BEFORE = re.compile(r"^PUT\s+<(\d+):\s*$")
 _RE_PUT_AFTER = re.compile(r"^PUT\s+>(\d+):\s*$")
 # CUT N.=M    delete lines N–M (no colon, no content block)
 _RE_CUT_RANGE = re.compile(r"^CUT\s+(\d+)\.=(\d+)\s*$")
+# CUT N.=M @name  delete lines N–M and save to named register
+_RE_CUT_RANGE_REG = re.compile(r"^CUT\s+(\d+)\.=(\d+)\s+@(\w+)\s*$")
+# PUT <N @name    insert register @name content before line N (no inline content)
+_RE_PUT_BEFORE_REG = re.compile(r"^PUT\s+<(\d+)\s+@(\w+)\s*$")
+# PUT >N @name    insert register @name content after line N (no inline content)
+_RE_PUT_AFTER_REG = re.compile(r"^PUT\s+>(\d+)\s+@(\w+)\s*$")
+# PUT N.=M: @name replace lines N–M with register @name content (no inline content)
+_RE_PUT_RANGE_REG = re.compile(r"^PUT\s+(\d+)\.=(\d+):\s+@(\w+)\s*$")
 # Header line [PATH#TAG]
 _RE_HEADER = re.compile(r"^\[(.+)#([0-9A-Fa-f]{8})\]\s*$")
 
@@ -113,11 +129,37 @@ def _parse_operations(code: str) -> tuple[str, str, list[HashlineOp]]:
     while i < len(lines):
         line = lines[i]
 
+        # Register-capture: CUT N.=M @name — delete and save to named register
+        if m := _RE_CUT_RANGE_REG.match(line):
+            start, end, reg = int(m.group(1)), int(m.group(2)), m.group(3)
+            if start > end:
+                raise ParseError(f"CUT range start {start} > end {end}")
+            ops.append(
+                HashlineOp(
+                    kind="delete", start=start, end=end, text=None, register_name=reg
+                )
+            )
+            i += 1
+            continue
+
         if m := _RE_CUT_RANGE.match(line):
             start, end = int(m.group(1)), int(m.group(2))
             if start > end:
                 raise ParseError(f"CUT range start {start} > end {end}")
             ops.append(HashlineOp(kind="delete", start=start, end=end, text=None))
+            i += 1
+            continue
+
+        # Register-paste: PUT N.=M: @name — replace with register content
+        if m := _RE_PUT_RANGE_REG.match(line):
+            start, end, reg = int(m.group(1)), int(m.group(2)), m.group(3)
+            if start > end:
+                raise ParseError(f"PUT range start {start} > end {end}")
+            ops.append(
+                HashlineOp(
+                    kind="replace", start=start, end=end, text=None, register_name=reg
+                )
+            )
             i += 1
             continue
 
@@ -129,10 +171,32 @@ def _parse_operations(code: str) -> tuple[str, str, list[HashlineOp]]:
             ops.append(HashlineOp(kind="replace", start=start, end=end, text=text))
             continue
 
+        # Register-paste: PUT <N @name — insert register content before line N
+        if m := _RE_PUT_BEFORE_REG.match(line):
+            n, reg = int(m.group(1)), m.group(2)
+            ops.append(
+                HashlineOp(
+                    kind="insert_before", start=n, end=n, text=None, register_name=reg
+                )
+            )
+            i += 1
+            continue
+
         if m := _RE_PUT_BEFORE.match(line):
             n = int(m.group(1))
             i, text = _collect_content(lines, i + 1)
             ops.append(HashlineOp(kind="insert_before", start=n, end=n, text=text))
+            continue
+
+        # Register-paste: PUT >N @name — insert register content after line N
+        if m := _RE_PUT_AFTER_REG.match(line):
+            n, reg = int(m.group(1)), m.group(2)
+            ops.append(
+                HashlineOp(
+                    kind="insert_after", start=n, end=n, text=None, register_name=reg
+                )
+            )
+            i += 1
             continue
 
         if m := _RE_PUT_AFTER.match(line):
@@ -164,6 +228,10 @@ def _is_op_header(line: str) -> bool:
         or _RE_PUT_BEFORE.match(line)
         or _RE_PUT_AFTER.match(line)
         or _RE_CUT_RANGE.match(line)
+        or _RE_CUT_RANGE_REG.match(line)
+        or _RE_PUT_BEFORE_REG.match(line)
+        or _RE_PUT_AFTER_REG.match(line)
+        or _RE_PUT_RANGE_REG.match(line)
     )
 
 
@@ -350,23 +418,53 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     Line numbers reference the ORIGINAL content.  Operations are applied
     bottom-up so earlier line numbers remain valid after later insertions/deletions.
 
-    Raises :class:`ValueError` on out-of-range line references.
+    Register operations are resolved in two passes:
+    1. Pre-scan: capture content for all ``CUT @name`` ops (using ORIGINAL lines).
+    2. Resolve: replace ``text=None, register_name=X`` on PUT ops with captured text.
+
+    Raises :class:`ValueError` on out-of-range line references or a missing register.
     """
     had_trailing_newline = content.endswith("\n")
     file_lines = content.splitlines()
     total = len(file_lines)
 
     # Resolve block_replace ops to concrete replace ranges before validation/sorting
-    resolved: list[HashlineOp] = []
+    step1: list[HashlineOp] = []
     for op in ops:
         if op.kind == "block_replace":
             end = _resolve_block_end(file_lines, op.start)
-            resolved.append(
+            step1.append(
                 HashlineOp(kind="replace", start=op.start, end=end, text=op.text)
             )
         else:
-            resolved.append(op)
-    ops = resolved
+            step1.append(op)
+    ops = step1
+
+    # Pre-scan: capture register content from CUT @name ops (original line numbers)
+    registers: dict[str, str] = {}
+    for op in ops:
+        if op.kind == "delete" and op.register_name:
+            s, e = op.start - 1, op.end  # 0-indexed slice
+            registers[op.register_name] = "\n".join(file_lines[s:e])
+
+    # Resolve register-read ops: replace text=None/register_name with captured text
+    step2: list[HashlineOp] = []
+    for op in ops:
+        if op.register_name and op.text is None and op.kind != "delete":
+            reg = op.register_name
+            if reg not in registers:
+                raise ValueError(
+                    f"Register @{reg} is not defined — "
+                    "add a 'CUT N.=M @{reg}' operation earlier in the same edit block"
+                )
+            step2.append(
+                HashlineOp(
+                    kind=op.kind, start=op.start, end=op.end, text=registers[reg]
+                )
+            )
+        else:
+            step2.append(op)
+    ops = step2
 
     for op in ops:
         # Allow PUT <1 on empty files
@@ -428,13 +526,17 @@ Re-read the file with ``read`` to get a new tag and restate your operations.
 
 ### Operations
 
-| Syntax       | Effect                                    |
-|-------------|------------------------------------------|
-| ``PUT N.=M:``| Replace lines N through M with new lines |
-| ``PUT N*:``  | Replace the syntactic block at line N    |
-| ``PUT <N:``  | Insert new lines BEFORE line N           |
-| ``PUT >N:``  | Insert new lines AFTER line N            |
-| ``CUT N.=M`` | Delete lines N through M                 |
+| Syntax            | Effect                                           |
+|-------------------|--------------------------------------------------|
+| ``PUT N.=M:``     | Replace lines N through M with new lines         |
+| ``PUT N*:``       | Replace the syntactic block at line N            |
+| ``PUT <N:``       | Insert new lines BEFORE line N                   |
+| ``PUT >N:``       | Insert new lines AFTER line N                    |
+| ``CUT N.=M``      | Delete lines N through M                         |
+| ``CUT N.=M @r``   | Delete lines N–M and save to register *r*        |
+| ``PUT N.=M: @r``  | Replace lines N–M with content of register *r*   |
+| ``PUT <N @r``     | Insert register *r* content BEFORE line N        |
+| ``PUT >N @r``     | Insert register *r* content AFTER line N         |
 
 ``PUT N*:`` replaces a whole indented construct — point it at the ``def``,
 ``class``, ``if``, ``for``, ``while``, or ``try`` line and the system finds the
@@ -450,8 +552,15 @@ spaces, or a header followed by a same-indentation line that is *not* a
 continuation clause (e.g. a one-line ``if x: y`` body) — for those, fall back to
 ``PUT N.=M:`` with an explicit line range.
 
+**Registers** allow move/copy within a single edit call: ``CUT N.=M @r`` captures
+deleted lines into register *r* (a short word); ``PUT >N @r`` or ``PUT <N @r``
+pastes them.  Registers are resolved from the original file state, so a cut at
+line 5 and a paste at line 20 work correctly regardless of apply order.
+
 New content lines are prefixed with ``+``.  An empty line ends a content block.
-CUT has no content block.  Line numbers reference the version shown by ``read``.
+CUT (with or without a register) has no content block.  Register-paste operations
+(``PUT ... @r``) also have no content block.  Line numbers reference the version
+shown by ``read``.
 
 ### Example
 
@@ -462,6 +571,14 @@ PUT 2.=3:
 CUT 4.=4
 PUT >5:
 +    return name
+```
+
+### Register example (move a function to the bottom)
+
+```
+[module.py#A1B2C3D4]
+CUT 3.=10 @fn
+PUT >40 @fn
 ```
 """.strip()
 

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -492,6 +492,27 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
             )
         starts.add(op.start)
 
+    # A register paste destination must survive every other mutation, not just
+    # the CUT that supplied its content. Otherwise bottom-up application can
+    # insert content inside a range that a later operation deletes or replaces.
+    for original_op, resolved_op in zip(step1, ops, strict=True):
+        if not (
+            original_op.register_name
+            and original_op.text is None
+            and original_op.kind != "delete"
+        ):
+            continue
+        for other in ops:
+            if other is resolved_op or other.kind not in {"delete", "replace"}:
+                continue
+            if resolved_op.start <= other.end and other.start <= resolved_op.end:
+                raise ValueError(
+                    f"Register @{original_op.register_name} PUT lines "
+                    f"{resolved_op.start}-{resolved_op.end} overlap "
+                    f"{other.kind} lines {other.start}-{other.end}; use a "
+                    "destination outside other mutation ranges"
+                )
+
     for op in ops:
         # Allow PUT <1 on empty files
         if total == 0 and op.kind == "insert_before" and op.start == 1:

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -480,6 +480,18 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
             step2.append(op)
     ops = step2
 
+    # Operations sharing a start coordinate have order-dependent semantics when
+    # applied to the same mutable line list. Reject them rather than silently
+    # shifting or overwriting a register paste.
+    starts: set[int] = set()
+    for op in ops:
+        if op.start in starts:
+            raise ValueError(
+                f"Multiple operations start at line {op.start}; "
+                "use distinct destination coordinates"
+            )
+        starts.add(op.start)
+
     for op in ops:
         # Allow PUT <1 on empty files
         if total == 0 and op.kind == "insert_before" and op.start == 1:

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -442,10 +442,12 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
 
     # Pre-scan: capture register content from CUT @name ops (original line numbers)
     registers: dict[str, str] = {}
+    register_sources: dict[str, HashlineOp] = {}
     for op in ops:
         if op.kind == "delete" and op.register_name:
             s, e = op.start - 1, op.end  # 0-indexed slice
             registers[op.register_name] = "\n".join(file_lines[s:e])
+            register_sources[op.register_name] = op
 
     # Resolve register-read ops: replace text=None/register_name with captured text
     step2: list[HashlineOp] = []
@@ -456,6 +458,13 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
                 raise ValueError(
                     f"Register @{reg} is not defined — "
                     "add a 'CUT N.=M @{reg}' operation earlier in the same edit block"
+                )
+            source = register_sources[reg]
+            if op.start <= source.end and source.start <= op.end:
+                raise ValueError(
+                    f"Register @{reg} PUT lines {op.start}-{op.end} overlap "
+                    f"its CUT lines {source.start}-{source.end}; use a destination "
+                    "outside the captured range"
                 )
             step2.append(
                 HashlineOp(
@@ -552,10 +561,12 @@ spaces, or a header followed by a same-indentation line that is *not* a
 continuation clause (e.g. a one-line ``if x: y`` body) — for those, fall back to
 ``PUT N.=M:`` with an explicit line range.
 
-**Registers** allow move/copy within a single edit call: ``CUT N.=M @r`` captures
-deleted lines into register *r* (a short word); ``PUT >N @r`` or ``PUT <N @r``
-pastes them.  Registers are resolved from the original file state, so a cut at
-line 5 and a paste at line 20 work correctly regardless of apply order.
+**Registers** avoid reproducing unchanged content when moving or copying exact
+lines within one edit call, reducing tokens and transcription mistakes.
+``CUT N.=M @r`` captures deleted lines into register *r* (a short word), then
+``PUT >N @r`` or ``PUT <N @r`` pastes them. Registers are resolved from the
+original file state, so a cut at line 5 and a paste at line 20 work correctly
+regardless of apply order. The PUT destination must be outside the CUT range.
 
 New content lines are prefixed with ``+``.  An empty line ends a content block.
 CUT (with or without a register) has no content block.  Register-paste operations

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -445,6 +445,11 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     register_sources: dict[str, HashlineOp] = {}
     for op in ops:
         if op.kind == "delete" and op.register_name:
+            if op.register_name in registers:
+                raise ValueError(
+                    f"Register @{op.register_name} is captured more than once; "
+                    "use a unique register name for each CUT"
+                )
             s, e = op.start - 1, op.end  # 0-indexed slice
             registers[op.register_name] = "\n".join(file_lines[s:e])
             register_sources[op.register_name] = op

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -72,6 +72,7 @@ class HashlineOp:
     end: int  # 1-indexed, inclusive (== start for insert ops)
     text: str | None  # None for delete or for register-read ops (resolved before apply)
     register_name: str | None = None  # for CUT @name (capture) or PUT @name (paste)
+    resolved_register_lines: list[str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -419,8 +420,8 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     bottom-up so earlier line numbers remain valid after later insertions/deletions.
 
     Register operations are resolved in two passes:
-    1. Pre-scan: capture content for all ``CUT @name`` ops (using ORIGINAL lines).
-    2. Resolve: replace ``text=None, register_name=X`` on PUT ops with captured text.
+    1. Pre-scan: capture lines for all ``CUT @name`` ops (using ORIGINAL lines).
+    2. Resolve: attach the captured lines to matching register PUT operations.
 
     Raises :class:`ValueError` on out-of-range line references or a missing register.
     """
@@ -441,7 +442,7 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
     ops = step1
 
     # Pre-scan: capture register content from CUT @name ops (original line numbers)
-    registers: dict[str, str] = {}
+    registers: dict[str, list[str]] = {}
     register_sources: dict[str, HashlineOp] = {}
     for op in ops:
         if op.kind == "delete" and op.register_name:
@@ -451,10 +452,10 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
                     "use a unique register name for each CUT"
                 )
             s, e = op.start - 1, op.end  # 0-indexed slice
-            registers[op.register_name] = "\n".join(file_lines[s:e])
+            registers[op.register_name] = file_lines[s:e]
             register_sources[op.register_name] = op
 
-    # Resolve register-read ops: replace text=None/register_name with captured text
+    # Resolve register-read ops by attaching the original captured line list.
     step2: list[HashlineOp] = []
     for op in ops:
         if op.register_name and op.text is None and op.kind != "delete":
@@ -473,24 +474,29 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
                 )
             step2.append(
                 HashlineOp(
-                    kind=op.kind, start=op.start, end=op.end, text=registers[reg]
+                    kind=op.kind,
+                    start=op.start,
+                    end=op.end,
+                    text=None,
+                    resolved_register_lines=registers[reg],
                 )
             )
         else:
             step2.append(op)
     ops = step2
 
-    # Operations sharing a start coordinate have order-dependent semantics when
-    # applied to the same mutable line list. Reject them rather than silently
-    # shifting or overwriting a register paste.
-    starts: set[int] = set()
-    for op in ops:
-        if op.start in starts:
+    # A register paste that shares its start coordinate with another operation
+    # has order-dependent semantics on the mutable line list. Preserve the
+    # existing behavior for same-coordinate ordinary edits.
+    for register_put in (op for op in ops if op.resolved_register_lines is not None):
+        if any(
+            other is not register_put and other.start == register_put.start
+            for other in ops
+        ):
             raise ValueError(
-                f"Multiple operations start at line {op.start}; "
+                f"Multiple operations start at line {register_put.start}; "
                 "use distinct destination coordinates"
             )
-        starts.add(op.start)
 
     # A register paste destination must survive every other mutation, not just
     # the CUT that supplied its content. Otherwise bottom-up application can
@@ -529,14 +535,20 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
 
         if op.kind == "delete":
             del file_lines[s:e]
-        elif op.kind == "replace":
-            new_lines = op.text.splitlines() if op.text else []
+            continue
+
+        new_lines = (
+            op.resolved_register_lines
+            if op.resolved_register_lines is not None
+            else op.text.splitlines()
+            if op.text
+            else []
+        )
+        if op.kind == "replace":
             file_lines[s:e] = new_lines
         elif op.kind == "insert_before":
-            new_lines = op.text.splitlines() if op.text else []
             file_lines[s:s] = new_lines
         elif op.kind == "insert_after":
-            new_lines = op.text.splitlines() if op.text else []
             file_lines[e:e] = new_lines
 
     result = "\n".join(file_lines)

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -503,7 +503,7 @@ def _apply_operations(content: str, ops: list[HashlineOp]) -> str:
         ):
             continue
         for other in ops:
-            if other is resolved_op or other.kind not in {"delete", "replace"}:
+            if other is resolved_op:
                 continue
             if resolved_op.start <= other.end and other.start <= resolved_op.end:
                 raise ValueError(

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -366,6 +366,19 @@ class TestRegisterOperations:
         with pytest.raises(ValueError, match="overlap its CUT lines 2-3"):
             _apply_operations(content, ops)
 
+    def test_duplicate_register_capture_raises(self):
+        """Each register has one unambiguous source range."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=1, end=1, register_name="x", text=None),
+            HashlineOp(kind="delete", start=4, end=4, register_name="x", text=None),
+            HashlineOp(
+                kind="insert_after", start=2, end=2, register_name="x", text=None
+            ),
+        ]
+        with pytest.raises(ValueError, match="Register @x is captured more than once"):
+            _apply_operations(content, ops)
+
     def test_undefined_register_raises(self):
         """Pasting from an undefined register raises ValueError."""
         content = "a\nb\nc\n"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -379,6 +379,28 @@ class TestRegisterOperations:
         with pytest.raises(ValueError, match="Register @x is captured more than once"):
             _apply_operations(content, ops)
 
+    @pytest.mark.parametrize(
+        "other",
+        [
+            HashlineOp(kind="replace", start=4, end=4, text="replacement"),
+            HashlineOp(kind="delete", start=4, end=4, text=None),
+            HashlineOp(kind="insert_before", start=4, end=4, text="before"),
+            HashlineOp(kind="insert_after", start=4, end=4, text="after"),
+        ],
+    )
+    def test_register_put_with_equal_start_operation_raises(self, other: HashlineOp):
+        """A register PUT cannot share a mutable coordinate with another edit."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=1, end=1, register_name="x", text=None),
+            HashlineOp(
+                kind="insert_after", start=4, end=4, register_name="x", text=None
+            ),
+            other,
+        ]
+        with pytest.raises(ValueError, match="Multiple operations start at line 4"):
+            _apply_operations(content, ops)
+
     def test_undefined_register_raises(self):
         """Pasting from an undefined register raises ValueError."""
         content = "a\nb\nc\n"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -20,6 +20,7 @@ from gptme.tools._hashline_snapshot import (
 )
 from gptme.tools.hashline_edit import (
     HashlineOp,
+    OperationKind,
     ParseError,
     _apply_operations,
     _parse_operations,
@@ -399,6 +400,36 @@ class TestRegisterOperations:
             other,
         ]
         with pytest.raises(ValueError, match="Multiple operations start at line 4"):
+            _apply_operations(content, ops)
+
+    @pytest.mark.parametrize("kind", ["delete", "replace"])
+    def test_register_put_inside_other_mutation_range_raises(self, kind: OperationKind):
+        """Another range mutation cannot consume a register PUT destination."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=5, end=5, register_name="x", text=None),
+            HashlineOp(
+                kind="insert_before", start=3, end=3, register_name="x", text=None
+            ),
+            HashlineOp(
+                kind=kind,
+                start=2,
+                end=4,
+                text=None if kind == "delete" else "replacement",
+            ),
+        ]
+        with pytest.raises(ValueError, match=f"PUT lines 3-3 overlap {kind} lines 2-4"):
+            _apply_operations(content, ops)
+
+    def test_register_put_range_containing_other_mutation_raises(self):
+        """A register PUT range cannot contain another mutation either."""
+        content = "a\nb\nc\nd\ne\nf\n"
+        ops = [
+            HashlineOp(kind="delete", start=6, end=6, register_name="x", text=None),
+            HashlineOp(kind="replace", start=2, end=4, register_name="x", text=None),
+            HashlineOp(kind="delete", start=3, end=3, text=None),
+        ]
+        with pytest.raises(ValueError, match="PUT lines 2-4 overlap delete lines 3-3"):
             _apply_operations(content, ops)
 
     def test_undefined_register_raises(self):

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -421,15 +421,25 @@ class TestRegisterOperations:
         with pytest.raises(ValueError, match=f"PUT lines 3-3 overlap {kind} lines 2-4"):
             _apply_operations(content, ops)
 
-    def test_register_put_range_containing_other_mutation_raises(self):
+    @pytest.mark.parametrize(
+        "kind", ["delete", "replace", "insert_before", "insert_after"]
+    )
+    def test_register_put_range_containing_other_mutation_raises(
+        self, kind: OperationKind
+    ):
         """A register PUT range cannot contain another mutation either."""
         content = "a\nb\nc\nd\ne\nf\n"
         ops = [
             HashlineOp(kind="delete", start=6, end=6, register_name="x", text=None),
             HashlineOp(kind="replace", start=2, end=4, register_name="x", text=None),
-            HashlineOp(kind="delete", start=3, end=3, text=None),
+            HashlineOp(
+                kind=kind,
+                start=3,
+                end=3,
+                text=None if kind == "delete" else "other",
+            ),
         ]
-        with pytest.raises(ValueError, match="PUT lines 2-4 overlap delete lines 3-3"):
+        with pytest.raises(ValueError, match=f"PUT lines 2-4 overlap {kind} lines 3-3"):
             _apply_operations(content, ops)
 
     def test_undefined_register_raises(self):

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -342,6 +342,30 @@ class TestRegisterOperations:
         result = _apply_operations(content, ops)
         assert result == "keep\nold1\nold2\n"
 
+    @pytest.mark.parametrize(
+        "put",
+        [
+            HashlineOp(
+                kind="insert_before", start=3, end=3, register_name="chunk", text=None
+            ),
+            HashlineOp(
+                kind="insert_after", start=2, end=2, register_name="chunk", text=None
+            ),
+            HashlineOp(
+                kind="replace", start=3, end=4, register_name="chunk", text=None
+            ),
+        ],
+    )
+    def test_overlapping_register_put_raises(self, put: HashlineOp):
+        """A PUT cannot address coordinates mutated by its register's CUT."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=2, end=3, register_name="chunk", text=None),
+            put,
+        ]
+        with pytest.raises(ValueError, match="overlap its CUT lines 2-3"):
+            _apply_operations(content, ops)
+
     def test_undefined_register_raises(self):
         """Pasting from an undefined register raises ValueError."""
         content = "a\nb\nc\n"

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -257,6 +257,157 @@ class TestApplyOperations:
 
 
 # ---------------------------------------------------------------------------
+# Register operations (CUT @name / PUT @name)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterOperations:
+    """Tests for CUT @name (capture) and PUT @name (paste) register operations."""
+
+    # ---- Parser tests ----
+
+    def test_parse_cut_with_register(self):
+        block = "[f.py#A1B2C3D4]\nCUT 3.=5 @fn\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 1
+        assert ops[0].kind == "delete"
+        assert ops[0].start == 3
+        assert ops[0].end == 5
+        assert ops[0].register_name == "fn"
+        assert ops[0].text is None
+
+    def test_parse_put_before_register(self):
+        block = "[f.py#A1B2C3D4]\nPUT <10 @fn\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 1
+        assert ops[0].kind == "insert_before"
+        assert ops[0].start == 10
+        assert ops[0].register_name == "fn"
+        assert ops[0].text is None
+
+    def test_parse_put_after_register(self):
+        block = "[f.py#A1B2C3D4]\nPUT >20 @fn\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 1
+        assert ops[0].kind == "insert_after"
+        assert ops[0].start == 20
+        assert ops[0].register_name == "fn"
+        assert ops[0].text is None
+
+    def test_parse_put_range_register(self):
+        block = "[f.py#A1B2C3D4]\nPUT 5.=7: @fn\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 1
+        assert ops[0].kind == "replace"
+        assert ops[0].start == 5
+        assert ops[0].end == 7
+        assert ops[0].register_name == "fn"
+        assert ops[0].text is None
+
+    # ---- Apply-engine tests ----
+
+    def test_cut_and_paste_after(self):
+        """CUT @r captures lines; PUT >N @r pastes them after the destination."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=2, end=3, register_name="chunk", text=None),
+            HashlineOp(
+                kind="insert_after", start=5, end=5, register_name="chunk", text=None
+            ),
+        ]
+        # After: lines 2-3 (b,c) deleted; b,c inserted after original line 5 (e)
+        result = _apply_operations(content, ops)
+        assert result == "a\nd\ne\nb\nc\n"
+
+    def test_cut_and_paste_before(self):
+        """CUT @r captures lines; PUT <N @r pastes them before the destination."""
+        content = "a\nb\nc\nd\ne\n"
+        ops = [
+            HashlineOp(kind="delete", start=1, end=1, register_name="x", text=None),
+            HashlineOp(
+                kind="insert_before", start=4, end=4, register_name="x", text=None
+            ),
+        ]
+        # After: line 1 (a) deleted; a inserted before original line 4 (d)
+        result = _apply_operations(content, ops)
+        assert result == "b\nc\na\nd\ne\n"
+
+    def test_cut_and_replace_range(self):
+        """CUT @r captures lines; PUT N.=M: @r replaces a range with the captured content."""
+        content = "old1\nold2\nkeep\nreplace_me\n"
+        ops = [
+            HashlineOp(kind="delete", start=1, end=2, register_name="src", text=None),
+            HashlineOp(kind="replace", start=4, end=4, register_name="src", text=None),
+        ]
+        result = _apply_operations(content, ops)
+        assert result == "keep\nold1\nold2\n"
+
+    def test_undefined_register_raises(self):
+        """Pasting from an undefined register raises ValueError."""
+        content = "a\nb\nc\n"
+        ops = [
+            HashlineOp(
+                kind="insert_after", start=2, end=2, register_name="nope", text=None
+            ),
+        ]
+        with pytest.raises(ValueError, match="@nope"):
+            _apply_operations(content, ops)
+
+    def test_register_captures_original_lines(self):
+        """Register content is based on original line positions, not post-mutation ones."""
+        content = "a\nb\nc\nd\n"
+        # CUT line 1, then paste after line 3 (which will shift to line 2 after cut)
+        # The result should be: b, c, d, a (a moved to end)
+        ops = [
+            HashlineOp(kind="delete", start=1, end=1, register_name="first", text=None),
+            HashlineOp(
+                kind="insert_after", start=4, end=4, register_name="first", text=None
+            ),
+        ]
+        result = _apply_operations(content, ops)
+        assert result == "b\nc\nd\na\n"
+
+    def test_cut_without_register_plain_delete(self):
+        """CUT without @name still works as a plain delete (no register_name)."""
+        content = "a\nb\nc\n"
+        ops = [HashlineOp(kind="delete", start=2, end=2, text=None)]
+        assert _apply_operations(content, ops) == "a\nc\n"
+
+    # ---- Full execution tests ----
+
+    def test_execute_cut_capture_and_paste(self, tmp_path: Path):
+        """End-to-end: CUT @fn to capture function, PUT >N @fn to paste at end."""
+        f = tmp_path / "module.txt"
+        f.write_text("# header\ndef foo():\n    pass\n# footer\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nCUT 2.=3 @fn\nPUT >4 @fn\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        result = f.read_text()
+        # The function should be moved after the footer
+        assert result == "# header\n# footer\ndef foo():\n    pass\n"
+
+    def test_execute_paste_before_register(self, tmp_path: Path):
+        """End-to-end: CUT @r followed by PUT <N @r (paste before)."""
+        f = tmp_path / "f.txt"
+        f.write_text("a\nb\nc\nd\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nCUT 1.=1 @first\nPUT <4 @first\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        assert f.read_text() == "b\nc\na\nd\n"
+
+    def test_parse_cut_register_in_mixed_block(self):
+        """Register CUT and plain PUT ops can coexist in the same edit block."""
+        block = "[f.py#A1B2C3D4]\nCUT 3.=5 @fn\nPUT 1.=1:\n+new header\n\nPUT >10 @fn\n"
+        _, _, ops = _parse_operations(block)
+        assert len(ops) == 3
+        assert ops[0].kind == "delete" and ops[0].register_name == "fn"
+        assert ops[1].kind == "replace" and ops[1].register_name is None
+        assert ops[2].kind == "insert_after" and ops[2].register_name == "fn"
+
+
+# ---------------------------------------------------------------------------
 # execute_hashline_edit integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -245,6 +245,14 @@ class TestApplyOperations:
         ]
         assert _apply_operations(content, ops) == "A\nb\nd\n"
 
+    def test_same_coordinate_ordinary_inserts_remain_supported(self):
+        """Register conflict checks do not reject existing ordinary edits."""
+        ops = [
+            HashlineOp(kind="insert_before", start=1, end=1, text="first"),
+            HashlineOp(kind="insert_before", start=1, end=1, text="second"),
+        ]
+        assert _apply_operations("", ops) == "second\nfirst"
+
     def test_out_of_range_raises(self):
         content = "a\nb\n"
         with pytest.raises(ValueError, match="out of range"):
@@ -342,6 +350,38 @@ class TestRegisterOperations:
         ]
         result = _apply_operations(content, ops)
         assert result == "keep\nold1\nold2\n"
+
+    @pytest.mark.parametrize(
+        ("content", "start", "end", "destination", "expected"),
+        [
+            # A register containing only one blank line must not become empty.
+            ("a\n\nb", 2, 2, 3, "a\nb\n"),
+            # A trailing blank in a multi-line capture must remain trailing.
+            ("a\nb\n\nc", 1, 3, 4, "c\na\nb\n"),
+        ],
+    )
+    def test_register_preserves_trailing_blank_lines(
+        self,
+        content: str,
+        start: int,
+        end: int,
+        destination: int,
+        expected: str,
+    ):
+        """A register preserves blank lines at the end of its captured range."""
+        ops = [
+            HashlineOp(
+                kind="delete", start=start, end=end, register_name="x", text=None
+            ),
+            HashlineOp(
+                kind="insert_after",
+                start=destination,
+                end=destination,
+                register_name="x",
+                text=None,
+            ),
+        ]
+        assert _apply_operations(content, ops) == expected
 
     @pytest.mark.parametrize(
         "put",


### PR DESCRIPTION
## Summary

Implements the register operations from issue #3476 spec — the last remaining Phase 1 items not shipped in PRs #3477 and #3480.

## What are register operations?

Registers let you **move or copy content within a single `hashline_edit` call** without rewriting the lines inline. Instead of pasting content manually with `+` lines, you name a capture (`@r`) on a CUT, then reference that name on a PUT.

## New syntax

| Operation | Syntax | Effect |
|---|---|---|
| Delete + capture | `CUT N.=M @r` | Delete lines N–M; save them to register *r* |
| Paste after | `PUT >N @r` | Insert register *r* content after line N |
| Paste before | `PUT <N @r` | Insert register *r* content before line N |
| Replace with register | `PUT N.=M: @r` | Replace lines N–M with register *r* content |

Register-paste operations have **no `+` content block** — the content comes from the captured register.

### Example: move a function to the bottom of a file

```
[module.py#A1B2C3D4]
CUT 3.=10 @fn
PUT >42 @fn
```

## Implementation notes

- Registers are collected in a **pre-scan pass** over the original content (before any bottom-up mutation), so a `CUT` at line 3 and a `PUT` at line 40 work correctly regardless of apply order.
- A `PUT @r` that references an undefined register raises `ValueError` with a clear message naming the missing register.
- The existing `CUT N.=M` (plain delete, no register) is unchanged.

## Tests

13 new tests covering:
- Parser: all four new syntax variants + mixed register/plain ops in one block
- Apply engine: cut+paste-after, cut+paste-before, cut+replace-range, undefined-register error, original-content capture semantics
- End-to-end execution: move via CUT+paste-after, move via CUT+paste-before

Implements the remaining Phase 1 register operations from #3476. The parent issue stays open for the separately scoped Phase 2 stale-snapshot recovery work.


<!-- gptme-id:v1:gai_7S4wPnbZAzoa5Bb0ydBbcmoy0RoCQngpw10AP1VbYgL -->
