### PR TITLE
fix(prompt_queue): preserve malformed lines on drain instead of dropping them

### DIFF
--- a/gptme/prompt_queue.py
+++ b/gptme/prompt_queue.py
@@ -100,6 +100,7 @@ def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Messa
                 record = json.loads(line)
             except json.JSONDecodeError:
                 logger.warning("Skipping malformed queued prompt in %s", queue_path)
+                remaining.append(line)
                 continue
 
             # Steer-flagged records are reserved for mid-turn draining via the

--- a/tests/test_prompt_queue.py
+++ b/tests/test_prompt_queue.py
@@ -1,0 +1,61 @@
+"""Tests for the durable prompt queue (`gptme.prompt_queue`).
+
+Focuses on how ``drain_prompt_queue`` handles malformed lines: a truncated or
+corrupted JSONL line (e.g. a half-written record left by a crash mid-append)
+must survive a drain cycle rather than being silently deleted.
+"""
+
+from gptme.prompt_queue import (
+    drain_prompt_queue,
+    get_prompt_queue_path,
+    queue_prompt,
+)
+
+
+def _write_malformed_line(logdir, raw: str) -> None:
+    """Append a raw (non-JSON) line directly to the queue file."""
+    queue_path = get_prompt_queue_path(logdir)
+    with queue_path.open("a", encoding="utf-8") as f:
+        f.write(raw + "\n")
+
+
+def test_drain_preserves_malformed_line(tmp_path):
+    """A malformed queue line survives a drain instead of being dropped.
+
+    Regression: ``drain_prompt_queue`` used to ``continue`` past a
+    ``JSONDecodeError`` without re-appending the offending line to
+    ``remaining``, so the line was removed from the queue file and lost
+    forever on the next drain.
+    """
+    logdir = tmp_path / "preserve-malformed"
+    logdir.mkdir()
+
+    queue_prompt(logdir, "valid prompt")
+    _write_malformed_line(logdir, '{"content": "truncated')  # truncated JSON
+
+    drained = drain_prompt_queue(logdir)
+
+    # The valid record is drained normally.
+    assert len(drained) == 1
+    assert "valid prompt" in drained[0].content
+
+    # The malformed line is preserved on disk for inspection / retry.
+    queue_path = get_prompt_queue_path(logdir)
+    assert queue_path.exists(), "malformed line was dropped instead of preserved"
+    remaining = queue_path.read_text(encoding="utf-8")
+    assert '{"content": "truncated' in remaining
+
+
+def test_drain_preserves_malformed_line_across_drains(tmp_path):
+    """The preserved malformed line is stable across repeated drains."""
+    logdir = tmp_path / "preserve-across-drains"
+    logdir.mkdir()
+
+    _write_malformed_line(logdir, '{"content": "truncated')
+
+    assert drain_prompt_queue(logdir) == []
+    assert drain_prompt_queue(logdir) == []
+
+    queue_path = get_prompt_queue_path(logdir)
+    assert queue_path.exists()
+    assert '{"content": "truncated' in queue_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
`drain_prompt_queue` silently deleted a malformed/truncated JSONL line on every
drain cycle. A corrupted line (e.g. a half-written record left behind by a crash
or disk-full mid-append) is now preserved on disk so it can be inspected or
repaired, instead of being lost forever.

## Root cause
In `drain_prompt_queue`, the `except json.JSONDecodeError` handler logged a
warning and then `continue`d **without** re-appending the offending line to
`remaining`. Because the queue file is rewritten from `remaining` at the end of
the drain, the malformed line was dropped on the next drain — unrecoverable.

Notably, the sibling function `drain_steer_prompts` already preserved malformed
lines (`remaining.append(line)` before `continue`), so this was an
inconsistency: regular drains lost data that steer drains kept.

## Change
- `gptme/prompt_queue.py`: in `drain_prompt_queue`'s `JSONDecodeError` handler,
  `remaining.append(line)` before `continue`, mirroring the existing behaviour
  in `drain_steer_prompts`. The existing warning log is kept unchanged.

The valid-line processing path, steer handling, and queue path resolution are
untouched. No retry/repair logic is added — malformed entries are simply kept
for inspection rather than silently deleted.

## Tests
New `tests/test_prompt_queue.py` (integration-style, writes the queue file on
disk and drains it — no heavy mocking), demonstrating RED before / GREEN after:

- `test_drain_preserves_malformed_line` — one valid + one truncated JSON line;
  after `drain_prompt_queue` the valid prompt is drained **and** the malformed
  line is still present in the queue file (before the fix the file was deleted).
- `test_drain_preserves_malformed_line_across_drains` — the preserved malformed
  line is stable across repeated drains.

Verified locally:
- `make test` green (full fast suite).
- `make lint` (`ruff check`) + `ruff format --check` clean.
- `make typecheck` (`mypy`) clean on `gptme/prompt_queue.py`.
- Existing queue/steer/drain tests (`tests/test_subagent_unit.py`,
  `tests/test_chat.py`) still pass — no regression (41 passed).

## Behaviour
Before: a single corrupted line in `prompt-queue.jsonl` is removed on the next
`drain_prompt_queue` and lost. After: it is preserved across drains, logged
with a warning, and can be inspected/repaired manually.
