### PR TITLE
fix(codeblock): normalize CRLF line endings when parsing code blocks

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -124,9 +124,6 @@ def _extract_codeblocks(
     # appears in the prefix at all).  We must NOT strip when <think> appears only
     # concatenated with a fence closer (e.g. "```<think>") — that is handled later
     # by the inner-loop fence-recovery logic.
-    # Normalize line endings so CRLF input does not leak carriage returns into content.
-    markdown = markdown.replace("\r\n", "\n").replace("\r", "\n")
-
     _concatenated_end_found = False
     _concatenated_end_pos = -1
     for _think_end_tag in ["</thinking>", "</think>"]:
@@ -180,6 +177,9 @@ def _extract_codeblocks(
     fence_pattern = re.compile(r"`{3,}")
     if len(fence_pattern.findall(markdown)) < 2:
         return
+
+    # Normalize line endings so CRLF input does not leak carriage returns into content.
+    markdown = markdown.replace("\r\n", "\n").replace("\r", "\n")
 
     lines = markdown.split("\n")
     i = 0

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -34,6 +34,7 @@ class Codeblock:
     @classmethod
     @trace_function(name="codeblock.from_markdown", attributes={"component": "parser"})
     def from_markdown(cls, content: str) -> "Codeblock":
+        content = content.replace("\r\n", "\n").replace("\r", "\n")
         stripped = content.strip()
         fence_len = 0
 
@@ -123,6 +124,9 @@ def _extract_codeblocks(
     # appears in the prefix at all).  We must NOT strip when <think> appears only
     # concatenated with a fence closer (e.g. "```<think>") — that is handled later
     # by the inner-loop fence-recovery logic.
+    # Normalize line endings so CRLF input does not leak carriage returns into content.
+    markdown = markdown.replace("\r\n", "\n").replace("\r", "\n")
+
     _concatenated_end_found = False
     _concatenated_end_pos = -1
     for _think_end_tag in ["</thinking>", "</think>"]:

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1478,3 +1478,17 @@ def test_xml_roundtrip_special_chars():
     xml = original.to_xml()
     restored = Codeblock.from_xml(xml)
     assert restored.content == original.content
+
+
+def test_from_markdown_normalizes_crlf():
+    """CRLF input must produce the same content as LF input (no carriage returns)."""
+    crlf = Codeblock.from_markdown("```python\r\nprint(1)\r\n```")
+    lf = Codeblock.from_markdown("```python\nprint(1)\n```")
+    assert crlf.content == lf.content
+    assert "\r" not in crlf.content
+
+
+def test_iter_from_markdown_normalizes_crlf():
+    """CRLF input to iter_from_markdown must not leave \\r in content."""
+    blocks = Codeblock.iter_from_markdown("```python\r\nprint(1)\r\n```")
+    assert blocks == [Codeblock("python", "print(1)")]

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1492,3 +1492,17 @@ def test_iter_from_markdown_normalizes_crlf():
     """CRLF input to iter_from_markdown must not leave \\r in content."""
     blocks = Codeblock.iter_from_markdown("```python\r\nprint(1)\r\n```")
     assert blocks == [Codeblock("python", "print(1)")]
+
+
+def test_from_markdown_normalizes_standalone_cr():
+    """Standalone \\r (old-Mac) line endings must also be normalized."""
+    cr = Codeblock.from_markdown("```python\rprint(1)\r```")
+    lf = Codeblock.from_markdown("```python\nprint(1)\n```")
+    assert cr.content == lf.content
+    assert "\r" not in cr.content
+
+
+def test_iter_from_markdown_normalizes_standalone_cr():
+    """Standalone \\r (old-Mac) line endings must also be normalized."""
+    blocks = Codeblock.iter_from_markdown("```python\rprint(1)\r```")
+    assert blocks == [Codeblock("python", "print(1)")]


### PR DESCRIPTION
## Summary

When a message contains a code block with CRLF (`\r\n`) line endings, `Codeblock.from_markdown` and `_extract_codeblocks` leak carriage returns into the extracted content. For example, parsing `` ```python\r\nprint(1)\r\n``` `` produced content `'\r\nprint(1)\r\n'` (from_markdown) or `'print(1)\r'` (iter_from_markdown) instead of the LF-equivalent `'print(1)\n'`.

This is a real correctness issue: extracted content is handed to tools like `shell`, `save`, and `ipython`, so a stray `\r` can corrupt commands or files written from messages that arrive with Windows line endings (e.g. a CRLF file read into context).

## Change

Normalize `\r\n` → `\n` (and standalone `\r` → `\n`) at both markdown parsing entry points, so CRLF input produces identical output to LF input. In `_extract_codeblocks` the normalization runs after the no-fence early exit so the scan is skipped for messages without code blocks.

## Tests

Added 4 regression tests in `tests/test_codeblock.py`:
- `test_from_markdown_normalizes_crlf` / `test_iter_from_markdown_normalizes_crlf`: CRLF input equals LF input, no `\r` in content
- `test_from_markdown_normalizes_standalone_cr` / `test_iter_from_markdown_normalizes_standalone_cr`: standalone `\r` (old-Mac) line endings handled

Verification: `pytest tests/test_codeblock.py` → 67 passed; parsing-related suites (test_message, test_xml_format, test_tools) → 140 passed. `ruff check`/`format` and `mypy` clean on the touched files.

## Tooling note

Implemented with assistance from an AI coding tool (Claude Code); the two-line change was reviewed and verified against both LF and CRLF inputs.
