### PR TITLE
test(review): fix brittle live-PR unresolved assertion + add mocked coverage (gptme#3442)

### DIFF
--- a/tests/test_util_gh.py
+++ b/tests/test_util_gh.py
@@ -340,11 +340,14 @@ def test_gh_tool_read_pr():
 
 
 @pytest.mark.slow
-def test_get_github_pr_content_with_unresolved():
-    """Test that unresolved review comments are included.
+def test_get_github_pr_content_with_review_comments():
+    """Test that review comment metadata is included for a merged PR.
 
-    Uses PR #271 from gptme/gptme which has 4 unresolved review threads
-    from ErikBjare (open since Nov 2024, stable test target).
+    Uses PR #271 from gptme/gptme (merged).  The unresolved-thread assertion
+    was removed — PR threads can be resolved at any time, making that check
+    fragile for a live test.  Mocked coverage for the ``Review Comments
+    (Unresolved)`` section lives in ``test_util_gh_mocked.py`` where it is
+    stable regardless of GitHub state.
     """
     content = get_github_pr_content("https://github.com/gptme/gptme/pull/271")
 
@@ -352,12 +355,10 @@ def test_get_github_pr_content_with_unresolved():
         pytest.skip("gh CLI not available or request failed")
     assert content is not None  # help mypy narrow type after skip
 
-    # Should have basic PR info
+    # Should have basic PR info — title contains "prompts"
     assert "gptme-util" in content or "prompts" in content
 
-    # PR #271 has unresolved review threads — verify they show up
-    assert "Review Comments (Unresolved)" in content
-    # Should contain ErikBjare's review comments with file references
+    # PR was authored by ErikBjare
     assert "ErikBjare" in content
 
 

--- a/tests/test_util_gh_mocked.py
+++ b/tests/test_util_gh_mocked.py
@@ -375,35 +375,28 @@ def test_no_context_or_suggestion(mock_pr_basic_response):
     assert "Suggested change:" not in content
 
 
-def test_unresolved_section_header_present_when_thread_open():
-    """Unresolved review threads produce a 'Review Comments (Unresolved)' section.
+def test_review_thread_resolution_controls_unresolved_section(mock_pr_basic_response):
+    """Only comments from unresolved review threads are rendered."""
+    mock_pr_basic_response["review_comments"] = [
+        {
+            "id": 2001,
+            "user": {"login": "reviewer"},
+            "body": "This needs documentation.",
+            "path": "gptme/util/review.py",
+            "line": 42,
+            "diff_hunk": "",
+        }
+    ]
 
-    This is a mocked regression guard for gptme#3442 — tests the section
-    header without depending on live GitHub PR state (live PRs can have their
-    threads resolved at any time, causing false failures).
-    """
-    mock_response = {
-        "pr_view": "Test PR #200\nOpen\n@author\n\nPR body",
-        "pr_comments": "",
-        "pr_details": {"number": 200, "title": "Test PR", "state": "open"},
-        "review_comments": [
-            {
-                "id": 2001,
-                "user": {"login": "ErikBjare"},
-                "body": "This needs documentation.",
-                "path": "gptme/util/review.py",
-                "line": 42,
-                "diff_hunk": "",
-            }
-        ],
-        "graphql_threads": {
+    for is_resolved, section_present in ((False, True), (True, False)):
+        mock_pr_basic_response["graphql_threads"] = {
             "data": {
                 "repository": {
                     "pullRequest": {
                         "reviewThreads": {
                             "nodes": [
                                 {
-                                    "isResolved": False,
+                                    "isResolved": is_resolved,
                                     "comments": {"nodes": [{"databaseId": 2001}]},
                                 }
                             ]
@@ -411,59 +404,17 @@ def test_unresolved_section_header_present_when_thread_open():
                     }
                 }
             }
-        },
-    }
+        }
 
-    with patch("subprocess.run", side_effect=mock_subprocess_run(mock_response)):
-        content = get_github_pr_content("https://github.com/owner/repo/pull/200")
+        with patch(
+            "subprocess.run",
+            side_effect=mock_subprocess_run(mock_pr_basic_response),
+        ):
+            content = get_github_pr_content("https://github.com/owner/repo/pull/200")
 
-    assert content is not None
-    # Section header must appear when there is at least one unresolved thread.
-    assert "Review Comments (Unresolved)" in content
-    assert "ErikBjare" in content
-    assert "This needs documentation." in content
-
-
-def test_unresolved_section_header_absent_when_all_resolved():
-    """Resolved review threads do NOT produce a 'Review Comments (Unresolved)' section."""
-    mock_response = {
-        "pr_view": "Test PR #201\nMerged\n@author\n\nPR body",
-        "pr_comments": "",
-        "pr_details": {"number": 201, "title": "Test PR", "state": "merged"},
-        "review_comments": [
-            {
-                "id": 2002,
-                "user": {"login": "ErikBjare"},
-                "body": "Fixed, looks good.",
-                "path": "gptme/util/gh.py",
-                "line": 10,
-                "diff_hunk": "",
-            }
-        ],
-        "graphql_threads": {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [
-                                {
-                                    "isResolved": True,
-                                    "comments": {"nodes": [{"databaseId": 2002}]},
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-    }
-
-    with patch("subprocess.run", side_effect=mock_subprocess_run(mock_response)):
-        content = get_github_pr_content("https://github.com/owner/repo/pull/201")
-
-    assert content is not None
-    # Resolved threads must NOT appear in the unresolved section.
-    assert "Review Comments (Unresolved)" not in content
+        assert content is not None
+        assert ("Review Comments (Unresolved)" in content) is section_present
+        assert ("This needs documentation." in content) is section_present
 
 
 def test_empty_diff_hunk():

--- a/tests/test_util_gh_mocked.py
+++ b/tests/test_util_gh_mocked.py
@@ -367,9 +367,103 @@ def test_no_context_or_suggestion(mock_pr_basic_response):
     assert "**@reviewer** on test.py:5 (ID: 1005):" in content
     assert "Looks good!" in content
 
+    # Should have "Review Comments (Unresolved)" section header since thread is open
+    assert "Review Comments (Unresolved)" in content
+
     # Should NOT have context or suggestion sections
     assert "Referenced code" not in content
     assert "Suggested change:" not in content
+
+
+def test_unresolved_section_header_present_when_thread_open():
+    """Unresolved review threads produce a 'Review Comments (Unresolved)' section.
+
+    This is a mocked regression guard for gptme#3442 — tests the section
+    header without depending on live GitHub PR state (live PRs can have their
+    threads resolved at any time, causing false failures).
+    """
+    mock_response = {
+        "pr_view": "Test PR #200\nOpen\n@author\n\nPR body",
+        "pr_comments": "",
+        "pr_details": {"number": 200, "title": "Test PR", "state": "open"},
+        "review_comments": [
+            {
+                "id": 2001,
+                "user": {"login": "ErikBjare"},
+                "body": "This needs documentation.",
+                "path": "gptme/util/review.py",
+                "line": 42,
+                "diff_hunk": "",
+            }
+        ],
+        "graphql_threads": {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "comments": {"nodes": [{"databaseId": 2001}]},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+    with patch("subprocess.run", side_effect=mock_subprocess_run(mock_response)):
+        content = get_github_pr_content("https://github.com/owner/repo/pull/200")
+
+    assert content is not None
+    # Section header must appear when there is at least one unresolved thread.
+    assert "Review Comments (Unresolved)" in content
+    assert "ErikBjare" in content
+    assert "This needs documentation." in content
+
+
+def test_unresolved_section_header_absent_when_all_resolved():
+    """Resolved review threads do NOT produce a 'Review Comments (Unresolved)' section."""
+    mock_response = {
+        "pr_view": "Test PR #201\nMerged\n@author\n\nPR body",
+        "pr_comments": "",
+        "pr_details": {"number": 201, "title": "Test PR", "state": "merged"},
+        "review_comments": [
+            {
+                "id": 2002,
+                "user": {"login": "ErikBjare"},
+                "body": "Fixed, looks good.",
+                "path": "gptme/util/gh.py",
+                "line": 10,
+                "diff_hunk": "",
+            }
+        ],
+        "graphql_threads": {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": True,
+                                    "comments": {"nodes": [{"databaseId": 2002}]},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+    with patch("subprocess.run", side_effect=mock_subprocess_run(mock_response)):
+        content = get_github_pr_content("https://github.com/owner/repo/pull/201")
+
+    assert content is not None
+    # Resolved threads must NOT appear in the unresolved section.
+    assert "Review Comments (Unresolved)" not in content
 
 
 def test_empty_diff_hunk():


### PR DESCRIPTION
## Problem

The test `test_get_github_pr_content_with_unresolved` in `tests/test_util_gh.py` was relying on PR #271 having 4 unresolved review threads from ErikBjare as a "stable" test target. Those threads have since been resolved, causing the assertion `assert 'Review Comments (Unresolved)' in content` to fail on every CI run.

This is part of the review pipeline convergence work (gptme#3442) — the review-watch tests and shared utilities pass, but this one live-test regression was blocking a clean test run.

## Fix

**`tests/test_util_gh.py`**
- Rename `test_get_github_pr_content_with_unresolved` → `test_get_github_pr_content_with_review_comments`
- Remove the brittle `assert 'Review Comments (Unresolved)' in content` assertion from the live test (live GitHub PR state changes over time; this is not a stable regression target)
- Keep the remaining assertions that verify basic PR metadata is fetched correctly

**`tests/test_util_gh_mocked.py`**
- Add `test_unresolved_section_header_present_when_thread_open`: verifies the `## Review Comments (Unresolved)` section appears when at least one thread has `isResolved=False`
- Add `test_unresolved_section_header_absent_when_all_resolved`: verifies the section is absent when all threads are `isResolved=True`
- Add the missing `Review Comments (Unresolved)` assertion to the existing `test_no_context_or_suggestion` test (it was already using an unresolved thread but did not assert the section header)

The mocked tests give stable, deterministic coverage of the section-header logic regardless of GitHub's live PR state.

## Tests

```
uv run pytest tests/test_util_gh.py tests/test_util_gh_mocked.py tests/test_util_review.py tests/test_util_cli_review_watch.py -q -m 'not slow'
# 299 passed
```

Closes gptme#3442 (the remaining non-webhook checklist items are now all implemented and tested — the webhook/GitHub App integration is explicitly a longer-term follow-up).

<!-- gptme-id:v1:gai_h29F68jalmjSqGhE12n9uhEuRuP2quFxW8ANXQsU4lZ -->