### PR TITLE
refactor(review): extract infer_owner_repo into shared gptme.util.gh — close last item from #3442

### DIFF
--- a/gptme/cli/cmd_review_pr.py
+++ b/gptme/cli/cmd_review_pr.py
@@ -41,7 +41,7 @@ from pathlib import Path
 
 import click
 
-from ..util.gh import run_gh_json
+from ..util.gh import infer_owner_repo, run_gh_json
 from ..util.review import (
     FindingSeverity,
     FindingStatus,
@@ -59,23 +59,8 @@ logger = logging.getLogger(__name__)
 
 _OWNER_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
 
-
-def _infer_owner_repo() -> str | None:
-    """Infer owner/repo from the current git remote."""
-    try:
-        result = subprocess.run(
-            ["gh", "repo", "view", "--json", "nameWithOwner"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            return data.get("nameWithOwner")
-    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
-        pass
-    return None
+# _infer_owner_repo is now the shared gptme.util.gh.infer_owner_repo.
+# The import at the top of this module exposes it as ``infer_owner_repo``.
 
 
 def _get_pr_metadata(owner: str, repo: str, pr_number: int) -> dict | None:
@@ -615,7 +600,7 @@ def review_pr(
     # Resolve owner/repo
     # ------------------------------------------------------------------
     if repo is None:
-        inferred = _infer_owner_repo()
+        inferred = infer_owner_repo()
         if inferred is None:
             raise click.UsageError(
                 "--repo is required (could not infer from git remote)."

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 import click
 
-from ..util.gh import is_trusted_reviewer, run_gh_json
+from ..util.gh import infer_owner_repo, is_trusted_reviewer, run_gh_json
 from ..util.review import FindingStatus, ReviewArtifact, ReviewFinding, ReviewStatus
 
 logger = logging.getLogger(__name__)
@@ -832,32 +832,12 @@ def review_watch(
 
     # Resolve repo from git remote when not provided
     if repo is None:
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "repo",
-                    "view",
-                    "--json",
-                    "nameWithOwner",
-                    "-q",
-                    ".nameWithOwner",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=10,
-            )
-            repo = result.stdout.strip()
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-            OSError,
-        ) as exc:
+        repo = infer_owner_repo()
+        if repo is None:
             raise click.ClickException(
                 "Could not infer repository from git remote. "
                 "Pass --repo owner/repo explicitly."
-            ) from exc
+            )
 
     if "/" not in repo:
         raise click.ClickException(

--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -59,6 +59,33 @@ def run_gh_json(
         return None
 
 
+def infer_owner_repo() -> str | None:
+    """Infer ``owner/repo`` for the current directory using the ``gh`` CLI.
+
+    Runs ``gh repo view --json nameWithOwner`` which honours the user's active
+    ``gh auth`` context and handles SSH remotes, HTTPS remotes, and repo
+    forks correctly.  Falls back to ``None`` when the ``gh`` CLI is unavailable,
+    the current directory is not inside a GitHub repository, or the command
+    fails for any reason.
+
+    Returns:
+        A ``"owner/repo"`` string or ``None``.
+
+    Example::
+
+        repo = infer_owner_repo()
+        if repo is None:
+            raise click.UsageError("--repo is required (could not infer from git remote).")
+        owner, repo_name = repo.split("/", 1)
+    """
+    data = run_gh_json(["gh", "repo", "view", "--json", "nameWithOwner"], timeout=10)
+    if isinstance(data, dict):
+        value = data.get("nameWithOwner")
+        if isinstance(value, str) and "/" in value:
+            return value
+    return None
+
+
 def is_bot_user(user: dict) -> bool:
     """Return ``True`` when a GitHub user dict describes a bot account.
 

--- a/tests/test_util_review.py
+++ b/tests/test_util_review.py
@@ -84,6 +84,80 @@ class TestRunGhJson:
         assert gh_util.run_gh_json(["gh", "pr", "view", "1"]) is None
 
 
+class TestInferOwnerRepo:
+    """Tests for gptme.util.gh.infer_owner_repo (shared across review pipeline)."""
+
+    def test_returns_owner_repo_string(self, monkeypatch):
+        """Happy path: gh returns a nameWithOwner dict."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args,
+                returncode=0,
+                stdout=json.dumps({"nameWithOwner": "ErikBjare/gptme"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() == "ErikBjare/gptme"
+
+    def test_returns_none_on_gh_failure(self, monkeypatch):
+        """Returns None when gh exits with a non-zero status (no git repo, auth error, etc.)."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, returncode=1, stdout="", stderr="not a git repo"
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() is None
+
+    def test_returns_none_on_missing_key(self, monkeypatch):
+        """Returns None when gh succeeds but nameWithOwner is absent."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, returncode=0, stdout=json.dumps({}), stderr=""
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() is None
+
+    def test_returns_none_on_invalid_json(self, monkeypatch):
+        """Returns None when gh returns non-JSON output."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, returncode=0, stdout="not json", stderr=""
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() is None
+
+    def test_returns_none_on_timeout(self, monkeypatch):
+        """Returns None when gh times out."""
+
+        def fake_run(args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=10)
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() is None
+
+    def test_value_must_contain_slash(self, monkeypatch):
+        """Returns None when nameWithOwner has no slash (malformed response)."""
+
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args,
+                returncode=0,
+                stdout=json.dumps({"nameWithOwner": "noslash"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gh_util.subprocess, "run", fake_run)
+        assert gh_util.infer_owner_repo() is None
+
+
 class TestIsBotUser:
     def test_bot_type(self):
         assert gh_util.is_bot_user({"type": "Bot", "login": "some-bot"})
@@ -1454,9 +1528,10 @@ Reviewed the diff carefully.
         diff_file.write_text(self._SAMPLE_DIFF)
 
         # Prevent infer_owner_repo from succeeding.
+        # The shared helper is imported into cmd_review_pr, so patch it there.
         from gptme.cli import cmd_review_pr
 
-        monkeypatch.setattr(cmd_review_pr, "_infer_owner_repo", lambda: None)
+        monkeypatch.setattr(cmd_review_pr, "infer_owner_repo", lambda: None)
 
         runner = self._runner()
         result = runner.invoke(


### PR DESCRIPTION
## Summary

Closes out the last actionable open item from #3442 ("Extract shared GitHub utilities").

Both `cmd_review_pr` and `cmd_review_watch` had independent inline implementations of the same `gh repo view --json nameWithOwner` pattern for discovering the current repo. This PR extracts it into a single public `infer_owner_repo()` in `gptme/util/gh.py` — next to the existing shared primitives (`run_gh_json`, `is_bot_user`, `is_trusted_reviewer`) — and rewires both callers.

## Changes

- **`gptme/util/gh.py`**: add `infer_owner_repo()` — delegates to `run_gh_json` (no new subprocess/JSON boilerplate); validates the `owner/repo` slash invariant before returning.
- **`gptme/cli/cmd_review_pr.py`**: remove local `_infer_owner_repo`; import and call the shared helper.
- **`gptme/cli/cmd_review_watch.py`**: replace 20-line inline `gh repo view` block with a single `infer_owner_repo()` call.
- **`tests/test_util_review.py`**: add `TestInferOwnerRepo` class (6 cases) covering happy path, gh failure, missing key, invalid JSON, timeout, and the slash-invariant guard; update the existing monkeypatch target from the removed `_infer_owner_repo` to `infer_owner_repo`.

## Context

#3442 checklist status after this PR:
- [x] Evaluate `review-watch` for local/GitHub-less mode → PR #3449
- [x] Design `ReviewArtifact` → `review-watch` structured handoff → PR #3449
- [x] Group commands under `gptme-util review *` → PR #3462
- [x] Extract shared GitHub utilities → **this PR**
- [ ] GitHub App webhook triggering → longer-term, explicitly deferred in issue

Resolves #3442

<!-- gptme-id:v1:gai_Cp7AI3VN2ZPfOlltOSZ6oL63AKoOrUC1P5rP3NJoZGi -->