### PR TITLE
fix(message): disable Rich markup for plain rendering

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -568,7 +568,8 @@ def format_msgs(
         output = ""
         if oneline:
             content = stripped_content.replace("\n", "\\n")
-            content = escape_markup(content)
+            if highlight:
+                content = escape_markup(content)
             output += textwrap.shorten(content, width=max_len, placeholder="...")
             if len(output) < 20:
                 output = content[:max_len] + "..."
@@ -577,11 +578,9 @@ def format_msgs(
             output += "\n" + indent * " " if multiline else ""
             for i, block in enumerate(stripped_content.split("```")):
                 if i % 2 == 0:
-                    # Always escape Rich markup in non-code-block content,
-                    # even when highlight=False (e.g. non-TTY). Path-like strings
-                    # such as "[/home/runner/run.sh]" are valid Rich markup tags and
-                    # will raise MarkupError if left unescaped.
-                    block = escape_markup(block)
+                    # Escape Rich markup in non-code-block content
+                    if highlight:
+                        block = escape_markup(block)
                     output += textwrap.indent(block, prefix=indent * " ")
                     continue
                 if highlight:
@@ -670,7 +669,10 @@ def print_msg(
             skipped_hidden += 1
             continue
         try:
-            console.print(s)
+            # Plain-text formatting intentionally preserves literal brackets. Disable
+            # Rich markup parsing at the rendering boundary so strings such as
+            # "[/home/runner/run.sh]" cannot be interpreted as closing tags.
+            console.print(s, markup=highlight)
         except Exception:
             # rich can throw errors, if so then print the raw message
             logger.exception("Error printing message")

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -669,10 +669,10 @@ def print_msg(
             skipped_hidden += 1
             continue
         try:
-            # Plain-text formatting intentionally preserves literal brackets. Disable
-            # Rich markup parsing at the rendering boundary so strings such as
-            # "[/home/runner/run.sh]" cannot be interpreted as closing tags.
-            console.print(s, markup=highlight)
+            # Plain-text formatting intentionally preserves literal Rich syntax.
+            # Disable markup and emoji parsing at the rendering boundary so strings
+            # such as "[/home/runner/run.sh]" and ":warning:" stay unchanged.
+            console.print(s, markup=highlight, emoji=False)
         except Exception:
             # rich can throw errors, if so then print the raw message
             logger.exception("Error printing message")

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -568,8 +568,7 @@ def format_msgs(
         output = ""
         if oneline:
             content = stripped_content.replace("\n", "\\n")
-            if highlight:
-                content = escape_markup(content)
+            content = escape_markup(content)
             output += textwrap.shorten(content, width=max_len, placeholder="...")
             if len(output) < 20:
                 output = content[:max_len] + "..."
@@ -578,9 +577,11 @@ def format_msgs(
             output += "\n" + indent * " " if multiline else ""
             for i, block in enumerate(stripped_content.split("```")):
                 if i % 2 == 0:
-                    # Escape Rich markup in non-code-block content
-                    if highlight:
-                        block = escape_markup(block)
+                    # Always escape Rich markup in non-code-block content,
+                    # even when highlight=False (e.g. non-TTY). Path-like strings
+                    # such as "[/home/runner/run.sh]" are valid Rich markup tags and
+                    # will raise MarkupError if left unescaped.
+                    block = escape_markup(block)
                     output += textwrap.indent(block, prefix=indent * " ")
                     continue
                 if highlight:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -86,12 +86,11 @@ def test_format_msgs_escapes_rich_markup():
         "Testing [project] with [bold]content[/bold]"
     )
 
-    # With highlight - should escape markup
+    # With highlight, escape message content while preserving generated role markup.
     outputs_highlight = format_msgs([msg], highlight=True)
-    assert len(outputs_highlight) == 1
-    # The escaped version should be different (escaped brackets)
-    # Note: We can't directly check the escape as it's in the Rich formatted string
-    # but we verify no exception is raised from Rich interpreting brackets as tags
+    assert outputs_highlight[0].endswith(
+        r"Testing \[project] with \[bold]content\[/bold]"
+    )
 
 
 def test_format_msgs_no_highlight_preserves_path_like_bracket():
@@ -154,6 +153,23 @@ def test_print_msg_no_highlight_path_like_bracket_no_crash(monkeypatch):
     (rendered,) = mock_console.print.call_args.args
     assert rendered.endswith("Run [/home/runner/run.sh]")
     assert mock_console.print.call_args.kwargs == {"markup": False}
+
+
+def test_print_msg_highlight_path_like_bracket_is_escaped(monkeypatch):
+    """TTY output must escape message content before enabling Rich markup."""
+    from unittest.mock import patch
+
+    from gptme.message import Message, print_msg
+
+    msg = Message("user", "Run [/home/runner/run.sh]")
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    with patch("gptme.message.console") as mock_console:
+        assert print_msg(msg, highlight=True) == 1
+
+    (rendered,) = mock_console.print.call_args.args
+    assert rendered.endswith(r"Run \[/home/runner/run.sh]")
+    assert mock_console.print.call_args.kwargs == {"markup": True}
 
 
 def test_format_msgs_preserves_codeblocks():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -80,7 +80,7 @@ def test_format_msgs_escapes_rich_markup():
     # Test with content containing Rich-like markup that should be escaped
     msg = Message("user", "Testing [project] with [bold]content[/bold]")
 
-    # Without highlight - should not escape
+    # Without highlight (non-TTY path) - must still escape to avoid MarkupError
     outputs_no_highlight = format_msgs([msg], highlight=False)
     assert len(outputs_no_highlight) == 1
 
@@ -92,16 +92,53 @@ def test_format_msgs_escapes_rich_markup():
     # but we verify no exception is raised from Rich interpreting brackets as tags
 
 
+def test_format_msgs_no_highlight_path_like_bracket_no_crash():
+    """Regression: highlight=False (non-TTY) must not crash on path-like [/...] markup.
+
+    Non-TTY gptme sessions (CI, headless agents, pipes) force highlight=False.
+    Content containing strings like '[/home/runner/run.sh]' looks like a Rich
+    closing tag and raises MarkupError if not escaped. Escaping must be
+    unconditional, not guarded by `if highlight`.
+    """
+    from gptme.message import Message, format_msgs
+
+    # Content that matches a Rich closing-tag pattern (slash prefix)
+    msg = Message(
+        "user", "Run the script at [/home/runner/run.sh] to reproduce the issue."
+    )
+
+    # highlight=False is the non-TTY path; must not raise MarkupError
+    outputs = format_msgs([msg], highlight=False)
+    assert len(outputs) == 1
+    assert "/home/runner/run.sh" in outputs[0]
+
+
 def test_format_msgs_oneline_escapes_rich_markup():
     """Test that Rich markup is escaped in oneline mode."""
     from gptme.message import Message, format_msgs
 
     msg = Message("user", "Testing [project]\nwith newlines")
 
+    # Without highlight (non-TTY path) - must still escape to avoid MarkupError
+    outputs_no_highlight = format_msgs([msg], oneline=True, highlight=False)
+    assert len(outputs_no_highlight) == 1
+
     # With highlight and oneline
-    outputs = format_msgs([msg], oneline=True, highlight=True)
-    assert len(outputs) == 1
+    outputs_highlight = format_msgs([msg], oneline=True, highlight=True)
+    assert len(outputs_highlight) == 1
     # Verify no Rich markup interpretation error
+
+
+def test_format_msgs_oneline_no_highlight_path_like_bracket_no_crash():
+    """Regression: oneline + highlight=False must not crash on path-like [/...] markup."""
+    from gptme.message import Message, format_msgs
+
+    msg = Message(
+        "user", "Run the script at [/home/runner/run.sh] to reproduce the issue."
+    )
+
+    outputs = format_msgs([msg], oneline=True, highlight=False)
+    assert len(outputs) == 1
 
 
 def test_format_msgs_preserves_codeblocks():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -80,9 +80,11 @@ def test_format_msgs_escapes_rich_markup():
     # Test with content containing Rich-like markup that should be escaped
     msg = Message("user", "Testing [project] with [bold]content[/bold]")
 
-    # Without highlight (non-TTY path) - must still escape to avoid MarkupError
+    # Without highlight, preserve the literal content for plaintext consumers
     outputs_no_highlight = format_msgs([msg], highlight=False)
-    assert len(outputs_no_highlight) == 1
+    assert outputs_no_highlight[0].endswith(
+        "Testing [project] with [bold]content[/bold]"
+    )
 
     # With highlight - should escape markup
     outputs_highlight = format_msgs([msg], highlight=True)
@@ -92,14 +94,8 @@ def test_format_msgs_escapes_rich_markup():
     # but we verify no exception is raised from Rich interpreting brackets as tags
 
 
-def test_format_msgs_no_highlight_path_like_bracket_no_crash():
-    """Regression: highlight=False (non-TTY) must not crash on path-like [/...] markup.
-
-    Non-TTY gptme sessions (CI, headless agents, pipes) force highlight=False.
-    Content containing strings like '[/home/runner/run.sh]' looks like a Rich
-    closing tag and raises MarkupError if not escaped. Escaping must be
-    unconditional, not guarded by `if highlight`.
-    """
+def test_format_msgs_no_highlight_preserves_path_like_bracket():
+    """Plaintext formatting must preserve path-like bracket content verbatim."""
     from gptme.message import Message, format_msgs
 
     # Content that matches a Rich closing-tag pattern (slash prefix)
@@ -107,10 +103,10 @@ def test_format_msgs_no_highlight_path_like_bracket_no_crash():
         "user", "Run the script at [/home/runner/run.sh] to reproduce the issue."
     )
 
-    # highlight=False is the non-TTY path; must not raise MarkupError
     outputs = format_msgs([msg], highlight=False)
-    assert len(outputs) == 1
-    assert "/home/runner/run.sh" in outputs[0]
+    assert outputs[0].endswith(
+        "Run the script at [/home/runner/run.sh] to reproduce the issue."
+    )
 
 
 def test_format_msgs_oneline_escapes_rich_markup():
@@ -119,9 +115,9 @@ def test_format_msgs_oneline_escapes_rich_markup():
 
     msg = Message("user", "Testing [project]\nwith newlines")
 
-    # Without highlight (non-TTY path) - must still escape to avoid MarkupError
+    # Without highlight, preserve literal brackets for plaintext consumers
     outputs_no_highlight = format_msgs([msg], oneline=True, highlight=False)
-    assert len(outputs_no_highlight) == 1
+    assert outputs_no_highlight[0].endswith("Testing [project]\\nwith newlines")
 
     # With highlight and oneline
     outputs_highlight = format_msgs([msg], oneline=True, highlight=True)
@@ -129,8 +125,8 @@ def test_format_msgs_oneline_escapes_rich_markup():
     # Verify no Rich markup interpretation error
 
 
-def test_format_msgs_oneline_no_highlight_path_like_bracket_no_crash():
-    """Regression: oneline + highlight=False must not crash on path-like [/...] markup."""
+def test_format_msgs_oneline_no_highlight_preserves_path_like_bracket():
+    """Oneline plaintext formatting must preserve path-like brackets verbatim."""
     from gptme.message import Message, format_msgs
 
     msg = Message(
@@ -138,7 +134,26 @@ def test_format_msgs_oneline_no_highlight_path_like_bracket_no_crash():
     )
 
     outputs = format_msgs([msg], oneline=True, highlight=False)
-    assert len(outputs) == 1
+    assert outputs[0].endswith(
+        "Run the script at [/home/runner/run.sh] to reproduce the issue."
+    )
+
+
+def test_print_msg_no_highlight_path_like_bracket_no_crash(monkeypatch):
+    """Non-TTY output must disable Rich markup parsing at the console boundary."""
+    from unittest.mock import patch
+
+    from gptme.message import Message, print_msg
+
+    msg = Message("user", "Run [/home/runner/run.sh]")
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+
+    with patch("gptme.message.console") as mock_console:
+        assert print_msg(msg) == 1
+
+    (rendered,) = mock_console.print.call_args.args
+    assert rendered.endswith("Run [/home/runner/run.sh]")
+    assert mock_console.print.call_args.kwargs == {"markup": False}
 
 
 def test_format_msgs_preserves_codeblocks():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -138,21 +138,21 @@ def test_format_msgs_oneline_no_highlight_preserves_path_like_bracket():
     )
 
 
-def test_print_msg_no_highlight_path_like_bracket_no_crash(monkeypatch):
-    """Non-TTY output must disable Rich markup parsing at the console boundary."""
+def test_print_msg_no_highlight_preserves_rich_syntax(monkeypatch):
+    """Non-TTY output must disable Rich parsing at the console boundary."""
     from unittest.mock import patch
 
     from gptme.message import Message, print_msg
 
-    msg = Message("user", "Run [/home/runner/run.sh]")
+    msg = Message("user", "Run [/home/runner/run.sh] :warning:")
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
 
     with patch("gptme.message.console") as mock_console:
         assert print_msg(msg) == 1
 
     (rendered,) = mock_console.print.call_args.args
-    assert rendered.endswith("Run [/home/runner/run.sh]")
-    assert mock_console.print.call_args.kwargs == {"markup": False}
+    assert rendered.endswith("Run [/home/runner/run.sh] :warning:")
+    assert mock_console.print.call_args.kwargs == {"markup": False, "emoji": False}
 
 
 def test_print_msg_highlight_path_like_bracket_is_escaped(monkeypatch):
@@ -169,7 +169,7 @@ def test_print_msg_highlight_path_like_bracket_is_escaped(monkeypatch):
 
     (rendered,) = mock_console.print.call_args.args
     assert rendered.endswith(r"Run \[/home/runner/run.sh]")
-    assert mock_console.print.call_args.kwargs == {"markup": True}
+    assert mock_console.print.call_args.kwargs == {"markup": True, "emoji": False}
 
 
 def test_format_msgs_preserves_codeblocks():


### PR DESCRIPTION
## Summary

Fixes #3504.

Non-TTY gptme sessions force `highlight=False` in `print_msg()`, but the final
`console.print()` call still parsed the formatted string as Rich markup. Content
such as `[/home/runner/run.sh]` was therefore interpreted as a closing tag and
could raise `rich.errors.MarkupError`.

## Fix

Keep `format_msgs(..., highlight=False)` as literal plaintext and disable Rich
markup parsing at the rendering boundary:

```python
console.print(s, markup=highlight)
```

Highlighted rendering continues to escape user-supplied brackets before passing
intentional role markup to Rich. Plaintext consumers no longer receive leaked
backslash escapes.

## Tests

Regression coverage now verifies:

- multiline and oneline plaintext formatting preserve path-like brackets
- non-TTY `print_msg()` passes literal content with `markup=False`
- TTY/highlighted `print_msg()` escapes path-like closing tags and uses
  `markup=True`
- existing formatter escaping produces the exact expected highlighted output

Local verification: `uv run pytest tests/test_message.py -q` (28 passed), targeted
Ruff and format checks, and pre-commit. Current-head CI is green and Greptile is
5/5.
