### PR TITLE
fix(codeblock): slice body on raw first-line length to avoid lang leaking into content

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -52,11 +52,16 @@ class Codeblock:
             if fence_len == end_fence_len:
                 stripped = stripped.strip()[:-end_fence_len]
 
-        lang = stripped.splitlines()[0].strip() if stripped.strip() else ""
+        # Slice the body on the raw first line length (including any leading
+        # whitespace), not on the stripped lang: a fence like "``` python" leaves
+        # a space before the lang, and slicing on len(lang) would leave the tail
+        # of the lang word (e.g. the "n" of "python") leaking into the content.
+        first_line = stripped.splitlines()[0] if stripped.strip() else ""
+        lang = first_line.strip()
         fence = "`" * fence_len if fence_len else "```"
         return cls(
             lang,
-            stripped[len(lang) :].lstrip("\n") if lang else stripped,
+            stripped[len(first_line) :].lstrip("\n") if lang else stripped,
             fence=fence,
         )
 

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1506,3 +1506,33 @@ def test_iter_from_markdown_normalizes_standalone_cr():
     """Standalone \\r (old-Mac) line endings must also be normalized."""
     blocks = Codeblock.iter_from_markdown("```python\rprint(1)\r```")
     assert blocks == [Codeblock("python", "print(1)")]
+
+
+def test_from_markdown_leading_whitespace_after_fence():
+    """Leading whitespace between the opening fence and the lang must not leak
+    lang characters into the content.
+
+    Regression test: the body was sliced on ``len(lang)`` (the *stripped* lang),
+    which ignored any whitespace between the fence and the lang. For an opening
+    like ```` ``` python ```` the slice was one short, so the tail of the lang
+    word leaked into the content — e.g. content became ``"n\\nprint(1)"``.
+    """
+    # single space between fence and lang
+    cb = Codeblock.from_markdown("``` python\nprint(1)\n```")
+    assert cb.lang == "python"
+    assert cb.content == "print(1)\n"
+
+    # multiple spaces between fence and lang
+    cb = Codeblock.from_markdown("```  python\nprint(1)\n```")
+    assert cb.lang == "python"
+    assert cb.content == "print(1)\n"
+
+    # trailing space on the lang line is consumed, not leaked into content
+    cb = Codeblock.from_markdown("``` python \nprint(1)\n```")
+    assert cb.lang == "python"
+    assert cb.content == "print(1)\n"
+
+    # path-like lang with leading whitespace (common in save blocks)
+    cb = Codeblock.from_markdown("``` save path/to/file.py\nprint(1)\n```")
+    assert cb.lang == "save path/to/file.py"
+    assert cb.content == "print(1)\n"


### PR DESCRIPTION
# w-top-gptme-2 — codeblock `from_markdown` leaks lang chars into content

**Status:** Bug found, verified at HEAD, fixed minimally + regression test. Committed (NOT pushed).
**HEAD:** `bd99a0944` (upstream/master, `feat(lessons): Stage 1 shadow logging …`)
**Branch:** `YuriNachos/w-top-gptme-2-2`

---

## 1. HEAD confirmation

`git fetch upstream --prune; git checkout master; git reset --hard upstream/master` → `bd99a0944`.
Worktree `YuriNachos/w-top-gptme-2-2` is on the same commit, clean before edits. The defect below
is present in `gptme/codeblock.py` at this HEAD.

## 2. The bug

**File:** `gptme/codeblock.py`, `Codeblock.from_markdown` (lines ~55–61).

When the opening fence is followed by **leading whitespace** before the language tag — the extremely
common `` ``` python `` form — the body was sliced on `len(lang)` where `lang` is the *stripped*
language string. The leading space(s) between the fence and the lang are part of the raw first line
but NOT part of the stripped `lang`, so the slice is too short by exactly the number of leading
whitespace chars. The tail of the language word then **leaks into the beginning of `content`**.

Off-by-N index bug (N = number of whitespace chars after the opening fence).

### Reproducer (deterministic, no network) — verified at HEAD before the fix

```python
from gptme.codeblock import Codeblock
Codeblock.from_markdown("```python\nprint(1)\n")   # lang='python', content='print(1)'   ✓ (no space)
Codeblock.from_markdown("``` python\nprint(1)\n")   # lang='python', content='n\nprint(1)' ✗ "n" leaked
Codeblock.from_markdown("```  python\nprint(1)\n")  # lang='python', content='on\nprint(1)' ✗ "on" leaked
```

With one leading space, the final `n` of `python` leaks into content; with two spaces, `on` leaks.
The corrupted content is used downstream, e.g. `gptme/tui/app.py:254` `_markdown_tool_renderable`
renders tool codeblocks via `Codeblock.from_markdown(segment)`, so a model-emitted `` ``` python ``
block would be rendered with a garbled first line.

## 3. Root cause

```python
# before
lang = stripped.splitlines()[0].strip() if stripped.strip() else ""
...
stripped[len(lang) :].lstrip("\n") if lang else stripped,
```

`stripped` (after fence removal) for `` ``` python\ncode `` is `" python\ncode"`. The first line is
`" python"` (7 chars) but `lang` is `"python"` (6 chars). `stripped[len(lang):]` = `stripped[6:]`
cuts into the word → `"n\ncode"`.

## 4. The fix (minimal)

Slice on the length of the **raw first line** (which includes the leading whitespace), not on the
stripped lang:

```python
# after
first_line = stripped.splitlines()[0] if stripped.strip() else ""
lang = first_line.strip()
...
stripped[len(first_line) :].lstrip("\n") if lang else stripped,
```

`first_line = " python"` → `len(first_line) == 7` → `stripped[7:]` = `"\ncode"` → `.lstrip("\n")`
→ `"code"`. Correct. No-space and empty-lang paths are unchanged.

## 5. What I deliberately did NOT change (and why)

A finder also flagged the fence-length comparison `if fence_len == end_fence_len:` (line 52) as a
CommonMark `>=` violation. **This is intentional project behaviour, pinned by an existing test:**
`tests/test_codeblock.py::test_mismatched_fence_lengths` asserts that `` ```text\nline 1\n```` ``
(triple open / quad close) is NOT a complete block (`len(blocks) == 0`). The project's documented
policy is "opening and closing fences must have the same length". Changing `==`→`>=` would break
that test and is out of scope. **One bug → one minimal fix.**

The `gh.py` "check-run id vs workflow run id" candidate was also investigated and **dropped**: the
GitHub Checks REST docs do not expose a documented `run_id` field on the check-run object, so the
proposed fix could not be re-derived rigorously offline (false-positive risk).

## 6. Files changed

```
gptme/codeblock.py        | 9 +++++++--       (the fix)
tests/test_codeblock.py   | 30 ++++++++++++++++++++++++++++++  (regression test)
```

Only the fix + its regression test. Nothing else touched (no formatting, deps, or unrelated modules).

## 7. Gate

Command (per task): `ruff format --check && ruff check && mypy && pytest -q`

- `ruff format --check gptme/codeblock.py tests/test_codeblock.py` → **PASS** ("2 files already formatted").
  Note: bare `ruff format --check .` over the whole repo is RED at HEAD for **10 pre-existing files**
  (e.g. `tests/test_worktree.py`) that drift on master — none of them are in this change.
- `ruff check .` (full repo lint) → **PASS** ("All checks passed!").
- `mypy gptme/codeblock.py` → **PASS** ("Success: no issues found in 1 source file").
- `pytest`:
  - `tests/test_codeblock.py` → **68 passed** (incl. the new regression test).
  - `tests/test_codeblock.py tests/test_message.py tests/test_reduce.py` → **121 passed**.
  - Full unit suite (deselected `slow/eval/requires_api/integration/x11`, ignored `browser/computer`):
    **9002 passed, 152 skipped, 57 failed**. **All 57 failures are pre-existing and unrelated** —
    verified by re-running the non-environmental failures (`test_xml_format`, `test_tools_patch_many`,
    `test_uri`) on a clean HEAD (stash): identical 5 failed / 47 passed. The rest of the 57 are
    environment-only (bubblewrap/sandbox unavailable on macOS, network PDF download, eval git-setup).
    **Zero failures in or caused by this change.**

Red/green proof for the new test: with the fix stashed, `test_from_markdown_leading_whitespace_after_fence`
FAILS; with the fix applied, it PASSES.

## 8. PR-body draft (for a later push)

**Summary**

`Codeblock.from_markdown` corrupted its `content` whenever the opening fence was followed by
whitespace before the language tag (`` ``` python ``). The tail of the language word leaked into the
start of the parsed content (e.g. content became `"n\nprint(1)"` instead of `"print(1)"`).

**Root cause**

The body was sliced on `len(lang)` (the *stripped* lang), ignoring the leading whitespace that
sits between the fence and the lang on the raw first line. The slice was short by exactly the
number of leading whitespace chars, leaving the corresponding tail of the lang word in `content`.

**Changes**

- `gptme/codeblock.py`: slice the body on the raw first-line length (`len(first_line)`) instead of
  `len(lang)`.
- `tests/test_codeblock.py`: add `test_from_markdown_leading_whitespace_after_fence` covering
  single space, multiple spaces, trailing space on the lang line, and a path-like lang with leading
  whitespace.

**Test plan**

- New test fails on unfixed HEAD, passes with the fix (red/green verified).
- Full `test_codeblock.py` (68) and `test_message.py` + `test_reduce.py` pass; no regressions.
- The separate fence-length `==` behaviour is intentionally preserved (see `test_mismatched_fence_lengths`).
