### PR TITLE
docs: add Paritok context-compression provider

### DIFF
--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -248,6 +248,103 @@ Setting a default model
     [env]
     MODEL = "local/llama3.2:3b"
 
+.. _paritok-compression:
+
+Paritok — context compression
+-----------------------------
+
+`Paritok <https://github.com/Paritok-official/paritok-4b-v1>`_ is a drop-in
+compression proxy. It sits between gptme and your real provider and, on every
+request, compresses file reads and tool outputs and summarizes stale history —
+then forwards upstream, billed on the *compressed* tokens. Nothing is
+permanently discarded: the model can pull back any exact original on demand, so
+compression is lossless from the agent's point of view.
+
+Paritok speaks both the OpenAI Chat Completions API and the Anthropic Messages
+API, so you wire it into gptme with **no code changes**.
+
+.. important::
+
+   Paritok compresses reads that arrive as **native tool calls**. Run gptme with
+   ``--tool-format tool`` (native function-calling) so the ``read`` tool's output
+   is a real tool message. With the default ``markdown`` tool-format the file
+   content is plain message text and Paritok passes it through unchanged — you
+   get the proxy but no savings.
+
+Start the proxy
+~~~~~~~~~~~~~~~
+
+Install with the ``proxy`` extra (pulls in the gateway server + the embedding
+tool-selector) and start it. First run pulls the ~2.5 GB Paritok-4B model via
+Ollama and serves on port ``8080``:
+
+.. code-block:: bash
+
+    pip install "paritok[proxy]"
+    paritok up
+
+**No local GPU / no Ollama?** Use the hosted Paritok GPU server instead — create a
+starter config, set ``use_gpu_server: true`` and your API key, then start as usual:
+
+.. code-block:: bash
+
+    paritok init        # writes paritok.yaml
+    # in paritok.yaml:  use_gpu_server: true  +  gpu_server.api_key: "<your key>"
+    paritok up          # now compresses via the hosted GPU, no model download
+
+An API key is created at https://paritok.com (dashboard → API keys).
+
+OpenAI-compatible models
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add a custom provider pointing at the proxy, in ``~/.config/gptme/config.toml``:
+
+.. code-block:: toml
+
+    [[providers]]
+    name = "paritok"
+    base_url = "http://127.0.0.1:8080/v1"
+    api_key_env = "OPENAI_API_KEY"   # your real upstream key; Paritok forwards it
+    default_model = "gpt-4o"          # any model your upstream serves
+
+.. code-block:: bash
+
+    gptme --tool-format tool -m paritok/gpt-4o 'summarize the largest file in this repo'
+
+Claude models
+~~~~~~~~~~~~~
+
+Custom providers are OpenAI-shaped, so Claude routes through the built-in
+``anthropic`` provider plus gptme's global proxy override ``LLM_PROXY_URL`` (which
+gptme passes to the Anthropic client). Paritok then receives native Anthropic
+Messages-API requests on ``/v1/messages``:
+
+.. code-block:: bash
+
+    export ANTHROPIC_API_KEY=sk-ant-...
+    LLM_PROXY_URL=http://127.0.0.1:8080/ \n        gptme --tool-format tool -m anthropic/claude-sonnet-4-5 'summarize the largest file'
+
+.. note::
+
+   ``LLM_PROXY_URL`` is global — it also redirects gptme's OpenAI/OpenRouter
+   clients. Use it in a Claude-focused setup, or make sure the proxy can handle
+   any other providers you call in the same session.
+
+Verify
+~~~~~~
+
+.. code-block:: bash
+
+    curl http://127.0.0.1:8080/stats     # live compressed-vs-original token totals
+
+On a native-tool-call read of a ~600-line file, Paritok compresses the file body
+by roughly 90% (e.g. ~6,700 tokens down to ~300), fully recallable on demand.
+
+.. note::
+
+   Paritok needs a Paritok-4B backend (local Ollama as above, or a hosted GPU
+   endpoint via an API key). See the Paritok README for hosted-backend setup.
+
 Backward compatibility
 ----------------------
 

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -326,9 +326,17 @@ Messages-API requests on ``/v1/messages``:
 
 .. note::
 
-   ``LLM_PROXY_URL`` is global — it also redirects gptme's OpenAI/OpenRouter
-   clients. Use it in a Claude-focused setup, or make sure the proxy can handle
-   any other providers you call in the same session.
+   ``LLM_PROXY_URL`` affects gptme's **built-in** providers only. The Anthropic
+   client takes it as its ``base_url`` verbatim, so Paritok receives
+   ``/v1/messages`` — the path used above. The OpenAI-family built-ins
+   (``openai``, ``openrouter``, ``requesty``) instead get ``/messages``
+   appended, a path Paritok does not serve. Custom ``[[providers]]`` ignore
+   ``LLM_PROXY_URL`` entirely and always use their own ``base_url``.
+
+   So the two paths compose cleanly: use the ``[[providers]]`` block above for
+   OpenAI-compatible models and ``LLM_PROXY_URL`` for Claude. Just don't set
+   ``LLM_PROXY_URL`` and then call a built-in ``-m openai/...`` model in the
+   same session.
 
 Verify
 ~~~~~~

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -322,7 +322,7 @@ Messages-API requests on ``/v1/messages``:
 .. code-block:: bash
 
     export ANTHROPIC_API_KEY=sk-ant-...
-    LLM_PROXY_URL=http://127.0.0.1:8080/ \n        gptme --tool-format tool -m anthropic/claude-sonnet-4-5 'summarize the largest file'
+    LLM_PROXY_URL=http://127.0.0.1:8080/ gptme --tool-format tool -m anthropic/claude-sonnet-4-5 'summarize the largest file'
 
 .. note::
 

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -336,7 +336,10 @@ Messages-API requests on ``/v1/messages``:
    So the two paths compose cleanly: use the ``[[providers]]`` block above for
    OpenAI-compatible models and ``LLM_PROXY_URL`` for Claude. Just don't set
    ``LLM_PROXY_URL`` and then call a built-in ``-m openai/...`` model in the
-   same session.
+   same session — the request goes to ``<proxy>/messages/chat/completions``,
+   Paritok answers ``404 Not Found``, and you get an ``openai.NotFoundError``
+   that never mentions ``LLM_PROXY_URL``, which is easy to misread as a Paritok
+   fault.
 
 Verify
 ~~~~~~


### PR DESCRIPTION
gptme already supports custom OpenAI-compatible providers via `[[providers]]`. [Paritok](https://github.com/Paritok-official/paritok-4b-v1) is a drop-in OpenAI/Anthropic-compatible **compression proxy** — it compresses file reads, shell/tool outputs and stale history before forwarding upstream, and lets the model recall any exact original on demand, so nothing is permanently lost.

Because it's just an OpenAI-compatible `base_url`, wiring it into gptme is a single `[[providers]]` block — **no code change**. This PR documents that in `docs/providers-custom.rst` (new "Paritok — context compression" section).

It composes with gptme's existing lossy shell-output truncation (`_shorten_stdout`): truncation caps worst-case size; Paritok is a lossless layer that cuts the steady-state token bill while keeping the full content recallable.

**Notes**
- Docs-only; no code or test changes.
- Compression fires on **native tool-call** reads, so the docs call out `--tool-format tool` (with the default markdown tool-format the read is plain text and is forwarded unchanged).
- Covers the OpenAI path (`[[providers]]`), the Claude path (built-in `anthropic/` provider + `LLM_PROXY_URL`), and a local-Ollama or hosted-GPU backend.

Happy to adjust placement, tone, or trim the section if you'd prefer it lighter.
