### PR TITLE
fix(webui): keep hosted demo CTA clickable

### DIFF
--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -67,7 +67,7 @@ function isHostedPageOrigin(): boolean {
   if (typeof window === 'undefined' || !window.location) {
     return false;
   }
-  return !/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])([:/]|$)/.test(window.location.origin);
+  return window.location.hostname === 'chat.gptme.org';
 }
 
 const CLOUD_AUTH_URL = getCloudAuthUrl();

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -63,6 +63,13 @@ function getCloudAuthUrl(): string {
   return `${cloudBaseUrl || 'https://gptme.ai'}/authorize`;
 }
 
+function isHostedPageOrigin(): boolean {
+  if (typeof window === 'undefined' || !window.location) {
+    return false;
+  }
+  return !/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])([:/]|$)/.test(window.location.origin);
+}
+
 const CLOUD_AUTH_URL = getCloudAuthUrl();
 const CLOUD_AUTH_ORIGIN = new URL(CLOUD_AUTH_URL).origin;
 const CLOUD_AUTH_MESSAGE_TYPE = 'gptme-cloud-auth-code';
@@ -97,7 +104,9 @@ export function SetupWizard() {
   // Also avoids React batching issues: completeSetup() + setStep('complete') update two separate
   // state atoms in the same event handler; a derived signal would close the dialog before the
   // 'complete' step could render.
-  const [isOpen, setIsOpen] = useState(!demoMode && !settings.hasCompletedSetup);
+  const [isOpen, setIsOpen] = useState(
+    !demoMode && !settings.hasCompletedSetup && !isHostedPageOrigin()
+  );
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [cloudLoginStarted, setCloudLoginStarted] = useState(false);

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -223,7 +223,7 @@ describe('SetupWizard', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('does not auto-open on hosted origins for first-time visitors', () => {
+  it('does not auto-open on chat.gptme.org for first-time visitors', () => {
     setLocation('https://chat.gptme.org/');
 
     render(
@@ -233,6 +233,34 @@ describe('SetupWizard', () => {
     );
 
     expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
+  });
+
+  it.each(['http://192.168.1.20/', 'https://gptme.internal.example/'])(
+    'still auto-opens on self-hosted origin %s',
+    (origin) => {
+      setLocation(origin);
+
+      render(
+        <SettingsProvider>
+          <SetupWizard />
+        </SettingsProvider>
+      );
+
+      expect(screen.getByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
+    }
+  );
+
+  it('still auto-opens in Tauri', () => {
+    setLocation('http://tauri.localhost/');
+    mockIsTauriEnvironment.mockReturnValue(true);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
   });
 
   it('still opens on hosted origins when requested explicitly', async () => {

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -18,6 +18,20 @@ const CLOUD_AUTH_BASE_URL = process.env['VITE_GPTME_CLOUD_BASE_URL'] || 'https:/
 const CLOUD_AUTH_URL = `${CLOUD_AUTH_BASE_URL}/authorize`;
 const CLOUD_AUTH_ORIGIN = new URL(CLOUD_AUTH_URL).origin;
 
+const setLocation = (href: string) => {
+  const url = new URL(href);
+  Object.defineProperty(window, 'location', {
+    value: {
+      ...window.location,
+      href: url.href,
+      origin: url.origin,
+      hostname: url.hostname,
+    },
+    writable: true,
+    configurable: true,
+  });
+};
+
 type MockTauriServerStatus = {
   running: boolean;
   port: number;
@@ -151,6 +165,7 @@ jest.mock('sonner', () => ({
 describe('SetupWizard', () => {
   beforeEach(() => {
     localStorage.clear();
+    setLocation('http://localhost/');
     isConnected$.set(false);
     setupWizard$.step.set('welcome');
     setupWizard$.open.set(false);
@@ -206,6 +221,32 @@ describe('SetupWizard', () => {
 
     expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-open on hosted origins for first-time visitors', () => {
+    setLocation('https://chat.gptme.org/');
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByRole('heading', { name: /welcome to gptme/i })).not.toBeInTheDocument();
+  });
+
+  it('still opens on hosted origins when requested explicitly', async () => {
+    setLocation('https://chat.gptme.org/');
+    setupWizard$.open.set(true);
+    setupWizard$.step.set('welcome');
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    expect(await screen.findByRole('heading', { name: /welcome to gptme/i })).toBeInTheDocument();
   });
 
   it('closes the wizard via Skip on the welcome step and persists hasCompletedSetup', async () => {

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -18,14 +18,31 @@ const CLOUD_AUTH_BASE_URL = process.env['VITE_GPTME_CLOUD_BASE_URL'] || 'https:/
 const CLOUD_AUTH_URL = `${CLOUD_AUTH_BASE_URL}/authorize`;
 const CLOUD_AUTH_ORIGIN = new URL(CLOUD_AUTH_URL).origin;
 
+// Replaces window.location with a stub for the given href.
+//
+// jsdom's Location exposes its fields as own enumerable properties, so the
+// spread does copy `pathname`/`search`/`protocol`/… — but it copies them from
+// the *previous* location, which would leave the stub internally inconsistent
+// with the href being set. Derive every URL-ish field from the URL instead, and
+// keep the navigation methods as no-op jest mocks so a stray call is inert
+// rather than a TypeError.
 const setLocation = (href: string) => {
   const url = new URL(href);
   Object.defineProperty(window, 'location', {
     value: {
-      ...window.location,
+      assign: jest.fn(),
+      replace: jest.fn(),
+      reload: jest.fn(),
+      toString: () => url.href,
       href: url.href,
       origin: url.origin,
+      protocol: url.protocol,
+      host: url.host,
       hostname: url.hostname,
+      port: url.port,
+      pathname: url.pathname,
+      search: url.search,
+      hash: url.hash,
     },
     writable: true,
     configurable: true,


### PR DESCRIPTION
## Summary
- stop auto-opening the setup wizard on hosted browser origins for first-time visitors
- keep explicit setup-wizard opens working from hosted origins
- add regression coverage for hosted-origin setup wizard behavior

## Repro
On 2026-08-10, `https://chat.gptme.org/` with no local server and no stored setup state rendered the first-run setup dialog over the disconnected banner. The visible `Try the offline demo` CTA was present behind the overlay, but the dialog backdrop intercepted pointer events, so the CTA could not be clicked.

## Scope of the suppression
`isHostedPageOrigin()` matches the single hosted origin, `chat.gptme.org`, exactly. This is deliberate: the first iteration used "any origin that is not localhost/127.0.0.1/[::1]", which suppressed the first-run wizard inside the Tauri desktop app (`tauri.localhost`) and for LAN self-hosters — a worse bug than the one being fixed. `chat.gptme.org` is the only origin the app actually runs on: it is a GitHub Pages deploy with a CNAME, `gptme.github.io/gptme-webui/` 301-redirects to it, and `www.chat.gptme.org` does not resolve.

## Verification
- `npm test -- --runTestsByPath src/components/__tests__/SetupWizard.test.tsx` — 28 passed. `does not auto-open on chat.gptme.org for first-time visitors` fails against `origin/master`'s `SetupWizard.tsx` and passes with the fix, so it is a real regression test for the shipped predicate.
- `npm run typecheck`
- `npm run lint` (passes; existing warning backlog only)

> Correction: an earlier revision of this description cited a Playwright check on the Vite LAN origin `http://192.168.1.49:5174/` reporting "modal count 0". That run predates `b74351211`, which narrowed the predicate to the exact hosted hostname; under the shipped code a LAN origin correctly *does* open the wizard, so that line no longer described this branch and has been removed. The jest test above is the reproducible verification of the shipped behavior.
