### PR TITLE
fix(cli): preserve lone separator prompt

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -388,6 +388,9 @@ def _find_missing_explicit_local_path(prompts: list[str]) -> str | None:
 
 def _group_prompt_args(prompts: list[str] | tuple[str, ...]) -> list[str]:
     """Group CLI prompt arguments on exact standalone separator arguments."""
+    if len(prompts) == 1:
+        return [prompts[0].strip()] if prompts[0].strip() else []
+
     grouped: list[str] = []
     current: list[str] = []
     for prompt in prompts:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from click.testing import CliRunner
 import gptme.cli.main as cli
 import gptme.constants
 import gptme.tools.browser
+from gptme.message import Message
 from gptme.tools import ToolUse
 
 project_root = Path(__file__).parent.parent
@@ -1333,6 +1334,28 @@ def test_group_prompt_args_splits_standalone_separator() -> None:
 
 def test_group_prompt_args_preserves_lone_separator() -> None:
     assert cli._group_prompt_args(("-",)) == ["-"]
+
+
+def test_cli_preserves_lone_separator_prompt(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    received_prompts: list[Message] = []
+
+    def fake_chat(prompt_msgs, *args, **kwargs):
+        received_prompts.extend(prompt_msgs)
+
+    monkeypatch.setattr("gptme.prompts.get_prompt", lambda **kwargs: [])
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(cli.main, ["--non-interactive", "-"])
+
+    assert result.exit_code == 0, result.output
+    assert received_prompts == [Message("user", "-")]
 
 
 def test_group_prompt_args_joins_non_separator_arguments() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1358,6 +1358,39 @@ def test_cli_preserves_lone_separator_prompt(
     assert received_prompts == [Message("user", "-")]
 
 
+def test_cli_lone_separator_prepends_to_piped_stdin(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+) -> None:
+    """A lone `-` stays the first prompt when stdin is also piped.
+
+    This is the pre-#3502 behaviour, restored deliberately: `-` is documented
+    only as the chained-prompt separator, never as a read-stdin marker, so a
+    sole `-` has always been passed through as a literal prompt and stdin
+    appended to it. Pinned here because the piped path is where the difference
+    is observable at all.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    received_prompts: list[Message] = []
+
+    def fake_chat(prompt_msgs, *args, **kwargs):
+        received_prompts.extend(prompt_msgs)
+
+    monkeypatch.setattr("gptme.prompts.get_prompt", lambda **kwargs: [])
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(cli.main, ["--non-interactive", "-"], input="hello\n")
+
+    assert result.exit_code == 0, result.output
+    assert len(received_prompts) == 1
+    content = received_prompts[0].content
+    assert content.startswith("-\n\n")
+    assert "hello" in content
+
+
 def test_group_prompt_args_joins_non_separator_arguments() -> None:
     assert cli._group_prompt_args(("first", "second")) == ["first\n\nsecond"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1331,6 +1331,10 @@ def test_group_prompt_args_splits_standalone_separator() -> None:
     assert cli._group_prompt_args(("first", "-", "second")) == ["first", "second"]
 
 
+def test_group_prompt_args_preserves_lone_separator() -> None:
+    assert cli._group_prompt_args(("-",)) == ["-"]
+
+
 def test_group_prompt_args_joins_non_separator_arguments() -> None:
     assert cli._group_prompt_args(("first", "second")) == ["first\n\nsecond"]
 


### PR DESCRIPTION
## What

Preserves a sole `-` prompt argument as a literal prompt while still treating exact standalone `-` arguments as separators when they appear inside a multi-prompt chain.

## Why

gptme/gptme#3502 fixed prompt truncation for chained prompts, but the helper dropped the compatibility case where the entire prompt list is just `-`. That used to be passed through as a literal prompt.

## Validation

- `uv run python3 -m pytest tests/test_cli.py -q -k group_prompt_args` — 4 passed, 105 deselected
- `uv run ruff check gptme/cli/main.py tests/test_cli.py`
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme` — 100/100 OPEN

Origin thread: https://github.com/gptme/gptme/pull/3502#issuecomment-5231808202