### PR TITLE
fix(read): reject non-positive line bounds instead of silently truncating

### DIFF
--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -340,6 +340,25 @@ def execute_read(
         )
         start_line, end_line = 1, None
 
+    # Reject non-positive range bounds instead of silently producing a wrong
+    # slice: start_line <= 0 clamps to the first line (hiding the bad input),
+    # and end_line <= 0 yields an empty or last-line-truncated codeblock
+    # (e.g. end_line=0 -> lines[N:0] == [], end_line=-1 -> lines[N:-1] drops
+    # the last line).  Same class of silent mislabel #3494 fixed for inverted
+    # ranges; checked after the multi-path reset for the same reason.
+    if start_line < 1:
+        yield Message(
+            "system",
+            f"Invalid line range: start_line ({start_line}) must be >= 1.",
+        )
+        return
+    if end_line is not None and end_line < 1:
+        yield Message(
+            "system",
+            f"Invalid line range: end_line ({end_line}) must be >= 1.",
+        )
+        return
+
     # Reject an inverted line range instead of silently yielding an empty
     # codeblock mislabeled with the requested range (e.g. lines[7:3] == []).
     # Checked after the multi-path reset so an inverted range on a batch read

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -291,6 +291,43 @@ def test_read_invalid_line_range(tmp_path: Path):
     assert "end_line (3)" in messages[0].content
 
 
+def test_read_nonpositive_start_line(tmp_path: Path):
+    """A non-positive start_line is rejected instead of silently clamping.
+
+    Regression: start_line <= 0 was silently clamped to line 1 by
+    ``max(0, start_line - 1)``, hiding the bad input from the caller.
+    """
+    path = tmp_path / "test.txt"
+    path.write_text("\n".join(f"line {i}" for i in range(1, 11)) + "\n")
+
+    for bad in ("0", "-2"):
+        messages = list(
+            execute_read(None, None, {"path": str(path), "start_line": bad})
+        )
+        assert len(messages) == 1
+        assert "Invalid line range" in messages[0].content
+        assert f"start_line ({bad})" in messages[0].content
+
+
+def test_read_nonpositive_end_line(tmp_path: Path):
+    """A non-positive end_line is rejected instead of silently truncating.
+
+    Regression: end_line=0 yielded an empty codeblock mislabeled with the
+    requested range (``lines[N:0] == []``), and end_line=-1 silently dropped
+    the last line (``lines[N:-1]``).  Same mislabel class as the inverted
+    range fixed in #3494.
+    """
+    path = tmp_path / "test.txt"
+    path.write_text("\n".join(f"line {i}" for i in range(1, 11)) + "\n")
+
+    for bad in ("0", "-1"):
+        messages = list(execute_read(None, None, {"path": str(path), "end_line": bad}))
+        assert len(messages) == 1
+        assert "Invalid line range" in messages[0].content
+        assert f"end_line ({bad})" in messages[0].content
+        assert "line 1" not in messages[0].content
+
+
 def test_read_line_range_start_equals_end(tmp_path: Path):
     """A single-line range (start_line == end_line) is valid, not inverted."""
     path = tmp_path / "test.txt"


### PR DESCRIPTION
## What

The `read` tool silently mishandled non-positive line-range bounds:

- `start_line <= 0` was clamped to line 1 by `max(0, start_line - 1)`, hiding the bad input from the caller.
- `end_line = 0` yielded an **empty** codeblock mislabeled with the requested range (`lines[N:0] == []`).
- `end_line = -1` **silently dropped the last line** (`lines[N:-1]`).

This is the same class of silent mislabel that #3494 fixed for inverted ranges (`start_line > end_line`).

## Why

A wrong slice that returns empty output (or truncates content) without an error is worse than a clear rejection — the caller can\'t tell their input was invalid. `end_line` has no lower-bound clamp (unlike `start_line`), so negative values flow straight into the slice and corrupt the output.

## How tested

- New regression tests: `test_read_nonpositive_start_line` (0, -2) and `test_read_nonpositive_end_line` (0, -1) — both assert the error message and that no file content leaks through.
- `uv run pytest tests/test_tools_read.py` → 33 passed.
- `ruff check` / `ruff format` clean.

The guard is placed after the multi-path reset, so a bad bound on a batch read is still treated as "ignored" exactly like the inverted-range guard in #3494.