### PR TITLE
fix(taskApi): include HTTP status code in all error messages

### DIFF
--- a/webui/src/utils/__tests__/taskApi.test.ts
+++ b/webui/src/utils/__tests__/taskApi.test.ts
@@ -10,6 +10,14 @@ const errorResponse = (status: number, statusText: string, error?: string): Resp
     json: async () => (error ? { error } : {}),
   }) as Response;
 
+const nonJsonErrorResponse = (status: number, statusText: string): Response =>
+  ({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.reject(new SyntaxError('Unexpected token')),
+  }) as Response;
+
 describe('taskApi error messages', () => {
   const originalFetch = global.fetch;
 
@@ -43,6 +51,30 @@ describe('taskApi error messages', () => {
 
     await expect(taskApi.getTask('missing-task')).rejects.toThrow(
       'Task not found: missing-task (404 Not Found)'
+    );
+  });
+
+  it('includes status in getTask non-404 error', async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(500, 'Internal Server Error'));
+
+    await expect(taskApi.getTask('task-1')).rejects.toThrow(
+      'Failed to get task: 500 Internal Server Error'
+    );
+  });
+
+  it('includes status in getSuggestedActions error', async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(403, 'Forbidden'));
+
+    await expect(taskApi.getSuggestedActions('task-1')).rejects.toThrow(
+      'Failed to get task actions: 403 Forbidden'
+    );
+  });
+
+  it('falls back to statusText when server returns non-JSON error body', async () => {
+    mockFetch.mockResolvedValueOnce(nonJsonErrorResponse(502, 'Bad Gateway'));
+
+    await expect(taskApi.createTask({ content: 'test' })).rejects.toThrow(
+      'Failed to create task: 502 Bad Gateway'
     );
   });
 });

--- a/webui/src/utils/__tests__/taskApi.test.ts
+++ b/webui/src/utils/__tests__/taskApi.test.ts
@@ -1,0 +1,48 @@
+import { taskApi } from '../taskApi';
+
+const mockFetch = jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>();
+
+const errorResponse = (status: number, statusText: string, error?: string): Response =>
+  ({
+    ok: false,
+    status,
+    statusText,
+    json: async () => (error ? { error } : {}),
+  }) as Response;
+
+describe('taskApi error messages', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it.each([
+    ['createTask', () => taskApi.createTask({ content: 'test' }), 'Failed to create task'],
+    [
+      'updateTask',
+      () => taskApi.updateTask('task-1', { content: 'test' }),
+      'Failed to update task',
+    ],
+    ['archiveTask', () => taskApi.archiveTask('task-1'), 'Failed to archive task'],
+    ['unarchiveTask', () => taskApi.unarchiveTask('task-1'), 'Failed to unarchive task'],
+    ['continueTask', () => taskApi.continueTask('task-1'), 'Failed to continue task'],
+  ])('includes status and structured server error for %s', async (_name, request, prefix) => {
+    mockFetch.mockResolvedValueOnce(errorResponse(409, 'Conflict', 'task state conflict'));
+
+    await expect(request()).rejects.toThrow(`${prefix}: 409 task state conflict`);
+  });
+
+  it('includes status in the dedicated task-not-found error', async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(404, 'Not Found'));
+
+    await expect(taskApi.getTask('missing-task')).rejects.toThrow(
+      'Task not found: missing-task (404 Not Found)'
+    );
+  });
+});

--- a/webui/src/utils/taskApi.ts
+++ b/webui/src/utils/taskApi.ts
@@ -62,7 +62,9 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to create task: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `Failed to create task: ${response.status} ${error.error || response.statusText}`
+      );
     }
 
     return response.json();
@@ -75,7 +77,7 @@ export const taskApi = {
     const response = await fetch(`${getApiBaseUrl()}/api/v2/tasks/${taskId}`, getFetchOptions());
     if (!response.ok) {
       if (response.status === 404) {
-        throw new Error(`Task not found: ${taskId}`);
+        throw new Error(`Task not found: ${taskId} (${response.status} ${response.statusText})`);
       }
       throw new Error(`Failed to get task: ${response.status} ${response.statusText}`);
     }
@@ -99,7 +101,9 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to update task: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `Failed to update task: ${response.status} ${error.error || response.statusText}`
+      );
     }
 
     return response.json();
@@ -118,7 +122,9 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to archive task: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `Failed to archive task: ${response.status} ${error.error || response.statusText}`
+      );
     }
   },
 
@@ -135,7 +141,9 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to unarchive task: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `Failed to unarchive task: ${response.status} ${error.error || response.statusText}`
+      );
     }
   },
 
@@ -152,7 +160,9 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to continue task: ${response.status} ${response.statusText}`);
+      throw new Error(
+        `Failed to continue task: ${response.status} ${error.error || response.statusText}`
+      );
     }
 
     return response.json();

--- a/webui/src/utils/taskApi.ts
+++ b/webui/src/utils/taskApi.ts
@@ -62,7 +62,7 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to create task: ${response.statusText}`);
+      throw new Error(error.error || `Failed to create task: ${response.status} ${response.statusText}`);
     }
 
     return response.json();
@@ -77,7 +77,7 @@ export const taskApi = {
       if (response.status === 404) {
         throw new Error(`Task not found: ${taskId}`);
       }
-      throw new Error(`Failed to get task: ${response.statusText}`);
+      throw new Error(`Failed to get task: ${response.status} ${response.statusText}`);
     }
     return response.json();
   },
@@ -99,7 +99,7 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to update task: ${response.statusText}`);
+      throw new Error(error.error || `Failed to update task: ${response.status} ${response.statusText}`);
     }
 
     return response.json();
@@ -118,7 +118,7 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to archive task: ${response.statusText}`);
+      throw new Error(error.error || `Failed to archive task: ${response.status} ${response.statusText}`);
     }
   },
 
@@ -135,7 +135,7 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to unarchive task: ${response.statusText}`);
+      throw new Error(error.error || `Failed to unarchive task: ${response.status} ${response.statusText}`);
     }
   },
 
@@ -152,7 +152,7 @@ export const taskApi = {
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `Failed to continue task: ${response.statusText}`);
+      throw new Error(error.error || `Failed to continue task: ${response.status} ${response.statusText}`);
     }
 
     return response.json();
@@ -167,7 +167,7 @@ export const taskApi = {
       getFetchOptions()
     );
     if (!response.ok) {
-      throw new Error(`Failed to get task actions: ${response.statusText}`);
+      throw new Error(`Failed to get task actions: ${response.status} ${response.statusText}`);
     }
 
     const result = await response.json();


### PR DESCRIPTION
## Summary

Standardize all task API error messages to consistently include HTTP status codes (e.g., '401 Unauthorized' instead of just 'Unauthorized'). This improves debugging experience.

## Changes

- Standardized error messages across createTask, getTask, updateTask, archiveTask, unarchiveTask, continueTask, getSuggestedActions
- All error paths now format as: Failed to X: {status} {statusText}
- Matches the pattern already used in listTasks()