### PR TITLE
fix(constants): escape assistant display name to prevent rich markup injection

### DIFF
--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -42,9 +42,11 @@ PROMPT_USER = prompt_user()
 
 
 def prompt_assistant(name: str | None) -> str:
+    from rich.markup import escape
+
     if not name:
         name = os.environ.get("GPTME_AGENT_NAME", "Assistant")
-    return f"[bold {ROLE_COLOR['assistant']}]{name}[/bold {ROLE_COLOR['assistant']}]"
+    return f"[bold {ROLE_COLOR['assistant']}]{escape(name)}[/bold {ROLE_COLOR['assistant']}]"
 
 
 INTERRUPT_CONTENT = "Interrupted by user"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,43 @@
+"""Tests for prompt helpers in gptme.constants."""
+
+from rich.console import Console
+
+from gptme.constants import prompt_assistant, prompt_user
+
+
+def _render(markup: str) -> str:
+    """Render a Rich markup string to plain text (tags parsed, no color)."""
+    console = Console(record=True, width=80, color_system=None)
+    console.print(markup)
+    return console.export_text()
+
+
+def test_prompt_assistant_escapes_markup_in_name():
+    """An agent name containing Rich markup syntax renders literally.
+
+    Regression: prompt_assistant interpolated the name verbatim, so a name
+    like "Agent [v2]" had "[v2]" swallowed by Rich as a (malformed) markup
+    tag — the brackets and their content vanished from the rendered output.
+    prompt_user already escaped its name; prompt_assistant now matches.
+    """
+    raw = prompt_assistant("Agent [v2]")
+    # The opening bracket is backslash-escaped so Rich treats it as literal.
+    assert "\\[v2]" in raw
+    # The surrounding style tags stay literal (not escaped).
+    assert "[bold " in raw
+    # Round-trip through Rich: the full name, brackets included, is visible.
+    rendered = _render(raw)
+    assert "Agent [v2]" in rendered
+    assert "[v2]" in rendered  # brackets survived (the buggy path dropped them)
+
+
+def test_prompt_assistant_default_name(monkeypatch):
+    """Falls back to GPTME_AGENT_NAME when no name is passed."""
+    monkeypatch.setenv("GPTME_AGENT_NAME", "DefaultBot")
+    assert "DefaultBot" in prompt_assistant(None)
+
+
+def test_prompt_assistant_escapes_like_prompt_user():
+    """Both prompt helpers escape user-controlled text identically."""
+    name = "C++ [dev]"
+    assert prompt_assistant(name).count("\\[") == prompt_user(name).count("\\[")


### PR DESCRIPTION
## What

`prompt_assistant` interpolated the agent display name verbatim, while its sibling `prompt_user` (11 lines above) escapes it with `rich.markup.escape`.

## Why it's a bug

The name is user-controlled — it comes from `config.chat.agent_config.name` or the `GPTME_AGENT_NAME` env var. All four callers feed the result straight into `rprint`, which parses Rich markup:

```python
rprint(f"\{prompt_assistant(agent_name)\}: ...")   # llm/__init__.py:342,354,707,782
```

So a name like `Agent [v2]` has `[v2]` parsed as a (malformed) markup tag and **swallowed from the rendered output**. Verified directly:

| input name `Agent [v2]` | rendered text |
|---|---|
| before fix (verbatim) | `Agent ` ← `[v2]` gone |
| after fix (`escape`)  | `Agent [v2]` ← correct |

## Fix

Mirror `prompt_user`: `from rich.markup import escape` and wrap only the interpolated `name`. The surrounding `[bold ...]` style tags stay literal. `escape()` only backslash-escapes markup chars, so it cannot break any existing name that doesn't contain `[`/`]`.

## How tested

- New `tests/test_constants.py`: asserts the bracket is escaped in the raw string, the style tags stay literal, and a Rich round-trip renders `Agent [v2]` in full (the regression — buggy path drops `[v2]`).
- `uv run pytest tests/test_constants.py` → 3 passed; `ruff check`/`format` clean. No existing test asserts the unescaped output (the `prompt_user` referenced in `test_prompt_templates.py` is a different function from `gptme.prompts`).