### PR TITLE
fix: correct editable-install detection in `--version` output (#3518)

### DIFF
--- a/gptme/__version__.py
+++ b/gptme/__version__.py
@@ -65,12 +65,22 @@ def _compute_version() -> str:
         except (KeyError, AttributeError, TypeError, ValueError, FileNotFoundError):
             pass
 
-        # Method 2: Try git command (for editable installs)
+        # Method 2: Try git command (for editable installs).
+        # Only do this when direct_url.json says dir_info.editable=true —
+        # PathDistribution is the concrete type for ALL pip/uv installs (editable
+        # or not), so isinstance(dist, PathDistribution) cannot distinguish them.
         if not git_hash:
-            is_editable = isinstance(
-                importlib.metadata.distribution("gptme"),
-                importlib.metadata.PathDistribution,
-            )
+            is_editable = False
+            try:
+                import json as _json
+
+                dist = importlib.metadata.distribution("gptme")
+                direct_url_text = dist.read_text("direct_url.json")
+                if direct_url_text:
+                    url_data = _json.loads(direct_url_text)
+                    is_editable = url_data.get("dir_info", {}).get("editable", False)
+            except Exception:
+                pass
             if is_editable:
                 package_dir = os.path.dirname(os.path.abspath(__file__))
                 git_version = get_git_version(package_dir)

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -621,14 +621,13 @@ Run 'gptme-util --help' for all utility commands."""
 @click.option(
     "--version",
     is_flag=True,
-    help="Show version and configuration information",
+    help="Show version and configuration information. First line is always 'gptme v<version>'.",
 )
 @click.option(
     "--version-json",
     "version_json",
     is_flag=True,
-    hidden=True,
-    help="Show version info as JSON (for scripting)",
+    help="Show version info as JSON (machine-readable, for scripting).",
 )
 @click.option(
     "--profile",

--- a/gptme/info.py
+++ b/gptme/info.py
@@ -271,10 +271,6 @@ def get_install_info() -> InstallInfo:
         except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
             pass
 
-        # Also check if PathDistribution (another indicator of editable)
-        if not editable and type(dist).__name__ == "PathDistribution":
-            editable = True
-
         # Determine method
         if installer == "uv":
             method = "uv"

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -430,13 +430,13 @@ class TestGetInstallInfo:
         assert info.path == "/home/user/dev/gptme"
 
     @patch("gptme.info.importlib.metadata.distribution")
-    def test_path_distribution_editable(self, mock_dist_fn):
-        """PathDistribution type name indicates editable install."""
+    def test_path_distribution_not_editable(self, mock_dist_fn):
+        """PathDistribution type alone does NOT mean editable — all pip/uv installs use it."""
         mock_dist_fn.return_value = self._mock_dist(
             installer="pip", dist_type_name="PathDistribution"
         )
         info = get_install_info()
-        assert info.editable is True
+        assert info.editable is False
 
     @patch("gptme.info.importlib.metadata.distribution")
     def test_package_not_found(self, mock_dist_fn):
@@ -1116,3 +1116,77 @@ class TestEdgeCases:
         mock_dist_fn.return_value = dist
         info = get_install_info()
         assert info.method == "unknown"
+
+
+# ─── Stable first-line contract ──────────────────────────────────────────────
+
+
+class TestVersionOutputContract:
+    """Guarantee the stable first-line format for --version output (issue #3518)."""
+
+    def _mock_all_info(self):
+        return {
+            "gptme.info.get_system_info": {
+                "python_version": "3.12.0",
+                "platform": "Linux",
+                "platform_version": "6.1.0",
+                "machine": "x86_64",
+            },
+            "gptme.info.get_config_info": {
+                "logs_dir": "/tmp/logs",
+                "config_path": "/tmp/config.toml",
+                "config_exists": True,
+            },
+            "gptme.info.get_install_info": InstallInfo(method="uv", editable=False),
+            "gptme.info.get_installed_extras": [],
+            "gptme.info.get_available_providers": [],
+            "gptme.info.get_default_model": None,
+            "gptme.info.get_tool_count": 0,
+            "gptme.info.get_quick_health": (4, 0, 0),
+        }
+
+    def _apply(self, patches):
+        managers = [patch(t, return_value=v) for t, v in patches.items()]
+        for m in managers:
+            m.start()
+        return managers
+
+    def _stop(self, managers):
+        for m in managers:
+            m.stop()
+
+    def test_first_line_format(self):
+        """First line of --version output is always 'gptme v<version>'."""
+        managers = self._apply(self._mock_all_info())
+        try:
+            result = format_version_info()
+            first_line = result.splitlines()[0]
+            assert first_line.startswith("gptme v"), (
+                f"First line must start with 'gptme v', got: {first_line!r}"
+            )
+        finally:
+            self._stop(managers)
+
+    def test_non_editable_pypi_no_editable_flag(self):
+        """A regular (non-editable) PyPI/uv install must not show '(editable)'."""
+        patches = self._mock_all_info()
+        patches["gptme.info.get_install_info"] = InstallInfo(
+            method="uv", editable=False
+        )
+        managers = self._apply(patches)
+        try:
+            result = format_version_info()
+            assert "(editable)" not in result
+        finally:
+            self._stop(managers)
+
+    def test_json_version_key_present(self):
+        """JSON output always has a 'version' key for scripting."""
+        managers = self._apply(self._mock_all_info())
+        try:
+            data = json.loads(format_version_info(output_json=True))
+            assert "version" in data
+            assert isinstance(data["version"], str)
+            assert len(data["version"]) > 0
+        finally:
+            self._stop(managers)


### PR DESCRIPTION
## Problem

Two bugs caused `--version` to misreport in regular PyPI installs (e.g. `uvx gptme@latest`):

1. **`+unknown` version suffix** — `v0.32.1+unknown` instead of `v0.32.1`
2. **`[uv (editable)]`** in the second line — should be `[uv]`

Root cause: both `__version__.py` and `info.py` used `isinstance(dist, PathDistribution)` to detect editable installs. But `PathDistribution` is the concrete type for **all** pip/uv-installed packages, not just editable ones. A regular `uvx gptme@latest` install was incorrectly flagged as editable, then `get_git_version()` failed (no git repo in site-packages), and `+unknown` was appended.

## Fix

Use `direct_url.json` / `dir_info.editable` for the editable check — this is the PEP 660 / pip metadata standard that correctly distinguishes editable from regular installs.

- **`gptme/__version__.py`**: replace `isinstance(dist, PathDistribution)` with a `direct_url.json` check
- **`gptme/info.py`**: remove the `type(dist).__name__ == "PathDistribution" → editable = True` heuristic

## Scripting / machine-readable output

Per issue request, also unhide `--version-json` (was `hidden=True`) so scripts have a stable machine-readable interface:

```bash
gptme --version-json | jq .version   # "0.32.1"
```

The `--version` human output already has a stable first-line contract (`gptme v<version>`) — documented in the help text and pinned by a new test.

## Tests

- Fixed `test_path_distribution_editable` → `test_path_distribution_not_editable` (was asserting the buggy behavior)
- Added `TestVersionOutputContract` with three tests:
  - first line always starts with `gptme v`
  - non-editable install doesn't show `(editable)`  
  - JSON output always has a `version` key

All 97 tests in `test_info.py` pass.

Closes #3518

<!-- gptme-id:v1:gai_3a56d09eqvwNoUKN9WGLTp7pNOK1hWGRBlZylZc6F2D -->