### PR TITLE
feat(tools/hashline_edit): 3-way merge recovery when file changes between read and edit (#3476 Phase 2)

### DIFF
--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -43,6 +43,8 @@ edit is rejected with a clear error — no silent corruption.
 from __future__ import annotations
 
 import re
+import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -680,6 +682,69 @@ def _path_from_args(
     return None
 
 
+def _try_3way_merge(
+    snapshot_content: str,
+    ops: list[HashlineOp],
+    live_content: str,
+) -> tuple[str, bool]:
+    """3-way merge recovery when the live file changed since the snapshot.
+
+    Applies *ops* to *snapshot_content* (our side), then merges the result with
+    *live_content* using *snapshot_content* as the common ancestor (base).  This
+    preserves both the model's intended edits and any concurrent external changes
+    to the file.
+
+    Returns ``(merged_text, had_conflicts)``.  On a clean merge
+    ``had_conflicts`` is False and ``merged_text`` is ready to write.  When
+    conflicts remain the text contains standard conflict markers and
+    ``had_conflicts`` is True.
+
+    Raises :class:`ValueError` if the edit cannot be applied to the snapshot
+    (forwarded from :func:`_apply_operations`) or if ``git`` is unavailable.
+    """
+    # Apply the edit to the snapshot — this is "our" side of the merge.
+    ours = _apply_operations(snapshot_content, ops)
+
+    # Write three temp files expected by git merge-file.
+    with (
+        tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ours", delete=False, encoding="utf-8"
+        ) as f_ours,
+        tempfile.NamedTemporaryFile(
+            mode="w", suffix=".base", delete=False, encoding="utf-8"
+        ) as f_base,
+        tempfile.NamedTemporaryFile(
+            mode="w", suffix=".theirs", delete=False, encoding="utf-8"
+        ) as f_theirs,
+    ):
+        f_ours.write(ours)
+        f_base.write(snapshot_content)
+        f_theirs.write(live_content)
+        ours_path = f_ours.name
+        base_path = f_base.name
+        theirs_path = f_theirs.name
+
+    try:
+        # -p sends output to stdout; return code 0 = no conflicts, >0 = conflicts.
+        result = subprocess.run(
+            ["git", "merge-file", "-p", ours_path, base_path, theirs_path],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        had_conflicts = result.returncode != 0
+        return result.stdout, had_conflicts
+    except FileNotFoundError as e:
+        raise ValueError(
+            "git not found — cannot attempt 3-way merge recovery; "
+            "call `read` again to get a fresh snapshot"
+        ) from e
+    finally:
+        for p in [ours_path, base_path, theirs_path]:
+            Path(p).unlink(missing_ok=True)
+
+
 def execute_hashline_edit(
     code: str | None,
     args: list[str] | None,
@@ -747,20 +812,34 @@ def execute_hashline_edit(
     # 4-byte SHA-256 prefix could collide on different content, letting a stale
     # edit silently overwrite the wrong lines.
     assert snapshot_content is not None
+    merge_recovered = False
     if live_content != snapshot_content:
-        yield Message(
-            "system",
-            f"hashline_edit: file has changed since snapshot was captured for {resolved}. "
-            "Call `read` again to get a fresh snapshot.",
-        )
-        return
-
-    # Apply operations
-    try:
-        updated = _apply_operations(live_content, ops)
-    except ValueError as e:
-        yield Message("system", f"hashline_edit: {e}")
-        return
+        # Phase 2: attempt 3-way merge recovery so concurrent external changes
+        # are preserved rather than forcing an unconditional re-read.
+        try:
+            updated, had_conflicts = _try_3way_merge(
+                snapshot_content, ops, live_content
+            )
+        except ValueError as e:
+            yield Message("system", f"hashline_edit: {e}")
+            return
+        if had_conflicts:
+            yield Message(
+                "system",
+                f"hashline_edit: file has changed since snapshot was captured for {resolved}. "
+                "Automatic 3-way merge produced conflicts:\n\n"
+                f"```\n{updated}\n```\n\n"
+                "Resolve the conflicts manually, then call `read` to capture a fresh snapshot.",
+            )
+            return
+        merge_recovered = True
+    else:
+        # Apply operations normally — file is unchanged since snapshot.
+        try:
+            updated = _apply_operations(live_content, ops)
+        except ValueError as e:
+            yield Message("system", f"hashline_edit: {e}")
+            return
 
     # Ask for confirmation before writing (matches sibling tools' safety model)
     from ..hooks import ConfirmAction, get_confirmation
@@ -794,9 +873,10 @@ def execute_hashline_edit(
     store_snapshot(str(resolved), updated)
 
     n = len(ops)
+    suffix = " (recovered via 3-way merge)" if merge_recovered else ""
     yield Message(
         "system",
-        f"hashline_edit applied to `{resolved}` ({n} operation{'s' if n != 1 else ''})",
+        f"hashline_edit applied to `{resolved}` ({n} operation{'s' if n != 1 else ''}){suffix}",
     )
 
 

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -721,12 +721,14 @@ def _try_3way_merge(
                 mode="w", suffix=".theirs", delete=False, encoding="utf-8"
             ) as f_theirs,
         ):
-            f_ours.write(ours)
-            f_base.write(snapshot_content)
-            f_theirs.write(live_content)
+            # Capture paths before writes so the finally block can clean up even
+            # if a write raises (e.g. OSError: disk full, UnicodeEncodeError).
             ours_path = f_ours.name
             base_path = f_base.name
             theirs_path = f_theirs.name
+            f_ours.write(ours)
+            f_base.write(snapshot_content)
+            f_theirs.write(live_content)
 
         # -p sends output to stdout; return code 0 = no conflicts, 1-127 = conflict
         # count.  Codes > 127 (e.g. 128/255) indicate git operational errors.
@@ -751,9 +753,12 @@ def _try_3way_merge(
             check=False,
         )
         had_conflicts = 0 < result.returncode <= 127
-        if result.returncode > 127 or (
-            result.returncode != 0 and not result.stdout.strip()
+        if (
+            result.returncode < 0
+            or result.returncode > 127
+            or (result.returncode != 0 and not result.stdout.strip())
         ):
+            # returncode < 0   → process killed by signal (OOM, SIGKILL, etc.)
             # returncode > 127 → git operational error.
             # returncode 1-127 with empty stdout → nothing to show, treat as error.
             # returncode 1-127 with non-empty stdout → real conflict (markers present);

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -735,8 +735,12 @@ def _try_3way_merge(
             check=False,
         )
         had_conflicts = result.returncode > 0
-        if result.returncode != 0 and not result.stdout.strip():
-            # Empty stdout with non-zero exit = git operational error, not a conflict.
+        if result.returncode != 0 and (
+            not result.stdout.strip() or result.stderr.strip()
+        ):
+            # Empty stdout OR stderr present with non-zero exit = operational error,
+            # not a conflict count.  A real conflict writes markers to stdout only;
+            # stderr content means git itself failed (bad args, I/O error, etc.).
             raise ValueError(
                 f"git merge-file failed (exit {result.returncode}): "
                 + (result.stderr.strip() or "no diagnostic available")
@@ -871,7 +875,9 @@ def execute_hashline_edit(
 
     # For merge-recovered edits, re-read the file right before writing to guard
     # against concurrent changes that arrived during the confirmation dialog.
-    if merge_recovered and confirm_result.action != ConfirmAction.EDIT:
+    # This applies regardless of whether the user edited the proposed content —
+    # the live file could have changed while the confirmation dialog was open.
+    if merge_recovered:
         try:
             post_confirm_content = resolved.read_text(encoding="utf-8")
         except (UnicodeDecodeError, PermissionError, OSError) as e:

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -725,7 +725,8 @@ def _try_3way_merge(
         theirs_path = f_theirs.name
 
     try:
-        # -p sends output to stdout; return code 0 = no conflicts, >0 = conflicts.
+        # -p sends output to stdout; return code 0 = no conflicts, >0 = conflict count.
+        # Negative or unusually large return codes (e.g. 128) indicate git errors.
         result = subprocess.run(
             ["git", "merge-file", "-p", ours_path, base_path, theirs_path],
             capture_output=True,
@@ -733,7 +734,13 @@ def _try_3way_merge(
             encoding="utf-8",
             check=False,
         )
-        had_conflicts = result.returncode != 0
+        had_conflicts = result.returncode > 0
+        if result.returncode != 0 and not result.stdout.strip():
+            # Empty stdout with non-zero exit = git operational error, not a conflict.
+            raise ValueError(
+                f"git merge-file failed (exit {result.returncode}): "
+                + (result.stderr.strip() or "no diagnostic available")
+            )
         return result.stdout, had_conflicts
     except FileNotFoundError as e:
         raise ValueError(
@@ -861,6 +868,24 @@ def execute_hashline_edit(
         and confirm_result.edited_content is not None
     ):
         updated = confirm_result.edited_content
+
+    # For merge-recovered edits, re-read the file right before writing to guard
+    # against concurrent changes that arrived during the confirmation dialog.
+    if merge_recovered and confirm_result.action != ConfirmAction.EDIT:
+        try:
+            post_confirm_content = resolved.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError, OSError) as e:
+            yield Message(
+                "system", f"hashline_edit: cannot re-read file before write: {e}"
+            )
+            return
+        if post_confirm_content != live_content:
+            yield Message(
+                "system",
+                f"hashline_edit: file changed again during confirmation for {resolved}. "
+                "Call `read` to get a fresh snapshot and retry.",
+            )
+            return
 
     # Write result
     try:

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -731,7 +731,20 @@ def _try_3way_merge(
         # -p sends output to stdout; return code 0 = no conflicts, 1-127 = conflict
         # count.  Codes > 127 (e.g. 128/255) indicate git operational errors.
         result = subprocess.run(
-            ["git", "merge-file", "-p", ours_path, base_path, theirs_path],
+            [
+                "git",
+                "merge-file",
+                "-p",
+                "-L",
+                "your edit (via hashline_edit)",
+                "-L",
+                "original snapshot",
+                "-L",
+                "current file",
+                ours_path,
+                base_path,
+                theirs_path,
+            ],
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -42,6 +42,7 @@ edit is rejected with a clear error — no silent corruption.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import tempfile
@@ -856,6 +857,10 @@ def execute_hashline_edit(
     if live_content != snapshot_content:
         # Phase 2: attempt 3-way merge recovery so concurrent external changes
         # are preserved rather than forcing an unconditional re-read.
+        # Limitation: merge is purely textual — semantic interactions between
+        # the model's edit and an external change on different lines are not
+        # detected.  The confirmation dialog below lets the user inspect the
+        # merged preview before it is written; this is the primary mitigation.
         try:
             updated, had_conflicts = _try_3way_merge(
                 snapshot_content, ops, live_content
@@ -922,9 +927,23 @@ def execute_hashline_edit(
             )
             return
 
-    # Write result
+    # Write result atomically: write to a temp file in the same directory,
+    # then rename into place.  os.replace() is a single POSIX syscall (rename(2))
+    # so readers always see either the old or the new content — never a partial
+    # write.  This closes the non-atomic write window noted by the AI reviewer
+    # (the check→write TOCTOU window above is inherent to file I/O without
+    # OS-level locking and is not specific to this path).
     try:
-        resolved.write_text(updated, encoding="utf-8")
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            dir=resolved.parent, prefix=".gptme_hashline_", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(updated)
+        except Exception:
+            os.unlink(tmp_name)
+            raise
+        os.replace(tmp_name, resolved)
     except (PermissionError, OSError) as e:
         yield Message("system", f"hashline_edit: write failed: {e}")
         return

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -779,7 +779,10 @@ def _try_3way_merge(
     finally:
         for p in [ours_path, base_path, theirs_path]:
             if p is not None:
-                Path(p).unlink(missing_ok=True)
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except OSError:
+                    pass  # best-effort cleanup; never let cleanup suppress the real result
 
 
 def execute_hashline_edit(

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -706,27 +706,30 @@ def _try_3way_merge(
     ours = _apply_operations(snapshot_content, ops)
 
     # Write three temp files expected by git merge-file.
-    with (
-        tempfile.NamedTemporaryFile(
-            mode="w", suffix=".ours", delete=False, encoding="utf-8"
-        ) as f_ours,
-        tempfile.NamedTemporaryFile(
-            mode="w", suffix=".base", delete=False, encoding="utf-8"
-        ) as f_base,
-        tempfile.NamedTemporaryFile(
-            mode="w", suffix=".theirs", delete=False, encoding="utf-8"
-        ) as f_theirs,
-    ):
-        f_ours.write(ours)
-        f_base.write(snapshot_content)
-        f_theirs.write(live_content)
-        ours_path = f_ours.name
-        base_path = f_base.name
-        theirs_path = f_theirs.name
-
+    # Paths are initialised to None so the finally always has valid names to
+    # attempt unlinking — even if a write raises before the name is captured.
+    ours_path = base_path = theirs_path = None
     try:
-        # -p sends output to stdout; return code 0 = no conflicts, >0 = conflict count.
-        # Negative or unusually large return codes (e.g. 128) indicate git errors.
+        with (
+            tempfile.NamedTemporaryFile(
+                mode="w", suffix=".ours", delete=False, encoding="utf-8"
+            ) as f_ours,
+            tempfile.NamedTemporaryFile(
+                mode="w", suffix=".base", delete=False, encoding="utf-8"
+            ) as f_base,
+            tempfile.NamedTemporaryFile(
+                mode="w", suffix=".theirs", delete=False, encoding="utf-8"
+            ) as f_theirs,
+        ):
+            f_ours.write(ours)
+            f_base.write(snapshot_content)
+            f_theirs.write(live_content)
+            ours_path = f_ours.name
+            base_path = f_base.name
+            theirs_path = f_theirs.name
+
+        # -p sends output to stdout; return code 0 = no conflicts, 1-127 = conflict
+        # count.  Codes > 127 (e.g. 128/255) indicate git operational errors.
         result = subprocess.run(
             ["git", "merge-file", "-p", ours_path, base_path, theirs_path],
             capture_output=True,
@@ -734,13 +737,15 @@ def _try_3way_merge(
             encoding="utf-8",
             check=False,
         )
-        had_conflicts = result.returncode > 0
+        had_conflicts = 0 < result.returncode <= 127
         if result.returncode != 0 and (
-            not result.stdout.strip() or result.stderr.strip()
+            result.returncode > 127
+            or not result.stdout.strip()
+            or result.stderr.strip()
         ):
-            # Empty stdout OR stderr present with non-zero exit = operational error,
-            # not a conflict count.  A real conflict writes markers to stdout only;
-            # stderr content means git itself failed (bad args, I/O error, etc.).
+            # returncode > 127, empty stdout, or stderr present with non-zero exit
+            # all indicate an operational error, not a conflict count.  A real
+            # conflict writes markers to stdout only with no stderr.
             raise ValueError(
                 f"git merge-file failed (exit {result.returncode}): "
                 + (result.stderr.strip() or "no diagnostic available")
@@ -751,9 +756,12 @@ def _try_3way_merge(
             "git not found — cannot attempt 3-way merge recovery; "
             "call `read` again to get a fresh snapshot"
         ) from e
+    except OSError as e:
+        raise ValueError(f"3-way merge failed: {e}") from e
     finally:
         for p in [ours_path, base_path, theirs_path]:
-            Path(p).unlink(missing_ok=True)
+            if p is not None:
+                Path(p).unlink(missing_ok=True)
 
 
 def execute_hashline_edit(

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -751,14 +751,14 @@ def _try_3way_merge(
             check=False,
         )
         had_conflicts = 0 < result.returncode <= 127
-        if result.returncode != 0 and (
-            result.returncode > 127
-            or not result.stdout.strip()
-            or result.stderr.strip()
+        if result.returncode > 127 or (
+            result.returncode != 0 and not result.stdout.strip()
         ):
-            # returncode > 127, empty stdout, or stderr present with non-zero exit
-            # all indicate an operational error, not a conflict count.  A real
-            # conflict writes markers to stdout only with no stderr.
+            # returncode > 127 → git operational error.
+            # returncode 1-127 with empty stdout → nothing to show, treat as error.
+            # returncode 1-127 with non-empty stdout → real conflict (markers present);
+            # git may write warnings to stderr even for genuine conflicts, so
+            # stderr presence alone is NOT a reliable indicator of operational failure.
             raise ValueError(
                 f"git merge-file failed (exit {result.returncode}): "
                 + (result.stderr.strip() or "no diagnostic available")

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -688,27 +688,29 @@ class TestExecuteHashlineEdit:
         assert f.read_text() == edited
 
     def test_live_file_changed_after_snapshot(self, tmp_path: Path):
-        """Edit must be rejected when the live file has changed since read (P1 fix)."""
+        """Phase 2: clean 3-way merge when file changed externally since read."""
         f = tmp_path / "f.txt"
         original = "alpha\nbeta\n"
         f.write_text(original)
         tag = store_snapshot(str(f.resolve()), original)
-        # Externally mutate the file after the snapshot was captured
+        # Externally mutate the file (add a new line that doesn't conflict with the edit)
         f.write_text("alpha\nbeta\nextra-line\n")
-        # The stored tag still matches the provided tag — but the live file differs
+        # Edit targets a different line — merge should be clean
         block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
         msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
-        assert "changed since snapshot" in msgs[0].lower(), msgs
-        # File must be untouched
-        assert f.read_text() == "alpha\nbeta\nextra-line\n"
+        # Phase 2: clean merge succeeds and notes the recovery
+        assert "applied" in msgs[0].lower(), msgs
+        assert "3-way merge" in msgs[0].lower(), msgs
+        # Merged result preserves both the edit and the external change
+        assert f.read_text() == "ALPHA\nbeta\nextra-line\n"
 
-    def test_content_mismatch_rejected_even_with_matching_tag(self, tmp_path: Path):
-        """Full content comparison catches stale content even when truncated tags match.
+    def test_content_mismatch_via_merge_recovery(self, tmp_path: Path):
+        """Phase 2: content mismatch triggers merge; non-conflicting result is written.
 
         Injects the snapshot store directly to simulate a 4-byte SHA-256 prefix
-        collision: the stored tag matches the edit-block tag, but the live file
-        content differs from the captured snapshot content. The old tag-only check
-        would silently accept this; the content comparison correctly rejects it.
+        collision scenario: the stored tag matches the edit-block tag, but the
+        live file content differs from the captured snapshot. Phase 2 attempts a
+        3-way merge rather than rejecting unconditionally.
         """
         from gptme.tools._hashline_snapshot import _store, compute_tag
 
@@ -717,15 +719,15 @@ class TestExecuteHashlineEdit:
         tag = compute_tag(original)
         # Inject the store so tag maps to original content
         _store[str(f.resolve())] = (tag, original)
-        # Write DIFFERENT content to disk (simulates the file changing after read,
-        # or — in the collision scenario — different content sharing the same tag prefix)
+        # Live file has a non-conflicting extra line (different from the edited line)
         changed = "alpha\nbeta\ngamma\n"
         f.write_text(changed)
         block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
         msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
-        # Content comparison catches this; tag-only comparison could miss a collision
-        assert "changed since snapshot" in msgs[0].lower(), msgs
-        assert f.read_text() == changed  # file must be untouched
+        # Phase 2 succeeds via merge (edit targets line 1; external change added line 3)
+        assert "applied" in msgs[0].lower(), msgs
+        assert "3-way merge" in msgs[0].lower(), msgs
+        assert f.read_text() == "ALPHA\nbeta\ngamma\n"
 
 
 # ---------------------------------------------------------------------------
@@ -1055,6 +1057,77 @@ class TestBlockReplace:
         assert result == "if z:\n    do_z()\ndo_c()\n"
         assert "# comment" not in result
         assert "else" not in result
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — 3-way merge recovery
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRecovery:
+    """Phase 2: 3-way merge when the live file changed since the snapshot."""
+
+    def test_clean_merge_preserves_concurrent_change(self, tmp_path: Path):
+        """Non-conflicting external change is preserved alongside the model's edit."""
+        f = tmp_path / "code.py"
+        original = "def foo():\n    pass\n\ndef bar():\n    pass\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # External change: add a line to bar() — doesn't conflict with our edit
+        f.write_text("def foo():\n    pass\n\ndef bar():\n    return 1\n")
+        # Model edit: replace foo body
+        block = f"[{f.resolve()}#{tag}]\nPUT 2.=2:\n+    return 'foo'\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        assert "3-way merge" in msgs[0].lower(), msgs
+        result = f.read_text()
+        assert "return 'foo'" in result  # our edit applied
+        assert "return 1" in result  # external change preserved
+
+    def test_conflicting_merge_reports_markers(self, tmp_path: Path):
+        """When both sides edit the same lines, conflict markers are reported."""
+        f = tmp_path / "conflict.txt"
+        original = "line1\nline2\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # External change: also modifies line 1
+        f.write_text("EXTERNAL_CHANGE\nline2\n")
+        # Model edit: replace line 1 with something different
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+MODEL_CHANGE\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        # Conflict is reported
+        assert "conflict" in msgs[0].lower(), msgs
+        # File is left unchanged so the user can resolve manually
+        assert f.read_text() == "EXTERNAL_CHANGE\nline2\n"
+
+    def test_merge_recovery_note_absent_on_clean_apply(self, tmp_path: Path):
+        """When file is unchanged, success message has no merge-recovery note."""
+        f = tmp_path / "f.txt"
+        f.write_text("a\nb\n")
+        tag = store_snapshot(str(f.resolve()), f.read_text())
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+A\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        assert "3-way merge" not in msgs[0].lower()
+
+    def test_merge_snapshot_updated_after_recovery(self, tmp_path: Path):
+        """After a successful merge recovery, the snapshot reflects the new content."""
+        f = tmp_path / "f.txt"
+        original = "a\nb\nc\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # External change at end — non-conflicting
+        f.write_text("a\nb\nc\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+A\n"
+        msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+        assert "applied" in msgs[0].lower(), msgs
+        new_content = f.read_text()
+        assert new_content == "A\nb\nc\nextra\n"
+        # Snapshot should reflect the merged content
+        new_tag = get_stored_tag(str(f.resolve()))
+        from gptme.tools._hashline_snapshot import compute_tag
+
+        assert new_tag == compute_tag(new_content)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -1192,6 +1192,57 @@ class TestMergeRecovery:
         # File should be left untouched so the user can resolve.
         assert f.read_text() == "alpha\nbeta\nextra\n"
 
+    def test_git_not_found_raises_informative_error(self, tmp_path: Path):
+        """FileNotFoundError from git being absent surfaces a clear diagnostic, not a traceback."""
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Trigger merge-recovery path by changing the live file.
+        f.write_text("alpha\nbeta\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("git not found")):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        # Should surface a human-readable message, not a raw traceback.
+        assert any("git" in m.lower() or "read" in m.lower() for m in msgs), msgs
+        # File must be left untouched.
+        assert f.read_text() == "alpha\nbeta\nextra\n"
+
+    def test_signal_killed_git_is_treated_as_error(self, tmp_path: Path):
+        """git merge-file killed by a signal (negative returncode) must not write partial output."""
+        from subprocess import CompletedProcess
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Trigger merge-recovery path by changing the live file.
+        f.write_text("alpha\nbeta\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        # Simulate OOM-kill: returncode -9 (SIGKILL), with some partial stdout.
+        # Before the fix, this partial content was written as a "clean" merge.
+        fake_result = CompletedProcess(
+            args=["git", "merge-file", "-p"],
+            returncode=-9,
+            stdout="partial\noutput\n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        # Must surface an error, not silently write the partial content.
+        assert any(
+            "git merge-file failed" in m or "failed" in m.lower() for m in msgs
+        ), msgs
+        # File must be left untouched.
+        assert f.read_text() == "alpha\nbeta\nextra\n"
+
     def test_edit_confirmation_race_aborts_on_concurrent_change(self, tmp_path: Path):
         """EDIT confirmation path must abort when the live file changes during the dialog."""
         from unittest.mock import patch

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -1129,8 +1129,8 @@ class TestMergeRecovery:
 
         assert new_tag == compute_tag(new_content)
 
-    def test_operational_merge_failure_with_nonempty_stdout(self, tmp_path: Path):
-        """git merge-file returning nonzero + nonempty stderr is reported as an error, not a conflict."""
+    def test_operational_merge_failure_high_exit_code(self, tmp_path: Path):
+        """git merge-file returning exit > 127 is reported as an operational error."""
         from subprocess import CompletedProcess
         from unittest.mock import patch
 
@@ -1142,22 +1142,55 @@ class TestMergeRecovery:
         f.write_text("alpha\nbeta\nextra\n")
         block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
 
-        # Simulate git merge-file writing partial junk to stdout AND an error to stderr.
-        # This is the case Greptile flagged: nonempty stdout was previously classified
-        # as a conflict, discarding the real error from stderr.
+        # Simulate git merge-file exiting with 128 (git internal error — e.g. git not
+        # found at runtime, or repository state corruption).  returncode > 127 is the
+        # reliable signal for an operational failure; conflict counts are 1-127.
         fake_result = CompletedProcess(
             args=["git", "merge-file", "-p"],
-            returncode=1,
-            stdout="partial-garbage-not-a-valid-conflict",
-            stderr="error: corrupt merge output",
+            returncode=128,
+            stdout="",
+            stderr="error: could not read repository",
         )
         with patch("subprocess.run", return_value=fake_result):
             msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
 
         # The error should be surfaced, not silently treated as a merge conflict.
-        assert any(
-            "git merge-file failed" in m or "corrupt merge" in m for m in msgs
-        ), msgs
+        assert any("git merge-file failed" in m or "repository" in m for m in msgs), (
+            msgs
+        )
+
+    def test_conflict_with_stderr_warning_shows_markers(self, tmp_path: Path):
+        """A real conflict that also emits a warning to stderr shows conflict markers, not an error."""
+        from subprocess import CompletedProcess
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Trigger merge-recovery path.
+        f.write_text("alpha\nbeta\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        # Simulate git merge-file finding a conflict (returncode=1 = 1 conflict section)
+        # while also writing a warning to stderr.  git CAN do this in edge cases
+        # (e.g. truncation warnings on very large files).  The old code treated any
+        # stderr as an operational failure, which would suppress the conflict markers.
+        conflict_output = "<<<<<<< your edit (via hashline_edit)\nALPHA\n=======\nalpha\n>>>>>>> current file\nbeta\nextra\n"
+        fake_result = CompletedProcess(
+            args=["git", "merge-file", "-p"],
+            returncode=1,
+            stdout=conflict_output,
+            stderr="warning: too many conflicts",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        # Conflict markers must be shown — not an error about git failing.
+        assert any("conflict" in m.lower() for m in msgs), msgs
+        assert not any("git merge-file failed" in m for m in msgs), msgs
+        # File should be left untouched so the user can resolve.
+        assert f.read_text() == "alpha\nbeta\nextra\n"
 
     def test_edit_confirmation_race_aborts_on_concurrent_change(self, tmp_path: Path):
         """EDIT confirmation path must abort when the live file changes during the dialog."""

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -1129,6 +1129,68 @@ class TestMergeRecovery:
 
         assert new_tag == compute_tag(new_content)
 
+    def test_operational_merge_failure_with_nonempty_stdout(self, tmp_path: Path):
+        """git merge-file returning nonzero + nonempty stderr is reported as an error, not a conflict."""
+        from subprocess import CompletedProcess
+        from unittest.mock import patch
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Trigger merge-recovery path by changing the live file.
+        f.write_text("alpha\nbeta\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        # Simulate git merge-file writing partial junk to stdout AND an error to stderr.
+        # This is the case Greptile flagged: nonempty stdout was previously classified
+        # as a conflict, discarding the real error from stderr.
+        fake_result = CompletedProcess(
+            args=["git", "merge-file", "-p"],
+            returncode=1,
+            stdout="partial-garbage-not-a-valid-conflict",
+            stderr="error: corrupt merge output",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        # The error should be surfaced, not silently treated as a merge conflict.
+        assert any(
+            "git merge-file failed" in m or "corrupt merge" in m for m in msgs
+        ), msgs
+
+    def test_edit_confirmation_race_aborts_on_concurrent_change(self, tmp_path: Path):
+        """EDIT confirmation path must abort when the live file changes during the dialog."""
+        from unittest.mock import patch
+
+        from gptme.hooks.confirm import ConfirmationResult
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        # Trigger merge recovery: external change at the bottom (non-conflicting)
+        f.write_text("alpha\nbeta\nextra\n")
+        # Model edit: replace alpha (top) — no conflict with the external change
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        # The confirmation returns EDIT with some edited content.  While the
+        # dialog is "open", a second concurrent process changes the file again.
+        concurrent_content = "CONCURRENT CHANGE\nbeta\nextra\n"
+
+        def fake_confirm(**kwargs):
+            # Simulate another process modifying the file mid-dialog.
+            f.write_text(concurrent_content)
+            return ConfirmationResult.edit("ALPHA\nbeta\nextra\nUSER_EDIT\n")
+
+        with patch("gptme.hooks.get_confirmation", side_effect=fake_confirm):
+            msgs = _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        # The race must be detected; the operation is aborted.
+        assert any("changed" in m.lower() or "read" in m.lower() for m in msgs), msgs
+        # The concurrent write must be preserved (file not overwritten by the edit).
+        assert f.read_text() == concurrent_content
+
 
 # ---------------------------------------------------------------------------
 # Tool metadata


### PR DESCRIPTION
## Summary

Implements Phase 2 of issue #3476 — automatic 3-way merge recovery when a file
changes externally between `read` and `hashline_edit`.

### Problem

Previously, any external change to a file between `read` and `hashline_edit`
caused an unconditional rejection:
```
hashline_edit: file has changed since snapshot was captured for /path/to/f.py.
Call `read` again to get a fresh snapshot.
```
The model was forced to re-read the whole file and restate the entire edit,
even when the external change was on completely different lines.

### Solution

When content mismatch is detected, the tool now attempts automatic 3-way merge
recovery via `git merge-file -p`:

| Role | Content |
|------|---------|
| base | snapshot (common ancestor of both sides) |
| ours | snapshot with the model's edits applied |
| theirs | current live file |

**Clean merge** → merged content is written; success message notes
`(recovered via 3-way merge)` for auditability.

**Conflicts** → conflict markers are reported and the file is left intact,
prompting the user to resolve manually and then `read` again.

### Changes

- `gptme/tools/hashline_edit.py`:
  - New `_try_3way_merge(snapshot_content, ops, live_content)` helper
  - `execute_hashline_edit` attempts merge recovery on content mismatch instead
    of rejecting unconditionally

- `tests/test_tools_hashline_edit.py`:
  - Updated two existing tests to reflect Phase 2 behavior (clean merge succeeds)
  - New `TestMergeRecovery` class (4 tests): clean merge, conflict reporting,
    success-message note, snapshot update after recovery

### Related

Closes #3476 (Phase 2 — the Phase 1 work landed in #3477, #3480, #3497)

<!-- gptme-id:v1:gai_2lKtXVRa8I3D44hqhLaEc5So7PrrLUDJsKkpOkVQTCA -->