### PR TITLE
fix(server): preserve webui html hint on config patch

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -319,6 +319,22 @@ def _append_conversation_system_prompt(
         messages.append(Message("system", system_prompt))
 
 
+_WEBUI_HTML_HINT = (
+    "Output format: you are in a web interface. "
+    "For interactive content (dashboards, tables, diagrams), "
+    "use ```html blocks — they render live in a sandboxed preview panel."
+)
+
+
+def _append_webui_html_hint(messages: list[Message], *, prompt: str = "full") -> None:
+    """Append the web UI HTML hint when this conversation uses it."""
+    if os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() == "false":
+        return
+    if prompt == "none":
+        return
+    messages.append(Message("system", _WEBUI_HTML_HINT))
+
+
 def _resolve_conversation_system_prompt(chat_config: ChatConfig) -> str | None:
     """Return the conversation prompt, falling back to the server default profile."""
     if chat_config.system_prompt:
@@ -1709,18 +1725,7 @@ def api_conversation_put(conversation_id: str):
     # Code/Preview tabs — inform the model so it can use HTML when it provides
     # a richer experience for the reader.
     # Set GPTME_SERVE_HTML_HINT=false to disable for non-webui API clients.
-    if (
-        os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() != "false"
-        and prompt != "none"
-    ):
-        msgs.append(
-            Message(
-                "system",
-                "Output format: you are in a web interface. "
-                "For interactive content (dashboards, tables, diagrams), "
-                "use ```html blocks — they render live in a sandboxed preview panel.",
-            )
-        )
+    _append_webui_html_hint(msgs, prompt=prompt)
 
     resolved_prompt = _resolve_conversation_system_prompt(chat_config)
     # Persist the resolved prompt back to chat_config so it survives server
@@ -2847,7 +2852,11 @@ def api_conversation_config_patch(conversation_id: str):
                 if m.role != "system":
                     break
                 first_non_system += 1
+            existing_system_msgs = manager.log.messages[:first_non_system]
             remaining_msgs = list(manager.log.messages[first_non_system:])
+            had_webui_html_hint = any(
+                m.content == _WEBUI_HTML_HINT for m in existing_system_msgs
+            )
 
             new_system_msgs = list(
                 get_prompt(
@@ -2859,6 +2868,8 @@ def api_conversation_config_patch(conversation_id: str):
                     agent_path=chat_config.agent,
                 )
             )
+            if had_webui_html_hint:
+                _append_webui_html_hint(new_system_msgs)
             _append_conversation_system_prompt(
                 new_system_msgs, _resolve_conversation_system_prompt(chat_config)
             )

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -2864,7 +2864,7 @@ def api_conversation_config_patch(conversation_id: str):
             existing_system_msgs = manager.log.messages[:first_non_system]
             remaining_msgs = list(manager.log.messages[first_non_system:])
             had_webui_html_hint = any(
-                m.content == _WEBUI_HTML_HINT for m in existing_system_msgs
+                _WEBUI_HTML_HINT in m.content for m in existing_system_msgs
             )
 
             new_system_msgs = list(

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -326,9 +326,18 @@ _WEBUI_HTML_HINT = (
 )
 
 
-def _append_webui_html_hint(messages: list[Message], *, prompt: str = "full") -> None:
-    """Append the web UI HTML hint when this conversation uses it."""
-    if os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() == "false":
+def _append_webui_html_hint(
+    messages: list[Message], *, prompt: str = "full", preserve: bool = False
+) -> None:
+    """Append the web UI HTML hint when this conversation uses it.
+
+    ``preserve=True`` skips the env-var check so an already-present hint is
+    kept across config PATCHes even when ``GPTME_SERVE_HTML_HINT=false``.
+    """
+    if (
+        not preserve
+        and os.environ.get("GPTME_SERVE_HTML_HINT", "true").lower() == "false"
+    ):
         return
     if prompt == "none":
         return
@@ -2869,7 +2878,7 @@ def api_conversation_config_patch(conversation_id: str):
                 )
             )
             if had_webui_html_hint:
-                _append_webui_html_hint(new_system_msgs)
+                _append_webui_html_hint(new_system_msgs, preserve=True)
             _append_conversation_system_prompt(
                 new_system_msgs, _resolve_conversation_system_prompt(chat_config)
             )

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2528,6 +2528,53 @@ def test_v2_chat_config_system_prompt_roundtrip_and_clear(client: FlaskClient):
     assert system_prompt not in cleared_system_messages
 
 
+def test_v2_chat_config_patch_preserves_webui_html_hint(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Renaming via config PATCH must not strip the webui HTML hint."""
+    monkeypatch.setenv("GPTME_SERVE_HTML_HINT", "true")
+
+    convname = f"test-server-v2-rename-{random.randint(0, 1000000)}"
+    create_response = client.put(
+        f"/api/v2/conversations/{convname}",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Rename/config patch sweep",
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                }
+            ],
+            "config": {"chat": {"name": "before rename"}},
+        },
+    )
+    assert create_response.status_code == 200
+    conversation_id = create_response.get_json()["conversation_id"]
+
+    before = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    before_system_msgs = [m["content"] for m in before["log"] if m["role"] == "system"]
+    assert len(before_system_msgs) == 2
+    assert "Output format: you are in a web interface." in before_system_msgs[1]
+
+    config_payload = client.get(
+        f"/api/v2/conversations/{conversation_id}/config"
+    ).get_json()
+    config_payload["chat"]["name"] = "after rename"
+    patch_response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json=config_payload,
+    )
+    assert patch_response.status_code == 200
+
+    after = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
+    after_system_msgs = [m["content"] for m in after["log"] if m["role"] == "system"]
+    assert after["name"] == "after rename"
+    assert len(after_system_msgs) == len(before_system_msgs)
+    assert "Output format: you are in a web interface." in after_system_msgs[1]
+    assert [m["role"] for m in after["log"]] == [m["role"] for m in before["log"]]
+    assert after["log"][-1]["content"] == "Rename/config patch sweep"
+
+
 def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskClient):
     """Test that updating config for a missing conversation returns a 404.
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2533,6 +2533,7 @@ def test_v2_chat_config_patch_preserves_webui_html_hint(
 ):
     """Renaming via config PATCH must not strip the webui HTML hint."""
     monkeypatch.setenv("GPTME_SERVE_HTML_HINT", "true")
+    monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
 
     convname = f"test-server-v2-rename-{random.randint(0, 1000000)}"
     create_response = client.put(


### PR DESCRIPTION
## What changed
Preserve the webui HTML output-format hint when `PATCH /api/v2/conversations/<id>/config` rebuilds a conversation's leading system messages.

## Why
A pure config update like a conversation rename was silently stripping the existing webui hint:
`Output format: you are in a web interface ... use ```html blocks ...````.
That changed later assistant behavior even though the user had only saved settings.

## Root cause
Conversation creation appended the webui HTML hint, but config PATCH rebuilt the leading system messages from `get_prompt(...)` and the conversation system prompt only. The hint was never re-added, so rename/settings saves shortened the system preamble and dropped the HTML capability instruction.

## Impact
- Renaming or saving settings no longer changes webui rendering guidance for an existing conversation.
- Existing conversations that started with the webui hint keep it after config PATCH.

## Validation
- Reproduced twice against Bob's live `gptme-server` on port 5700: create conversation -> rename via config PATCH -> hint disappeared before this fix.
- `python -m pytest tests/test_server_v2.py -k 'webui_html_hint or chat_config_patch_preserves_webui_html_hint' -q`
