### PR TITLE
fix(llm): normalize proxy URL in _is_proxy() to match init() suffix rule

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -691,6 +691,10 @@ def _is_proxy(client: OpenAI) -> bool:
     # If client has the proxy URL set, it is using the proxy
     if not proxy_url:
         return False
+    # Apply the same /messages normalization that init() applies before building the client,
+    # so the comparison never fails due to a missing suffix.
+    if not proxy_url.endswith("/messages"):
+        proxy_url = proxy_url + "/messages"
     # Normalize URLs for comparison (remove trailing slashes)
     return str(client.base_url).rstrip("/") == proxy_url.rstrip("/")
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -3429,3 +3429,43 @@ class TestMakeResolvedModel:
             f"openrouter/moonshotai/kimi-k2.5@{suffix}", "Moonshot AI"
         )
         assert result is None
+
+
+class TestIsProxy:
+    """Direct unit tests for _is_proxy() URL comparison — regression for #3526."""
+
+    @pytest.mark.parametrize(
+        ("proxy_url", "client_base_url"),
+        [
+            # no suffix: init() appends /messages, httpx normalizes with trailing slash
+            ("http://127.0.0.1:8080", "http://127.0.0.1:8080/messages/"),
+            # trailing slash: double slash preserved in client base_url
+            ("http://127.0.0.1:8080/", "http://127.0.0.1:8080//messages/"),
+            # already has /messages: init() leaves it unchanged, httpx adds trailing slash
+            ("http://127.0.0.1:8080/messages", "http://127.0.0.1:8080/messages/"),
+        ],
+    )
+    def test_proxy_url_spellings_return_true(
+        self, monkeypatch, proxy_url, client_base_url
+    ):
+        from gptme.llm.llm_openai import _is_proxy
+
+        _is_proxy.cache_clear()
+        monkeypatch.setenv("LLM_PROXY_URL", proxy_url)
+        client = MagicMock()
+        client.base_url = client_base_url
+        assert _is_proxy(client), (
+            f"LLM_PROXY_URL={proxy_url!r} should be detected as proxy"
+        )
+        _is_proxy.cache_clear()
+
+    def test_no_proxy_url_returns_false(self, monkeypatch):
+        from gptme.llm.llm_openai import _is_proxy
+
+        _is_proxy.cache_clear()
+        monkeypatch.delenv("LLM_PROXY_URL", raising=False)
+        monkeypatch.delenv("GPTME_LLM_PROXY_URL", raising=False)
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:8080/messages/"
+        assert not _is_proxy(client)
+        _is_proxy.cache_clear()


### PR DESCRIPTION
Fixes #3526.

## Root cause

`init()` appends `/messages` to `LLM_PROXY_URL` before building the OpenAI client, but `_is_proxy()` compared `client.base_url` against the raw env var. The two could never be equal unless the user already wrote `/messages` at the end of their URL.

## Fix

Apply the same `/messages` normalization in `_is_proxy()` before comparing, mirroring exactly what `init()` does. This keeps the logic in one place without introducing a module-level variable.

## Verification

All three natural spellings from the bug report now return `True`:

| `LLM_PROXY_URL` | `client.base_url` | `_is_proxy()` |
|---|---|---|
| `http://127.0.0.1:8080` | `http://127.0.0.1:8080/messages/` | ✅ `True` |
| `http://127.0.0.1:8080/` | `http://127.0.0.1:8080//messages/` | ✅ `True` |
| `http://127.0.0.1:8080/messages` | `http://127.0.0.1:8080/messages/` | ✅ `True` |