### PR TITLE
feat(cli): add JSON output to status command

### DIFF
--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -9,6 +9,7 @@ health, blockers, and ready backlog items.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -38,7 +39,9 @@ def _run(cmd: list[str], *, timeout: int = 10) -> str:
         return ""
 
 
+@functools.lru_cache(maxsize=1)
 def _git_root() -> Path | None:
+    """Return the git root for the current working directory (cached per process)."""
     raw = _run([GIT_CMD, "rev-parse", "--show-toplevel"])
     return Path(raw) if raw else None
 

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -346,6 +346,7 @@ def _status_data() -> dict[str, object]:
     is_bob = _is_bob_workspace()
     root = _git_root()
     status_data: dict[str, object] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "session_id": _session_id(),
         "active_tasks": [
             {"id": task.get("_id", task.get("id", "")), "title": task.get("title", "")}
@@ -516,7 +517,9 @@ def status(
 
         gptme-util status --json                # structured JSON
     """
-    if as_json and (not markdown or output_format != "narrative" or write):
+    if as_json and (
+        not markdown or output_format != "narrative" or (write and not output)
+    ):
         raise click.UsageError(
             "--json cannot be combined with --no-markdown, --format, or --write"
             " (use -o/--output to write JSON to a file)"

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypedDict
 
 import click
 
@@ -80,12 +81,18 @@ def _recent_commits(n: int = 3) -> list[str]:
     return raw.splitlines() if raw else []
 
 
+class _PRQueueRow(TypedDict):
+    repo: str
+    count: int
+    cap: int | None
+
+
 def _pr_queue(
     repos: list[tuple[str, int | None]], author: str | None = None
-) -> list[dict[str, str]]:
+) -> list[_PRQueueRow]:
     if author is None:
         author = _gh_user() or "TimeToBuildBob"
-    rows: list[dict[str, str]] = []
+    rows: list[_PRQueueRow] = []
     for repo, cap in repos:
         prs_json = _run(
             [
@@ -110,14 +117,15 @@ def _pr_queue(
         except json.JSONDecodeError:
             continue
         count = len(prs)
-        cap_str = (
-            f"{count}/{cap}"
-            + (" ⚠ at limit" if cap is not None and count >= cap else "")
-            if cap is not None
-            else str(count)
-        )
-        rows.append({"repo": repo, "count": cap_str})
+        rows.append({"repo": repo, "count": count, "cap": cap})
     return rows
+
+
+def _pr_queue_display(count: int, cap: int | None) -> str:
+    """Format a PR count as a human-readable string with optional cap."""
+    if cap is not None:
+        return f"{count}/{cap}" + (" ⚠ at limit" if count >= cap else "")
+    return str(count)
 
 
 def _service_status() -> list[dict[str, str]]:
@@ -278,7 +286,9 @@ def section_pr_queue() -> str:
     if rows:
         lines.append("| Repo | Open |")
         lines.append("|------|------|")
-        lines.extend(f"| {row['repo']} | {row['count']} |" for row in rows)
+        for row in rows:
+            display = _pr_queue_display(row["count"], row["cap"])
+            lines.append(f"| {row['repo']} | {display} |")
     else:
         lines.append("- Unable to fetch PR data")
     return "\n".join(lines)
@@ -379,7 +389,11 @@ def build_table_document() -> str:
     # pending_prs
     pr_rows = _pr_queue(_TRACKED_REPOS)
     pending_prs = (
-        ", ".join(f"{r['repo']}:{r['count']}" for r in pr_rows) if pr_rows else "none"
+        ", ".join(
+            f"{r['repo']}:{_pr_queue_display(r['count'], r['cap'])}" for r in pr_rows
+        )
+        if pr_rows
+        else "none"
     )
 
     # waiting_for
@@ -502,9 +516,10 @@ def status(
 
         gptme-util status --json                # structured JSON
     """
-    if as_json and (not markdown or output_format != "narrative"):
+    if as_json and (not markdown or output_format != "narrative" or write):
         raise click.UsageError(
-            "--json cannot be combined with --no-markdown or --format"
+            "--json cannot be combined with --no-markdown, --format, or --write"
+            " (use -o/--output to write JSON to a file)"
         )
 
     if as_json:

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -274,13 +274,7 @@ def section_active_work(is_bob: bool = False) -> str:
 
 def section_pr_queue() -> str:
     lines = ["## PR Queue"]
-    tracked = [
-        ("gptme/gptme", 10),
-        ("gptme/gptme-cloud", 3),
-        ("ErikBjare/bob", None),
-        ("gptme/gptme-contrib", None),
-    ]
-    rows = _pr_queue(tracked)
+    rows = _pr_queue(_TRACKED_REPOS)
     if rows:
         lines.append("| Repo | Open |")
         lines.append("|------|------|")
@@ -329,6 +323,44 @@ def section_ready_next() -> str:
 # ── build ─────────────────────────────────────────────────────────────
 
 
+_TRACKED_REPOS: list[tuple[str, int | None]] = [
+    ("gptme/gptme", 10),
+    ("gptme/gptme-cloud", 3),
+    ("ErikBjare/bob", None),
+    ("gptme/gptme-contrib", None),
+]
+
+
+def _status_data() -> dict[str, object]:
+    """Collect status data shared by JSON and presentation renderers."""
+    is_bob = _is_bob_workspace()
+    root = _git_root()
+    status_data: dict[str, object] = {
+        "session_id": _session_id(),
+        "active_tasks": [
+            {"id": task.get("_id", task.get("id", "")), "title": task.get("title", "")}
+            for task in _active_tasks(3)
+        ],
+        "recent_commits": _recent_commits(3),
+        "pr_queue": _pr_queue(_TRACKED_REPOS),
+        "disk_usage": _disk_usage(root),
+        "journal_entries": _journal_entries(5),
+    }
+    if is_bob:
+        status_data.update(
+            services=_service_status(),
+            dead_timers=_dead_timers(),
+            blockers=_blockers(3),
+            ready_tasks=_ready_tasks(3),
+        )
+    return status_data
+
+
+def build_json_status() -> str:
+    """Build the structured JSON status document."""
+    return json.dumps(_status_data(), indent=2)
+
+
 def build_table_document() -> str:
     """Build a machine-readable markdown table of session state."""
     is_bob = _is_bob_workspace()
@@ -345,13 +377,7 @@ def build_table_document() -> str:
     last_commit = commits[0] if commits else "none"
 
     # pending_prs
-    tracked = [
-        ("gptme/gptme", 10),
-        ("gptme/gptme-cloud", 3),
-        ("ErikBjare/bob", None),
-        ("gptme/gptme-contrib", None),
-    ]
-    pr_rows = _pr_queue(tracked)
+    pr_rows = _pr_queue(_TRACKED_REPOS)
     pending_prs = (
         ", ".join(f"{r['repo']}:{r['count']}" for r in pr_rows) if pr_rows else "none"
     )
@@ -448,7 +474,14 @@ def build_document() -> str:
     default="narrative",
     help="Output format: narrative (default) or table.",
 )
-def status(write: bool, output: str | None, markdown: bool, output_format: str):
+@click.option("--json", "as_json", is_flag=True, help="Output status as JSON.")
+def status(
+    write: bool,
+    output: str | None,
+    markdown: bool,
+    output_format: str,
+    as_json: bool,
+) -> None:
     """Generate a portable operator handoff / session-status document.
 
     Produces a compact briefing: active work, PR queue, service health,
@@ -465,9 +498,18 @@ def status(write: bool, output: str | None, markdown: bool, output_format: str):
 
         gptme-util status --no-markdown         # plain-text output
 
-        gptme-util status --format table        # machine-readable table
+        gptme-util status --format table        # compact Markdown table
+
+        gptme-util status --json                # structured JSON
     """
-    if output_format == "table":
+    if as_json and (not markdown or output_format != "narrative"):
+        raise click.UsageError(
+            "--json cannot be combined with --no-markdown or --format"
+        )
+
+    if as_json:
+        doc = build_json_status()
+    elif output_format == "table":
         doc = build_table_document()
     else:
         doc = build_document()
@@ -482,7 +524,7 @@ def status(write: bool, output: str | None, markdown: bool, output_format: str):
         out_path = (root or Path.cwd()) / "status.md"
 
     if out_path:
-        out_path.write_text(doc)
+        out_path.write_text(doc, encoding="utf-8")
         click.echo(f"Written to {out_path}")
     else:
         click.echo(doc)

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -9,7 +9,6 @@ health, blockers, and ready backlog items.
 
 from __future__ import annotations
 
-import functools
 import json
 import logging
 import os
@@ -39,9 +38,8 @@ def _run(cmd: list[str], *, timeout: int = 10) -> str:
         return ""
 
 
-@functools.lru_cache(maxsize=1)
 def _git_root() -> Path | None:
-    """Return the git root for the current working directory (cached per process)."""
+    """Return the git root for the current working directory."""
     raw = _run([GIT_CMD, "rev-parse", "--show-toplevel"])
     return Path(raw) if raw else None
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from click.testing import CliRunner
 
 import gptme.cli.cmd_status as cmd_status
@@ -100,6 +102,73 @@ def test_status_format_table_via_util():
     assert result.exit_code == 0
     assert "| Field | Value |" in result.output
     assert "| session_id |" in result.output
+
+
+def test_status_json(monkeypatch):
+    """Verify --json emits structured status without Markdown."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: True)
+    monkeypatch.setattr(
+        cmd_status,
+        "_active_tasks",
+        lambda lines=3: [{"_id": "task-1", "title": "First task"}],
+    )
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: ["abc123 Fix"])
+    monkeypatch.setattr(
+        cmd_status,
+        "_pr_queue",
+        lambda _tracked: [{"repo": "gptme/gptme", "count": 2}],
+    )
+    monkeypatch.setattr(
+        cmd_status,
+        "_service_status",
+        lambda: [{"label": "worker", "icon": "✅", "status": "active"}],
+    )
+    monkeypatch.setattr(cmd_status, "_dead_timers", lambda: 0)
+    monkeypatch.setattr(
+        cmd_status,
+        "_blockers",
+        lambda limit=3: [{"id": "blocked", "waiting_for": "review"}],
+    )
+    monkeypatch.setattr(
+        cmd_status,
+        "_ready_tasks",
+        lambda limit=3: [{"id": "ready", "name": "Ready task"}],
+    )
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-1")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: ["entry.md"])
+
+    result = CliRunner().invoke(status, ["--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "session_id": "session-1",
+        "active_tasks": [{"id": "task-1", "title": "First task"}],
+        "recent_commits": ["abc123 Fix"],
+        "pr_queue": [{"repo": "gptme/gptme", "count": 2}],
+        "disk_usage": "1G / 2G (50%)",
+        "journal_entries": ["entry.md"],
+        "services": [{"label": "worker", "icon": "✅", "status": "active"}],
+        "dead_timers": 0,
+        "blockers": [{"id": "blocked", "waiting_for": "review"}],
+        "ready_tasks": [{"id": "ready", "name": "Ready task"}],
+    }
+
+
+def test_status_json_via_util():
+    """Verify gptme-util status exposes the --json flag."""
+    result = CliRunner().invoke(util_main, ["status", "--json"])
+    assert result.exit_code == 0
+    assert isinstance(json.loads(result.output), dict)
+
+
+def test_status_json_rejects_rendering_options():
+    """Verify JSON cannot be combined with presentation-only options."""
+    runner = CliRunner()
+    for args in (["--json", "--no-markdown"], ["--json", "--format", "table"]):
+        result = runner.invoke(status, args)
+        assert result.exit_code == 2
 
 
 def test_status_format_narrative_is_default():

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -163,6 +163,50 @@ def test_status_json_via_util():
     assert isinstance(json.loads(result.output), dict)
 
 
+def test_status_json_with_output_file(tmp_path, monkeypatch):
+    """Verify --json -o path writes valid JSON with expected schema to a file."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
+    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
+    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-x")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+
+    out_file = tmp_path / "status.json"
+    result = CliRunner().invoke(status, ["--json", "-o", str(out_file)])
+
+    assert result.exit_code == 0
+    assert out_file.exists()
+    data = json.loads(out_file.read_text())
+    assert data["session_id"] == "session-x"
+    assert "active_tasks" in data
+    assert "pr_queue" in data
+    assert "disk_usage" in data
+
+
+def test_status_json_excludes_bob_fields_in_non_bob_workspace(monkeypatch):
+    """Verify Bob-only fields are absent when not in Bob's workspace."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
+    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
+    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-y")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+
+    result = CliRunner().invoke(status, ["--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    for bob_key in ("services", "dead_timers", "blockers", "ready_tasks"):
+        assert bob_key not in data, (
+            f"Bob-only field '{bob_key}' present outside Bob workspace"
+        )
+
+
 def test_status_json_rejects_rendering_options():
     """Verify JSON cannot be combined with presentation-only options."""
     runner = CliRunner()

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -161,11 +161,23 @@ def test_status_json(monkeypatch):
     }
 
 
-def test_status_json_via_util():
-    """Verify gptme-util status exposes the --json flag."""
+def test_status_json_via_util(monkeypatch):
+    """Verify gptme-util status exposes the --json flag (deterministic)."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
+    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
+    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-util")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+
     result = CliRunner().invoke(util_main, ["status", "--json"])
     assert result.exit_code == 0
-    assert isinstance(json.loads(result.output), dict)
+    data = json.loads(result.output)
+    assert isinstance(data, dict)
+    assert data["session_id"] == "session-util"
+    assert "timestamp" in data
 
 
 def test_status_json_with_output_file(tmp_path, monkeypatch):
@@ -211,6 +223,27 @@ def test_status_json_excludes_bob_fields_in_non_bob_workspace(monkeypatch):
         assert bob_key not in data, (
             f"Bob-only field '{bob_key}' present outside Bob workspace"
         )
+
+
+def test_status_json_write_with_output_path(tmp_path, monkeypatch):
+    """Verify --json --write -o path is accepted and writes JSON (unambiguous destination)."""
+    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
+    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
+    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-w")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+
+    out_file = tmp_path / "out.json"
+    result = CliRunner().invoke(status, ["--json", "--write", "-o", str(out_file)])
+
+    assert result.exit_code == 0, result.output
+    assert out_file.exists()
+    data = json.loads(out_file.read_text())
+    assert data["session_id"] == "session-w"
+    assert "timestamp" in data
 
 
 def test_status_json_rejects_rendering_options():

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -116,7 +116,7 @@ def test_status_json(monkeypatch):
     monkeypatch.setattr(
         cmd_status,
         "_pr_queue",
-        lambda _tracked: [{"repo": "gptme/gptme", "count": 2}],
+        lambda _tracked: [{"repo": "gptme/gptme", "count": 2, "cap": None}],
     )
     monkeypatch.setattr(
         cmd_status,
@@ -146,7 +146,7 @@ def test_status_json(monkeypatch):
         "session_id": "session-1",
         "active_tasks": [{"id": "task-1", "title": "First task"}],
         "recent_commits": ["abc123 Fix"],
-        "pr_queue": [{"repo": "gptme/gptme", "count": 2}],
+        "pr_queue": [{"repo": "gptme/gptme", "count": 2, "cap": None}],
         "disk_usage": "1G / 2G (50%)",
         "journal_entries": ["entry.md"],
         "services": [{"label": "worker", "icon": "✅", "status": "active"}],
@@ -166,7 +166,11 @@ def test_status_json_via_util():
 def test_status_json_rejects_rendering_options():
     """Verify JSON cannot be combined with presentation-only options."""
     runner = CliRunner()
-    for args in (["--json", "--no-markdown"], ["--json", "--format", "table"]):
+    for args in (
+        ["--json", "--no-markdown"],
+        ["--json", "--format", "table"],
+        ["--json", "--write"],
+    ):
         result = runner.invoke(status, args)
         assert result.exit_code == 2
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 import gptme.cli.cmd_status as cmd_status
 from gptme.cli.cmd_status import (
+    _pr_queue_display,
     _session_id,
     _strip_markdown,
     build_table_document,
@@ -142,7 +143,11 @@ def test_status_json(monkeypatch):
     result = CliRunner().invoke(status, ["--json"])
 
     assert result.exit_code == 0
-    assert json.loads(result.output) == {
+    data = json.loads(result.output)
+    # Timestamp is dynamic; validate presence and format separately.
+    assert "timestamp" in data
+    assert "T" in data.pop("timestamp")
+    assert data == {
         "session_id": "session-1",
         "active_tasks": [{"id": "task-1", "title": "First task"}],
         "recent_commits": ["abc123 Fix"],
@@ -181,6 +186,7 @@ def test_status_json_with_output_file(tmp_path, monkeypatch):
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert data["session_id"] == "session-x"
+    assert "timestamp" in data
     assert "active_tasks" in data
     assert "pr_queue" in data
     assert "disk_usage" in data
@@ -213,10 +219,18 @@ def test_status_json_rejects_rendering_options():
     for args in (
         ["--json", "--no-markdown"],
         ["--json", "--format", "table"],
-        ["--json", "--write"],
+        ["--json", "--write"],  # --write without -o is rejected
     ):
         result = runner.invoke(status, args)
         assert result.exit_code == 2
+
+
+def test_pr_queue_display():
+    """Verify _pr_queue_display formats count/cap and at-limit suffix correctly."""
+    assert _pr_queue_display(2, None) == "2"
+    assert _pr_queue_display(2, 10) == "2/10"
+    assert _pr_queue_display(10, 10) == "10/10 ⚠ at limit"
+    assert _pr_queue_display(11, 10) == "11/10 ⚠ at limit"
 
 
 def test_status_format_narrative_is_default():


### PR DESCRIPTION
## Summary

- add `gptme-util status --json` using the existing CLI-wide boolean `--json` convention
- expose active tasks, commits, PR queue, disk usage, journals, and Bob-only service/blocker/ready-task fields as structured JSON
- reject ambiguous combinations with `--no-markdown` or `--format table`
- preserve `-o/--output` so JSON can be written directly to a file

## Verification

- `poetry run python3 -m pytest tests/test_cli_status.py -q` (16 passed)
- `poetry run ruff check gptme/cli/cmd_status.py tests/test_cli_status.py`
- `poetry run mypy gptme/cli/cmd_status.py`
- targeted pre-commit hooks pass with a clean cache
- live `python3 -m gptme.cli.util status --json` output parses with `python3 -m json.tool`

Related: gptme/gptme#3518 (the original version-output scripting pain is fixed by gptme/gptme#3519; this adds the largest remaining structured-output gap found in the CLI audit).
