### PR TITLE
docs(tools): document hashline_edit tool + fix read examples with tag header (#3476)

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -13,6 +13,7 @@ Overview
 - `Save`_ - Create and overwrite files
 - `Patch`_ - Apply precise changes to existing files
 - `Morph`_ - Apply fast targeted edits using Morph Fast Apply
+- `Hashline Edit`_ - Snapshot-anchored line-range edits with stale-file detection
 
 💻 Code & Development
 ^^^^^^^^^^^^^^^^^^^^^
@@ -447,6 +448,15 @@ Morph
 -----
 
 .. automodule:: gptme.tools.morph
+    :members:
+    :noindex:
+
+.. _hashline edit:
+
+Hashline Edit
+-------------
+
+.. automodule:: gptme.tools.hashline_edit
     :members:
     :noindex:
 

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -50,13 +50,18 @@ instructions_format = {
 
 
 def examples(tool_format):
+    from ._hashline_snapshot import compute_tag
+
+    hello = 'print("Hello world")\n'
+    goodbye = 'print("Goodbye world")\n'
+    combined = hello + goodbye
     batch_paths = "hello.py\ngoodbye.py"
     return f"""
 > User: read hello.py
 > Assistant:
 {ToolUse("read", ["hello.py"], "").to_output(tool_format)}
 > System: ```hello.py
-> [hello.py#09FAFB7D]
+> [hello.py#{compute_tag(combined)}]
 >    1\tprint("Hello world")
 >    2\tprint("Goodbye world")
 > ```
@@ -65,11 +70,11 @@ def examples(tool_format):
 > Assistant:
 {ToolUse("read", [], batch_paths).to_output(tool_format)}
 > System: ```hello.py
-> [hello.py#D4E0A53D]
+> [hello.py#{compute_tag(hello)}]
 >    1\tprint("Hello world")
 > ```
 > ```goodbye.py
-> [goodbye.py#CF728AB6]
+> [goodbye.py#{compute_tag(goodbye)}]
 >    1\tprint("Goodbye world")
 > ```
 """.strip()

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -56,6 +56,7 @@ def examples(tool_format):
 > Assistant:
 {ToolUse("read", ["hello.py"], "").to_output(tool_format)}
 > System: ```hello.py
+> [hello.py#09FAFB7D]
 >    1\tprint("Hello world")
 >    2\tprint("Goodbye world")
 > ```
@@ -64,9 +65,11 @@ def examples(tool_format):
 > Assistant:
 {ToolUse("read", [], batch_paths).to_output(tool_format)}
 > System: ```hello.py
+> [hello.py#D4E0A53D]
 >    1\tprint("Hello world")
 > ```
 > ```goodbye.py
+> [goodbye.py#CF728AB6]
 >    1\tprint("Goodbye world")
 > ```
 """.strip()

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -7,8 +7,19 @@ from unittest.mock import patch
 
 import pytest
 
+from gptme.tools._hashline_snapshot import compute_tag
 from gptme.tools.pruner import PrunePlan
-from gptme.tools.read import execute_read
+from gptme.tools.read import examples, execute_read
+
+
+def test_examples_compute_hashline_tags_from_displayed_content():
+    rendered = examples("markdown")
+    hello = 'print("Hello world")\n'
+    goodbye = 'print("Goodbye world")\n'
+
+    assert f"[hello.py#{compute_tag(hello)}]" in rendered
+    assert f"[goodbye.py#{compute_tag(goodbye)}]" in rendered
+    assert f"[hello.py#{compute_tag(hello + goodbye)}]" in rendered
 
 
 def test_read_file(tmp_path: Path):


### PR DESCRIPTION
## Summary

Adds documentation for the `hashline_edit` tool which was implemented across PRs #3477, #3480, #3497, and #3520 but was never added to the official tool documentation.

### Changes

**`docs/tools.rst`**
- Add `hashline_edit` to the 📁 File System overview section
- Add a full `Hashline Edit` automodule section (after Morph, before GH)

**`gptme/tools/read.py`**
- Update the `read` tool examples to show the `[PATH#TAG]` header that is now always included in real output (since the hashline integration in PR #3477)
- Without this fix, the examples claim the output format is ````path\n1\tline````` when the actual format is ````path\n[path#TAG]\n1\tline`````

### Verification

All 131 hashline_edit tests pass, all 33 read tool tests pass, all 183 prompt/tools base tests pass.

Closes #3476

<!-- gptme-id:v1:gai_MTtytptPlzkXQ29WY0oJOU75FXn7owyKUAKBAuhVGNC -->