### PR TITLE
feat(models): refresh MiniMax plugin registry

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -21,7 +21,7 @@ Where ``provider`` is a ``ProviderPlugin`` instance.
 **Usage:** Once installed, use the provider name as the model prefix::
 
     pip install gptme-provider-minimax
-    gptme "hello" -m minimax/abab6.5s-chat
+    gptme "hello" -m minimax/MiniMax-M3
 
 **Creating a provider plugin:**
 
@@ -34,7 +34,23 @@ Where ``provider`` is a ``ProviderPlugin`` instance.
         api_key_env="MINIMAX_API_KEY",           # Env var for API key
         base_url="https://api.minimax.chat/v1",  # OpenAI-compatible endpoint
         models=[
-            ModelMeta(provider="unknown", model="minimax/abab6.5s-chat", context=245_760),
+            ModelMeta(
+                provider="unknown",
+                model="minimax/MiniMax-M3",
+                context=1_000_000,
+                price_input=0.6,
+                price_output=2.4,
+                supports_vision=True,
+                supports_reasoning=True,
+            ),
+            ModelMeta(
+                provider="unknown",
+                model="minimax/MiniMax-M2.7",
+                context=204_800,
+                price_input=0.3,
+                price_output=1.2,
+                supports_reasoning=True,
+            ),
         ],
     )
 

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -199,7 +199,23 @@ class ProviderPlugin:
             api_key_env="MINIMAX_API_KEY",
             base_url="https://api.minimax.chat/v1",
             models=[
-                ModelMeta(provider="unknown", model="minimax/abab6.5s-chat", context=245_760),
+                ModelMeta(
+                    provider="unknown",
+                    model="minimax/MiniMax-M3",
+                    context=1_000_000,
+                    price_input=0.6,
+                    price_output=2.4,
+                    supports_vision=True,
+                    supports_reasoning=True,
+                ),
+                ModelMeta(
+                    provider="unknown",
+                    model="minimax/MiniMax-M2.7",
+                    context=204_800,
+                    price_input=0.3,
+                    price_output=1.2,
+                    supports_reasoning=True,
+                ),
             ],
         )
     """

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -340,16 +340,24 @@ def test_list_models_json_available_keeps_plugin_models(
     mock_get_model_list.return_value = [
         ModelMeta(
             provider="unknown",
-            model="minimax/abab6.5s-chat",
-            context=245_760,
-        )
+            model="minimax/MiniMax-M3",
+            context=1_000_000,
+        ),
+        ModelMeta(
+            provider="unknown",
+            model="minimax/MiniMax-M2.7",
+            context=204_800,
+        ),
     ]
 
     list_models(json_output=True, available_only=True)
     output = capsys.readouterr().out
     data = json.loads(output)
 
-    assert [model["model"] for model in data] == ["minimax/abab6.5s-chat"]
+    assert [model["model"] for model in data] == [
+        "minimax/MiniMax-M3",
+        "minimax/MiniMax-M2.7",
+    ]
 
 
 # --- Tests for closest-match heuristic ---

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -297,6 +297,39 @@ class TestGetModelWithPlugin:
         assert result.context == 128_000
         assert result.model == "myprovider/fast-model"
 
+    @pytest.mark.parametrize(
+        ("model_name", "context"),
+        [("MiniMax-M3", 1_000_000), ("MiniMax-M2.7", 204_800)],
+    )
+    def test_minimax_registry_models_resolve(
+        self, model_name: str, context: int
+    ) -> None:
+        """Current MiniMax plugin models should resolve with their own metadata."""
+        from gptme.llm.models.resolution import get_model
+
+        plugin = _make_plugin(
+            name="minimax",
+            models=[
+                ModelMeta(
+                    provider="unknown",
+                    model="minimax/MiniMax-M3",
+                    context=1_000_000,
+                ),
+                ModelMeta(
+                    provider="unknown",
+                    model="minimax/MiniMax-M2.7",
+                    context=204_800,
+                ),
+            ],
+        )
+        with patch(
+            "importlib.metadata.entry_points",
+            return_value=[_make_entry_point(plugin)],
+        ):
+            result = get_model(f"minimax/{model_name}")
+
+        assert result.context == context
+
 
 class TestPluginRouting:
     def test_init_llm_allows_custom_plugin_init_that_registers_client(self):

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -662,22 +662,41 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
             SimpleNamespace(
                 provider="unknown",
                 provider_key="minimax",
-                model="minimax/abab6.5s-chat",
-                full="minimax/abab6.5s-chat",
-                context=245760,
+                model="minimax/MiniMax-M3",
+                full="minimax/MiniMax-M3",
+                context=1_000_000,
                 max_output=None,
                 supports_streaming=True,
-                supports_vision=False,
-                supports_reasoning=False,
+                supports_vision=True,
+                supports_reasoning=True,
                 supports_parallel_tool_calls=False,
                 supports_responses_api=False,
-                price_input=0,
-                price_output=0,
+                price_input=0.6,
+                price_output=2.4,
                 knowledge_cutoff=None,
                 deprecated=False,
                 preferred_edit_format=None,
                 pricing_type="per_token",
-            )
+            ),
+            SimpleNamespace(
+                provider="unknown",
+                provider_key="minimax",
+                model="minimax/MiniMax-M2.7",
+                full="minimax/MiniMax-M2.7",
+                context=204_800,
+                max_output=None,
+                supports_streaming=True,
+                supports_vision=False,
+                supports_reasoning=True,
+                supports_parallel_tool_calls=False,
+                supports_responses_api=False,
+                price_input=0.3,
+                price_output=1.2,
+                knowledge_cutoff=None,
+                deprecated=False,
+                preferred_edit_format=None,
+                pricing_type="per_token",
+            ),
         ],
     )
     mocker.patch(
@@ -689,7 +708,10 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
 
     assert result.exit_code == 0
     parsed = json.loads(result.output)
-    assert [model["model"] for model in parsed] == ["minimax/abab6.5s-chat"]
+    assert [model["model"] for model in parsed] == [
+        "minimax/MiniMax-M3",
+        "minimax/MiniMax-M2.7",
+    ]
 
 
 def test_models_info():


### PR DESCRIPTION
Reason: model-add | 2026-08-11 | MiniMax plugin model registries and canonical tests list only abab6.5s-chat; add MiniMax-M3 and MiniMax-M2.7 metadata so both target models resolve and appear in model listings.

## Summary

- Register MiniMax-M3 and MiniMax-M2.7 metadata in the provider plugin example.
- Update the plugin usage example to select MiniMax-M3.
- Verify both models resolve with their own context metadata and remain visible in model listings.

## Testing

- .venv/bin/pytest tests/test_provider_plugins.py tests/test_llm_models.py tests/test_util_cli.py -q
- .venv/bin/ruff check gptme/llm/models/types.py tests/test_llm_models.py tests/test_provider_plugins.py tests/test_util_cli.py
- .venv/bin/ruff format --check gptme/llm/models/types.py tests/test_llm_models.py tests/test_provider_plugins.py tests/test_util_cli.py
- .venv/bin/mypy gptme/llm/models/types.py tests/test_llm_models.py tests/test_provider_plugins.py tests/test_util_cli.py
- .venv/bin/python scripts/check_rst_formatting.py docs/providers.rst
