### PR TITLE
ci: add a focused Windows path/config smoke lane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,62 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results
 
+  # Windows smoke tests: a narrow, no-API slice covering the areas that actually
+  # bit users (filesystem paths, config loading, CLI entrypoints). Deliberately
+  # not a full matrix — a broad skip-marked suite would only buy fake confidence.
+  test-windows:
+    needs: changes
+    # Always run on push to master; on PRs, only when code changed
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    name: Test Windows path/config slice
+    runs-on: windows-latest
+    # The path-walk bug this job exists to catch manifests as an infinite loop,
+    # so cap the job rather than burning the 6h default on a hang.
+    timeout-minutes: 15
+    env:
+      RELEASE: false
+      OPENAI_API_KEY: ''
+      ANTHROPIC_API_KEY: ''
+      DEEPSEEK_API_KEY: ''
+      OPENROUTER_API_KEY: ''
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: 'recursive'
+
+    - name: Store cache ID in file .cache-id
+      shell: pwsh
+      run: Set-Content -Path .cache-id -Value windows-path-config
+
+    # Must precede setup-python: `cache: 'poetry'` resolves the poetry binary.
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+        cache: 'poetry'
+        cache-dependency-path: |
+          poetry.lock
+          .cache-id
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run Windows path/config smoke tests
+      env:
+        TERM: xterm
+        MODEL: local/test
+      run: |
+        poetry run pytest -v `
+          tests/test_dirs.py `
+          tests/test_config.py::test_custom_tool_file_allowlist_preserved `
+          tests/test_config.py::test_custom_tool_file_mixed_allowlist `
+          tests/test_llm_openai.py::TestIsProxy `
+          tests/test_cli.py::test_help `
+          tests/test_cli.py::test_version
+
   # API tests: only run requires_api tests, across multiple cheap models
   # Skipped on docs/config-only PRs to reduce API spend (~$30+/day in Haiku costs)
   # Note: Anthropic tests route through OpenRouter (OPENROUTER_API_KEY) for cost controls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,9 @@ jobs:
           .cache-id
 
     - name: Install dependencies
-      run: poetry install
+      run: |
+        make build
+        poetry install
 
     - name: Run Windows path/config smoke tests
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,9 +241,7 @@ jobs:
           .cache-id
 
     - name: Install dependencies
-      run: |
-        make build
-        poetry install
+      run: poetry install
 
     - name: Run Windows path/config smoke tests
       env:


### PR DESCRIPTION
Two Windows-specific bugs reached users without CI catching them (#3509, #3526). If Windows is a real surface, it needs at least one real runner.

## What this adds

A single `windows-latest` job covering the areas that actually broke:

- `tests/test_dirs.py` — filesystem path walking (the #3509 territory)
- two `tests/test_config.py` tool-allowlist cases
- `tests/test_llm_openai.py::TestIsProxy`
- `tests/test_cli.py::test_help` / `test_version`

No API keys. Deliberately **not** a full matrix — a broad, skip-marked suite would buy fake confidence for real maintenance cost.

`timeout-minutes: 15`, because the path-walk bug this job exists to catch manifests as an *infinite loop*; without a cap a regression burns the 6h default on a hang.

## ⚠️ Depends on #3509 — do not merge before it

This job runs `tests/test_dirs.py`, which contains tests that walk upward from a real `tmp_path` with no marker file (`test_returns_none_when_no_markers`, `test_returns_none_without_git`). On current master:

```python
while path != Path("/"):   # on Windows, C:\ never equals Path("/")
```

`C:\`.parent is `C:\`, so the loop never terminates. **Merging this job before #3509 lands would make the Windows lane hang (and time out red) on master.** #3509 by @illiand is the correct fix; this PR intentionally does not duplicate it.

## Scope note

An earlier draft of this branch also carried its own `gptme/dirs.py` fix plus mock-based tests. I dropped both: they duplicated #3509, and the variant was subtly worse — `while path != path.parent` never checks the root directory itself, so a marker file at `/` or `C:\` would be missed. #3509's check-then-break ordering handles that correctly.