### PR TITLE
feat(cli): add --version-short output

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -624,6 +624,12 @@ Run 'gptme-util --help' for all utility commands."""
     help="Show version and configuration information. First line is always 'gptme v<version>'.",
 )
 @click.option(
+    "--version-short",
+    "version_short",
+    is_flag=True,
+    help="Show only the gptme version string for scripting.",
+)
+@click.option(
     "--version-json",
     "version_json",
     is_flag=True,
@@ -722,6 +728,7 @@ def main(
     show_hidden: bool,
     show_prompt_stats: bool,
     version: bool,
+    version_short: bool,
     version_json: bool,
     resume: bool,
     workspace: str | None,
@@ -739,9 +746,10 @@ def main(
     manifest_dir: Path | None,
 ):
     """Main entrypoint for the CLI."""
+    show_version = version or version_short or version_json
 
     # Dispatch: `gptme search QUERY` → chats search (discoverability alias)
-    if prompts and prompts[0] == "search" and not version and not version_json:
+    if prompts and prompts[0] == "search" and not show_version:
         from ..tools.chats import search_chats  # fmt: skip
 
         query = " ".join(prompts[1:]).strip()
@@ -756,7 +764,7 @@ def main(
 
     # gptme-util subcommand mirroring: `gptme chats [...]` → `gptme-util chats [...]`
     # Any top-level gptme-util subcommand can be invoked without typing 'gptme-util'.
-    if prompts and not version and not version_json:
+    if prompts and not show_version:
         from .util import UTIL_SUBCOMMANDS  # cheap: just a sorted list constant
 
         if prompts[0] in UTIL_SUBCOMMANDS:
@@ -772,7 +780,7 @@ def main(
 
     # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
     # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.
-    if prompts and not version and not version_json:
+    if prompts and not show_version:
         plugin = f"gptme-{prompts[0]}"
         if plugin_path := shutil.which(plugin):
             sys.exit(subprocess.call([plugin_path, *prompts[1:]]))
@@ -963,7 +971,13 @@ def main(
 
     interactive = not non_interactive
     auto_switched_noninteractive = False
-    if version or version_json:
+    if show_version:
+        if version_short:
+            from ..__version__ import __version__
+
+            print(__version__)
+            exit(0)
+
         from ..info import format_version_info
 
         print(format_version_info(verbose=verbose, output_json=version_json))

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -940,7 +940,7 @@ def main(
 
     _validate_custom_tool_paths(tool_allowlist_str)
 
-    if profile:
+    if profile and not show_version:
         import cProfile
         import pstats
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from click.testing import CliRunner
 import gptme.cli.main as cli
 import gptme.constants
 import gptme.tools.browser
+from gptme.__version__ import __version__
 from gptme.message import Message
 from gptme.tools import ToolUse
 
@@ -159,6 +160,12 @@ def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0
     assert "gptme" in result.output
+
+
+def test_version_short(runner: CliRunner):
+    result = runner.invoke(cli.main, ["--version-short"])
+    assert result.exit_code == 0
+    assert result.output == f"{__version__}\n"
 
 
 def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner):

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from gptme.__version__ import __version__
 from gptme.cli.main import main
 
 
@@ -76,6 +77,14 @@ class TestSearchAlias:
         assert result.exit_code == 0
         mock_search.assert_not_called()
         assert "{" in result.output or "version" in result.output.lower()
+
+    def test_search_does_not_swallow_version_short(self, runner: CliRunner):
+        """gptme --version-short search QUERY shows only the version string."""
+        with patch("gptme.tools.chats.search_chats") as mock_search:
+            result = runner.invoke(main, ["--version-short", "search", "anything"])
+        assert result.exit_code == 0
+        mock_search.assert_not_called()
+        assert result.output == f"{__version__}\n"
 
 
 class TestPluginDispatch:


### PR DESCRIPTION
Add a compact version output mode for machine-readable contexts.

## What This Does
- Adds `gptme --version-short` flag that outputs just the version string (e.g., `0.32.0`)
- Useful for scripts and machine-readable contexts where just the version is needed

## Next JSON Output Candidates
After this lands, consider these related machine-readable output modes:
- `gptme-auth status` — expose auth status in JSON
- `gptme-util hooks status` — expose hook status in JSON

These follow the same pattern: minimal machine-readable output for scripting contexts.