### PR TITLE
refactor(cli): move Bob-specific status fields out of core; add StatusProvider extension point

### DIFF
--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -398,7 +398,21 @@ def build_document(providers: list[StatusProvider] | None = None) -> str:
     for provider in providers:
         try:
             extra_sections = provider.narrative_sections()
-            sections.extend(extra_sections)
+            if not isinstance(extra_sections, list):
+                logger.debug(
+                    "Provider %r narrative_sections() returned %r, expected list[str]; skipping",
+                    _provider_name(provider),
+                    type(extra_sections).__name__,
+                )
+            else:
+                valid = [s for s in extra_sections if isinstance(s, str)]
+                if len(valid) < len(extra_sections):
+                    logger.debug(
+                        "Provider %r narrative_sections() returned %d non-string item(s); dropped",
+                        _provider_name(provider),
+                        len(extra_sections) - len(valid),
+                    )
+                sections.extend(valid)
         except Exception as exc:
             logger.debug(
                 "Provider %r narrative_sections() failed: %s",

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -3,8 +3,13 @@
 Provides ``gptme-util status`` (via lazy registration in ``util.py``) and
 ``gptme-status`` (standalone entry point registered in ``pyproject.toml``).
 
-Produces a compact, human-readable briefing: active work, PR queue, service
-health, blockers, and ready backlog items.
+Produces a compact, human-readable briefing: recent commits, disk usage, and
+any extra sections contributed by installed :class:`~gptme.status_provider.StatusProvider`
+plugins registered under the ``gptme.status_providers`` entry-point group.
+
+Agent- or workspace-specific status fields (task queues, service health,
+blockers, journal entries) live in dedicated packages that register a provider.
+Core only collects generic information that is useful to any gptme user.
 """
 
 from __future__ import annotations
@@ -21,12 +26,13 @@ from typing import TypedDict
 
 import click
 
+from ..status_provider import StatusProvider, load_providers
 from ..util.git_cmd import GIT_CMD
 
 logger = logging.getLogger(__name__)
 
 
-# ── helpers ────────────────────────────────────────────────────────────
+# ── generic helpers ────────────────────────────────────────────────────
 
 
 def _run(cmd: list[str], *, timeout: int = 10) -> str:
@@ -44,39 +50,6 @@ def _git_root() -> Path | None:
     return Path(raw) if raw else None
 
 
-def _gh_user() -> str:
-    """Return the current gh CLI authenticated username."""
-    return _run(["gh", "api", "user", "--jq", ".login"], timeout=10)
-
-
-def _is_bob_workspace() -> bool:
-    """Detect if we are inside Bob's workspace by checking for Bob-specific files."""
-    root = _git_root()
-    if not root:
-        return False
-    return (root / "tasks").is_dir() and (root / "gptme.toml").is_file()
-
-
-def _active_tasks(lines: int = 3) -> list[dict]:
-    """Parse gptodo status --compact output for active tasks (Bob workspace)."""
-    raw = _run(["gptodo", "status", "--compact"], timeout=15)
-    if not raw:
-        return []
-    tasks: list[dict] = []
-    for line in raw.splitlines():
-        line = line.strip()
-        # Lines look like "  task-id  Title text here  (N ago)"
-        if not line or line.startswith("📋") or "0 tasks" in line or "Summary" in line:
-            continue
-        parts = line.split(None, 1)
-        if len(parts) >= 2:
-            task_id = parts[0]
-            # Strip trailing " (N unit ago)" timestamp to get the full title
-            title = re.sub(r"\s+\(\d+\s+\w+\s+ago\)\s*$", "", parts[1]).strip()
-            tasks.append({"_id": task_id, "title": title})
-    return tasks[:lines]
-
-
 def _recent_commits(n: int = 3) -> list[str]:
     raw = _run([GIT_CMD, "log", "--oneline", f"-{n}", "--no-merges"])
     return raw.splitlines() if raw else []
@@ -91,8 +64,16 @@ class _PRQueueRow(TypedDict):
 def _pr_queue(
     repos: list[tuple[str, int | None]], author: str | None = None
 ) -> list[_PRQueueRow]:
+    """Fetch open PR counts for the given repos.
+
+    This is a generic helper exposed for use by :class:`~gptme.status_provider.StatusProvider`
+    implementations.  Core ``build_document`` / ``_status_data`` do **not** call
+    it with any hardcoded repo list.
+    """
+    if not repos:
+        return []
     if author is None:
-        author = _gh_user() or "TimeToBuildBob"
+        author = _run(["gh", "api", "user", "--jq", ".login"], timeout=10) or ""
     rows: list[_PRQueueRow] = []
     for repo, cap in repos:
         prs_json = _run(
@@ -117,8 +98,7 @@ def _pr_queue(
             prs = json.loads(prs_json)
         except json.JSONDecodeError:
             continue
-        count = len(prs)
-        rows.append({"repo": repo, "count": count, "cap": cap})
+        rows.append({"repo": repo, "count": len(prs), "cap": cap})
     return rows
 
 
@@ -127,59 +107,6 @@ def _pr_queue_display(count: int, cap: int | None) -> str:
     if cap is not None:
         return f"{count}/{cap}" + (" ⚠ at limit" if count >= cap else "")
     return str(count)
-
-
-def _service_status() -> list[dict[str, str]]:
-    services = [
-        ("Operator loop", "bob-operator-loop.service"),
-        ("Autonomous", "bob-autonomous.service"),
-    ]
-    results: list[dict[str, str]] = []
-    for label, unit in services:
-        status = _run(["systemctl", "--user", "is-active", unit])
-        icon = "✓" if status == "active" else ("⚠" if status == "activating" else "✗")
-        results.append({"label": label, "icon": icon, "status": status})
-    return results
-
-
-def _dead_timers() -> int:
-    out = _run(["systemctl", "--user", "list-timers", "--all"])
-    return sum(
-        1
-        for line in out.splitlines()
-        if "dead" in line.lower() and "bob-" in line.lower()
-    )
-
-
-def _blockers(limit: int = 3) -> list[dict]:
-    raw = _run(["gptodo", "ready", "--state", "waiting", "--jsonl"], timeout=15)
-    if not raw:
-        return []
-    blockers: list[dict] = []
-    for line in raw.splitlines():
-        try:
-            t = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if t.get("waiting_for"):
-            blockers.append(t)
-    return blockers[:limit]
-
-
-def _ready_tasks(limit: int = 3) -> list[dict]:
-    raw = _run(["gptodo", "ready", "--state", "backlog", "--jsonl"], timeout=15)
-    if not raw:
-        return []
-    tasks: list[dict] = []
-    for line in raw.splitlines():
-        try:
-            t = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if t.get("waiting_for") or t.get("wait"):
-            continue
-        tasks.append(t)
-    return tasks[:limit]
 
 
 def _session_id() -> str:
@@ -217,29 +144,6 @@ def _markdown_table_cell(value: object) -> str:
     return text.replace("|", r"\|")
 
 
-def _journal_entries(limit: int = 5) -> list[str]:
-    """Return the last N journal entry filenames (Bob workspace)."""
-    root = _git_root()
-    if not root:
-        return []
-    journal_dir = root / "journal"
-    if not journal_dir.is_dir():
-        return []
-    entries: list[Path] = []
-    for day_dir in sorted(journal_dir.iterdir(), reverse=True):
-        if not day_dir.is_dir():
-            continue
-        day_entries = [
-            entry.relative_to(root)
-            for entry in sorted(day_dir.iterdir(), reverse=True)
-            if entry.is_file() and entry.suffix == ".md"
-        ]
-        entries.extend(day_entries)
-        if len(entries) >= limit:
-            break
-    return [str(e) for e in entries[:limit]]
-
-
 def _strip_markdown(doc: str) -> str:
     """Strip Markdown formatting for plain-text output."""
     lines = []
@@ -253,7 +157,7 @@ def _strip_markdown(doc: str) -> str:
     return "\n".join(lines)
 
 
-# ── sections ──────────────────────────────────────────────────────────
+# ── core sections ──────────────────────────────────────────────────────
 
 
 def section_header() -> str:
@@ -264,154 +168,79 @@ def section_header() -> str:
     return f"# gptme Status — {now}\n\n**Model**: {model}{agent_part}\n"
 
 
-def section_active_work(is_bob: bool = False) -> str:
+def section_active_work() -> str:
     lines = ["## Active Work"]
-    if is_bob:
-        tasks = _active_tasks(3)
-        if tasks:
-            lines.extend(
-                f"- **Task**: `{t['_id']}` — {t.get('title', '')[:60]}" for t in tasks
-            )
     commits = _recent_commits(3)
     if commits:
         lines.append("- **Recent commits** (last 3):")
         for commit in commits:
             sha, _, msg = commit.partition(" ")
             lines.append(f"  - `{sha}` {msg[:65]}")
-    return "\n".join(lines)
-
-
-def section_pr_queue() -> str:
-    lines = ["## PR Queue"]
-    rows = _pr_queue(_TRACKED_REPOS)
-    if rows:
-        lines.append("| Repo | Open |")
-        lines.append("|------|------|")
-        for row in rows:
-            display = _pr_queue_display(row["count"], row["cap"])
-            lines.append(f"| {row['repo']} | {display} |")
     else:
-        lines.append("- Unable to fetch PR data")
+        lines.append("- No recent commits")
     return "\n".join(lines)
 
 
-def section_services() -> str:
-    lines = ["## Services"]
-    services = _service_status()
-    lines.extend(f"- {svc['label']}: {svc['icon']} {svc['status']}" for svc in services)
-    dead = _dead_timers()
-    if dead:
-        lines.append(f"- ⚠ {dead} dead bob-* timer(s)")
-    return "\n".join(lines)
-
-
-def section_blockers() -> str:
-    lines = ["## Top Blockers"]
-    blockers = _blockers(3)
-    if blockers:
-        for t in blockers:
-            wf = str(t.get("waiting_for", "")).split("\n")[0][:70]
-            since = t.get("waiting_since", "")
-            since_str = f" (since {since})" if since else ""
-            lines.append(f"- `{t['id']}`: {wf}{since_str}")
-    else:
-        lines.append("- No active blockers with waiting_for set")
-    return "\n".join(lines)
-
-
-def section_ready_next() -> str:
-    lines = ["## Ready Next (top 3)"]
-    ready = _ready_tasks(3)
-    if ready:
-        for i, t in enumerate(ready, 1):
-            title = str(t.get("name", t.get("id", "")))[:65]
-            lines.append(f"{i}. `{t['id']}` — {title}")
-    else:
-        lines.append("- No ready backlog tasks found")
-    return "\n".join(lines)
+def section_disk() -> str:
+    root = _git_root()
+    disk = _disk_usage(root)
+    return f"## Disk\n\n- **Usage**: {disk}"
 
 
 # ── build ─────────────────────────────────────────────────────────────
 
 
-_TRACKED_REPOS: list[tuple[str, int | None]] = [
-    ("gptme/gptme", 10),
-    ("gptme/gptme-cloud", 3),
-    ("ErikBjare/bob", None),
-    ("gptme/gptme-contrib", None),
-]
+def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, object]:
+    """Collect status data shared by JSON and presentation renderers.
 
+    Core fields are generic and workspace-agnostic.  Extra fields from installed
+    :class:`~gptme.status_provider.StatusProvider` implementations are merged in
+    at the top level.
 
-def _status_data() -> dict[str, object]:
-    """Collect status data shared by JSON and presentation renderers."""
-    is_bob = _is_bob_workspace()
+    Parameters
+    ----------
+    providers:
+        Pre-loaded providers (for testing).  When ``None``, :func:`~gptme.status_provider.load_providers`
+        is called automatically.
+    """
+    if providers is None:
+        providers = load_providers()
+
     root = _git_root()
     status_data: dict[str, object] = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "session_id": _session_id(),
-        "active_tasks": [
-            {"id": task.get("_id", task.get("id", "")), "title": task.get("title", "")}
-            for task in _active_tasks(3)
-        ],
         "recent_commits": _recent_commits(3),
-        "pr_queue": _pr_queue(_TRACKED_REPOS),
         "disk_usage": _disk_usage(root),
-        "journal_entries": _journal_entries(5),
     }
-    if is_bob:
-        status_data.update(
-            services=_service_status(),
-            dead_timers=_dead_timers(),
-            blockers=_blockers(3),
-            ready_tasks=_ready_tasks(3),
-        )
+
+    for provider in providers:
+        try:
+            extra = provider.collect()
+            status_data.update(extra)
+        except Exception as exc:
+            logger.debug("Provider %r collect() failed: %s", provider.name, exc)
+
     return status_data
 
 
-def build_json_status() -> str:
+def build_json_status(providers: list[StatusProvider] | None = None) -> str:
     """Build the structured JSON status document."""
-    return json.dumps(_status_data(), indent=2)
+    return json.dumps(_status_data(providers), indent=2)
 
 
-def build_table_document() -> str:
+def build_table_document(providers: list[StatusProvider] | None = None) -> str:
     """Build a machine-readable markdown table of session state."""
-    is_bob = _is_bob_workspace()
+    if providers is None:
+        providers = load_providers()
+
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     session_id = _session_id()
     root = _git_root()
 
-    # active_task
-    active = _active_tasks(1)
-    active_task = active[0].get("_id", "none") if active else "none"
-
-    # last_commit
     commits = _recent_commits(1)
     last_commit = commits[0] if commits else "none"
-
-    # pending_prs
-    pr_rows = _pr_queue(_TRACKED_REPOS)
-    pending_prs = (
-        ", ".join(
-            f"{r['repo']}:{_pr_queue_display(r['count'], r['cap'])}" for r in pr_rows
-        )
-        if pr_rows
-        else "none"
-    )
-
-    # waiting_for
-    blockers = _blockers(1)
-    waiting_for = (
-        _markdown_table_cell(blockers[0].get("waiting_for", "none"))
-        if blockers
-        else "none"
-    )
-
-    # disk_usage
     disk = _markdown_table_cell(_disk_usage(root))
-
-    # journal_entries
-    journals = _journal_entries(5)
-    journal_str = _markdown_table_cell(", ".join(journals) if journals else "none")
 
     lines = [
         f"# gptme Status — {now}",
@@ -419,42 +248,44 @@ def build_table_document() -> str:
         "| Field | Value |",
         "|-------|-------|",
         f"| session_id | `{_markdown_table_cell(session_id)}` |",
-        f"| active_task | `{_markdown_table_cell(active_task)}` |",
         f"| last_commit | `{_markdown_table_cell(last_commit)}` |",
-        f"| pending_prs | {_markdown_table_cell(pending_prs)} |",
-        f"| waiting_for | {waiting_for} |",
         f"| disk_usage | {disk} |",
-        f"| journal_entries | {journal_str} |",
     ]
 
-    if is_bob:
-        services = _service_status()
-        svc_str = _markdown_table_cell(
-            ", ".join(f"{s['label']}={s['status']}" for s in services)
-        )
-        lines.append(f"| services | {svc_str} |")
-        dead = _dead_timers()
-        if dead:
-            lines.append(f"| dead_timers | {dead} |")
+    for provider in providers:
+        try:
+            extra = provider.collect()
+            for key, val in extra.items():
+                cell = _markdown_table_cell(val)
+                lines.append(f"| {key} | {cell} |")
+        except Exception as exc:
+            logger.debug(
+                "Provider %r collect() failed in table: %s", provider.name, exc
+            )
 
     return "\n".join(lines)
 
 
-def build_document() -> str:
-    is_bob = _is_bob_workspace()
+def build_document(providers: list[StatusProvider] | None = None) -> str:
+    """Build the narrative Markdown status document."""
+    if providers is None:
+        providers = load_providers()
+
     sections: list[str] = [
         section_header(),
-        section_active_work(is_bob=is_bob),
-        section_pr_queue(),
+        section_active_work(),
+        section_disk(),
     ]
-    if is_bob:
-        sections.extend(
-            [
-                section_services(),
-                section_blockers(),
-                section_ready_next(),
-            ]
-        )
+
+    for provider in providers:
+        try:
+            extra_sections = provider.narrative_sections()
+            sections.extend(extra_sections)
+        except Exception as exc:
+            logger.debug(
+                "Provider %r narrative_sections() failed: %s", provider.name, exc
+            )
+
     doc = "\n\n".join(sections)
     token_est = len(doc) // 4
     doc += f"\n\n---\n*~{token_est} tokens*"
@@ -500,8 +331,12 @@ def status(
 ) -> None:
     """Generate a portable operator handoff / session-status document.
 
-    Produces a compact briefing: active work, PR queue, service health,
-    blockers, and ready-next tasks.
+    Produces a compact briefing: recent commits, disk usage, and any extra
+    sections contributed by installed StatusProvider plugins.
+
+    Extra status fields (task queues, service health, journal entries) are
+    provided by installed packages that register a ``gptme.status_providers``
+    entry point — no workspace auto-detection, no cwd code loading.
 
     \b
     Examples:

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -307,8 +307,17 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
                     continue
                 # Sanitize nested dict keys: json.dumps requires all dict keys
                 # at every nesting level to be strings, and default= only handles
-                # non-serializable *values*, not invalid *keys*.
-                status_data[key] = _sanitize_nested_dict_keys(val)
+                # non-serializable *values*, not invalid *keys*.  Isolate malformed
+                # values to one field so valid fields from the provider survive.
+                try:
+                    status_data[key] = _sanitize_nested_dict_keys(val)
+                except Exception as exc:
+                    logger.debug(
+                        "Provider %r value for key %r failed to sanitize: %s — skipping",
+                        _provider_name(provider),
+                        key,
+                        exc,
+                    )
         except Exception as exc:
             logger.debug(
                 "Provider %r collect() failed: %s", _provider_name(provider), exc

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -254,6 +254,15 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
         try:
             extra = provider.collect()
             for key, val in extra.items():
+                if not isinstance(key, str):
+                    logger.debug(
+                        "Provider %r returned non-string key %r (type %s) — skipping;"
+                        " JSON requires string keys",
+                        _provider_name(provider),
+                        key,
+                        type(key).__name__,
+                    )
+                    continue
                 if key in _CORE_KEYS:
                     logger.debug(
                         "Provider %r tried to overwrite reserved core key %r — skipping",
@@ -316,6 +325,14 @@ def build_table_document(providers: list[StatusProvider] | None = None) -> str:
         try:
             extra = provider.collect()
             for key, val in extra.items():
+                if not isinstance(key, str):
+                    logger.debug(
+                        "Provider %r returned non-string key %r (type %s) — skipping",
+                        _provider_name(provider),
+                        key,
+                        type(key).__name__,
+                    )
+                    continue
                 if key in seen_keys:
                     logger.debug(
                         "Provider %r key %r is already present in the status"

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -190,12 +190,29 @@ def section_disk() -> str:
 # ── build ─────────────────────────────────────────────────────────────
 
 
+_CORE_KEYS = frozenset({"timestamp", "session_id", "recent_commits", "disk_usage"})
+"""Reserved top-level keys owned by gptme core.
+
+Providers must not use these names; any collision is logged and skipped so that
+core fields are never silently overwritten.
+"""
+
+
+def _json_default(obj: object) -> object:
+    """Fallback JSON serialiser for non-standard types returned by providers.
+
+    Converts unknown objects to their ``str()`` representation so that
+    ``json.dumps`` never raises ``TypeError`` on provider-contributed values.
+    """
+    return str(obj)
+
+
 def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, object]:
     """Collect status data shared by JSON and presentation renderers.
 
     Core fields are generic and workspace-agnostic.  Extra fields from installed
     :class:`~gptme.status_provider.StatusProvider` implementations are merged in
-    at the top level.
+    at the top level, with collision detection against reserved core keys.
 
     Parameters
     ----------
@@ -217,7 +234,21 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
     for provider in providers:
         try:
             extra = provider.collect()
-            status_data.update(extra)
+            for key, val in extra.items():
+                if key in _CORE_KEYS:
+                    logger.debug(
+                        "Provider %r tried to overwrite reserved core key %r — skipping",
+                        provider.name,
+                        key,
+                    )
+                    continue
+                if key in status_data:
+                    logger.debug(
+                        "Provider %r key %r collides with an earlier provider's key — overwriting",
+                        provider.name,
+                        key,
+                    )
+                status_data[key] = val
         except Exception as exc:
             logger.debug("Provider %r collect() failed: %s", provider.name, exc)
 
@@ -226,7 +257,7 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
 
 def build_json_status(providers: list[StatusProvider] | None = None) -> str:
     """Build the structured JSON status document."""
-    return json.dumps(_status_data(providers), indent=2)
+    return json.dumps(_status_data(providers), indent=2, default=_json_default)
 
 
 def build_table_document(providers: list[StatusProvider] | None = None) -> str:

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -258,10 +258,12 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
                     continue
                 if key in status_data:
                     logger.debug(
-                        "Provider %r key %r collides with an earlier provider's key — overwriting",
+                        "Provider %r key %r collides with an earlier provider's key — skipping"
+                        " (first-writer wins, consistent with table output)",
                         _provider_name(provider),
                         key,
                     )
+                    continue
                 status_data[key] = val
         except Exception as exc:
             logger.debug(

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -372,7 +372,10 @@ def build_table_document(providers: list[StatusProvider] | None = None) -> str:
                     )
                     continue
                 seen_keys.add(key)
-                cell = _markdown_table_cell(val)
+                try:
+                    cell = _markdown_table_cell(val)
+                except Exception:
+                    cell = "<unserializable>"
                 lines.append(f"| {key} | {cell} |")
         except Exception as exc:
             logger.debug(

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -226,6 +226,29 @@ def _json_default(obj: object) -> object:
         return "<unserializable>"
 
 
+def _sanitize_nested_dict_keys(obj: object) -> object:
+    """Recursively convert non-string keys in nested dicts to their ``str()`` form.
+
+    :func:`_status_data` already drops top-level provider keys that are not
+    strings, but a provider value can itself be a :class:`dict` whose *nested*
+    keys are non-strings.  ``json.dumps`` raises :exc:`TypeError` on such keys
+    because the ``default=`` hook only handles non-serializable **values**, not
+    invalid dict **keys**.
+
+    This helper traverses :class:`dict` and :class:`list` values recursively,
+    converting any non-string key to its ``str()`` representation so the
+    entire value tree is safe to pass to ``json.dumps``.
+    """
+    if isinstance(obj, dict):
+        return {
+            (k if isinstance(k, str) else str(k)): _sanitize_nested_dict_keys(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_sanitize_nested_dict_keys(v) for v in obj]
+    return obj
+
+
 def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, object]:
     """Collect status data shared by JSON and presentation renderers.
 
@@ -278,7 +301,10 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
                         key,
                     )
                     continue
-                status_data[key] = val
+                # Sanitize nested dict keys: json.dumps requires all dict keys
+                # at every nesting level to be strings, and default= only handles
+                # non-serializable *values*, not invalid *keys*.
+                status_data[key] = _sanitize_nested_dict_keys(val)
         except Exception as exc:
             logger.debug(
                 "Provider %r collect() failed: %s", _provider_name(provider), exc

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -215,10 +215,15 @@ core fields are never silently overwritten.
 def _json_default(obj: object) -> object:
     """Fallback JSON serialiser for non-standard types returned by providers.
 
-    Converts unknown objects to their ``str()`` representation so that
-    ``json.dumps`` never raises ``TypeError`` on provider-contributed values.
+    Converts unknown objects to their ``str()`` representation, using a fixed
+    placeholder when the object's string conversion itself fails.  This ensures
+    that a provider returning an object with a broken ``__str__()`` cannot abort
+    ``gptme-util status --json``.
     """
-    return str(obj)
+    try:
+        return str(obj)
+    except Exception:
+        return "<unserializable>"
 
 
 def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, object]:

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -190,6 +190,20 @@ def section_disk() -> str:
 # ── build ─────────────────────────────────────────────────────────────
 
 
+def _provider_name(provider: StatusProvider) -> str:
+    """Return the provider's name without raising.
+
+    Defense-in-depth companion to the name probe in :func:`~gptme.status_provider.load_providers`.
+    If a provider's name property raises despite the load-time probe, this
+    helper returns a safe fallback so that error-handler log lines never
+    themselves raise and escape isolation.
+    """
+    try:
+        return provider.name
+    except Exception:
+        return "<unnamed-provider>"
+
+
 _CORE_KEYS = frozenset({"timestamp", "session_id", "recent_commits", "disk_usage"})
 """Reserved top-level keys owned by gptme core.
 
@@ -238,19 +252,21 @@ def _status_data(providers: list[StatusProvider] | None = None) -> dict[str, obj
                 if key in _CORE_KEYS:
                     logger.debug(
                         "Provider %r tried to overwrite reserved core key %r — skipping",
-                        provider.name,
+                        _provider_name(provider),
                         key,
                     )
                     continue
                 if key in status_data:
                     logger.debug(
                         "Provider %r key %r collides with an earlier provider's key — overwriting",
-                        provider.name,
+                        _provider_name(provider),
                         key,
                     )
                 status_data[key] = val
         except Exception as exc:
-            logger.debug("Provider %r collect() failed: %s", provider.name, exc)
+            logger.debug(
+                "Provider %r collect() failed: %s", _provider_name(provider), exc
+            )
 
     return status_data
 
@@ -291,7 +307,9 @@ def build_table_document(providers: list[StatusProvider] | None = None) -> str:
                 lines.append(f"| {key} | {cell} |")
         except Exception as exc:
             logger.debug(
-                "Provider %r collect() failed in table: %s", provider.name, exc
+                "Provider %r collect() failed in table: %s",
+                _provider_name(provider),
+                exc,
             )
 
     return "\n".join(lines)
@@ -314,7 +332,9 @@ def build_document(providers: list[StatusProvider] | None = None) -> str:
             sections.extend(extra_sections)
         except Exception as exc:
             logger.debug(
-                "Provider %r narrative_sections() failed: %s", provider.name, exc
+                "Provider %r narrative_sections() failed: %s",
+                _provider_name(provider),
+                exc,
             )
 
     doc = "\n\n".join(sections)

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -235,9 +235,11 @@ def _sanitize_nested_dict_keys(obj: object) -> object:
     because the ``default=`` hook only handles non-serializable **values**, not
     invalid dict **keys**.
 
-    This helper traverses :class:`dict` and :class:`list` values recursively,
-    converting any non-string key to its ``str()`` representation so the
-    entire value tree is safe to pass to ``json.dumps``.
+    This helper traverses :class:`dict`, :class:`list`, and :class:`tuple`
+    values recursively, converting any non-string key to its ``str()``
+    representation so the entire value tree is safe to pass to ``json.dumps``.
+    Tuples are reconstructed as tuples so the original container type is
+    preserved; ``json.dumps`` serialises them as JSON arrays, the same as lists.
     """
     if isinstance(obj, dict):
         return {
@@ -246,6 +248,8 @@ def _sanitize_nested_dict_keys(obj: object) -> object:
         }
     if isinstance(obj, list):
         return [_sanitize_nested_dict_keys(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(_sanitize_nested_dict_keys(v) for v in obj)
     return obj
 
 

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -299,10 +299,25 @@ def build_table_document(providers: list[StatusProvider] | None = None) -> str:
         f"| disk_usage | {disk} |",
     ]
 
+    # Track keys already in the table so providers cannot produce contradictory
+    # duplicate rows.  Initialised with the core table fields plus the names
+    # reserved for JSON output (_CORE_KEYS) — some differ (last_commit vs
+    # recent_commits) so both sets are merged.
+    seen_keys: set[str] = {"session_id", "last_commit", "disk_usage"} | _CORE_KEYS
+
     for provider in providers:
         try:
             extra = provider.collect()
             for key, val in extra.items():
+                if key in seen_keys:
+                    logger.debug(
+                        "Provider %r key %r is already present in the status"
+                        " table — skipping to prevent contradictory duplicate rows",
+                        _provider_name(provider),
+                        key,
+                    )
+                    continue
+                seen_keys.add(key)
                 cell = _markdown_table_cell(val)
                 lines.append(f"| {key} | {cell} |")
         except Exception as exc:

--- a/gptme/status_provider.py
+++ b/gptme/status_provider.py
@@ -1,0 +1,104 @@
+"""StatusProvider protocol and entry-point registry for ``gptme-util status``.
+
+External packages register implementations under the ``gptme.status_providers``
+entry-point group.  Only *installed* packages can register entry points — the
+current working directory is never scanned, which prevents auto-loading code
+from arbitrary repositories.
+
+Security model
+--------------
+``importlib.metadata.entry_points`` discovers providers from *installed* Python
+packages only.  No filesystem scanning, no ``importlib.import_module`` from the
+current directory, no ``exec()`` of repo-local files.  A malicious repository
+cannot inject a provider simply by being ``cd``'d into.
+
+Example ``pyproject.toml`` snippet (provider package side):
+
+.. code-block:: toml
+
+    [project.entry-points."gptme.status_providers"]
+    my-provider = "my_package.status:make_provider"
+
+The value must be a zero-argument callable that returns a
+:class:`StatusProvider` instance.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class StatusProvider(Protocol):
+    """Protocol for external status data providers.
+
+    Implementations contribute extra fields to ``gptme-util status`` output
+    without requiring any changes to gptme core.
+
+    Register via Python entry points (group ``gptme.status_providers``).  The
+    registered value must be a zero-argument factory that returns a
+    :class:`StatusProvider` instance.
+
+    Security
+    --------
+    Only *installed* packages can register entry points.  gptme core never
+    loads Python from the current working directory or any repository checkout
+    automatically — no ``importlib.import_module(path)`` from cwd, no
+    ``exec()`` of repo-local files.
+    """
+
+    @property
+    def name(self) -> str:
+        """Short identifier used as a label in output (e.g. ``"bob"``)."""
+        ...
+
+    def collect(self) -> dict[str, object]:
+        """Collect and return status data as a flat mapping.
+
+        Keys are merged into the top-level ``--json`` output.  Use a provider-
+        specific prefix on keys to avoid collisions (e.g. ``"bob_tasks"``
+        rather than plain ``"tasks"``).
+        """
+        ...
+
+    def narrative_sections(self) -> list[str]:
+        """Return zero or more Markdown section strings for narrative output.
+
+        Each returned string is appended to the document built by
+        :func:`gptme.cli.cmd_status.build_document` after the core sections.
+        Return an empty list when no extra narrative is needed.
+        """
+        ...
+
+
+def load_providers() -> list[StatusProvider]:
+    """Return all installed :class:`StatusProvider` implementations.
+
+    Scans the ``gptme.status_providers`` entry-point group in installed
+    packages only.  Any provider that fails to import or instantiate is
+    silently skipped and logged at ``DEBUG`` level so that a broken provider
+    does not break the status command for unrelated providers.
+
+    Returns
+    -------
+    list[StatusProvider]
+        Instantiated providers in entry-point registration order.
+    """
+    from importlib.metadata import entry_points  # lazy — keeps startup fast
+
+    providers: list[StatusProvider] = []
+    try:
+        eps = entry_points(group="gptme.status_providers")
+        for ep in eps:
+            try:
+                factory = ep.load()
+                provider = factory()
+                providers.append(provider)
+            except Exception as exc:
+                logger.debug("Failed to load status provider %r: %s", ep.name, exc)
+    except Exception as exc:
+        logger.debug("Failed to enumerate status providers: %s", exc)
+    return providers

--- a/gptme/status_provider.py
+++ b/gptme/status_provider.py
@@ -78,9 +78,10 @@ def load_providers() -> list[StatusProvider]:
     """Return all installed :class:`StatusProvider` implementations.
 
     Scans the ``gptme.status_providers`` entry-point group in installed
-    packages only.  Any provider that fails to import or instantiate is
-    silently skipped and logged at ``DEBUG`` level so that a broken provider
-    does not break the status command for unrelated providers.
+    packages only.  Any provider that fails to import, instantiate, or
+    satisfy the protocol is silently skipped and logged at ``DEBUG`` level so
+    that a broken provider does not break the status command for unrelated
+    providers.
 
     Returns
     -------
@@ -96,6 +97,14 @@ def load_providers() -> list[StatusProvider]:
             try:
                 factory = ep.load()
                 provider = factory()
+                if not isinstance(provider, StatusProvider):
+                    logger.debug(
+                        "Status provider factory %r returned %r which does not"
+                        " satisfy the StatusProvider protocol — skipping",
+                        ep.name,
+                        type(provider).__name__,
+                    )
+                    continue
                 providers.append(provider)
             except Exception as exc:
                 logger.debug("Failed to load status provider %r: %s", ep.name, exc)

--- a/gptme/status_provider.py
+++ b/gptme/status_provider.py
@@ -105,6 +105,24 @@ def load_providers() -> list[StatusProvider]:
                         type(provider).__name__,
                     )
                     continue
+                # Probe that the name property is safely readable.  The
+                # runtime_checkable isinstance() check only verifies that the
+                # attribute *exists* on the type — it does not call the
+                # property getter.  A provider whose name property raises would
+                # pass the isinstance check above but crash the error handlers
+                # in cmd_status.py which dereference provider.name inside
+                # except blocks.
+                try:
+                    _ = provider.name
+                except Exception as name_exc:
+                    logger.debug(
+                        "Status provider loaded from entry point %r has a"
+                        " name property that raises (%s) — skipping to prevent"
+                        " error-handler crashes",
+                        ep.name,
+                        name_exc,
+                    )
+                    continue
                 providers.append(provider)
             except Exception as exc:
                 logger.debug("Failed to load status provider %r: %s", ep.name, exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,6 +514,19 @@ def temp_file():
 
 
 @pytest.fixture(autouse=True)
+def cleanup_logged_warnings():
+    """Clear the log_warn_once cache between tests to ensure test isolation."""
+    yield
+    # Reset the module-level warning cache after each test
+    try:
+        from gptme.llm.models.resolution import _logged_warnings
+
+        _logged_warnings.clear()
+    except (ImportError, AttributeError):
+        pass
+
+
+@pytest.fixture(autouse=True)
 def init_(monkeypatch):
     # Pass MODEL from env explicitly to avoid picking up stale config.chat.model
     # values left by server tests. When _init_done is reset per-test, init_model()

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -664,3 +664,55 @@ def test_build_table_document_cross_provider_collision():
     assert "from_first" in doc
     assert "from_second" not in doc
     assert "| unique_key |" in doc
+
+
+def test_status_json_provider_non_string_key_does_not_crash(monkeypatch):
+    """Verify a provider returning non-string mapping keys does not abort --json output.
+
+    json.dumps() requires string keys; the default= fallback only handles non-serializable
+    *values*, not non-string *keys*.  Non-string keys must be filtered before json.dumps().
+    """
+
+    class _NonStringKeyProvider:
+        name = "nonstring"
+
+        def collect(self) -> dict:
+            return {(1, 2): "tuple_key_value", "normal_key": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-ns")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_NonStringKeyProvider()])
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # The non-string key must be silently dropped; all surviving keys are strings.
+    assert all(isinstance(k, str) for k in data)
+    # The normal string key still makes it through.
+    assert data["normal_key"] == "ok"
+
+
+def test_build_table_document_provider_non_string_key_skipped():
+    """Verify non-string provider keys are silently dropped from table output."""
+
+    class _NonStringKeyProvider:
+        name = "nonstring"
+
+        def collect(self) -> dict:
+            return {(1, 2): "should_be_dropped", "string_key": "kept"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_NonStringKeyProvider()])
+    # The tuple key must not appear in any form in the table.
+    assert "should_be_dropped" not in doc
+    assert "(1, 2)" not in doc
+    # The valid string key still appears.
+    assert "| string_key |" in doc
+    assert "kept" in doc

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -820,6 +820,39 @@ def test_status_json_provider_nested_non_string_key_does_not_crash(monkeypatch):
     assert nested["str_key"] == "ok"
 
 
+def test_status_json_provider_broken_nested_key_does_not_drop_other_fields(
+    monkeypatch,
+):
+    """A nested key with broken __str__ is isolated to its top-level field."""
+
+    class _BadStrKey:
+        def __str__(self) -> str:
+            raise RuntimeError("__str__ is broken")
+
+    class _BrokenNestedKeyProvider:
+        name = "broken_nested_key"
+
+        def collect(self) -> dict:
+            return {"broken": {_BadStrKey(): "bad"}, "normal_key": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-broken-key")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(
+        cmd_status, "load_providers", lambda: [_BrokenNestedKeyProvider()]
+    )
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "broken" not in data
+    assert data["normal_key"] == "ok"
+
+
 def test_status_json_provider_tuple_nested_non_string_key_does_not_crash(monkeypatch):
     """Verify a provider returning a tuple containing a dict with non-string keys
     does not crash --json.

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -310,6 +310,57 @@ def test_status_broken_provider_does_not_crash(monkeypatch):
     assert "# gptme Status" in result.output
 
 
+def test_load_providers_skips_raising_name_provider(monkeypatch):
+    """Verify load_providers() skips a provider whose name property raises.
+
+    Runtime-checkable isinstance() only verifies attribute *presence*, not that
+    property getters actually work.  A provider with a raising name property must
+    be excluded so error-handler log lines in cmd_status.py never themselves raise.
+    """
+    import importlib.metadata as im
+
+    class _RaisingNameProvider:
+        """Structurally-conforming provider whose name property always raises."""
+
+        @property
+        def name(self) -> str:
+            raise RuntimeError("name property is broken")
+
+        def collect(self) -> dict:
+            return {}
+
+        def narrative_sections(self) -> list[str]:
+            return []
+
+    def _factory():
+        return _RaisingNameProvider()
+
+    class _FakeEP:
+        name = "raising-name-provider"
+
+        def load(self):
+            return _factory
+
+    original_ep = im.entry_points
+
+    def _patched_ep(**kw):
+        if kw.get("group") == "gptme.status_providers":
+            return [_FakeEP()]
+        return original_ep(**kw)
+
+    monkeypatch.setattr(im, "entry_points", _patched_ep)
+    from gptme.status_provider import load_providers
+
+    providers = load_providers()
+    # The raising-name provider must be silently dropped
+    assert all(
+        p.name == p.name for p in providers
+    )  # all returned providers have safe names
+    # And the raising provider itself must not be present
+    for p in providers:
+        assert not isinstance(p, _RaisingNameProvider)
+
+
 def test_load_providers_returns_empty_when_none_installed():
     """Verify load_providers() returns an empty list when no providers installed."""
     from gptme.status_provider import load_providers

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -15,25 +15,46 @@ from gptme.cli.cmd_status import (
     status,
 )
 from gptme.cli.util import main as util_main
+from gptme.status_provider import StatusProvider
+
+# ── fixtures / helpers ─────────────────────────────────────────────────
+
+
+class _FakeProvider:
+    """A minimal StatusProvider test double."""
+
+    name = "test"
+
+    def collect(self) -> dict:
+        return {"test_key": "test_value", "test_count": 42}
+
+    def narrative_sections(self) -> list[str]:
+        return ["## Test Section\n\n- item from provider"]
+
+
+def _noop_providers() -> list:
+    """Return an empty provider list to suppress entry-point loading in tests."""
+    return []
+
+
+# ── core output tests ──────────────────────────────────────────────────
 
 
 def test_status_output_contains_expected_sections():
     """Verify the status output contains always-present sections."""
     runner = CliRunner()
     result = runner.invoke(status)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "# gptme Status" in result.output
     assert "## Active Work" in result.output
-    assert "## PR Queue" in result.output
-    # Services/blockers/ready sections are only included in Bob's workspace
-    # (when gptme.toml + tasks/ are present); not asserted here.
+    assert "## Disk" in result.output
 
 
 def test_status_invoked_via_util_subcommand():
     """Verify gptme-util status dispatches correctly."""
     runner = CliRunner()
     result = runner.invoke(util_main, ["status"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "# gptme Status" in result.output
 
 
@@ -42,7 +63,7 @@ def test_status_write_to_file(tmp_path):
     runner = CliRunner()
     output_file = tmp_path / "handoff.md"
     result = runner.invoke(status, ["-o", str(output_file)])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert output_file.exists()
     content = output_file.read_text()
     assert "# gptme Status" in content
@@ -53,7 +74,7 @@ def test_status_no_markdown():
     """Verify --no-markdown strips heading markers from output."""
     runner = CliRunner()
     result = runner.invoke(status, ["--no-markdown"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "# gptme Status" not in result.output
     assert "gptme Status" in result.output
 
@@ -63,7 +84,7 @@ def test_status_agent_name_from_env(monkeypatch):
     monkeypatch.setenv("GPTME_AGENT_NAME", "TestAgent")
     runner = CliRunner()
     result = runner.invoke(status)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "TestAgent" in result.output
 
 
@@ -82,98 +103,85 @@ def test_strip_markdown_removes_headings():
 
 
 def test_status_format_table():
-    """Verify --format table outputs a markdown table with expected fields."""
+    """Verify --format table outputs a markdown table with core fields."""
     runner = CliRunner()
     result = runner.invoke(status, ["--format", "table"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "| Field | Value |" in result.output
     assert "| session_id |" in result.output
-    assert "| active_task |" in result.output
     assert "| last_commit |" in result.output
-    assert "| pending_prs |" in result.output
-    assert "| waiting_for |" in result.output
     assert "| disk_usage |" in result.output
-    assert "| journal_entries |" in result.output
 
 
 def test_status_format_table_via_util():
     """Verify gptme-util status --format table dispatches correctly."""
     runner = CliRunner()
     result = runner.invoke(util_main, ["status", "--format", "table"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "| Field | Value |" in result.output
     assert "| session_id |" in result.output
 
 
-def test_status_json(monkeypatch):
-    """Verify --json emits structured status without Markdown."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: True)
-    monkeypatch.setattr(
-        cmd_status,
-        "_active_tasks",
-        lambda lines=3: [{"_id": "task-1", "title": "First task"}],
-    )
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: ["abc123 Fix"])
-    monkeypatch.setattr(
-        cmd_status,
-        "_pr_queue",
-        lambda _tracked: [{"repo": "gptme/gptme", "count": 2, "cap": None}],
-    )
-    monkeypatch.setattr(
-        cmd_status,
-        "_service_status",
-        lambda: [{"label": "worker", "icon": "✅", "status": "active"}],
-    )
-    monkeypatch.setattr(cmd_status, "_dead_timers", lambda: 0)
-    monkeypatch.setattr(
-        cmd_status,
-        "_blockers",
-        lambda limit=3: [{"id": "blocked", "waiting_for": "review"}],
-    )
-    monkeypatch.setattr(
-        cmd_status,
-        "_ready_tasks",
-        lambda limit=3: [{"id": "ready", "name": "Ready task"}],
-    )
+# ── JSON output tests ──────────────────────────────────────────────────
+
+
+def test_status_json_core_fields(monkeypatch):
+    """Verify --json emits core status fields without Bob-specific data."""
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: ["abc123 Fix"])
     monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-1")
     monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: ["entry.md"])
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [])
 
     result = CliRunner().invoke(status, ["--json"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     data = json.loads(result.output)
-    # Timestamp is dynamic; validate presence and format separately.
     assert "timestamp" in data
     assert "T" in data.pop("timestamp")
     assert data == {
         "session_id": "session-1",
-        "active_tasks": [{"id": "task-1", "title": "First task"}],
         "recent_commits": ["abc123 Fix"],
-        "pr_queue": [{"repo": "gptme/gptme", "count": 2, "cap": None}],
         "disk_usage": "1G / 2G (50%)",
-        "journal_entries": ["entry.md"],
-        "services": [{"label": "worker", "icon": "✅", "status": "active"}],
-        "dead_timers": 0,
-        "blockers": [{"id": "blocked", "waiting_for": "review"}],
-        "ready_tasks": [{"id": "ready", "name": "Ready task"}],
     }
+
+
+def test_status_json_no_bob_fields_by_default(monkeypatch):
+    """Verify Bob-specific fields are absent from core JSON output."""
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-y")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [])
+
+    result = CliRunner().invoke(status, ["--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    for bob_key in (
+        "services",
+        "dead_timers",
+        "blockers",
+        "ready_tasks",
+        "active_tasks",
+        "journal_entries",
+        "pr_queue",
+    ):
+        assert bob_key not in data, (
+            f"Bob-specific field '{bob_key}' present in core JSON output"
+        )
 
 
 def test_status_json_via_util(monkeypatch):
     """Verify gptme-util status exposes the --json flag (deterministic)."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
-    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
-    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
     monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-util")
     monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [])
 
     result = CliRunner().invoke(util_main, ["status", "--json"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     data = json.loads(result.output)
     assert isinstance(data, dict)
     assert data["session_id"] == "session-util"
@@ -182,59 +190,31 @@ def test_status_json_via_util(monkeypatch):
 
 def test_status_json_with_output_file(tmp_path, monkeypatch):
     """Verify --json -o path writes valid JSON with expected schema to a file."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
-    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
-    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
     monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-x")
     monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [])
 
     out_file = tmp_path / "status.json"
     result = CliRunner().invoke(status, ["--json", "-o", str(out_file)])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert data["session_id"] == "session-x"
     assert "timestamp" in data
-    assert "active_tasks" in data
-    assert "pr_queue" in data
+    assert "recent_commits" in data
     assert "disk_usage" in data
 
 
-def test_status_json_excludes_bob_fields_in_non_bob_workspace(monkeypatch):
-    """Verify Bob-only fields are absent when not in Bob's workspace."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
-    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
-    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
-    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-y")
-    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
-
-    result = CliRunner().invoke(status, ["--json"])
-
-    assert result.exit_code == 0
-    data = json.loads(result.output)
-    for bob_key in ("services", "dead_timers", "blockers", "ready_tasks"):
-        assert bob_key not in data, (
-            f"Bob-only field '{bob_key}' present outside Bob workspace"
-        )
-
-
 def test_status_json_write_with_output_path(tmp_path, monkeypatch):
-    """Verify --json --write -o path is accepted and writes JSON (unambiguous destination)."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
-    monkeypatch.setattr(cmd_status, "_active_tasks", lambda lines=3: [])
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda limit=3: [])
-    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
+    """Verify --json --write -o path is accepted and writes JSON."""
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
     monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-w")
     monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda limit=5: [])
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [])
 
     out_file = tmp_path / "out.json"
     result = CliRunner().invoke(status, ["--json", "--write", "-o", str(out_file)])
@@ -258,6 +238,93 @@ def test_status_json_rejects_rendering_options():
         assert result.exit_code == 2
 
 
+# ── StatusProvider tests ───────────────────────────────────────────────
+
+
+def test_status_provider_protocol():
+    """Verify _FakeProvider satisfies the StatusProvider protocol."""
+    provider = _FakeProvider()
+    assert isinstance(provider, StatusProvider)
+    assert provider.name == "test"
+    assert provider.collect() == {"test_key": "test_value", "test_count": 42}
+    sections = provider.narrative_sections()
+    assert len(sections) == 1
+    assert "## Test Section" in sections[0]
+
+
+def test_status_json_merges_provider_fields(monkeypatch):
+    """Verify provider collect() is merged into --json output."""
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-p")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_FakeProvider()])
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["test_key"] == "test_value"
+    assert data["test_count"] == 42
+
+
+def test_status_narrative_includes_provider_sections(monkeypatch):
+    """Verify provider narrative_sections() are included in narrative output."""
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_FakeProvider()])
+
+    result = CliRunner().invoke(status)
+    assert result.exit_code == 0, result.output
+    assert "## Test Section" in result.output
+    assert "item from provider" in result.output
+
+
+def test_status_table_includes_provider_fields(monkeypatch):
+    """Verify provider collect() keys appear as rows in table format."""
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "s")
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=1: [])
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "0G / 0G (0%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_FakeProvider()])
+
+    result = CliRunner().invoke(status, ["--format", "table"])
+    assert result.exit_code == 0, result.output
+    assert "| test_key |" in result.output
+    assert "test_value" in result.output
+
+
+def test_status_broken_provider_does_not_crash(monkeypatch):
+    """Verify a provider whose collect() raises does not crash the command."""
+
+    class _BrokenProvider:
+        name = "broken"
+
+        def collect(self) -> dict:
+            raise RuntimeError("provider is broken")
+
+        def narrative_sections(self) -> list[str]:
+            raise RuntimeError("provider is broken")
+
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_BrokenProvider()])
+
+    result = CliRunner().invoke(status)
+    assert result.exit_code == 0, result.output
+    assert "# gptme Status" in result.output
+
+
+def test_load_providers_returns_empty_when_none_installed():
+    """Verify load_providers() returns an empty list when no providers installed."""
+    from gptme.status_provider import load_providers
+
+    providers = load_providers()
+    # In the gptme package itself, no providers are registered.
+    # If some are installed in this environment, they should still satisfy the protocol.
+    assert isinstance(providers, list)
+    for p in providers:
+        assert isinstance(p, StatusProvider)
+
+
+# ── formatting helpers ─────────────────────────────────────────────────
+
+
 def test_pr_queue_display():
     """Verify _pr_queue_display formats count/cap and at-limit suffix correctly."""
     assert _pr_queue_display(2, None) == "2"
@@ -270,7 +337,7 @@ def test_status_format_narrative_is_default():
     """Verify default format is narrative (not table)."""
     runner = CliRunner()
     result = runner.invoke(status)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "## Active Work" in result.output
     assert "| Field | Value |" not in result.output
 
@@ -297,30 +364,17 @@ def test_session_id_fallback(monkeypatch):
 
 
 def test_build_table_document_structure():
-    """Verify build_table_document produces a markdown table."""
-    doc = build_table_document()
+    """Verify build_table_document produces a markdown table with core fields."""
+    doc = build_table_document(providers=[])
     lines = doc.splitlines()
     assert any("| Field | Value |" in line for line in lines)
     assert any("| session_id |" in line for line in lines)
     assert any("| last_commit |" in line for line in lines)
+    assert any("| disk_usage |" in line for line in lines)
 
 
-def test_build_table_document_escapes_multiline_waiting_for(monkeypatch):
-    """Verify multiline blockers stay inside a single markdown table row."""
-    monkeypatch.setattr(cmd_status, "_is_bob_workspace", lambda: False)
-    monkeypatch.setattr(cmd_status, "_active_tasks", lambda _limit=1: [])
-    monkeypatch.setattr(cmd_status, "_recent_commits", lambda _limit=1: [])
-    monkeypatch.setattr(cmd_status, "_pr_queue", lambda _tracked: [])
-    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
-    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _root=None: "1G / 2G (50%)")
-    monkeypatch.setattr(cmd_status, "_journal_entries", lambda _limit=5: [])
-    monkeypatch.setattr(
-        cmd_status,
-        "_blockers",
-        lambda _limit=1: [{"waiting_for": "first line\nsecond | line"}],
-    )
-
-    doc = build_table_document()
-
-    assert "| waiting_for | first line second \\| line |" in doc
-    assert "second | line" not in doc
+def test_build_table_document_with_provider():
+    """Verify provider fields appear as table rows."""
+    doc = build_table_document(providers=[_FakeProvider()])
+    assert "| test_key |" in doc
+    assert "test_value" in doc

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -622,6 +622,27 @@ def test_build_table_document_core_key_collision():
     assert "| safe_key |" in doc
 
 
+def test_build_table_document_provider_str_raises_does_not_drop_other_fields():
+    """A malformed provider value is isolated to its own table cell."""
+
+    class _BadStrValue:
+        def __str__(self) -> str:
+            raise RuntimeError("__str__ is broken")
+
+    class _BadStrProvider:
+        name = "bad_str"
+
+        def collect(self) -> dict:
+            return {"broken_value": _BadStrValue(), "normal_key": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_BadStrProvider()])
+    assert "| broken_value | <unserializable> |" in doc
+    assert "| normal_key | ok |" in doc
+
+
 def test_status_json_provider_str_raises_does_not_crash(monkeypatch):
     """Verify a provider value whose __str__() raises does not abort --json output."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -739,6 +739,44 @@ def test_status_json_provider_nested_non_string_key_does_not_crash(monkeypatch):
     assert nested["str_key"] == "ok"
 
 
+def test_status_json_provider_tuple_nested_non_string_key_does_not_crash(monkeypatch):
+    """Verify a provider returning a tuple containing a dict with non-string keys
+    does not crash --json.
+
+    _sanitize_nested_dict_keys() must recurse into tuples, not only dicts and
+    lists. Without tuple traversal, json.dumps() reaches the inner dict and
+    raises TypeError on its non-string key, aborting the command without output.
+    """
+
+    class _TupleNestedNonStringKeyProvider:
+        name = "tuple_nested"
+
+        def collect(self) -> dict:
+            # Top-level key is a valid string; value is a tuple whose element is
+            # a dict with an int key — the shape that escaped earlier sanitizers.
+            return {"data": ({1: "int_key_in_tuple"},)}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-tuple")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(
+        cmd_status, "load_providers", lambda: [_TupleNestedNonStringKeyProvider()]
+    )
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "data" in data
+    # The tuple becomes a JSON array; the inner dict's int key is coerced to str.
+    inner = data["data"]
+    assert isinstance(inner, list)
+    assert inner[0]["1"] == "int_key_in_tuple"
+
+
 def test_build_table_document_provider_non_string_key_skipped():
     """Verify non-string provider keys are silently dropped from table output."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -322,6 +322,111 @@ def test_load_providers_returns_empty_when_none_installed():
         assert isinstance(p, StatusProvider)
 
 
+def test_load_providers_skips_malformed_factory_result(monkeypatch):
+    """Verify load_providers() skips a factory that returns a non-provider."""
+    import gptme.status_provider as sp_mod
+
+    # A factory that returns None instead of a StatusProvider
+    def _bad_factory():
+        return None
+
+    class _FakeEP:
+        name = "bad-provider"
+
+        def load(self):
+            return _bad_factory
+
+    monkeypatch.setattr(
+        sp_mod,
+        "entry_points",
+        lambda **_kw: [_FakeEP()],
+        raising=False,
+    )
+    # Patch entry_points in the module namespace it's imported into
+    import importlib.metadata as im
+
+    original_ep = im.entry_points
+
+    def _patched_ep(**kw):
+        if kw.get("group") == "gptme.status_providers":
+            return [_FakeEP()]
+        return original_ep(**kw)
+
+    monkeypatch.setattr(im, "entry_points", _patched_ep)
+    from gptme.status_provider import load_providers
+
+    providers = load_providers()
+    # The bad factory result must be silently dropped
+    assert all(isinstance(p, StatusProvider) for p in providers)
+
+
+def test_status_json_provider_unserializable_value_does_not_crash(monkeypatch):
+    """Verify non-JSON-serializable provider values don't crash --json output."""
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    class _UnserializableProvider:
+        name = "unser"
+
+        def collect(self) -> dict:
+            return {
+                "a_datetime": datetime.now(timezone.utc),  # not JSON-serializable
+                "a_path": Path("/tmp"),  # not JSON-serializable
+            }
+
+        def narrative_sections(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-u")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(
+        cmd_status, "load_providers", lambda: [_UnserializableProvider()]
+    )
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # Values should be coerced to strings, not cause a crash
+    assert "a_datetime" in data
+    assert "a_path" in data
+    assert isinstance(data["a_datetime"], str)
+    assert isinstance(data["a_path"], str)
+
+
+def test_status_json_provider_cannot_overwrite_core_keys(monkeypatch):
+    """Verify provider collect() cannot overwrite reserved core fields."""
+
+    class _EvilProvider:
+        name = "evil"
+
+        def collect(self) -> dict:
+            return {
+                "session_id": "HIJACKED",
+                "disk_usage": "HIJACKED",
+                "extra_key": "allowed",
+            }
+
+        def narrative_sections(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "real-session")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_EvilProvider()])
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # Core keys must NOT be overwritten
+    assert data["session_id"] == "real-session"
+    assert data["disk_usage"] == "1G / 2G (50%)"
+    # Non-core key from provider is allowed through
+    assert data["extra_key"] == "allowed"
+
+
 # ── formatting helpers ─────────────────────────────────────────────────
 
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -562,6 +562,45 @@ def test_build_table_document_core_key_collision():
     assert "| safe_key |" in doc
 
 
+def test_status_json_cross_provider_collision_first_writer_wins(monkeypatch):
+    """Verify JSON output uses first-writer-wins for provider key collisions (same as table)."""
+
+    class _FirstProvider:
+        name = "first"
+
+        def collect(self) -> dict:
+            return {"shared_key": "from_first", "first_only": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    class _SecondProvider:
+        name = "second"
+
+        def collect(self) -> dict:
+            return {"shared_key": "from_second", "second_only": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-collision")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(
+        cmd_status, "load_providers", lambda: [_FirstProvider(), _SecondProvider()]
+    )
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # First provider wins; second provider's value for the colliding key is dropped.
+    assert data["shared_key"] == "from_first"
+    # Non-colliding keys from both providers are present.
+    assert data["first_only"] == "ok"
+    assert data["second_only"] == "ok"
+
+
 def test_build_table_document_cross_provider_collision():
     """Later provider cannot add a row that duplicates an earlier provider's key."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -697,6 +697,48 @@ def test_status_json_provider_non_string_key_does_not_crash(monkeypatch):
     assert data["normal_key"] == "ok"
 
 
+def test_status_json_provider_nested_non_string_key_does_not_crash(monkeypatch):
+    """Verify a provider returning nested dicts with non-string keys does not crash --json.
+
+    The top-level key filter in _status_data() skips non-string *top-level* provider
+    keys, but a provider can return a value that is itself a dict with non-string keys
+    at any nesting depth.  json.dumps() raises TypeError on such keys because default=
+    only handles non-serializable *values*, not invalid dict *keys*.
+
+    _sanitize_nested_dict_keys() must convert non-string nested keys to str() before
+    json.dumps() is called.
+    """
+
+    class _NestedNonStringKeyProvider:
+        name = "nested_nonstring"
+
+        def collect(self) -> dict:
+            # Top-level key is a valid string; nested dict has an int key.
+            return {"nested": {1: "int_key_val", "str_key": "ok"}}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-nested")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(
+        cmd_status, "load_providers", lambda: [_NestedNonStringKeyProvider()]
+    )
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # The top-level key is present.
+    assert "nested" in data
+    nested = data["nested"]
+    # The int key must have been coerced to its str() form.
+    assert all(isinstance(k, str) for k in nested)
+    assert nested["1"] == "int_key_val"
+    assert nested["str_key"] == "ok"
+
+
 def test_build_table_document_provider_non_string_key_skipped():
     """Verify non-string provider keys are silently dropped from table output."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -562,6 +562,42 @@ def test_build_table_document_core_key_collision():
     assert "| safe_key |" in doc
 
 
+def test_status_json_provider_str_raises_does_not_crash(monkeypatch):
+    """Verify a provider value whose __str__() raises does not abort --json output."""
+
+    class _BadStrValue:
+        """A value object whose __str__ always raises."""
+
+        def __str__(self) -> str:
+            raise RuntimeError("__str__ is broken")
+
+        def __repr__(self) -> str:
+            return "<BadStrValue>"
+
+    class _BadStrProvider:
+        name = "bad_str"
+
+        def collect(self) -> dict:
+            return {"broken_value": _BadStrValue(), "normal_key": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    monkeypatch.setattr(cmd_status, "_recent_commits", lambda n=3: [])
+    monkeypatch.setattr(cmd_status, "_session_id", lambda: "session-badstr")
+    monkeypatch.setattr(cmd_status, "_git_root", lambda: None)
+    monkeypatch.setattr(cmd_status, "_disk_usage", lambda _path=None: "1G / 2G (50%)")
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_BadStrProvider()])
+
+    result = CliRunner().invoke(status, ["--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    # The broken value should be replaced with the sentinel placeholder.
+    assert data["broken_value"] == "<unserializable>"
+    # Other provider keys still make it through.
+    assert data["normal_key"] == "ok"
+
+
 def test_status_json_cross_provider_collision_first_writer_wins(monkeypatch):
     """Verify JSON output uses first-writer-wins for provider key collisions (same as table)."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -291,6 +291,66 @@ def test_status_table_includes_provider_fields(monkeypatch):
     assert "test_value" in result.output
 
 
+def test_status_narrative_non_list_return_does_not_crash(monkeypatch):
+    """Verify a provider returning a non-list from narrative_sections() does not crash.
+
+    The protocol promises list[str], but a provider could return a bare string.
+    extend(str) iterates over its chars and inserts each as a separate section,
+    producing garbage.  The guard inside build_document() must skip the return
+    value entirely when it is not a list, so the join at the end never crashes
+    and the output contains none of the stray characters.
+    """
+
+    class _StringReturnProvider:
+        name = "string_return"
+
+        def collect(self) -> dict:
+            return {}
+
+        def narrative_sections(self):
+            return "## Not A List\n\nThis is a bare string."
+
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_StringReturnProvider()])
+
+    result = CliRunner().invoke(status)
+    assert result.exit_code == 0, result.output
+    # The bare string must NOT appear in the output (not even single chars as sections).
+    assert "## Not A List" not in result.output
+    # Core sections must still be present.
+    assert "# gptme Status" in result.output
+
+
+def test_status_narrative_non_string_elements_dropped(monkeypatch):
+    """Verify non-string elements from narrative_sections() are silently dropped.
+
+    A provider may return a mixed list such as [42, "## Valid Section"].
+    Passing that list directly to sections.extend() succeeds, but
+    '\\n\\n'.join(sections) then crashes because 42 is not a str.
+    The guard inside build_document() must filter out non-string elements
+    so only the valid string sections reach the join.
+    """
+
+    class _MixedListProvider:
+        name = "mixed_list"
+
+        def collect(self) -> dict:
+            return {}
+
+        def narrative_sections(self):
+            # Mix: an integer, a valid string, and None.
+            return [42, "## Valid Section\n\n- from provider", None]
+
+    monkeypatch.setattr(cmd_status, "load_providers", lambda: [_MixedListProvider()])
+
+    result = CliRunner().invoke(status)
+    assert result.exit_code == 0, result.output
+    # Only the valid string section should appear.
+    assert "## Valid Section" in result.output
+    assert "from provider" in result.output
+    # Core sections must still be present.
+    assert "# gptme Status" in result.output
+
+
 def test_status_broken_provider_does_not_crash(monkeypatch):
     """Verify a provider whose collect() raises does not crash the command."""
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -534,3 +534,58 @@ def test_build_table_document_with_provider():
     doc = build_table_document(providers=[_FakeProvider()])
     assert "| test_key |" in doc
     assert "test_value" in doc
+
+
+def test_build_table_document_core_key_collision():
+    """Provider cannot inject a row that duplicates a core table field."""
+
+    class _CoreClobberProvider:
+        name = "clobber"
+
+        def collect(self) -> dict:
+            # session_id and disk_usage are core fields rendered by core itself.
+            return {
+                "session_id": "INJECTED",
+                "disk_usage": "INJECTED",
+                "safe_key": "ok",
+            }
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_CoreClobberProvider()])
+    # The core fields must appear exactly once (no duplicate rows).
+    assert doc.count("| session_id |") == 1, "session_id should appear exactly once"
+    assert doc.count("| disk_usage |") == 1, "disk_usage should appear exactly once"
+    assert "INJECTED" not in doc, "provider must not overwrite core table values"
+    # Non-conflicting key still appears.
+    assert "| safe_key |" in doc
+
+
+def test_build_table_document_cross_provider_collision():
+    """Later provider cannot add a row that duplicates an earlier provider's key."""
+
+    class _FirstProvider:
+        name = "first"
+
+        def collect(self) -> dict:
+            return {"shared_key": "from_first"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    class _SecondProvider:
+        name = "second"
+
+        def collect(self) -> dict:
+            return {"shared_key": "from_second", "unique_key": "ok"}
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_FirstProvider(), _SecondProvider()])
+    # Only the first provider's value should appear; no duplicate rows.
+    assert doc.count("| shared_key |") == 1, "shared_key should appear exactly once"
+    assert "from_first" in doc
+    assert "from_second" not in doc
+    assert "| unique_key |" in doc


### PR DESCRIPTION
## Summary

Resolves #3534.

Moves Bob-specific status fields out of `gptme` core and defines a secure `StatusProvider` extension point that external packages can register via Python entry points.

## Changes

### New: `gptme/status_provider.py`

Defines the `StatusProvider` protocol:

```python
class StatusProvider(Protocol):
    @property
    def name(self) -> str: ...
    def collect(self) -> dict[str, object]: ...        # merged into --json output
    def narrative_sections(self) -> list[str]: ...    # appended to narrative doc
```

And `load_providers()` which discovers implementations from the `gptme.status_providers` entry-point group.

**Security model**: `importlib.metadata.entry_points` only sees *installed* packages — the current working directory is never scanned. Running `gptme-util status` inside a malicious repository cannot auto-load arbitrary code. This directly addresses Concern 2 in the issue.

### Updated: `gptme/cli/cmd_status.py`

Removed all Bob-specific logic:
- `_is_bob_workspace()` — filesystem heuristic
- `_active_tasks()` / `_blockers()` / `_ready_tasks()` — `gptodo` calls
- `_service_status()` / `_dead_timers()` — `bob-*.service` systemd units
- `_journal_entries()` — Bob's `journal/` directory
- `_TRACKED_REPOS` — hardcoded Bob PR repos
- `section_services()` / `section_blockers()` / `section_ready_next()`

Core now collects only generic, workspace-agnostic data:
- `session_id` (env vars)
- `recent_commits` (git log)
- `disk_usage` (shutil.disk_usage)

The generic `_pr_queue()` helper is kept (useful for providers that check GitHub PRs), but core no longer calls it with any hardcoded repo list.

`build_document()`, `build_table_document()`, and `_status_data()` accept an explicit `providers` list (for testing). When omitted, `load_providers()` is called automatically.

### Updated: `tests/test_cli_status.py`

- Added `_FakeProvider` test double satisfying the `StatusProvider` protocol
- Updated tests to reflect the clean core (no Bob-specific monkeypatching)
- Added provider-focused tests: JSON merging, narrative injection, table rows, broken-provider isolation, `load_providers()` smoke test

## How a Bob provider would look (gptme-contrib side)

```toml
# packages/gptme-bob/pyproject.toml
[project.entry-points."gptme.status_providers"]
bob = "gptme_bob.status:make_provider"
```

```python
# packages/gptme-bob/src/gptme_bob/status.py
from gptme.status_provider import StatusProvider
from gptme.cli.cmd_status import _pr_queue, _pr_queue_display

_TRACKED_REPOS = [("gptme/gptme", 10), ("ErikBjare/bob", None), ...]

class BobStatusProvider:
    name = "bob"

    def collect(self) -> dict:
        return {
            "active_tasks": _active_tasks(3),
            "pr_queue": _pr_queue(_TRACKED_REPOS),
            "journal_entries": _journal_entries(5),
            "services": _service_status(),
            ...
        }

    def narrative_sections(self) -> list[str]:
        return [section_services(), section_blockers(), section_ready_next()]

def make_provider() -> StatusProvider:
    return BobStatusProvider()
```

## Tests

```
26 passed in 1.27s
```
