### PR TITLE
fix(cli): rethink --version output format, remove --version-short

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -621,13 +621,7 @@ Run 'gptme-util --help' for all utility commands."""
 @click.option(
     "--version",
     is_flag=True,
-    help="Show version and configuration information. First line is always 'gptme v<version>'.",
-)
-@click.option(
-    "--version-short",
-    "version_short",
-    is_flag=True,
-    help="Show only the gptme version string for scripting.",
+    help="Show version. With -v/--verbose, show full configuration info.",
 )
 @click.option(
     "--version-json",
@@ -728,7 +722,6 @@ def main(
     show_hidden: bool,
     show_prompt_stats: bool,
     version: bool,
-    version_short: bool,
     version_json: bool,
     resume: bool,
     workspace: str | None,
@@ -746,7 +739,7 @@ def main(
     manifest_dir: Path | None,
 ):
     """Main entrypoint for the CLI."""
-    show_version = version or version_short or version_json
+    show_version = version or version_json
 
     # Dispatch: `gptme search QUERY` → chats search (discoverability alias)
     if prompts and prompts[0] == "search" and not show_version:
@@ -972,20 +965,20 @@ def main(
     interactive = not non_interactive
     auto_switched_noninteractive = False
     if show_version:
-        if version_short:
+        if version_json:
+            from ..info import format_version_info
+
+            print(format_version_info(verbose=verbose, output_json=True))
+        elif verbose:
+            from ..info import format_version_info
+
+            print(format_version_info(verbose=True, output_json=False))
+            print()
+            print("Utilities: gptme-util (run 'gptme-util --help' for more)")
+        else:
             from ..__version__ import __version__
 
             print(__version__)
-            exit(0)
-
-        from ..info import format_version_info
-
-        print(format_version_info(verbose=verbose, output_json=version_json))
-
-        # hint about utilities (non-JSON only)
-        if not version_json:
-            print()
-            print("Utilities: gptme-util (run 'gptme-util --help' for more)")
         exit(0)
 
     if "PYTEST_CURRENT_TEST" in os.environ:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,13 +159,16 @@ def test_help_no_external_subcommands_section_when_none_installed(
 def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0
-    assert "gptme" in result.output
-
-
-def test_version_short(runner: CliRunner):
-    result = runner.invoke(cli.main, ["--version-short"])
-    assert result.exit_code == 0
+    # --version outputs just the bare version string, usable in scripts
     assert result.output == f"{__version__}\n"
+
+
+def test_version_verbose(runner: CliRunner):
+    result = runner.invoke(cli.main, ["--version", "--verbose"])
+    assert result.exit_code == 0
+    # --version --verbose shows the full human-readable info block
+    assert "gptme" in result.output
+    assert __version__ in result.output
 
 
 def test_show_prompt_stats_exits_before_chat(monkeypatch, tmp_path: Path, runner):
@@ -479,7 +482,7 @@ def test_model_allows_provider_owned_nested_model_path(runner: CliRunner):
     )
 
     assert result.exit_code == 0, result.output
-    assert "gptme v" in result.output
+    assert __version__ in result.output
 
 
 def test_model_allows_nested_path_through_validation_block(
@@ -1644,7 +1647,7 @@ def test_tools_short_option_equals_syntax_works(runner: CliRunner):
     """The documented `-t=-browser` short form should parse successfully."""
     result = runner.invoke(cli.main, ["-t=-browser", "--version"])
     assert result.exit_code == 0, result.output
-    assert "gptme v" in result.output
+    assert __version__ in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1156,7 +1156,7 @@ class TestVersionOutputContract:
             m.stop()
 
     def test_first_line_format(self):
-        """First line of --version output is always 'gptme v<version>'."""
+        """First line of format_version_info() (verbose/json output) always starts with 'gptme v<version>'."""
         managers = self._apply(self._mock_all_info())
         try:
             result = format_version_info()

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -63,12 +63,13 @@ class TestSearchAlias:
         assert "search" in result.output.lower()
 
     def test_search_does_not_swallow_version(self, runner: CliRunner):
-        """gptme --version search QUERY shows version, not search results."""
+        """gptme --version search QUERY shows bare version string, not search results."""
         with patch("gptme.tools.chats.search_chats") as mock_search:
             result = runner.invoke(main, ["--version", "search", "anything"])
         assert result.exit_code == 0
         mock_search.assert_not_called()
-        assert "gptme" in result.output.lower() or "version" in result.output.lower()
+        # --version now outputs just the bare version string
+        assert result.output == f"{__version__}\n"
 
     def test_search_does_not_swallow_version_json(self, runner: CliRunner):
         """gptme --version-json search QUERY shows version JSON, not search results."""
@@ -77,14 +78,6 @@ class TestSearchAlias:
         assert result.exit_code == 0
         mock_search.assert_not_called()
         assert "{" in result.output or "version" in result.output.lower()
-
-    def test_search_does_not_swallow_version_short(self, runner: CliRunner):
-        """gptme --version-short search QUERY shows only the version string."""
-        with patch("gptme.tools.chats.search_chats") as mock_search:
-            result = runner.invoke(main, ["--version-short", "search", "anything"])
-        assert result.exit_code == 0
-        mock_search.assert_not_called()
-        assert result.output == f"{__version__}\n"
 
 
 class TestPluginDispatch:


### PR DESCRIPTION
## Summary

Implements Option A from issue #3538: change `gptme --version` to output just the bare version string, and remove `--version-short` (which is now redundant).

## Changes

- **`gptme --version`** now prints just the bare version string (e.g. `0.32.0`), making `$(gptme --version)` directly usable in scripts without any parsing
- **`gptme --version --verbose`** (or `-v`) prints the full rich human-readable info block that `--version` showed before
- **`--version-short`** removed — `--version` now does the same thing
- **`--version-json`** unchanged — still outputs JSON

## Rationale

Unix convention: `python --version`, `git --version`, `node --version` all output just the version string. This removes the need for scripting workarounds like `gptme --version | head -1 | awk '{print $NF}'`.

The rich info output is preserved under `--version --verbose`, which is the natural extension point for that level of detail.

## Testing

- Updated `test_version` to assert bare version string output
- Added `test_version_verbose` for the rich format path
- Updated all tests that checked for `"gptme v"` in `--version` output
- Removed `test_version_short` and `test_search_does_not_swallow_version_short`
- 120 tests pass

Fixes #3538

<!-- gptme-id:v1:gai_BqOsSOXqcuMNSLUQTq5aFHFHhs67WM4ZLVIU73dJgM3 -->