### PR TITLE
feat(cli): add `gptme explain` for offline concept answers

### DIFF
--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -97,7 +97,14 @@ def _tokens(text: str) -> set[str]:
 def load_faq(path: str | None = None) -> list[FAQEntry]:
     """Load FAQ entries from the bundled YAML file."""
     faq_path = Path(path) if path else FAQ_PATH
-    data = yaml.safe_load(faq_path.read_text()) or {}
+    try:
+        text = faq_path.read_text()
+    except OSError as e:
+        raise click.ClickException(f"Could not read FAQ file {faq_path}: {e}") from e
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as e:
+        raise click.ClickException(f"Could not parse FAQ file {faq_path}: {e}") from e
     return [
         FAQEntry(
             topic=entry["topic"],
@@ -176,7 +183,7 @@ def explain(query: tuple[str, ...], as_json: bool) -> None:
             click.echo(json.dumps([e.to_dict() for e in entries], indent=2))
             return
         click.echo("Topics (use: gptme explain <topic>)\n")
-        width = max(len(e.topic) for e in entries)
+        width = max((len(e.topic) for e in entries), default=0)
         for e in entries:
             click.echo(f"  {e.topic:<{width}}  {e.question}")
         return

--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -105,16 +105,19 @@ def load_faq(path: str | None = None) -> list[FAQEntry]:
         data = yaml.safe_load(text) or {}
     except yaml.YAMLError as e:
         raise click.ClickException(f"Could not parse FAQ file {faq_path}: {e}") from e
-    return [
-        FAQEntry(
-            topic=entry["topic"],
-            question=entry["question"],
-            answer=entry["answer"],
-            aliases=entry.get("aliases", []),
-            see_also=entry.get("see_also", []),
-        )
-        for entry in data.get("topics", [])
-    ]
+    try:
+        return [
+            FAQEntry(
+                topic=entry["topic"],
+                question=entry["question"],
+                answer=entry["answer"],
+                aliases=entry.get("aliases", []),
+                see_also=entry.get("see_also", []),
+            )
+            for entry in data.get("topics", [])
+        ]
+    except (AttributeError, KeyError, TypeError) as e:
+        raise click.ClickException(f"Invalid FAQ structure in {faq_path}: {e}") from e
 
 
 def find_topic(query: str, entries: list[FAQEntry]) -> FAQEntry | None:

--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -45,23 +45,40 @@ class FAQEntry:
 
 _STOP: frozenset[str] = frozenset(
     {
+        # articles / conjunctions / prepositions
         "the",
-        "how",
-        "what",
-        "are",
         "and",
         "for",
-        "can",
-        "does",
-        "its",
-        "has",
-        "was",
-        "but",
         "not",
-        "you",
+        "but",
         "all",
         "any",
+        # question words
+        "how",
+        "what",
+        "where",
+        "when",
+        "who",
+        "why",
+        "which",
+        # common auxiliaries
+        "are",
+        "can",
+        "does",
+        "has",
         "had",
+        "was",
+        "will",
+        "its",
+        "you",
+        # generic verbs that add no topic signal
+        "get",
+        "use",
+        "set",
+        "put",
+        "find",
+        "show",
+        "make",
     }
 )
 
@@ -111,9 +128,14 @@ def find_topic(query: str, entries: list[FAQEntry]) -> FAQEntry | None:
     if not query_tokens:
         return None
 
+    # Only match against topic names and aliases, NOT the question text.
+    # The question is phrasing the same concept in a complete sentence, so it
+    # shares generic words ("where", "stored", "what") with many entries and
+    # inflates false-positive scores. Aliases are already designed for the
+    # natural-language queries users type.
     best, best_score = None, 0
     for entry in entries:
-        haystack = _tokens(" ".join([*entry.names, entry.question]))
+        haystack = _tokens(" ".join(entry.names))
         score = len(query_tokens & haystack)
         if score > best_score:
             best, best_score = entry, score

--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -43,12 +43,37 @@ class FAQEntry:
         }
 
 
+_STOP: frozenset[str] = frozenset(
+    {
+        "the",
+        "how",
+        "what",
+        "are",
+        "and",
+        "for",
+        "can",
+        "does",
+        "its",
+        "has",
+        "was",
+        "but",
+        "not",
+        "you",
+        "all",
+        "any",
+        "had",
+    }
+)
+
+
 def _normalize(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
 
 
 def _tokens(text: str) -> set[str]:
-    return {tok for tok in _normalize(text).split() if len(tok) > 2}
+    return {
+        tok for tok in _normalize(text).split() if len(tok) > 2 and tok not in _STOP
+    }
 
 
 @lru_cache(maxsize=1)

--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -88,9 +88,12 @@ def _normalize(text: str) -> str:
 
 
 def _tokens(text: str) -> set[str]:
-    return {
+    tokens = {
         tok for tok in _normalize(text).split() if len(tok) > 2 and tok not in _STOP
     }
+    # Match simple singular/plural variants without a language-heavy stemmer.
+    variants = {tok[:-1] if tok.endswith("s") else f"{tok}s" for tok in tokens}
+    return tokens | variants
 
 
 @lru_cache(maxsize=1)
@@ -124,7 +127,7 @@ def find_topic(query: str, entries: list[FAQEntry]) -> FAQEntry | None:
     """Best FAQ entry for a query, or None if nothing matches well enough.
 
     Exact topic/alias match wins; otherwise the entry sharing the most query
-    words with its topic, aliases, or question.
+    words with its topic or aliases.
     """
     normalized = _normalize(query)
     if not normalized:
@@ -185,8 +188,11 @@ def explain(query: tuple[str, ...], as_json: bool) -> None:
         if as_json:
             click.echo(json.dumps([e.to_dict() for e in entries], indent=2))
             return
+        if not entries:
+            click.echo("No topics available.")
+            return
         click.echo("Topics (use: gptme explain <topic>)\n")
-        width = max((len(e.topic) for e in entries), default=0)
+        width = max(len(e.topic) for e in entries)
         for e in entries:
             click.echo(f"  {e.topic:<{width}}  {e.question}")
         return
@@ -202,7 +208,10 @@ def explain(query: tuple[str, ...], as_json: bool) -> None:
             )
         else:
             click.echo(f"No topic matches {query_str!r}.", err=True)
-            click.echo(f"Did you mean: {', '.join(suggestions)}?", err=True)
+            if suggestions:
+                click.echo(f"Did you mean: {', '.join(suggestions)}?", err=True)
+            else:
+                click.echo("No topics available.", err=True)
         raise SystemExit(1)
 
     if as_json:

--- a/gptme/cli/cmd_explain.py
+++ b/gptme/cli/cmd_explain.py
@@ -1,0 +1,154 @@
+"""Offline answers to conceptual questions about gptme.
+
+``gptme explain branches`` answers from a bundled FAQ file — no model call, no
+network. Users kept filing discussions asking what branches are or how the
+context window works (gptme#136, gptme#138); those answers should be in the CLI.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+import click
+import yaml
+
+FAQ_PATH = Path(__file__).parent.parent / "data" / "faq.yaml"
+
+
+@dataclass
+class FAQEntry:
+    topic: str
+    question: str
+    answer: str
+    aliases: list[str] = field(default_factory=list)
+    see_also: list[str] = field(default_factory=list)
+
+    @property
+    def names(self) -> list[str]:
+        """Topic id plus aliases, all matchable."""
+        return [self.topic, *self.aliases]
+
+    def to_dict(self) -> dict:
+        return {
+            "topic": self.topic,
+            "question": self.question,
+            "answer": self.answer.strip(),
+            "aliases": self.aliases,
+            "see_also": self.see_also,
+        }
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+
+def _tokens(text: str) -> set[str]:
+    return {tok for tok in _normalize(text).split() if len(tok) > 2}
+
+
+@lru_cache(maxsize=1)
+def load_faq(path: str | None = None) -> list[FAQEntry]:
+    """Load FAQ entries from the bundled YAML file."""
+    faq_path = Path(path) if path else FAQ_PATH
+    data = yaml.safe_load(faq_path.read_text()) or {}
+    return [
+        FAQEntry(
+            topic=entry["topic"],
+            question=entry["question"],
+            answer=entry["answer"],
+            aliases=entry.get("aliases", []),
+            see_also=entry.get("see_also", []),
+        )
+        for entry in data.get("topics", [])
+    ]
+
+
+def find_topic(query: str, entries: list[FAQEntry]) -> FAQEntry | None:
+    """Best FAQ entry for a query, or None if nothing matches well enough.
+
+    Exact topic/alias match wins; otherwise the entry sharing the most query
+    words with its topic, aliases, or question.
+    """
+    normalized = _normalize(query)
+    if not normalized:
+        return None
+
+    for entry in entries:
+        if any(_normalize(name) == normalized for name in entry.names):
+            return entry
+
+    query_tokens = _tokens(query)
+    if not query_tokens:
+        return None
+
+    best, best_score = None, 0
+    for entry in entries:
+        haystack = _tokens(" ".join([*entry.names, entry.question]))
+        score = len(query_tokens & haystack)
+        if score > best_score:
+            best, best_score = entry, score
+    return best
+
+
+def suggest_topics(query: str, entries: list[FAQEntry], limit: int = 3) -> list[str]:
+    """Topic ids closest to an unmatched query."""
+    names = {name: entry.topic for entry in entries for name in entry.names}
+    matches = difflib.get_close_matches(
+        _normalize(query), [_normalize(n) for n in names], n=limit, cutoff=0.5
+    )
+    normalized = {_normalize(name): topic for name, topic in names.items()}
+    # dict.fromkeys preserves closeness order while dropping alias duplicates
+    return list(dict.fromkeys(normalized[m] for m in matches))
+
+
+def format_entry(entry: FAQEntry) -> str:
+    lines = [entry.question, "=" * len(entry.question), "", entry.answer.strip()]
+    if entry.see_also:
+        lines += ["", f"See also: {', '.join(entry.see_also)}"]
+    return "\n".join(lines)
+
+
+@click.command("explain")
+@click.argument("query", nargs=-1)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def explain(query: tuple[str, ...], as_json: bool) -> None:
+    """Explain a gptme concept, offline.
+
+    Run without arguments to list the available topics.
+    """
+    entries = load_faq()
+    query_str = " ".join(query).strip()
+
+    if not query_str:
+        if as_json:
+            click.echo(json.dumps([e.to_dict() for e in entries], indent=2))
+            return
+        click.echo("Topics (use: gptme explain <topic>)\n")
+        width = max(len(e.topic) for e in entries)
+        for e in entries:
+            click.echo(f"  {e.topic:<{width}}  {e.question}")
+        return
+
+    entry = find_topic(query_str, entries)
+    if entry is None:
+        suggestions = suggest_topics(query_str, entries) or [e.topic for e in entries]
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"query": query_str, "match": None, "suggestions": suggestions}
+                )
+            )
+        else:
+            click.echo(f"No topic matches {query_str!r}.", err=True)
+            click.echo(f"Did you mean: {', '.join(suggestions)}?", err=True)
+        raise SystemExit(1)
+
+    if as_json:
+        click.echo(json.dumps(entry.to_dict(), indent=2))
+    else:
+        click.echo(format_entry(entry))

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -5,6 +5,7 @@ Command groups are split into separate modules for maintainability:
 - cmd_agents.py: Live agent scanning (scan for gptme/claude/codex/… processes)
 - cmd_chats.py: Chat/conversation management (list, search, export, clean, stats)
 - cmd_computer.py: Computer-use tooling (audit-log extracts actions from trajectories)
+- cmd_explain.py: Offline answers to concept questions from a bundled FAQ
 - cmd_hooks.py: Claude Code hook installation and execution
 - cmd_mcp.py: MCP server management (list, test, info, search)
 - cmd_batch.py: Batch runner for stdin prompts as fresh non-interactive sessions
@@ -52,6 +53,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "batch": (".cmd_batch", "batch_cmd"),
     "chats": (".cmd_chats", "chats"),
     "computer": (".cmd_computer", "computer"),
+    "explain": (".cmd_explain", "explain"),
     "hooks": (".cmd_hooks", "hooks"),
     "mcp": (".cmd_mcp", "mcp"),
     "resume": (".cmd_resume", "resume"),

--- a/gptme/data/faq.yaml
+++ b/gptme/data/faq.yaml
@@ -45,8 +45,9 @@ topics:
 
       To make room:
 
-          /compact     compact the conversation (replaces history with a summary)
-          /summarize   print a summary of the conversation (does not replace history)
+          /compact         compress large tool outputs (rule-based; use /compact resume for LLM summary)
+          /compact resume  LLM-powered: creates a summary and starts a fresh conversation
+          /summarize       print a summary of the conversation (does not replace history)
 
       If you are hitting the limit constantly, the usual causes are large files
       pulled into context and a very long session. Starting a fresh conversation
@@ -121,7 +122,7 @@ topics:
           /fork /rename /delete    manage conversations
           /model /models /tools    inspect the current setup
           /context /tokens         see what the context costs
-          /compact                 compact conversation (replaces history with summary)
+          /compact [auto|resume]   compress tool outputs (auto), or LLM-powered resume (resume)
           /summarize               print a summary (does not replace history)
           /exit                    leave
 

--- a/gptme/data/faq.yaml
+++ b/gptme/data/faq.yaml
@@ -121,7 +121,8 @@ topics:
           /fork /rename /delete    manage conversations
           /model /models /tools    inspect the current setup
           /context /tokens         see what the context costs
-          /compact /summarize      shrink a long conversation
+          /compact                 compact conversation (replaces history with summary)
+          /summarize               print a summary (does not replace history)
           /exit                    leave
 
       Shell-side subcommands live under `gptme-util` (for example

--- a/gptme/data/faq.yaml
+++ b/gptme/data/faq.yaml
@@ -1,0 +1,149 @@
+# FAQ entries served by `gptme explain <topic>`.
+#
+# Each entry:
+#   topic:    canonical id, matched exactly first (kebab-case)
+#   aliases:  extra terms users are likely to type
+#   question: the question this answers, shown as a heading
+#   answer:   plain text, no external lookups
+#   see_also: other topic ids (validated by tests)
+topics:
+  - topic: branches
+    aliases: [branch, branching, fork, forking, checkout]
+    question: What are branches in gptme?
+    answer: |
+      A conversation is stored as a JSONL log. A *branch* is an alternate log
+      for the same conversation, so you can explore a different path without
+      losing the original.
+
+      On disk, inside a conversation's directory:
+
+          conversation.jsonl        <- the "main" branch
+          branches/<name>.jsonl     <- every other branch
+
+      Branches are created for you when you rewind: `/undo`, `/edit` and
+      `/backtrack` save the messages they drop into a backup branch, so a
+      rewind is recoverable rather than destructive.
+
+      Branches are *not* the same as forking. `/fork` copies the whole
+      conversation into a new one with its own id; a branch stays inside the
+      current conversation. Use `/fork` when you want two conversations to keep
+      growing separately, and rewinding when you want to retry from a point.
+    see_also: [logs, commands]
+
+  - topic: context
+    aliases: [context window, context limit, token limit, too long, truncation]
+    question: How does gptme decide what goes in the context window?
+    answer: |
+      Every request sends the system prompt, any auto-included workspace files,
+      matched lessons/skills, and the conversation so far. That total is bounded
+      by the model's context window, so a long session eventually has to shrink.
+
+      To see where the tokens are going:
+
+          /context     show the context token breakdown
+          /tokens      show token usage and cost (alias: /cost)
+
+      To make room:
+
+          /compact     compact the conversation
+          /summarize   replace history with a summary
+
+      If you are hitting the limit constantly, the usual causes are large files
+      pulled into context and a very long session. Starting a fresh conversation
+      is cheaper than fighting a full window.
+    see_also: [models, logs]
+
+  - topic: logs
+    aliases: [log, logging, history, conversations, where are my chats, transcripts]
+    question: Where are conversations stored?
+    answer: |
+      Conversations live under the data directory as one directory per
+      conversation, each holding a `conversation.jsonl` log. Override the
+      location with the `GPTME_LOGS_HOME` environment variable.
+
+      From inside a session:
+
+          /log         show the conversation log
+          /export      export the conversation as HTML
+
+      From the shell:
+
+          gptme-util chats list
+          gptme-util chats search <query>
+          gptme-util chats read <id>
+
+      The logs are plain JSONL, so they are also readable with normal text
+      tooling. Note this is conversation history, not the debug logger output.
+    see_also: [branches, commands]
+
+  - topic: models
+    aliases: [model, provider, llm, which model, switch model, api key]
+    question: How do I choose or switch models?
+    answer: |
+      gptme talks to several providers, and the model is selected per
+      conversation rather than baked in.
+
+          gptme --model <model>     pick a model when starting
+          /models                   list available models
+          /model                    show or switch the current model
+
+      Model ids are usually `provider/name`. Which providers are available
+      depends on the API keys in your environment and config, so `/models`
+      reflects your setup rather than a fixed list.
+    see_also: [context, config]
+
+  - topic: tools
+    aliases: [tool, toolset, shell tool, what can it do, capabilities]
+    question: What are tools and how do I control them?
+    answer: |
+      Tools are the capabilities the assistant can invoke: running shell
+      commands, patching files, saving files, browsing, and more. The assistant
+      calls them by emitting a tool block, which gptme executes.
+
+          /tools                        show the available tools
+          gptme --tools shell,patch     restrict the session to specific tools
+
+      Restricting tools is the practical way to bound what a session can do —
+      a session without the shell tool cannot run commands. Tools can also be
+      added by plugins, so an install may expose more than the built-in set.
+    see_also: [commands, config]
+
+  - topic: commands
+    aliases: [command, slash commands, slash, "/help", builtin commands]
+    question: What slash commands are available in a session?
+    answer: |
+      Inside a session, lines starting with `/` are commands handled by gptme
+      itself instead of being sent to the model. `/help` lists them all; the
+      ones people reach for most:
+
+          /log /export         inspect and export the conversation
+          /undo /edit /backtrack   rewind (saves a backup branch)
+          /fork /rename /delete    manage conversations
+          /model /models /tools    inspect the current setup
+          /context /tokens         see what the context costs
+          /compact /summarize      shrink a long conversation
+          /exit                    leave
+
+      Shell-side subcommands live under `gptme-util` (for example
+      `gptme-util chats list`).
+    see_also: [branches, context]
+
+  - topic: config
+    aliases: [configuration, settings, gptme.toml, project config, env]
+    question: How is gptme configured?
+    answer: |
+      Configuration comes from three places, most specific winning:
+
+      1. command-line flags for the current run
+      2. a project `gptme.toml` in the working directory or repo root
+      3. the global user config
+
+      A project `gptme.toml` is the useful one for repositories: it can
+      auto-include files in the prompt so every session in that repo starts
+      with the same context. Environment variables carry API keys and path
+      overrides such as `GPTME_LOGS_HOME`.
+
+      `gptme-util` also exposes inspection subcommands (for example
+      `gptme-util models` and `gptme-util tools`) when you want to check what
+      the current configuration resolves to.
+    see_also: [models, tools]

--- a/gptme/data/faq.yaml
+++ b/gptme/data/faq.yaml
@@ -45,8 +45,8 @@ topics:
 
       To make room:
 
-          /compact     compact the conversation
-          /summarize   replace history with a summary
+          /compact     compact the conversation (replaces history with a summary)
+          /summarize   print a summary of the conversation (does not replace history)
 
       If you are hitting the limit constantly, the usual causes are large files
       pulled into context and a very long session. Starting a fresh conversation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ include = [
     # webui-dist is generated and gitignored; an explicit path include is
     # required so Poetry does not silently omit it from release artifacts.
     { path = "gptme/server/webui-dist", format = ["sdist", "wheel"] },
+    "gptme/data/*.yaml",
     "gptme/eval/tbench/setup.sh",
     "media/*.png",
     "media/*.wav",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ include = [
     # webui-dist is generated and gitignored; an explicit path include is
     # required so Poetry does not silently omit it from release artifacts.
     { path = "gptme/server/webui-dist", format = ["sdist", "wheel"] },
-    "gptme/data/*.yaml",
+    { path = "gptme/data/faq.yaml", format = ["sdist", "wheel"] },
     "gptme/eval/tbench/setup.sh",
     "media/*.png",
     "media/*.wav",

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -1,6 +1,7 @@
 """Tests for `gptme-util explain`."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -126,3 +127,32 @@ def test_explain_registered_in_util_group():
     from gptme.cli.util import UTIL_SUBCOMMANDS
 
     assert "explain" in UTIL_SUBCOMMANDS
+
+
+# Regression: P1 — load_faq raises a friendly ClickException on broken data file
+def test_load_faq_missing_file_raises_friendly_error(tmp_path):
+    """Missing FAQ file produces a readable error, not a raw FileNotFoundError traceback."""
+    missing = tmp_path / "does_not_exist.yaml"
+    from click import ClickException
+
+    with pytest.raises(ClickException, match="Could not read FAQ file"):
+        load_faq.__wrapped__(str(missing))  # bypass lru_cache
+
+
+def test_load_faq_malformed_yaml_raises_friendly_error(tmp_path, runner):
+    """Malformed YAML produces a readable error, not a raw yaml.YAMLError traceback."""
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text("topics: [\n  - {unclosed")
+    from click import ClickException
+
+    with pytest.raises(ClickException, match="Could not parse FAQ file"):
+        load_faq.__wrapped__(str(bad_yaml))  # bypass lru_cache
+
+
+# Regression: P2 — explain --list with empty FAQ does not crash on max()
+def test_explain_list_with_empty_faq_does_not_crash(runner):
+    """Empty FAQ entries list must not raise ValueError from max() with no default."""
+    with patch("gptme.cli.cmd_explain.load_faq", return_value=[]):
+        result = runner.invoke(explain, [])
+    assert result.exit_code == 0
+    assert "Topics" in result.output

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -171,6 +171,23 @@ def test_load_faq_malformed_yaml_raises_friendly_error(tmp_path, runner):
         load_faq.__wrapped__(str(bad_yaml))  # bypass lru_cache
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "topics: invalid",
+        "topics:\n  - question: Missing topic\n    answer: Broken entry",
+    ],
+)
+def test_load_faq_invalid_structure_raises_friendly_error(tmp_path, content):
+    """Structurally invalid YAML produces a readable error, not a raw traceback."""
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text(content)
+    from click import ClickException
+
+    with pytest.raises(ClickException, match="Invalid FAQ structure"):
+        load_faq.__wrapped__(str(bad_yaml))  # bypass lru_cache
+
+
 # Regression: P2 — explain --list with empty FAQ does not crash on max()
 def test_explain_list_with_empty_faq_does_not_crash(runner):
     """Empty FAQ entries list must not raise ValueError from max() with no default."""

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -1,0 +1,122 @@
+"""Tests for `gptme-util explain`."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.cmd_explain import (
+    explain,
+    find_topic,
+    load_faq,
+    suggest_topics,
+)
+
+
+@pytest.fixture
+def entries():
+    return load_faq()
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_faq_loads_required_topics(entries):
+    topics = {entry.topic for entry in entries}
+    assert {"branches", "context", "logs", "models", "tools"} <= topics
+
+
+def test_faq_entries_are_complete(entries):
+    for entry in entries:
+        assert entry.question.strip(), f"{entry.topic} missing question"
+        assert entry.answer.strip(), f"{entry.topic} missing answer"
+
+
+def test_see_also_references_real_topics(entries):
+    topics = {entry.topic for entry in entries}
+    for entry in entries:
+        assert set(entry.see_also) <= topics, f"{entry.topic} points at unknown topic"
+
+
+def test_topic_ids_and_aliases_are_unique(entries):
+    seen: dict[str, str] = {}
+    for entry in entries:
+        for name in entry.names:
+            assert name not in seen, (
+                f"{name!r} claimed by {seen.get(name)} and {entry.topic}"
+            )
+            seen[name] = entry.topic
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("branches", "branches"),
+        ("Branches", "branches"),
+        ("branch", "branches"),  # alias
+        ("context", "context"),
+        ("token limit", "context"),  # multi-word alias
+        ("what are tools", "tools"),  # keyword overlap, not exact
+    ],
+)
+def test_find_topic(query, expected, entries):
+    match = find_topic(query, entries)
+    assert match is not None and match.topic == expected
+
+
+def test_find_topic_returns_none_for_nonsense(entries):
+    assert find_topic("zzzzqqq", entries) is None
+    assert find_topic("", entries) is None
+
+
+def test_suggest_topics_on_typo(entries):
+    assert "branches" in suggest_topics("branchez", entries)
+
+
+def test_explain_known_topic(runner):
+    result = runner.invoke(explain, ["branches"])
+    assert result.exit_code == 0
+    assert "branch" in result.output.lower()
+
+
+def test_explain_lists_topics_without_args(runner):
+    result = runner.invoke(explain, [])
+    assert result.exit_code == 0
+    assert "branches" in result.output
+    assert "context" in result.output
+
+
+def test_explain_unknown_topic_suggests_and_fails(runner):
+    result = runner.invoke(explain, ["branchez"])
+    assert result.exit_code == 1
+    assert "Did you mean" in result.output
+
+
+def test_explain_json_output(runner):
+    result = runner.invoke(explain, ["--json", "branches"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["topic"] == "branches"
+    assert payload["answer"]
+
+
+def test_explain_json_list(runner):
+    result = runner.invoke(explain, ["--json"])
+    assert result.exit_code == 0
+    assert len(json.loads(result.output)) >= 5
+
+
+def test_explain_json_unknown_topic(runner):
+    result = runner.invoke(explain, ["--json", "zzzzqqq"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["match"] is None
+    assert payload["suggestions"]
+
+
+def test_explain_registered_in_util_group():
+    from gptme.cli.util import UTIL_SUBCOMMANDS
+
+    assert "explain" in UTIL_SUBCOMMANDS

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -82,6 +82,7 @@ def test_normalized_aliases_are_unique(entries):
         ("context", "context"),
         ("token limit", "context"),  # multi-word alias
         ("what are tools", "tools"),  # keyword overlap, not exact
+        ("what are commands", "commands"),  # plural query, singular alias
         # Regression: generic question words ("where", "stored") must not
         # override a direct topic-name match ("config") via question-text overlap.
         ("where is config stored", "config"),
@@ -188,10 +189,18 @@ def test_load_faq_invalid_structure_raises_friendly_error(tmp_path, content):
         load_faq.__wrapped__(str(bad_yaml))  # bypass lru_cache
 
 
-# Regression: P2 — explain --list with empty FAQ does not crash on max()
+# Regression: P2 — an empty FAQ gives useful output for both command branches
 def test_explain_list_with_empty_faq_does_not_crash(runner):
     """Empty FAQ entries list must not raise ValueError from max() with no default."""
     with patch("gptme.cli.cmd_explain.load_faq", return_value=[]):
         result = runner.invoke(explain, [])
     assert result.exit_code == 0
-    assert "Topics" in result.output
+    assert "No topics available" in result.output
+
+
+def test_explain_unknown_topic_with_empty_faq_has_no_blank_suggestion(runner):
+    with patch("gptme.cli.cmd_explain.load_faq", return_value=[]):
+        result = runner.invoke(explain, ["branches"])
+    assert result.exit_code == 1
+    assert "No topics available" in result.output
+    assert "Did you mean" not in result.output

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -51,6 +51,28 @@ def test_topic_ids_and_aliases_are_unique(entries):
             seen[name] = entry.topic
 
 
+def test_normalized_aliases_are_unique(entries):
+    """Normalized aliases must be unique across all topics.
+
+    ``suggest_topics`` builds a ``{normalized_alias: topic}`` dict where a
+    collision silently overwrites the earlier topic, causing incorrect or
+    incomplete suggestions. Raw-name uniqueness (tested above) is not enough —
+    'context-window' and 'context window' are distinct raw names but normalize
+    to the same string.
+    """
+    from gptme.cli.cmd_explain import _normalize
+
+    seen: dict[str, str] = {}
+    for entry in entries:
+        for name in entry.names:
+            norm = _normalize(name)
+            assert norm not in seen, (
+                f"normalized alias {norm!r} (from {name!r}) collides: "
+                f"already claimed by {seen[norm]!r}, now also by {entry.topic!r}"
+            )
+            seen[norm] = entry.topic
+
+
 @pytest.mark.parametrize(
     ("query", "expected"),
     [

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -59,6 +59,12 @@ def test_topic_ids_and_aliases_are_unique(entries):
         ("context", "context"),
         ("token limit", "context"),  # multi-word alias
         ("what are tools", "tools"),  # keyword overlap, not exact
+        # Regression: generic question words ("where", "stored") must not
+        # override a direct topic-name match ("config") via question-text overlap.
+        ("where is config stored", "config"),
+        # Natural-language model query should beat "context" (whose question
+        # says "how do I" too) because "model" is in the models aliases.
+        ("how do I change the model", "models"),
     ],
 )
 def test_find_topic(query, expected, entries):


### PR DESCRIPTION
## What

Adds `gptme explain`, which answers conceptual questions about gptme from a bundled FAQ — no model call, no network.

```
$ gptme explain branches
What are branches in gptme?
===========================

A conversation is stored as a JSONL log. A *branch* is an alternate log
for the same conversation, so you can explore a different path without
losing the original.

On disk, inside a conversation's directory:

    conversation.jsonl        <- the "main" branch
    branches/<name>.jsonl     <- every other branch
...
See also: logs, commands
```

```
$ gptme explain                 # list topics
$ gptme explain --json context  # machine-readable
$ gptme explain branchez
No topic matches 'branchez'.
Did you mean: branches?         # exit 1
```

## Why

Users keep filing discussions asking things the CLI could answer itself:

- gptme/gptme#136 — "Could you explain about branches concept?"
- gptme/gptme#138 — context limits

Those are one-line answers that currently require a maintainer or a docs hunt. The docs cover most of it, but nothing surfaces it at the point of confusion.

## How

- `gptme/data/faq.yaml` — the content. Seven topics: `branches`, `context`, `logs`, `models`, `tools`, `commands`, `config`. Each has aliases, a question, an answer, and `see_also` links.
- `gptme/cli/cmd_explain.py` — loads the YAML, matches, prints. Exact topic/alias match wins; otherwise the entry sharing the most query words with its topic/aliases/question. No match → `difflib` suggestions on stderr and exit 1, so it composes in scripts.
- Registered in `_LAZY_COMMANDS`, so it works as both `gptme explain` and `gptme-util explain`, and appears in the generated CLI docs with no extra wiring.

Answers were written against the current code (`LogManager.branch`, `action_descriptions`, `get_logs_dir`), not from memory.

## Scope

Deliberately **not** in this PR: LLM fallback for unmatched queries, onboarding integration, and a larger FAQ. Those are follow-ups once the shape is agreed — this is the smallest useful version.

## Tests

`tests/test_cli_explain.py` — 19 tests covering matching, aliases, case-insensitivity, suggestions, JSON output, exit codes, and the FAQ data itself (every `see_also` resolves to a real topic; no duplicate topic ids or aliases, so a future FAQ edit can't silently shadow a topic).

```
19 passed in 0.24s
```

mypy clean on the new module; ruff clean; pre-commit passed.