### PR TITLE
feat(tools): add read-only audit preset

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -597,8 +597,18 @@ Pass a comma-separated list of tool names to ``--tools`` (CLI) or set the
     # Disable all tools (pure conversation)
     gptme --tools "" "just talk to me"
 
+    # Strict audit mode: only the built-in read tool, no writes or execution
+    gptme --tools read-only "summarise this repo"
+
 Glob patterns (``*``, ``?``, ``[...]``) are also supported, matched against tool
 names with :func:`fnmatch.fnmatchcase`.
+
+``read-only`` is a named preset, not a hint pattern. It expands to the built-in
+``read`` tool only, and cannot be combined with other tool names. This makes it
+safe for auditing untrusted workspaces where ``shell``, ``ipython``, ``save``,
+``append`` and ``patch`` must stay unavailable. Use ``hint:read-only`` only when
+you explicitly want to trust third-party tool annotations, such as MCP server
+metadata.
 
 .. _hint-allowlist:
 
@@ -611,7 +621,7 @@ once using the ``hint:`` prefix:
 
 .. code-block:: bash
 
-    # Allow only tools annotated as read-only (safe for untrusted workspaces)
+    # Allow only tools annotated as read-only
     gptme --tools "hint:read-only" "summarise this repo"
 
     # Mix exact names with hint patterns
@@ -637,9 +647,9 @@ The following hints are defined:
 
 .. note::
 
-    Built-in gptme tools do not carry hints in the current release. Hints are
-    currently populated automatically from **MCP tool annotations** (see below).
-    You can also set hints explicitly when :doc:`writing custom tools <custom_tool>`.
+    The built-in ``read`` tool carries the ``read-only`` hint. MCP tools can also
+    carry the hint through server-supplied annotations (see below), so
+    ``hint:read-only`` is broader than the strict ``read-only`` preset.
 
 MCP tool annotations
 ^^^^^^^^^^^^^^^^^^^^^

--- a/gptme/cli/cmd_review_pr.py
+++ b/gptme/cli/cmd_review_pr.py
@@ -77,6 +77,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ..tools._allowlist import READ_ONLY_TOOL_PRESET
 from ..util.gh import infer_owner_repo, run_gh_json
 from ..util.review import (
     FindingSeverity,
@@ -403,7 +404,7 @@ REVIEW_TOOL_PRESETS: dict[str, tuple[str, ...]] = {
     # shell, or make network requests. There is no ``grep``/``glob`` tool in
     # core — searching would require ``shell``, which is code-exec and is
     # excluded on purpose.
-    "read-only": (_READ_TOOL,),
+    "read-only": READ_ONLY_TOOL_PRESET,
 }
 
 DEFAULT_REVIEW_TOOL_PRESET = "none"

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -410,8 +410,11 @@ def _known_tool_names() -> list[str]:
     --help rendering) — never at module import time.
     """
     from ..tools import get_available_tools
+    from ..tools._allowlist import TOOL_PRESET_NAMES
 
-    return sorted(tool.name for tool in get_available_tools(include_mcp=False))
+    names = {tool.name for tool in get_available_tools(include_mcp=False)}
+    names.update(TOOL_PRESET_NAMES)
+    return sorted(names)
 
 
 docstring = f"""
@@ -426,6 +429,7 @@ Examples:
   gptme "fix TODOs" main.py                  Include file or URL in context
   gptme "review" github.com/org/repo/pull/1  Include a GitHub PR in context
   gptme --tools none "what is 2+2"           No tools, just chat
+  gptme -t read-only "summarize this repo"   Read files only; no writes or execution
   gptme -t patch,save "fix typo" main.py     Only specific tools (comma-separated)
   gptme -t +subagent "plan a refactor"       Default tools + subagent
   gptme -t=-browser "summarize code"         Default tools minus browser

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -417,6 +417,19 @@ def _known_tool_names() -> list[str]:
     return sorted(names)
 
 
+def _known_hint_names() -> list[str]:
+    """Hint tags defined across all known built-in tools.
+
+    Imports the tool subsystem, so only call this lazily — never at module import time.
+    """
+    from ..tools import get_available_tools
+
+    hints: set[str] = set()
+    for tool in get_available_tools(include_mcp=False):
+        hints.update(tool.hints)
+    return sorted(hints)
+
+
 docstring = f"""
 gptme is a chat-CLI for LLMs, empowering them with tools to run shell commands, execute code, read and manipulate files, and more.
 
@@ -567,7 +580,7 @@ Run 'gptme-util --help' for all utility commands."""
         allow_prefixes=["+", "-", "hint:"],
         extra_choices_for_prefix={
             "-": _known_tool_names,
-            "hint:": lambda: ["read-only"],
+            "hint:": _known_hint_names,
         },
         # '+' is lenient: plugin tools (added via '+tool') aren't known at
         # parse time. '-tool' exclusions and built-in hint tags stay strict so

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -564,12 +564,14 @@ Run 'gptme-util --help' for all utility commands."""
         # misleading "invalid choice" here. Resolved lazily: tool discovery
         # imports most of gptme and must not run at module import time.
         lambda: _known_tool_names() + ["none"],
-        allow_prefixes=["+", "-"],
+        allow_prefixes=["+", "-", "hint:"],
         extra_choices_for_prefix={"-": _known_tool_names},
-        # Only '+' is lenient: plugin tools (added via '+tool') aren't known at
-        # parse time. '-tool' exclusions stay strict against known tools so typos
-        # like '-shel' are caught early instead of being silently ignored.
-        lenient_prefixes=["+"],
+        # '+' is lenient: plugin tools (added via '+tool') aren't known at
+        # parse time. '-tool' exclusions stay strict against known tools so
+        # typos like '-shel' are caught early instead of being silently ignored.
+        # 'hint:' is also lenient: hint tag names (e.g. 'hint:read-only') are
+        # not in the tool-name choice set; they're validated at load time.
+        lenient_prefixes=["+", "hint:"],
         metavar="TOOL",
     ),
     help="Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). See 'Available tools' above for the list.",

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -565,13 +565,14 @@ Run 'gptme-util --help' for all utility commands."""
         # imports most of gptme and must not run at module import time.
         lambda: _known_tool_names() + ["none"],
         allow_prefixes=["+", "-", "hint:"],
-        extra_choices_for_prefix={"-": _known_tool_names},
+        extra_choices_for_prefix={
+            "-": _known_tool_names,
+            "hint:": lambda: ["read-only"],
+        },
         # '+' is lenient: plugin tools (added via '+tool') aren't known at
-        # parse time. '-tool' exclusions stay strict against known tools so
-        # typos like '-shel' are caught early instead of being silently ignored.
-        # 'hint:' is also lenient: hint tag names (e.g. 'hint:read-only') are
-        # not in the tool-name choice set; they're validated at load time.
-        lenient_prefixes=["+", "hint:"],
+        # parse time. '-tool' exclusions and built-in hint tags stay strict so
+        # typos like '-shel' or 'hint:red-only' fail before tool loading.
+        lenient_prefixes=["+"],
         metavar="TOOL",
     ),
     help="Tools to allow. Comma-separated or repeated. Use '+tool' to add to defaults (e.g., '-t +subagent'). Use '-tool' to exclude from defaults (e.g., '-t=-browser'). Use 'none' to disable all tools. Supports .py file paths for custom tools (e.g., '-t path/to/tool.py'). See 'Available tools' above for the list.",

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -14,7 +14,6 @@ from ..tools import get_toolchain
 from ..tools._allowlist import (
     TOOL_PRESETS,
     expand_tool_allowlist_presets,
-    is_exclusive_preset_expansion,
 )
 from .chat import ChatConfig
 from .core import Config, get_config, set_config, set_config_from_workspace
@@ -51,13 +50,24 @@ def _is_tool_file_path(value: str) -> bool:
 
 
 def _normalize_tool_allowlist(allowlist: list[str] | None) -> list[str] | None:
-    """Normalize an allowlist while preserving custom tool file paths.
+    """Normalize an allowlist while preserving custom tool file paths and preset names.
+
+    Preset names (e.g. ``"read-only"``) are kept verbatim so that provenance is
+    preserved when the config is saved and later resumed.  Expansion into concrete
+    tool names happens at toolchain initialisation time (``tools/__init__.py``),
+    not here.
 
     ``get_toolchain()`` validates and expands named tools, but custom tool files
     are loaded later by ``init_tools()`` and must remain as file paths.
     """
     if allowlist is None:
         return None
+
+    # If the allowlist is a single named preset, preserve it as-is so that
+    # resumed sessions can still detect it as a preset (not just a tool list
+    # that happens to match the preset's expansion).
+    if len(allowlist) == 1 and allowlist[0] in TOOL_PRESETS:
+        return list(allowlist)
 
     allowlist = expand_tool_allowlist_presets(allowlist)
     assert allowlist is not None
@@ -210,15 +220,13 @@ def setup_config_from_cli(
         # Fall back to env/config for new conversations or when no saved tools
         resolved_tool_allowlist = [tool.strip() for tool in tools_env.split(",")]
 
-    # A preset is "selected" if the allowlist is a literal preset name, or if it
-    # exactly matches a preset's expansion (the persisted form on resume — the
-    # preset name is replaced by concrete tools when the config is saved).
-    tool_preset_selected = resolved_tool_allowlist is not None and (
-        (
-            len(resolved_tool_allowlist) == 1
-            and resolved_tool_allowlist[0] in TOOL_PRESETS
-        )
-        or is_exclusive_preset_expansion(resolved_tool_allowlist)
+    # A preset is "selected" if the allowlist is a literal preset name.
+    # Preset names are now persisted verbatim (not expanded) so that resumed
+    # sessions continue to be recognised here without ambiguity.
+    tool_preset_selected = (
+        resolved_tool_allowlist is not None
+        and len(resolved_tool_allowlist) == 1
+        and resolved_tool_allowlist[0] in TOOL_PRESETS
     )
 
     # Automatically add 'complete' tool in non-interactive mode, except for

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, cast
 from ..gears import parse_gear, resolve_gear
 from ..profiles import get_profile
 from ..tools import get_toolchain
+from ..tools._allowlist import TOOL_PRESETS, expand_tool_allowlist_presets
 from .chat import ChatConfig
 from .core import Config, get_config, set_config, set_config_from_workspace
 
@@ -54,6 +55,8 @@ def _normalize_tool_allowlist(allowlist: list[str] | None) -> list[str] | None:
     if allowlist is None:
         return None
 
+    allowlist = expand_tool_allowlist_presets(allowlist)
+    assert allowlist is not None
     normalized: list[str] = []
     seen: set[str] = set()
 
@@ -203,8 +206,15 @@ def setup_config_from_cli(
         # Fall back to env/config for new conversations or when no saved tools
         resolved_tool_allowlist = [tool.strip() for tool in tools_env.split(",")]
 
-    # Automatically add 'complete' tool in non-interactive mode
-    if not interactive:
+    tool_preset_selected = (
+        resolved_tool_allowlist is not None
+        and len(resolved_tool_allowlist) == 1
+        and resolved_tool_allowlist[0] in TOOL_PRESETS
+    )
+
+    # Automatically add 'complete' tool in non-interactive mode, except for
+    # exclusive named presets such as read-only audit mode.
+    if not interactive and not tool_preset_selected:
         if resolved_tool_allowlist is None:
             # Get default tools and add complete to them
             default_tools = [tool.name for tool in get_toolchain(None)]

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -235,6 +235,13 @@ def setup_config_from_cli(
             tool.strip() for tool in tools_env.split(",") if tool.strip()
         ]
 
+    # Profiles may override a gear's tool list. Apply that final override before
+    # deciding whether non-interactive mode should add the completion signal.
+    if gear_profile_name and not agent_path:
+        gear_profile = get_profile(gear_profile_name)
+        if gear_profile and gear_profile.tools is not None and tool_allowlist is None:
+            resolved_tool_allowlist = list(gear_profile.tools)
+
     # A preset is "selected" if the allowlist is a literal preset name.
     # Preset names are now persisted verbatim (not expanded) so that resumed
     # sessions continue to be recognised here without ambiguity.
@@ -283,11 +290,6 @@ def setup_config_from_cli(
     resolved_no_confirm = gear_no_confirm if no_confirm is None else no_confirm
 
     # Handle agent_path with similar precedence
-    if gear_profile_name and not agent_path:
-        gear_profile = get_profile(gear_profile_name)
-        if gear_profile and gear_profile.tools is not None and tool_allowlist is None:
-            resolved_tool_allowlist = list(gear_profile.tools)
-
     resolved_agent_path: Path | None = agent_path
     if agent_path is None and existing_chat_config and existing_chat_config.agent:
         # When resuming, use saved conversation agent unless CLI override provided

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, cast
 from ..gears import parse_gear, resolve_gear
 from ..profiles import get_profile
 from ..tools import get_toolchain
-from ..tools._allowlist import TOOL_PRESETS, expand_tool_allowlist_presets
+from ..tools._allowlist import (
+    TOOL_PRESETS,
+    expand_tool_allowlist_presets,
+    is_exclusive_preset_expansion,
+)
 from .chat import ChatConfig
 from .core import Config, get_config, set_config, set_config_from_workspace
 
@@ -206,10 +210,15 @@ def setup_config_from_cli(
         # Fall back to env/config for new conversations or when no saved tools
         resolved_tool_allowlist = [tool.strip() for tool in tools_env.split(",")]
 
-    tool_preset_selected = (
-        resolved_tool_allowlist is not None
-        and len(resolved_tool_allowlist) == 1
-        and resolved_tool_allowlist[0] in TOOL_PRESETS
+    # A preset is "selected" if the allowlist is a literal preset name, or if it
+    # exactly matches a preset's expansion (the persisted form on resume — the
+    # preset name is replaced by concrete tools when the config is saved).
+    tool_preset_selected = resolved_tool_allowlist is not None and (
+        (
+            len(resolved_tool_allowlist) == 1
+            and resolved_tool_allowlist[0] in TOOL_PRESETS
+        )
+        or is_exclusive_preset_expansion(resolved_tool_allowlist)
     )
 
     # Automatically add 'complete' tool in non-interactive mode, except for

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -186,8 +186,24 @@ def setup_config_from_cli(
             excluded_tools = [
                 tool.strip() for tool in tool_list_str.split(",") if tool.strip()
             ]
+            # Detect attempts to exclude preset names (they're not tools in the
+            # default set; '-read-only' does nothing and is almost certainly wrong).
+            preset_exclusions = [t for t in excluded_tools if t in TOOL_PRESETS]
+            if preset_exclusions:
+                logger.warning(
+                    "Cannot exclude preset name(s) %s with '-' syntax. "
+                    "Presets select an exclusive tool boundary — use "
+                    "'--tools %s' to select one, not '--%s'.",
+                    ", ".join(preset_exclusions),
+                    preset_exclusions[0],
+                    preset_exclusions[0],
+                )
             default_tools = [tool.name for tool in get_toolchain(None)]
-            non_default = [t for t in excluded_tools if t not in default_tools]
+            non_default = [
+                t
+                for t in excluded_tools
+                if t not in default_tools and t not in TOOL_PRESETS
+            ]
             if non_default:
                 logger.warning(
                     "Tool(s) %s are not in the default toolset and cannot be excluded",
@@ -218,7 +234,9 @@ def setup_config_from_cli(
         resolved_tool_allowlist = existing_chat_config.tools
     elif tools_env := config.get_env("TOOL_ALLOWLIST"):
         # Fall back to env/config for new conversations or when no saved tools
-        resolved_tool_allowlist = [tool.strip() for tool in tools_env.split(",")]
+        resolved_tool_allowlist = [
+            tool.strip() for tool in tools_env.split(",") if tool.strip()
+        ]
 
     # A preset is "selected" if the allowlist is a literal preset name.
     # Preset names are now persisted verbatim (not expanded) so that resumed

--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -187,16 +187,13 @@ def setup_config_from_cli(
                 tool.strip() for tool in tool_list_str.split(",") if tool.strip()
             ]
             # Detect attempts to exclude preset names (they're not tools in the
-            # default set; '-read-only' does nothing and is almost certainly wrong).
+            # default set; '-read-only' selects nothing and is almost certainly wrong).
             preset_exclusions = [t for t in excluded_tools if t in TOOL_PRESETS]
             if preset_exclusions:
-                logger.warning(
-                    "Cannot exclude preset name(s) %s with '-' syntax. "
-                    "Presets select an exclusive tool boundary — use "
-                    "'--tools %s' to select one, not '--%s'.",
-                    ", ".join(preset_exclusions),
-                    preset_exclusions[0],
-                    preset_exclusions[0],
+                raise ValueError(
+                    f"Cannot exclude preset name '{preset_exclusions[0]}' with '-' syntax. "
+                    f"Presets select an exclusive tool boundary — use "
+                    f"'--tools {preset_exclusions[0]}' to select one."
                 )
             default_tools = [tool.name for tool in get_toolchain(None)]
             non_default = [
@@ -218,7 +215,7 @@ def setup_config_from_cli(
         else:
             # Normal mode - CLI override replaces defaults
             resolved_tool_allowlist = [
-                tool.strip() for tool in tool_allowlist.split(",")
+                tool.strip() for tool in tool_allowlist.split(",") if tool.strip()
             ]
     elif gear_tool_allowlist is not None:
         if gear_tool_allowlist and gear_tool_allowlist[0].startswith("+"):

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -17,6 +17,7 @@ from ..util.interrupt import clear_interruptible
 from ..util.terminal import terminal_state_title
 from ._allowlist import (
     allowlist_contains_glob,
+    expand_tool_allowlist_presets,
     is_hint_pattern,
     matching_allowlist_tools,
     tool_matches_allowlist,
@@ -183,6 +184,8 @@ def init_tools(
             elif config.chat and config.chat.tools:
                 allowlist = config.chat.tools
 
+        allowlist = expand_tool_allowlist_presets(allowlist)
+
         # Partition allowlist into file paths and tool names
         file_paths: list[str] = []
         tool_names: list[str] = []
@@ -254,6 +257,8 @@ def _unavailable_message(tool_name: str, matched_tools: list[ToolSpec]) -> str:
 def get_toolchain(
     allowlist: list[str] | None, *, strict: bool = True
 ) -> list[ToolSpec]:
+    allowlist = expand_tool_allowlist_presets(allowlist)
+
     # Validate allowlist if provided
     # When strict=False, warn about missing/unavailable tools instead of raising.
     # Server contexts use strict=False since conversations may reference tools

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -3,6 +3,32 @@ from fnmatch import fnmatchcase
 from .base import ToolSpec
 
 _HINT_PREFIX = "hint:"
+READ_ONLY_TOOL_PRESET = ("read",)
+TOOL_PRESETS: dict[str, tuple[str, ...]] = {
+    "read-only": READ_ONLY_TOOL_PRESET,
+}
+TOOL_PRESET_NAMES = tuple(TOOL_PRESETS)
+
+
+def expand_tool_allowlist_presets(allowlist: list[str] | None) -> list[str] | None:
+    """Expand named tool presets into concrete tool names.
+
+    Presets are exclusive capability boundaries, not shortcuts that can be mixed
+    with arbitrary tools. Use hint-based allowlists for intentionally broad
+    category matching.
+    """
+    if allowlist is None:
+        return None
+
+    presets = [item for item in allowlist if item in TOOL_PRESETS]
+    if not presets:
+        return allowlist
+    if len(allowlist) != 1:
+        preset_list = ", ".join(presets)
+        raise ValueError(
+            f"Tool preset(s) {preset_list} cannot be combined with other tools"
+        )
+    return list(TOOL_PRESETS[presets[0]])
 
 
 def is_hint_pattern(pattern: str) -> bool:

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -31,15 +31,6 @@ def expand_tool_allowlist_presets(allowlist: list[str] | None) -> list[str] | No
     return list(TOOL_PRESETS[presets[0]])
 
 
-def is_exclusive_preset_expansion(allowlist: list[str]) -> bool:
-    """Return True if the allowlist exactly matches the expansion of any named preset.
-
-    Used to detect persisted preset expansions on conversation resume, where the
-    preset name has already been replaced by the concrete tool list.
-    """
-    return any(list(expansion) == allowlist for expansion in TOOL_PRESETS.values())
-
-
 def is_hint_pattern(pattern: str) -> bool:
     """Return True if the pattern is a hint-based filter (e.g. 'hint:read-only')."""
     return pattern.startswith(_HINT_PREFIX)

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -31,6 +31,15 @@ def expand_tool_allowlist_presets(allowlist: list[str] | None) -> list[str] | No
     return list(TOOL_PRESETS[presets[0]])
 
 
+def is_exclusive_preset_expansion(allowlist: list[str]) -> bool:
+    """Return True if the allowlist exactly matches the expansion of any named preset.
+
+    Used to detect persisted preset expansions on conversation resume, where the
+    preset name has already been replaced by the concrete tool list.
+    """
+    return any(list(expansion) == allowlist for expansion in TOOL_PRESETS.values())
+
+
 def is_hint_pattern(pattern: str) -> bool:
     """Return True if the pattern is a hint-based filter (e.g. 'hint:read-only')."""
     return pattern.startswith(_HINT_PREFIX)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1657,6 +1657,20 @@ def test_tools_read_only_preset_is_valid_cli_choice(runner: CliRunner):
     assert __version__ in result.output
 
 
+def test_tools_hint_prefix_is_valid_cli_choice(runner: CliRunner):
+    """hint:X patterns must pass --tools CLI validation.
+
+    Hint tag names are not tool names, so they aren't in the choice set, but
+    they should be accepted at parse time and validated against loaded tools at
+    runtime.  Regression for P2 finding: docs showed hint:read-only as a
+    working CLI option but CommaSeparatedChoice was rejecting it.
+    """
+    result = runner.invoke(cli.main, ["-t", "hint:read-only", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert __version__ in result.output
+
+
 @pytest.mark.parametrize(
     "tool_spec",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1664,6 +1664,14 @@ def test_tools_hint_prefix_is_valid_cli_choice(runner: CliRunner):
     assert __version__ in result.output
 
 
+def test_tools_hint_destructive_is_valid_cli_choice(runner: CliRunner):
+    """hint:destructive must be accepted — it is a real hint used by shell, patch, save, etc."""
+    result = runner.invoke(cli.main, ["-t", "hint:destructive", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert __version__ in result.output
+
+
 def test_tools_unknown_hint_fails_cli_validation(runner: CliRunner):
     result = runner.invoke(cli.main, ["-t", "hint:red-only", "--version"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1658,17 +1658,17 @@ def test_tools_read_only_preset_is_valid_cli_choice(runner: CliRunner):
 
 
 def test_tools_hint_prefix_is_valid_cli_choice(runner: CliRunner):
-    """hint:X patterns must pass --tools CLI validation.
-
-    Hint tag names are not tool names, so they aren't in the choice set, but
-    they should be accepted at parse time and validated against loaded tools at
-    runtime.  Regression for P2 finding: docs showed hint:read-only as a
-    working CLI option but CommaSeparatedChoice was rejecting it.
-    """
     result = runner.invoke(cli.main, ["-t", "hint:read-only", "--version"])
 
     assert result.exit_code == 0, result.output
     assert __version__ in result.output
+
+
+def test_tools_unknown_hint_fails_cli_validation(runner: CliRunner):
+    result = runner.invoke(cli.main, ["-t", "hint:red-only", "--version"])
+
+    assert result.exit_code != 0
+    assert "invalid choice: hint:red-only" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1650,6 +1650,13 @@ def test_tools_short_option_equals_syntax_works(runner: CliRunner):
     assert __version__ in result.output
 
 
+def test_tools_read_only_preset_is_valid_cli_choice(runner: CliRunner):
+    result = runner.invoke(cli.main, ["-t", "read-only", "--version"])
+
+    assert result.exit_code == 0, result.output
+    assert __version__ in result.output
+
+
 @pytest.mark.parametrize(
     "tool_spec",
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1351,7 +1351,8 @@ def test_setup_config_from_cli_read_only_preset(tmp_path):
     )
 
     assert config.chat is not None
-    assert config.chat.tools == ["read"]
+    # Preset name is persisted verbatim so that resume detection is unambiguous.
+    assert config.chat.tools == ["read-only"]
 
 
 def test_setup_config_from_cli_read_only_preset_does_not_add_complete(tmp_path):
@@ -1372,7 +1373,40 @@ def test_setup_config_from_cli_read_only_preset_does_not_add_complete(tmp_path):
     )
 
     assert config.chat is not None
-    assert config.chat.tools == ["read"]
+    # Preset name is persisted verbatim (not expanded) to preserve provenance.
+    assert config.chat.tools == ["read-only"]
+    assert "complete" not in (config.chat.tools or [])
+
+
+def test_setup_config_from_cli_explicit_read_tool_adds_complete_noninteractive(
+    tmp_path,
+):
+    """--tools read (explicit, not a preset) must still get 'complete' in non-interactive mode.
+
+    Greptile P1: expansion-based detection conflated an explicit ["read"] allowlist
+    with the read-only preset, incorrectly suppressing 'complete'.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist="read",
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert "complete" in (config.chat.tools or []), (
+        "Non-interactive session with explicit --tools read must include 'complete'; "
+        f"got tools={config.chat.tools}"
+    )
 
 
 def test_setup_config_from_cli_read_only_preset_survives_noninteractive_resume(
@@ -1380,9 +1414,8 @@ def test_setup_config_from_cli_read_only_preset_survives_noninteractive_resume(
 ):
     """Non-interactive resume of a read-only session must not append 'complete'.
 
-    When --tools read-only is expanded to ["read"] and persisted, a subsequent
-    resume without --tools should detect the preset expansion and keep the
-    strict boundary intact.
+    The preset name is persisted verbatim so that resumed sessions can detect
+    it unambiguously without relying on expansion-equality heuristics.
     """
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -1414,8 +1447,12 @@ def test_setup_config_from_cli_read_only_preset_survives_noninteractive_resume(
     )
 
     assert resumed.chat is not None
-    assert resumed.chat.tools == ["read"], (
-        "Non-interactive resume of a read-only session silently added tools: "
+    assert resumed.chat.tools == ["read-only"], (
+        "Non-interactive resume of a read-only session silently changed tools: "
+        f"{resumed.chat.tools}"
+    )
+    assert "complete" not in (resumed.chat.tools or []), (
+        "Non-interactive resume of a read-only session silently added 'complete': "
         f"{resumed.chat.tools}"
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1457,6 +1457,74 @@ def test_setup_config_from_cli_read_only_preset_survives_noninteractive_resume(
     )
 
 
+def test_setup_config_from_cli_tool_allowlist_env_trailing_comma(tmp_path, monkeypatch):
+    """TOOL_ALLOWLIST env var with a trailing comma must not raise or add an empty tool.
+
+    Regression for P2 finding: 'read-only,' split into ['read-only', ''] which
+    then failed the len==1 preset check, causing 'complete' to be appended and
+    expand_tool_allowlist_presets to raise ValueError.
+    """
+    monkeypatch.setenv("TOOL_ALLOWLIST", "read-only,")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=None,
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    # Trailing comma is stripped; preset name is preserved verbatim.
+    assert config.chat.tools == ["read-only"]
+    assert "complete" not in (config.chat.tools or [])
+    assert "" not in (config.chat.tools or [])
+
+
+def test_setup_config_from_cli_preset_exclusion_warns(tmp_path, caplog):
+    """Using '-read-only' exclusion syntax must warn that presets can't be excluded.
+
+    Regression for P2 finding: 'read-only' was in _known_tool_names (as a
+    preset) so -read-only passed CLI validation but then silently did nothing
+    with a generic 'not in default toolset' message.  The fix adds a specific
+    preset-exclusion warning to guide the user toward the correct syntax.
+    """
+    import logging
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="gptme.config.cli_setup"):
+        setup_config_from_cli(
+            workspace=workspace,
+            logdir=logdir,
+            model=None,
+            tool_allowlist="-read-only",
+            tool_format=None,
+            stream=True,
+            interactive=False,
+            agent_path=None,
+        )
+
+    assert any(
+        "preset" in record.message.lower() and "read-only" in record.message
+        for record in caplog.records
+    ), (
+        "Expected a warning mentioning 'preset' and 'read-only'; "
+        f"got: {[r.message for r in caplog.records]}"
+    )
+
+
 def test_custom_tool_file_allowlist_preserved(tmp_path):
     """Custom .py tool paths should survive CLI config setup unchanged."""
     workspace = tmp_path / "workspace"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1333,6 +1333,48 @@ def test_tool_exclusion_multiple(tmp_path):
         )
 
 
+def test_setup_config_from_cli_read_only_preset(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist="read-only",
+        tool_format=None,
+        stream=True,
+        interactive=True,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert config.chat.tools == ["read"]
+
+
+def test_setup_config_from_cli_read_only_preset_does_not_add_complete(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist="read-only",
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert config.chat.tools == ["read"]
+
+
 def test_custom_tool_file_allowlist_preserved(tmp_path):
     """Custom .py tool paths should survive CLI config setup unchanged."""
     workspace = tmp_path / "workspace"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1375,6 +1375,51 @@ def test_setup_config_from_cli_read_only_preset_does_not_add_complete(tmp_path):
     assert config.chat.tools == ["read"]
 
 
+def test_setup_config_from_cli_read_only_preset_survives_noninteractive_resume(
+    tmp_path,
+):
+    """Non-interactive resume of a read-only session must not append 'complete'.
+
+    When --tools read-only is expanded to ["read"] and persisted, a subsequent
+    resume without --tools should detect the preset expansion and keep the
+    strict boundary intact.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    # Initial session: create the conversation with read-only preset
+    setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist="read-only",
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    # Resume non-interactively without repeating --tools: preset must hold
+    resumed = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=None,
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    assert resumed.chat is not None
+    assert resumed.chat.tools == ["read"], (
+        "Non-interactive resume of a read-only session silently added tools: "
+        f"{resumed.chat.tools}"
+    )
+
+
 def test_custom_tool_file_allowlist_preserved(tmp_path):
     """Custom .py tool paths should survive CLI config setup unchanged."""
     workspace = tmp_path / "workspace"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2062,3 +2062,25 @@ def test_setup_config_from_cli_explicit_tools_override_gear(tmp_path):
     assert config.chat is not None
     assert config.chat.gear == 3
     assert config.chat.tools == ["read"]
+
+
+def test_setup_config_from_cli_noninteractive_gear_profile_adds_complete(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist=None,
+        tool_format=None,
+        gear=0,
+        stream=True,
+        interactive=False,
+        agent_path=None,
+    )
+
+    assert config.chat is not None
+    assert config.chat.tools == ["read", "chats", "complete"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1489,22 +1489,20 @@ def test_setup_config_from_cli_tool_allowlist_env_trailing_comma(tmp_path, monke
     assert "" not in (config.chat.tools or [])
 
 
-def test_setup_config_from_cli_preset_exclusion_warns(tmp_path, caplog):
-    """Using '-read-only' exclusion syntax must warn that presets can't be excluded.
+def test_setup_config_from_cli_preset_exclusion_raises(tmp_path):
+    """Using '-read-only' exclusion syntax must raise, not silently use the full toolset.
 
-    Regression for P2 finding: 'read-only' was in _known_tool_names (as a
-    preset) so -read-only passed CLI validation but then silently did nothing
-    with a generic 'not in default toolset' message.  The fix adds a specific
-    preset-exclusion warning to guide the user toward the correct syntax.
+    Security regression: 'read-only' is now in _known_tool_names (as a preset)
+    so '-read-only' passes CLI validation. The exclusion branch must raise
+    ValueError (promoted from a warning) so the call fails closed instead of
+    proceeding with the full default toolset — a fail-open security boundary.
     """
-    import logging
-
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     logdir = tmp_path / "logs"
     logdir.mkdir()
 
-    with caplog.at_level(logging.WARNING, logger="gptme.config.cli_setup"):
+    with pytest.raises(ValueError, match="Cannot exclude preset name 'read-only'"):
         setup_config_from_cli(
             workspace=workspace,
             logdir=logdir,
@@ -1516,13 +1514,38 @@ def test_setup_config_from_cli_preset_exclusion_warns(tmp_path, caplog):
             agent_path=None,
         )
 
-    assert any(
-        "preset" in record.message.lower() and "read-only" in record.message
-        for record in caplog.records
-    ), (
-        "Expected a warning mentioning 'preset' and 'read-only'; "
-        f"got: {[r.message for r in caplog.records]}"
+
+def test_setup_config_from_cli_tool_allowlist_direct_trailing_comma(tmp_path):
+    """Direct tool_allowlist parameter with trailing comma must not crash or add empty tool.
+
+    Regression for P2 finding: the env-var branch already filtered empty
+    elements ('if tool.strip()'), but the normal-mode branch (direct parameter
+    path) did not.  'read-only,' split to ['read-only', ''], which failed the
+    len==1 preset check, causing 'complete' to be appended and
+    expand_tool_allowlist_presets to raise ValueError (preset cannot combine
+    with other tools).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "logs"
+    logdir.mkdir()
+
+    config = setup_config_from_cli(
+        workspace=workspace,
+        logdir=logdir,
+        model=None,
+        tool_allowlist="read-only,",
+        tool_format=None,
+        stream=True,
+        interactive=False,
+        agent_path=None,
     )
+
+    assert config.chat is not None
+    # Trailing comma is stripped; preset name is preserved verbatim.
+    assert config.chat.tools == ["read-only"]
+    assert "complete" not in (config.chat.tools or [])
+    assert "" not in (config.chat.tools or [])
 
 
 def test_custom_tool_file_allowlist_preserved(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
+from gptme.message import Message
 from gptme.tools import (
     _discover_tools,
     clear_tools,
+    execute_msg,
     get_available_tools,
     get_tool,
     get_tool_for_langtag,
@@ -19,7 +21,8 @@ from gptme.tools import (
     is_supported_langtag,
     load_tool,
 )
-from gptme.tools.base import load_from_file
+from gptme.tools._allowlist import READ_ONLY_TOOL_PRESET
+from gptme.tools.base import load_from_file, set_tool_format
 
 
 def test_init_tools():
@@ -37,6 +40,63 @@ def test_init_tools_allowlist():
     clear_tools()  # clear before testing second allowlist
     init_tools(allowlist=["save", "patch"])
     assert len(get_tools()) == 2
+
+
+def test_read_only_tool_preset_loads_only_observation_tools():
+    clear_tools()
+
+    tools = init_tools(allowlist=["read-only"])
+    available = {tool.name: tool for tool in get_available_tools(include_mcp=False)}
+
+    assert [tool.name for tool in tools] == list(READ_ONLY_TOOL_PRESET)
+    assert set(READ_ONLY_TOOL_PRESET) <= set(available)
+    assert all("read-only" in tool.hints for tool in tools)
+
+
+def test_read_only_tool_preset_blocks_mutating_and_execution_tools():
+    clear_tools()
+    set_tool_format("tool")
+    init_tools(allowlist=["read-only"])
+
+    content = """@save(call-save): {"path": "x.txt", "content": "x"}
+@append(call-append): {"path": "x.txt", "content": "x"}
+@patch(call-patch): {"path": "x.txt", "patch": "@@\\n-x\\n+y"}
+@ipython(call-ipython): {"code": "print(1)"}
+@shell(call-shell): {"command": "echo unsafe"}"""
+
+    results = list(execute_msg(Message("assistant", content)))
+
+    assert {result.call_id for result in results} == {
+        "call-save",
+        "call-append",
+        "call-patch",
+        "call-ipython",
+        "call-shell",
+    }
+    assert all("not available for execution" in result.content for result in results)
+
+
+def test_read_only_tool_preset_allows_read_tool(tmp_path):
+    clear_tools()
+    set_tool_format("tool")
+    init_tools(allowlist=["read-only"])
+    target = tmp_path / "example.txt"
+    target.write_text("hello audit mode\n")
+
+    results = list(
+        execute_msg(Message("assistant", f'@read(call-read): {{"path": "{target!s}"}}'))
+    )
+
+    assert len(results) == 1
+    assert results[0].call_id == "call-read"
+    assert "hello audit mode" in results[0].content
+
+
+def test_read_only_tool_preset_cannot_be_combined_with_other_tools():
+    clear_tools()
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        init_tools(allowlist=["read-only", "save"])
 
 
 def test_init_tools_allowlist_glob_matches_mcp_tools():


### PR DESCRIPTION
## Summary
- add a strict `--tools read-only` preset that expands to the built-in `read` tool only
- reject combinations like `read-only,save` so the preset stays an enforceable boundary
- keep non-interactive read-only sessions from auto-adding `complete`, and document why `hint:read-only` is broader than the preset

## Verification
- `uv run ruff check gptme/tools/_allowlist.py gptme/tools/__init__.py gptme/config/cli_setup.py gptme/cli/main.py gptme/cli/cmd_review_pr.py tests/test_tools.py tests/test_config.py tests/test_cli.py`
- `PYTHONPATH=/tmp/worktrees/gptme-read-only-audit-mode/tests uv run python -m pytest -q tests/test_tools.py tests/test_config.py::test_tool_exclusion_config tests/test_config.py::test_tool_exclusion_multiple tests/test_config.py::test_setup_config_from_cli_read_only_preset tests/test_config.py::test_setup_config_from_cli_read_only_preset_does_not_add_complete tests/test_config.py::test_setup_config_from_cli_applies_gear_preset tests/test_config.py::test_setup_config_from_cli_explicit_tools_override_gear tests/test_cli.py::test_tools_read_only_preset_is_valid_cli_choice tests/test_cli.py::test_tools_short_option_equals_syntax_works tests/test_cli.py::test_tool_exclusion_mixed_bare_and_minus_raises tests/test_gears.py tests/test_execute_msg_defensive.py`
- pre-commit hooks during `git commit`