### PR TITLE
docs: clarify conversation, branch, fork, and session terminology

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -119,7 +119,8 @@ a branch lives inside the original conversation's directory (server-side only).
 
 ### Log / LogManager
 The conversation history and its management system. Stores all messages exchanged in a session.
-`LogManager` handles file locking, branching, view compression, and workspace linking.
+`LogManager` handles file locking, branching, and workspace resolution. View reduction lives in
+`gptme/util/reduce.py`; workspace symlink creation happens in `ChatConfig.save()`.
 
 **Code reference**: `gptme/logmanager/manager.py`
 
@@ -148,8 +149,9 @@ the `auto_snapshots` plugin is enabled.
 **Commands**: `/snapshot create [label]`, `/snapshot list`, `/snapshot restore <sha>`, `/snapshot diff <sha>`
 
 ### Backtrack Marker
-An in-memory conversation position marker. Rewinding with `/backtrack` replays the conversation
-log up to the marker — only the message history changes, not the filesystem.
+A named conversation position persisted to disk (in `conv-checkpoints.jsonl` alongside the log).
+Rewinding with `/backtrack` truncates the conversation log to the saved index and creates a backup
+branch — the log on disk is modified, but workspace files are not.
 
 **Commands**: `/backtrack mark [label]`, `/backtrack list`, `/backtrack <label|N>`
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -61,13 +61,112 @@ A parsed representation of a tool invocation found in an assistant's response.
 ### Runnable Tool
 A tool that can be executed in the current context. Some tools may be defined but not runnable (e.g., disabled or context-restricted).
 
-## Session Concepts
+## Conversation and Session Concepts
+
+(conversation)=
+### Conversation
+The primary unit of persistence in gptme. A named history of messages exchanged with an LLM,
+stored as a directory on disk. Each conversation has a unique ID (a random adjective-color-animal
+name by default, or a name you supply with `--name`).
+
+**Storage**: `~/.local/share/gptme/logs/<conversation-id>/conversation.jsonl`
+
+**Commands**:
+- Start: `gptme --name my-project "your prompt"` or just `gptme` (auto-names)
+- Resume: `gptme --name my-project` (by name) or `gptme -r` (most recent)
+- List: `gptme chats list`
+- Search: `gptme chats search <query>`
+- Rename: `/rename` in the TUI, or `gptme chats rename <id>`
+- Delete: `/delete` in the TUI
+
+**Disambiguation**: "conversation" is the persistent log on disk. A "run" or "session" (everyday use)
+means launching gptme and working in a conversation — no special object, just a process attached to
+a log. For analytics-tracking sessions, see [Analytics Session](#analytics-session).
+
+(branch)=
+### Branch
+An alternative message thread stored alongside the main thread within the same conversation
+directory. The default branch is named `"main"` and stored as `conversation.jsonl`.
+Named branches are stored as `branches/<branch-name>.jsonl` in the same log directory.
+
+Branches are mainly a **server-side concept**: the `gptme-server` API accepts a `branch` parameter
+on step/tool calls, allowing multiple AI exploration paths in the same conversation simultaneously.
+The TUI's `/fork` command creates a new top-level conversation rather than a branch within
+the current one.
+
+**Storage**: `…/<conversation-id>/branches/<branch-name>.jsonl`
+
+(fork)=
+### Fork
+A new, independent conversation created from a copy of messages 0 through turn N of an
+existing conversation. The original conversation is never modified. Both the TUI command
+and the CLI produce a new conversation directory.
+
+**Usage**:
+```bash
+# Fork at turn 3 (includes turns 0–2, the first 3 user+assistant exchanges)
+gptme-util chats fork my-project --at-turn 3
+
+# Fork with a custom name
+gptme-util chats fork my-project --at-turn 3 --name my-project-v2
+
+# Within a running conversation, fork at the current turn:
+# /fork my-experiment
+```
+
+**Distinction from Branch**: A fork creates a separate conversation ID with its own directory;
+a branch lives inside the original conversation's directory (server-side only).
 
 ### Log / LogManager
 The conversation history and its management system. Stores all messages exchanged in a session.
+`LogManager` handles file locking, branching, view compression, and workspace linking.
+
+**Code reference**: `gptme/logmanager/manager.py`
 
 ### Workspace
-The directory context in which gptme operates. Tools like file operations are scoped to the workspace.
+The filesystem directory gptme operates in during a conversation. File operations, shell commands,
+and checkpoints are scoped to this directory.
+
+**Storage**: Symlinked at `…/<conversation-id>/workspace/` → the actual directory.
+
+**Set via**: `gptme --workspace <dir>`
+
+### Checkpoint
+A clean git HEAD reference recorded in the workspace's git history. Use to restore the workspace
+to a known good state before large or risky changes. Requires a committed working tree.
+
+**Commands**: `/checkpoint create`, `/checkpoint list`, `/checkpoint diff <id>`, `/checkpoint restore <id>`
+
+**Distinction from Snapshot**: Checkpoints require a committed tree; snapshots capture any state
+including uncommitted changes.
+
+### Snapshot
+A workspace state capture recorded in a side-git shadow repository. Can capture committed
+or uncommitted changes. Created automatically before and after each mutating tool call when
+the `auto_snapshots` plugin is enabled.
+
+**Commands**: `/snapshot create [label]`, `/snapshot list`, `/snapshot restore <sha>`, `/snapshot diff <sha>`
+
+### Backtrack Marker
+An in-memory conversation position marker. Rewinding with `/backtrack` replays the conversation
+log up to the marker — only the message history changes, not the filesystem.
+
+**Commands**: `/backtrack mark [label]`, `/backtrack list`, `/backtrack <label|N>`
+
+**Distinction**: Unlike `/checkpoint` and `/snapshot`, backtracking does not touch workspace files.
+
+(analytics-session)=
+### Analytics Session
+A completed run record stored by the `gptme-sessions` package. Tracks metadata about a finished
+run: duration, cost, model, category, and quality grades. Cross-harness: records runs from
+gptme, Claude Code, Codex, and other compatible harnesses.
+
+**Storage**: `~/.local/share/gptme-sessions/sessions.jsonl` (configurable)
+
+**Commands**: `gptme sessions query`, `gptme sessions show <id>`, `gptme sessions stats`
+
+**Disambiguation**: Not the same as "starting a session" (everyday usage for launching gptme
+in a conversation). The analytics session is only created *after* the run completes.
 
 ## Configuration
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,75 @@ Common commands:
 - ``/tokens`` - Show token usage and costs
 - ``/exit`` - Exit the program
 
+.. _usage-conversations:
+
+Managing Conversations
+----------------------
+
+Every gptme interaction is part of a **conversation** — a named history of
+messages persisted on disk. Conversations can be resumed, searched, forked,
+and renamed.
+
+For term definitions (conversation, branch, fork, analytics session), see the :doc:`glossary`.
+
+**Start or resume a named conversation**
+
+Give a conversation an explicit name so you can return to it later:
+
+.. code-block:: bash
+
+    # Start a new named conversation
+    gptme --name my-refactor "let's refactor the auth module"
+
+    # Resume that same conversation in a future session
+    gptme --name my-refactor
+
+    # Resume the most recently modified conversation (any name)
+    gptme -r
+
+Without ``--name``, gptme assigns a random name (e.g. ``hopping-blue-robot``).
+
+**List and search conversations**
+
+.. code-block:: bash
+
+    # List the 20 most recent conversations
+    gptme chats list
+
+    # Show full metadata (model, cost, token counts)
+    gptme chats list --metadata
+
+    # Search conversation content
+    gptme chats search "auth module refactor"
+
+    # Machine-readable JSON output
+    gptme chats list --json
+
+**Fork a conversation to explore an alternate approach**
+
+Forking creates a new independent conversation from messages up to turn N.
+The original conversation is unchanged.
+
+.. code-block:: bash
+
+    # Fork after the third user+assistant exchange
+    gptme-util chats fork my-refactor --at-turn 3
+
+    # Fork with a custom name for the new conversation
+    gptme-util chats fork my-refactor --at-turn 3 --name my-refactor-v2
+
+    # Then resume the fork normally
+    gptme --name my-refactor-v2
+
+Within a running conversation, ``/fork my-experiment`` achieves the same result
+at the current turn (see :doc:`commands`).
+
+.. note::
+
+   ``/fork`` and ``gptme-util chats fork`` both create a **new top-level conversation**,
+   not a branch inside the current one. For workspace rollback before risky changes,
+   use ``/checkpoint`` (committed state) or ``/snapshot`` (any state) instead.
+
 Interfaces
 ----------
 


### PR DESCRIPTION
## Problem

The docs use 'session', 'branch', and 'fork' inconsistently, leaving new users uncertain about which state persists, which command manages it, and how fork differs from branch.

## Changes

### `docs/glossary.md`
Expands the thin 'Session Concepts' section into a comprehensive 'Conversation and Session Concepts' section with cross-linked anchor entries for:
- **Conversation** — primary persistence unit; `--name`, `-r`, `gptme chats list/search`
- **Branch** — alternative thread within a conversation directory (mainly a server-side concept); clarifies that the TUI's `/fork` creates a new conversation, not a branch
- **Fork** — new conversation copied from turns 0..N; `/fork`, `gptme-util chats fork`
- **Workspace Checkpoint** — `/checkpoint`; committed-state recovery
- **Workspace Snapshot** — `/snapshot`; any-state shadow-repo capture
- **Backtrack Marker** — `/backtrack`; in-memory conversation rewind (does not touch filesystem)
- **Analytics Session** — `gptme-sessions` run records; explicitly disambiguated from 'launching gptme in a conversation'

### `docs/usage.rst`
Adds a **'Managing Conversations'** section with three verified examples:
1. Create and name a conversation, resume by name or `-r`
2. List conversations (`gptme chats list`) and search (`gptme chats search`)
3. Fork at a specific turn (`gptme-util chats fork --at-turn N`)

All commands verified against `gptme --help` and `gptme-util chats --help` output.

## Key Disambiguations

| Confusion | Clarification |
|---|---|
| `/fork` creates a branch? | No — it creates a new top-level conversation |
| 'Session' = conversation? | 'Session' is ambiguous; prefer 'conversation' for the log, 'run' for analytics records |
| Branches are user-facing? | Branches are mainly server-side (`gptme-server` API); the TUI exposes fork, not branch switching |

Ref: Idea #1004 from [gptme Discussion #136](https://github.com/gptme/gptme/discussions/136)