### PR TITLE
fix(server): validate provider API key before saving it

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -3069,6 +3069,8 @@ def api_user():
     summary="Save provider API key",
     description=(
         "Persist a provider API key into the user's global gptme config. "
+        "The key is checked against the provider before it is written, so an "
+        "invalid key is rejected with 400 rather than saved. "
         "Intended for first-run onboarding flows; callers should restart the "
         "server after a successful write if they need the running process to "
         "pick the key up immediately."
@@ -3110,6 +3112,18 @@ def api_user_api_key():
         )
     except ValueError as exc:
         return flask.jsonify({"error": str(exc)}), 400
+
+    # Check the key with the provider before writing it. `/account setup` has always
+    # done this (gptme/commands/account.py); this endpoint did not, so onboarding
+    # accepted a bad key, reported "status": "ok", and the user only found out when
+    # the first generation came back with a raw provider auth error. Same validator,
+    # so both onboarding paths agree on what "valid" means: a rate-limited or
+    # quota-exhausted key is valid, and providers without a check are skipped.
+    from ..llm.validate import validate_api_key  # fmt: skip
+
+    is_valid, validation_error = validate_api_key(trimmed_api_key, provider)
+    if not is_valid:
+        return flask.jsonify({"error": validation_error}), 400
 
     env_var = PROVIDER_API_KEYS[provider]
     set_config_value(f"env.{env_var}", trimmed_api_key, reload=False, local=True)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -356,6 +356,18 @@ def test_webui_deploy_trigger_dispatches_workflow(client: FlaskClient, monkeypat
     }
 
 
+def stub_key_validation(monkeypatch, *, valid: bool = True, message: str = ""):
+    """Stand in for the live provider call /api/v2/user/api-key makes.
+
+    The endpoint checks the key with the provider before persisting it, so
+    every save test has to say what the provider would answer.
+    """
+    monkeypatch.setattr(
+        "gptme.llm.validate.validate_api_key",
+        lambda api_key, provider, timeout=10: (valid, message),
+    )
+
+
 def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monkeypatch):
     """Saving an API key should write the provider env var into user config."""
     import gptme.config.user as user_mod
@@ -364,6 +376,7 @@ def test_v2_user_api_key_persists_env_entry(client: FlaskClient, tmp_path, monke
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    stub_key_validation(monkeypatch)
 
     response = client.post(
         "/api/v2/user/api-key",
@@ -396,6 +409,7 @@ def test_v2_user_api_key_applies_to_env_immediately(
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    stub_key_validation(monkeypatch)
 
     response = client.post(
         "/api/v2/user/api-key",
@@ -418,6 +432,7 @@ def test_v2_user_api_key_persists_default_model(
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("MODEL", raising=False)
+    stub_key_validation(monkeypatch)
 
     response = client.post(
         "/api/v2/user/api-key",
@@ -448,6 +463,73 @@ def test_v2_user_api_key_rejects_model_provider_mismatch(client: FlaskClient):
     assert response.status_code == 400
     data = response.get_json()
     assert data == {"error": "Model openai/gpt-4.1 does not match provider anthropic"}
+
+
+def test_v2_user_api_key_rejects_invalid_key(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """A key the provider rejects must not be persisted or applied."""
+    import os
+
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    stub_key_validation(
+        monkeypatch,
+        valid=False,
+        message="Invalid API key. Please check your key and try again.",
+    )
+
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={"provider": "anthropic", "api_key": "sk-ant-bad-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Invalid API key. Please check your key and try again."
+    }
+    assert not (tmp_path / "config.local.toml").exists()
+    assert os.environ.get("ANTHROPIC_API_KEY") is None
+
+
+def test_v2_user_api_key_saves_when_validation_is_non_fatal(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """A key the validator calls valid is saved even when it carries a message.
+
+    `validate_api_key` returns (True, message) for a working key whose account has
+    hit a quota. That is a valid key and must still save; the response shape is
+    unchanged.
+    """
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    stub_key_validation(
+        monkeypatch, message="API quota exhausted — credit balance too low"
+    )
+
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={"provider": "anthropic", "api_key": "sk-ant-out-of-credit"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "ok",
+        "provider": "anthropic",
+        "env_var": "ANTHROPIC_API_KEY",
+        "restart_required": False,
+    }
+
+    saved = tomlkit.loads((tmp_path / "config.local.toml").read_text()).unwrap()
+    assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-out-of-credit"
 
 
 def test_v2_user_api_key_rejects_unknown_provider(client: FlaskClient):


### PR DESCRIPTION
## What happens

`POST /api/v2/user/api-key` checks the *shape* of the key and never asks the provider
whether it works. It writes the key into `config.local.toml`, exports it into
`os.environ`, and answers `{"status": "ok", "restart_required": false}`. The desktop
BYOK wizard treats that 200 as success, restarts, reads `provider_configured` — which is
`get_default_model() is not None`, i.e. "a MODEL is set", not "the key is good" — and
shows `You're all set!`. The first generation is where the user learns the key is bad,
as a raw provider 401.

## The validator is already in the tree

`gptme/llm/validate.py::validate_api_key` makes a cheap live call per provider and
returns `(is_valid, message)`. `/account setup` has called it all along and refuses to
store a key that fails (`gptme/commands/account.py`). The onboarding endpoint is the one path that
skips it, so the same product has two doors onto the same action and only one is locked.

This calls the same validator from the endpoint, before anything is written, and returns
`400 {"error": ...}` when the provider rejects the key.

## No webui change is needed

`saveApiKeyToServer` already parses `error` out of a non-ok response and throws
(`webui/src/components/SetupWizard.tsx`), and `handleSaveApiKey` already catches it into
`apiKeyError` without restarting the server or advancing the step. A 400 from this
endpoint stops the wizard on the provider step showing the provider's own reason.

## Why the validator rather than new checks

It already decides the awkward cases, and re-deciding them here would let the two paths
drift: HTTP 429 is a valid key, an Anthropic 400 whose message mentions usage limits is a
valid key **with a message**, and providers with no check (azure, nvidia, local, custom)
are skipped and still save. `test_v2_user_api_key_saves_when_validation_is_non_fatal`
pins that: a quota-exhausted key still saves and the response shape does not change.

The response shape is unchanged on purpose. An earlier revision of this branch returned
that non-fatal message as a `warning` field, and a review pointed out that no client
reads it — surfacing a quota warning needs a change in `SetupWizard.tsx` and
`ServerApiKeySettings.tsx`, which is a separate piece of work with its own tests, and I
have no way to run the webui suite here. So the field is gone rather than half-wired.

## What I ran, and what I did not

Ran, on this branch: `pytest tests/test_server_v2.py tests/test_server_cli_fallback.py`
— **230 passed, 5 skipped**. `ruff format --check`, `ruff check`
and `mypy` clean on both changed files. The new rejection test was confirmed to fail
without the endpoint change and pass with it.

**Not run: the AppImage repro from the issue.** I have no desktop build, display or
packaged sidecar here, so I have not re-driven the wizard end to end. The claim about the
webui above is from reading `SetupWizard.tsx`, not from running it.

## Noticed, deliberately not changed

The endpoint answers `restart_required: false` and its comment says the key is "applied
live". That holds only while the provider's client has not been built yet — `init_llm()`
is idempotent ("if not already initialized") and this endpoint never calls the `reinit()`
helpers that `/account` uses for exactly this — so re-keying a running server does not
take effect live. Separate defect, and whether onboarding should reinit is your call, so
it is not folded in here.

Closes #3545.
