### PR TITLE
fix(review): verify finding file/line target matches inline comment location

### DIFF
--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -436,21 +436,24 @@ def _verify_comment_reviewer(
             return False, ""
 
         if expected_line is not None:
-            # Inline review comments carry both ``line`` (current diff position)
-            # and ``original_line`` (position in the original file). The finding's
-            # ``line`` maps to ``original_line`` when round-tripped via
-            # ``ReviewFinding.from_github_comment``, so compare against that
-            # first and fall back to ``line`` for comments lacking it.
-            comment_line = data.get("original_line") or data.get("line")
-            if comment_line != expected_line:
+            # ``ReviewFinding.from_github_comment`` records ``original_line``,
+            # while other artifact producers may record the current ``line``.
+            # Both locations are authenticated by this inline comment, so accept
+            # either when GitHub returns both values for a moved line.
+            comment_lines = {
+                line
+                for line in (data.get("original_line"), data.get("line"))
+                if line is not None
+            }
+            if expected_line not in comment_lines:
                 logger.warning(
                     "GitHub comment %d line mismatch: artifact targets line %s "
-                    "on '%s', comment is on line %s; rejecting finding (prevents "
-                    "location forgery).",
+                    "on '%s', comment is on line(s) %s; rejecting finding "
+                    "(prevents location forgery).",
                     comment_id,
                     expected_line,
                     expected_file,
-                    comment_line,
+                    sorted(comment_lines),
                 )
                 return False, ""
 

--- a/gptme/cli/cmd_review_watch.py
+++ b/gptme/cli/cmd_review_watch.py
@@ -303,6 +303,8 @@ def _verify_comment_reviewer(
     expected_reviewer: str,
     expected_body: str = "",
     target_pr_number: int | None = None,
+    expected_file: str = "",
+    expected_line: int | None = None,
 ) -> tuple[bool, str]:
     """Verify a PR review comment belongs to the claimed reviewer and has matching body.
 
@@ -310,14 +312,17 @@ def _verify_comment_reviewer(
     1. ``user.login`` case-insensitively (using casefold for proper Unicode handling)
     2. Comment body matches the artifact finding body exactly (if provided)
     3. If target_pr_number is provided, verifies the comment is on that specific PR
+    4. If expected_file is provided, verifies the comment is an inline review
+       comment on that same file (and same line when expected_line is given) so
+       a genuine trusted body cannot be replayed against a forged code location
 
     Tries the inline review-comment endpoint first (``pulls/comments``); falls
     back to the issue-comment endpoint (``issues/comments``) for PR-level
     conversation comments, which live in a separate ID space.
 
-    Returns (verified, body) where verified is True only if login matches and
-    body is authentic. When verification fails, body is empty string.
-    Fails closed on network errors or mismatches.
+    Returns (verified, body) where verified is True only if login, body, and
+    (when requested) file/line location are authentic. When verification fails,
+    body is empty string. Fails closed on network errors or mismatches.
     """
     # Try inline review comment endpoint first.
     data = run_gh_json(
@@ -400,6 +405,55 @@ def _verify_comment_reviewer(
             )
             return False, ""
 
+    # Verify the finding's file/line target matches the comment's code location.
+    # A file-targeted finding is only authentic when the backing comment is an
+    # inline review comment (attached to a diff line) on that same file — and
+    # same line, when the finding specifies one. Without this, an attacker can
+    # replay a genuine trusted body + comment ID but redirect the fix session at
+    # attacker-chosen code (see gptme/gptme#3451 threat model).
+    if expected_file:
+        if is_issue_comment:
+            # Conversation (issue) comments are not attached to a diff line, so
+            # they carry no file/line location and cannot authenticate a
+            # file-targeted finding. Reject fail-closed.
+            logger.warning(
+                "GitHub comment %d is a conversation comment with no code "
+                "location; cannot authenticate finding targeting '%s'; rejecting.",
+                comment_id,
+                expected_file,
+            )
+            return False, ""
+
+        comment_path = data.get("path", "")
+        if comment_path != expected_file:
+            logger.warning(
+                "GitHub comment %d file mismatch: artifact targets '%s', "
+                "comment is on '%s'; rejecting finding (prevents location forgery).",
+                comment_id,
+                expected_file,
+                comment_path,
+            )
+            return False, ""
+
+        if expected_line is not None:
+            # Inline review comments carry both ``line`` (current diff position)
+            # and ``original_line`` (position in the original file). The finding's
+            # ``line`` maps to ``original_line`` when round-tripped via
+            # ``ReviewFinding.from_github_comment``, so compare against that
+            # first and fall back to ``line`` for comments lacking it.
+            comment_line = data.get("original_line") or data.get("line")
+            if comment_line != expected_line:
+                logger.warning(
+                    "GitHub comment %d line mismatch: artifact targets line %s "
+                    "on '%s', comment is on line %s; rejecting finding (prevents "
+                    "location forgery).",
+                    comment_id,
+                    expected_line,
+                    expected_file,
+                    comment_line,
+                )
+                return False, ""
+
     return True, comment_body
 
 
@@ -422,9 +476,9 @@ def _filter_findings_by_trusted_reviewers(
     When ``trusted_reviewers`` is enabled, all findings MUST carry a
     ``github_comment_id`` to be verifiable against the GitHub API.  This
     prevents forged artifacts from injecting attacker-controlled findings.
-    The reviewer field and finding body are cross-checked against GitHub
-    before the finding is accepted.  Findings that fail API verification or
-    lack a ``github_comment_id`` are rejected (fail-closed).
+    The reviewer field, finding body, and file/line target are cross-checked
+    against GitHub before the finding is accepted.  Findings that fail API
+    verification or lack a ``github_comment_id`` are rejected (fail-closed).
 
     When ``pr_number`` is provided, verified comments are checked to ensure
     they are on the target PR (prevents cross-PR comment injection).
@@ -468,6 +522,8 @@ def _filter_findings_by_trusted_reviewers(
                 expected_reviewer=f.reviewer,
                 expected_body=f.body,  # Verify the finding body matches the comment
                 target_pr_number=pr_number,  # Verify comment is on target PR
+                expected_file=f.file,  # Verify finding's file target matches comment
+                expected_line=f.line,  # Verify finding's line target matches comment
             )
             if not verified:
                 continue

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -1100,6 +1100,159 @@ def test_filter_findings_forged_body_rejected(monkeypatch):
     assert len(result) == 0, "Forged finding body must be rejected"
 
 
+def test_filter_findings_forged_file_rejected(monkeypatch):
+    """A finding that replays a genuine trusted body + comment ID but points at a
+    different file must be rejected (prevents location forgery)."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/evil.py",
+            line=42,
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    # API confirms ErikBjare authored comment 12345 with a matching body, but the
+    # comment is an inline comment on a *different* file.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "original_line": 42,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, "Forged file target must be rejected"
+
+
+def test_filter_findings_forged_line_rejected(monkeypatch):
+    """A finding that replays a genuine trusted body + comment ID but points at a
+    different line on the same file must be rejected (prevents location forgery)."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/real.py",
+            line=99,
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    # API confirms matching body + file, but the comment is on a different line.
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "original_line": 42,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 0, "Forged line target must be rejected"
+
+
+def test_filter_findings_matching_file_and_line_accepted(monkeypatch):
+    """A finding whose reviewer, body, file, and line all match the inline comment
+    is accepted."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/real.py",
+            line=42,
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "original_line": 42,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 1, "Fully-matching finding (file + line) must be accepted"
+
+
+def test_filter_findings_conversation_comment_with_file_target_rejected(monkeypatch):
+    """A file-targeted finding backed by a conversation (issue) comment must be
+    rejected: conversation comments carry no code location, so they cannot
+    authenticate a file/line target."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="PR-level conversation comment",
+            file="src/real.py",
+            line=42,
+            reviewer="ErikBjare",
+            github_comment_id=55555,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        joined = " ".join(args)
+        if "pulls/comments/55555" in joined:
+            return None
+        if "issues/comments/55555" in joined:
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "PR-level conversation comment",
+                "issue_url": "https://api.github.com/repos/owner/repo/issues/1",
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+        pr_number=1,
+    )
+    assert len(result) == 0, (
+        "Conversation comment cannot authenticate a file-targeted finding"
+    )
+
+
 def test_filter_findings_missing_comment_id_rejected(monkeypatch):
     """When trusted-reviewer filtering is enabled, findings without a
     github_comment_id must be rejected (fail-closed) to prevent forged findings

--- a/tests/test_util_cli_review_watch.py
+++ b/tests/test_util_cli_review_watch.py
@@ -1211,6 +1211,113 @@ def test_filter_findings_matching_file_and_line_accepted(monkeypatch):
     assert len(result) == 1, "Fully-matching finding (file + line) must be accepted"
 
 
+def test_filter_findings_current_line_accepted(monkeypatch):
+    """A current-side line is accepted when GitHub also returns a different
+    original-side line for the same inline comment."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/real.py",
+            line=47,
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "original_line": 42,
+                "line": 47,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 1, "Current-side line on the comment must be accepted"
+
+
+def test_filter_findings_line_only_comment_accepted(monkeypatch):
+    """A comment on an added line is accepted when GitHub omits original_line."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/real.py",
+            line=42,
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "line": 42,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 1, "Line-only inline comment must be accepted"
+
+
+def test_filter_findings_file_without_line_accepted(monkeypatch):
+    """A file-only finding authenticates against the comment path without
+    requiring a line."""
+    from gptme.util.review import ReviewFinding
+
+    findings = [
+        ReviewFinding(
+            body="Real review comment",
+            file="src/real.py",
+            reviewer="ErikBjare",
+            github_comment_id=12345,
+        ),
+    ]
+
+    def fake_run_gh_json(args, **kwargs):
+        if "pulls/comments/12345" in " ".join(args):
+            return {
+                "user": {"login": "ErikBjare"},
+                "body": "Real review comment",
+                "path": "src/real.py",
+                "original_line": 42,
+            }
+        return None
+
+    monkeypatch.setattr(cmd_review_watch, "run_gh_json", fake_run_gh_json)
+
+    result = cmd_review_watch._filter_findings_by_trusted_reviewers(
+        findings,
+        ("ErikBjare",),
+        owner="owner",
+        repo="repo",
+    )
+    assert len(result) == 1, "Matching file-only finding must be accepted"
+
+
 def test_filter_findings_conversation_comment_with_file_target_rejected(monkeypatch):
     """A file-targeted finding backed by a conversation (issue) comment must be
     rejected: conversation comments carry no code location, so they cannot


### PR DESCRIPTION
## Problem

`gptme-util review watch --trusted-reviewer LOGIN` (#3470) verifies a finding's
reviewer *identity* and *body* against the GitHub API, but does **not** verify
that the finding's `file`/`line` target matches the inline comment's code
location.

This leaves a forgery vector in the trusted-reviewer allowlist: an attacker who
can supply a crafted artifact could:

1. Replay a *genuine* trusted reviewer's `body` + `github_comment_id` (both
   cross-check correctly against GitHub), but
2. Change the `file` (and/or `line`) fields to point the fix session at
   attacker-chosen code.

The fix session would then be directed to make attacker-controlled edits to a
file the trusted reviewer never commented on.

## Fix

Extend `_verify_comment_reviewer` to cross-check the finding's code location:

- When a finding targets a `file`, the backing comment must be an **inline
  review comment** on that same file. A conversation/issue comment (which
  carries no code location) can no longer authenticate a file-targeted finding
  — rejected fail-closed.
- When the finding also specifies a `line`, it must match the inline comment's
  line (`original_line`, falling back to `line`, matching the round-trip
  semantics of `ReviewFinding.from_github_comment`).

`_filter_findings_by_trusted_reviewers` now passes the finding's `file` and
`line` through to verification, so the check is always on when
`--trusted-reviewer` is set (no new opt-in flag — body + location verification
should always accompany reviewer allowlisting).

## Tests

Added to `tests/test_util_cli_review_watch.py`:

- `test_filter_findings_forged_file_rejected` — genuine body + forged file → blocked
- `test_filter_findings_forged_line_rejected` — genuine body + forged line → blocked
- `test_filter_findings_matching_file_and_line_accepted` — all axes match → allowed
- `test_filter_findings_conversation_comment_with_file_target_rejected` — conversation comment can't authenticate a file target

## Verification

- `pytest tests/test_util_cli_review_watch.py tests/test_util_review.py` — 207 passed
- `ruff check` / `ruff format --check` clean on changed files

Refs: gptme/gptme#3451 (threat model), gptme/gptme#3460 (prior `--verify-bodies` work, closed as duplicate of #3470).