### PR TITLE
feat(hooks): add agent-devtools trace exporter

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -60,6 +60,37 @@ Plugin ``init(config)`` hooks can read that config via
 ``config.project.plugin.get("my_plugin", {}) if config.project else {}`` and
 ``config.user.plugin.get("my_plugin", {}) if config.user else {}``.
 
+Agent-Devtools Tracing
+----------------------
+
+``gptme`` already exposes the runtime lifecycle hooks needed for tracing, so
+Agent-Devtools integration is an **optional plugin** layered on top of that
+existing hook surface rather than a second hook framework.
+
+.. code-block:: toml
+
+   [plugin.agent_devtools]
+   endpoint = "http://127.0.0.1:3000/events"
+   timeout = 1.0
+   include_sensitive = false
+
+When enabled, the plugin exports best-effort HTTP traces for these existing hook
+events:
+
+- ``session.start``
+- ``session.end``
+- ``turn.pre``
+- ``tool.execute.pre``
+- ``tool.execute.post``
+- ``generation.pre``
+- ``generation.post``
+
+Privacy defaults are conservative: raw prompts, file contents, and full tool
+payloads are omitted unless ``include_sensitive = true`` is explicitly set.
+
+``TOOL_CONFIRM`` remains the blocking policy surface. The Agent-Devtools plugin
+only observes and exports traces; it does not approve or deny tool execution.
+
 Skills vs Plugins
 -----------------
 

--- a/gptme/hooks/agent_devtools.py
+++ b/gptme/hooks/agent_devtools.py
@@ -1,0 +1,482 @@
+"""Agent-Devtools trace exporter built on gptme's existing hook surface.
+
+This plugin is intentionally narrow:
+
+- opt-in via ``[plugin.agent_devtools]`` or environment variables
+- exports lifecycle events over best-effort HTTP POSTs
+- defaults to privacy-safe summaries instead of raw prompts/tool payloads
+- never blocks or changes normal gptme execution
+
+The exporter observes existing hooks. Blocking policy remains owned by
+``tool.confirm`` and related confirmation hooks.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import requests
+
+from ..hooks import (
+    HookType,
+    current_conversation_id,
+    current_session_id,
+    register_hook,
+)
+from ..message import Message
+from ..plugins.plugin import GptmePlugin
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..hooks import StopPropagation
+    from ..hooks.types import ToolExecutePostData, ToolExecutePreData
+    from ..logmanager import Log, LogManager
+    from ..tools.base import ToolUse
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 1.0
+_MAX_TOOL_AGE_S = 300.0
+_tool_start_times_var: ContextVar[dict[int, float] | None] = ContextVar(
+    "agent_devtools_tool_start_times",
+    default=None,
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _enabled() -> bool:
+    return _truthy(os.environ.get("GPTME_AGENT_DEVTOOLS")) or bool(_endpoint())
+
+
+def _endpoint() -> str | None:
+    raw = os.environ.get("GPTME_AGENT_DEVTOOLS_ENDPOINT", "").strip()
+    return raw or None
+
+
+def _timeout_s() -> float:
+    raw = os.environ.get("GPTME_AGENT_DEVTOOLS_TIMEOUT", "").strip()
+    if not raw:
+        return _DEFAULT_TIMEOUT_S
+    try:
+        return max(float(raw), 0.05)
+    except ValueError:
+        return _DEFAULT_TIMEOUT_S
+
+
+def _include_sensitive() -> bool:
+    return _truthy(os.environ.get("GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE"))
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _workspace_str(workspace: Path | None) -> str | None:
+    return str(workspace) if workspace is not None else None
+
+
+def _conversation_and_session_ids(
+    *,
+    manager: LogManager | None = None,
+    logdir: Path | None = None,
+) -> tuple[str | None, str | None]:
+    conversation_id = current_conversation_id.get()
+    session_id = current_session_id.get()
+
+    derived = None
+    if manager is not None:
+        derived = getattr(manager, "chat_id", None)
+        if derived is None and getattr(manager, "logdir", None) is not None:
+            derived = Path(manager.logdir).name
+    elif logdir is not None:
+        derived = logdir.name
+
+    if conversation_id is None:
+        conversation_id = derived
+    if session_id is None:
+        session_id = conversation_id or derived
+
+    return conversation_id, session_id
+
+
+def _messages_from_log(log: Log | None) -> list[Message]:
+    if log is None:
+        return []
+    messages = getattr(log, "messages", None)
+    if isinstance(messages, list):
+        return cast(list[Message], messages)
+    return []
+
+
+def _turn_index(messages: list[Message]) -> int | None:
+    user_count = sum(1 for msg in messages if msg.role == "user")
+    if user_count == 0:
+        return None
+    return user_count - 1
+
+
+def _safe_text_summary(text: str | None) -> dict[str, Any]:
+    if not text:
+        return {"chars": 0}
+    return {"chars": len(text), "lines": text.count("\n") + 1}
+
+
+def _message_text(messages: tuple[Message, ...] | None) -> str | None:
+    if not messages:
+        return None
+    chunks = [msg.content for msg in messages if isinstance(msg.content, str)]
+    if not chunks:
+        return None
+    return "\n".join(chunks)
+
+
+def _tool_payload_preview(
+    tool_use: ToolUse, *, include_sensitive: bool
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": tool_use.tool,
+        "call_id": tool_use.call_id,
+        "format": tool_use._format,
+        "args_preview": {
+            "arg_count": len(tool_use.args or []),
+            "kwarg_keys": sorted((tool_use.kwargs or {}).keys()),
+            "has_content": bool(tool_use.content),
+            "content_summary": _safe_text_summary(tool_use.content),
+        },
+    }
+    if include_sensitive:
+        payload["args"] = list(tool_use.args or [])
+        if tool_use.kwargs is not None:
+            payload["kwargs"] = dict(tool_use.kwargs)
+        if tool_use.content is not None:
+            payload["content"] = tool_use.content
+    return payload
+
+
+def _usage_from_message(message: Message) -> dict[str, Any]:
+    usage: dict[str, Any] = {"output_chars": len(message.content or "")}
+    metadata = message.metadata or {}
+    if model := metadata.get("model"):
+        usage["model"] = model
+    if resolved_model := metadata.get("resolved_model"):
+        usage["resolved_model"] = resolved_model
+    if usage_meta := metadata.get("usage"):
+        usage.update(cast(dict[str, Any], usage_meta))
+    if timings := metadata.get("timings"):
+        usage.update(cast(dict[str, Any], timings))
+    return usage
+
+
+def _base_envelope(
+    event: str,
+    *,
+    workspace: Path | None = None,
+    manager: LogManager | None = None,
+    logdir: Path | None = None,
+    turn_index: int | None = None,
+    step_index: int | None = None,
+) -> dict[str, Any]:
+    conversation_id, session_id = _conversation_and_session_ids(
+        manager=manager, logdir=logdir
+    )
+    return {
+        "schema_version": 1,
+        "event": event,
+        "timestamp": _iso_now(),
+        "session_id": session_id,
+        "conversation_id": conversation_id,
+        "workspace": _workspace_str(workspace),
+        "turn_index": turn_index,
+        "step_index": step_index,
+    }
+
+
+def _send_event(envelope: dict[str, Any]) -> None:
+    endpoint = _endpoint()
+    if not _enabled() or endpoint is None:
+        return
+    try:
+        response = requests.post(
+            endpoint,
+            json=envelope,
+            timeout=_timeout_s(),
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "gptme-agent-devtools/1",
+            },
+        )
+        if response.status_code >= 400:
+            logger.warning(
+                "agent_devtools sink returned %s for %s",
+                response.status_code,
+                envelope.get("event"),
+            )
+    except requests.RequestException as exc:
+        logger.debug("agent_devtools export failed open: %s", exc)
+
+
+def _ensure_tool_start_times() -> dict[int, float]:
+    tool_start_times = _tool_start_times_var.get()
+    if tool_start_times is None:
+        tool_start_times = {}
+        _tool_start_times_var.set(tool_start_times)
+    return tool_start_times
+
+
+def _remember_tool_start(
+    data: ToolExecutePreData,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled() or data.tool_use is None:
+        return
+    tool_start_times = _ensure_tool_start_times()
+    now = time.monotonic()
+    stale = [k for k, v in tool_start_times.items() if now - v > _MAX_TOOL_AGE_S]
+    for key in stale:
+        del tool_start_times[key]
+    tool_start_times[id(data.tool_use)] = now
+    _tool_start_times_var.set(tool_start_times)
+    return
+    yield
+
+
+def emit_session_start(
+    logdir: Path,
+    workspace: Path | None,
+    initial_msgs: list[Message],
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled():
+        return
+    envelope = _base_envelope(
+        HookType.SESSION_START.value,
+        workspace=workspace,
+        logdir=logdir,
+        turn_index=_turn_index(initial_msgs),
+    )
+    envelope["context"] = {"initial_message_count": len(initial_msgs)}
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_session_end(
+    manager: LogManager,
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    del kwargs
+    if not _enabled():
+        return
+    envelope = _base_envelope(
+        HookType.SESSION_END.value,
+        workspace=manager.workspace,
+        manager=manager,
+        turn_index=_turn_index(manager.log.messages),
+    )
+    envelope["context"] = {"message_count": len(manager.log.messages)}
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_turn_pre(
+    manager: LogManager,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled():
+        return
+    messages = manager.log.messages
+    envelope = _base_envelope(
+        HookType.TURN_PRE.value,
+        workspace=manager.workspace,
+        manager=manager,
+        turn_index=_turn_index(messages),
+    )
+    envelope["context"] = {"message_count": len(messages)}
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_tool_pre(
+    data: ToolExecutePreData,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled() or data.tool_use is None:
+        return
+    messages = _messages_from_log(data.log)
+    envelope = _base_envelope(
+        HookType.TOOL_EXECUTE_PRE.value,
+        workspace=data.workspace,
+        turn_index=_turn_index(messages),
+    )
+    envelope["tool"] = _tool_payload_preview(
+        data.tool_use, include_sensitive=_include_sensitive()
+    )
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_tool_post(
+    data: ToolExecutePostData,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled() or data.tool_use is None:
+        return
+    messages = _messages_from_log(data.log)
+    include_sensitive = _include_sensitive()
+    envelope = _base_envelope(
+        HookType.TOOL_EXECUTE_POST.value,
+        workspace=data.workspace,
+        turn_index=_turn_index(messages),
+    )
+    tool = _tool_payload_preview(data.tool_use, include_sensitive=include_sensitive)
+    result_text = _message_text(data.result_msgs)
+    if include_sensitive and result_text is not None:
+        tool["result"] = result_text
+    elif data.result_msgs:
+        tool["result_preview"] = _safe_text_summary(result_text)
+    envelope["tool"] = tool
+
+    started = _ensure_tool_start_times().pop(id(data.tool_use), None)
+    usage: dict[str, Any] = {"success": True}
+    if started is not None:
+        usage["duration_ms"] = max(int(round((time.monotonic() - started) * 1000)), 0)
+    if data.result_msgs:
+        usage["result_message_count"] = len(data.result_msgs)
+    envelope["usage"] = usage
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_generation_pre(
+    messages: list[Message],
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled():
+        return
+    workspace = kwargs.get("workspace")
+    model = kwargs.get("model")
+    envelope = _base_envelope(
+        HookType.GENERATION_PRE.value,
+        workspace=workspace,
+        turn_index=_turn_index(messages),
+    )
+    envelope["context"] = {"message_count": len(messages), "model": model}
+    _send_event(envelope)
+    return
+    yield
+
+
+def emit_generation_post(
+    message: Message,
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    if not _enabled():
+        return
+    workspace = kwargs.get("workspace")
+    envelope = _base_envelope(
+        HookType.GENERATION_POST.value,
+        workspace=workspace,
+    )
+    envelope["usage"] = _usage_from_message(message)
+    if _include_sensitive():
+        envelope["assistant"] = {"content": message.content}
+    _send_event(envelope)
+    return
+    yield
+
+
+def register() -> None:
+    register_hook(
+        "agent_devtools.tool_pre_state",
+        HookType.TOOL_EXECUTE_PRE,
+        _remember_tool_start,
+        priority=100,
+    )
+    register_hook(
+        "agent_devtools.session_start",
+        HookType.SESSION_START,
+        emit_session_start,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.session_end",
+        HookType.SESSION_END,
+        emit_session_end,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.turn_pre",
+        HookType.TURN_PRE,
+        emit_turn_pre,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.tool_pre",
+        HookType.TOOL_EXECUTE_PRE,
+        emit_tool_pre,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.tool_post",
+        HookType.TOOL_EXECUTE_POST,
+        emit_tool_post,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.generation_pre",
+        HookType.GENERATION_PRE,
+        emit_generation_pre,
+        async_mode=True,
+    )
+    register_hook(
+        "agent_devtools.generation_post",
+        HookType.GENERATION_POST,
+        emit_generation_post,
+        async_mode=True,
+    )
+    logger.debug("Registered agent_devtools hooks")
+
+
+def _init_from_config(config: object) -> None:
+    user_cfg = getattr(getattr(config, "user", None), "plugin", {}) or {}
+    project = getattr(config, "project", None)
+    project_cfg = getattr(project, "plugin", {}) or {} if project else {}
+
+    merged: dict[str, object] = {}
+    if isinstance(user_cfg, dict):
+        merged.update(user_cfg.get("agent_devtools", {}) or {})
+    if isinstance(project_cfg, dict):
+        merged.update(project_cfg.get("agent_devtools", {}) or {})
+
+    if (
+        merged
+        or (isinstance(user_cfg, dict) and "agent_devtools" in user_cfg)
+        or (isinstance(project_cfg, dict) and "agent_devtools" in project_cfg)
+    ):
+        os.environ.setdefault("GPTME_AGENT_DEVTOOLS", "1")
+
+    config_to_env = {
+        "endpoint": "GPTME_AGENT_DEVTOOLS_ENDPOINT",
+        "timeout": "GPTME_AGENT_DEVTOOLS_TIMEOUT",
+        "include_sensitive": "GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE",
+    }
+    for key, env_name in config_to_env.items():
+        value = merged.get(key)
+        if value not in (None, ""):
+            os.environ.setdefault(env_name, str(value))
+
+
+plugin = GptmePlugin(
+    name="agent_devtools",
+    register_hooks=register,
+    init=_init_from_config,
+)

--- a/gptme/hooks/tests/test_agent_devtools.py
+++ b/gptme/hooks/tests/test_agent_devtools.py
@@ -1,0 +1,216 @@
+"""Tests for the Agent-Devtools hook plugin."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
+import requests
+
+from gptme.hooks import HookRegistry, HookType, get_registry, set_registry
+from gptme.hooks.agent_devtools import (
+    _init_from_config,
+    _remember_tool_start,
+    _send_event,
+    emit_generation_post,
+    emit_tool_post,
+    emit_tool_pre,
+    register,
+)
+from gptme.hooks.types import ToolExecutePostData, ToolExecutePreData
+from gptme.logmanager import Log
+from gptme.message import Message
+from gptme.tools.base import ToolUse
+
+
+def test_tool_pre_omits_sensitive_payload_by_default(monkeypatch):
+    monkeypatch.setenv("GPTME_AGENT_DEVTOOLS_ENDPOINT", "http://trace.local/events")
+    monkeypatch.delenv("GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE", raising=False)
+    tool_use = ToolUse(
+        tool="shell",
+        args=["bash"],
+        content="echo secret",
+        kwargs={"command": "echo secret", "mode": "fast"},
+        call_id="call-123",
+    )
+
+    with patch("gptme.hooks.agent_devtools.requests.post") as post:
+        post.return_value.status_code = 200
+        assert (
+            list(
+                emit_tool_pre(
+                    ToolExecutePreData(
+                        log=cast(
+                            Log, SimpleNamespace(messages=[Message("user", "hi")])
+                        ),
+                        workspace=Path("/tmp/workspace"),
+                        tool_use=tool_use,
+                    )
+                )
+            )
+            == []
+        )
+
+    payload = post.call_args.kwargs["json"]
+    assert payload["event"] == HookType.TOOL_EXECUTE_PRE.value
+    assert payload["tool"]["name"] == "shell"
+    assert payload["tool"]["call_id"] == "call-123"
+    assert payload["tool"]["args_preview"]["arg_count"] == 1
+    assert payload["tool"]["args_preview"]["kwarg_keys"] == ["command", "mode"]
+    assert "args" not in payload["tool"]
+    assert "kwargs" not in payload["tool"]
+    assert "content" not in payload["tool"]
+
+
+def test_tool_post_includes_sensitive_payload_when_enabled(monkeypatch):
+    monkeypatch.setenv("GPTME_AGENT_DEVTOOLS_ENDPOINT", "http://trace.local/events")
+    monkeypatch.setenv("GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE", "1")
+    tool_use = ToolUse(
+        tool="shell",
+        args=["bash"],
+        content="echo hello",
+        kwargs={"command": "echo hello"},
+        call_id="call-456",
+    )
+    result_msg = Message("system", "hello\n")
+
+    with (
+        patch(
+            "gptme.hooks.agent_devtools.time.monotonic",
+            side_effect=[10.0, 10.25],
+        ),
+        patch("gptme.hooks.agent_devtools.requests.post") as post,
+    ):
+        post.return_value.status_code = 200
+        list(
+            _remember_tool_start(
+                ToolExecutePreData(
+                    log=cast(Log, SimpleNamespace(messages=[Message("user", "hi")])),
+                    workspace=Path("/tmp/workspace"),
+                    tool_use=tool_use,
+                )
+            )
+        )
+        list(
+            emit_tool_pre(
+                ToolExecutePreData(
+                    log=cast(Log, SimpleNamespace(messages=[Message("user", "hi")])),
+                    workspace=Path("/tmp/workspace"),
+                    tool_use=tool_use,
+                )
+            )
+        )
+        assert (
+            list(
+                emit_tool_post(
+                    ToolExecutePostData(
+                        log=cast(
+                            Log, SimpleNamespace(messages=[Message("user", "hi")])
+                        ),
+                        workspace=Path("/tmp/workspace"),
+                        tool_use=tool_use,
+                        result_msgs=(result_msg,),
+                    )
+                )
+            )
+            == []
+        )
+
+    payload = post.call_args.kwargs["json"]
+    assert payload["event"] == HookType.TOOL_EXECUTE_POST.value
+    assert payload["tool"]["args"] == ["bash"]
+    assert payload["tool"]["kwargs"] == {"command": "echo hello"}
+    assert payload["tool"]["content"] == "echo hello"
+    assert payload["tool"]["result"] == "hello\n"
+    assert payload["usage"]["duration_ms"] == 250
+    assert payload["usage"]["result_message_count"] == 1
+
+
+def test_generation_post_uses_message_metadata(monkeypatch):
+    monkeypatch.setenv("GPTME_AGENT_DEVTOOLS_ENDPOINT", "http://trace.local/events")
+    msg = Message(
+        "assistant",
+        "done",
+        metadata={
+            "model": "openai/test",
+            "resolved_model": "openai/test@provider",
+            "usage": {"input_tokens": 12, "output_tokens": 5},
+            "timings": {"ttft_ms": 40.0, "gen_ms": 120.0},
+        },
+    )
+
+    with patch("gptme.hooks.agent_devtools.requests.post") as post:
+        post.return_value.status_code = 200
+        assert list(emit_generation_post(msg, workspace=Path("/tmp/workspace"))) == []
+
+    payload = post.call_args.kwargs["json"]
+    assert payload["event"] == HookType.GENERATION_POST.value
+    assert payload["usage"]["model"] == "openai/test"
+    assert payload["usage"]["resolved_model"] == "openai/test@provider"
+    assert payload["usage"]["input_tokens"] == 12
+    assert payload["usage"]["output_tokens"] == 5
+    assert payload["usage"]["ttft_ms"] == 40.0
+    assert payload["usage"]["gen_ms"] == 120.0
+    assert "assistant" not in payload
+
+
+def test_send_event_fails_open_on_timeout(monkeypatch):
+    monkeypatch.setenv("GPTME_AGENT_DEVTOOLS_ENDPOINT", "http://trace.local/events")
+
+    with patch(
+        "gptme.hooks.agent_devtools.requests.post",
+        side_effect=requests.Timeout("boom"),
+    ):
+        _send_event({"event": "tool.execute.pre"})
+
+
+def test_register_adds_async_export_hooks():
+    old = get_registry()
+    set_registry(HookRegistry())
+    try:
+        register()
+        tool_pre_hooks = get_registry().get_hooks(HookType.TOOL_EXECUTE_PRE)
+        hook_map = {hook.name: hook for hook in tool_pre_hooks}
+        assert hook_map["agent_devtools.tool_pre_state"].async_mode is False
+        assert hook_map["agent_devtools.tool_pre"].async_mode is True
+
+        session_hooks = get_registry().get_hooks(HookType.SESSION_START)
+        assert any(
+            hook.name == "agent_devtools.session_start" and hook.async_mode
+            for hook in session_hooks
+        )
+    finally:
+        set_registry(old)
+
+
+def test_init_from_config_sets_env(monkeypatch):
+    for name in (
+        "GPTME_AGENT_DEVTOOLS",
+        "GPTME_AGENT_DEVTOOLS_ENDPOINT",
+        "GPTME_AGENT_DEVTOOLS_TIMEOUT",
+        "GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    config = SimpleNamespace(
+        user=SimpleNamespace(
+            plugin={
+                "agent_devtools": {
+                    "endpoint": "http://trace.local/events",
+                    "timeout": 2.5,
+                    "include_sensitive": True,
+                }
+            }
+        ),
+        project=None,
+    )
+
+    _init_from_config(config)
+
+    assert os.environ["GPTME_AGENT_DEVTOOLS"] == "1"
+    assert os.environ["GPTME_AGENT_DEVTOOLS_ENDPOINT"] == "http://trace.local/events"
+    assert os.environ["GPTME_AGENT_DEVTOOLS_TIMEOUT"] == "2.5"
+    assert os.environ["GPTME_AGENT_DEVTOOLS_INCLUDE_SENSITIVE"] == "True"

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -862,9 +862,7 @@ class ToolUse:
                         log=log,
                         workspace=workspace,
                         tool_use=self,
-                        result_msgs=tuple(result_msgs)
-                        if generator_result is not None
-                        else None,
+                        result_msgs=tuple(result_msgs) if result_msgs else None,
                     )
                     if post_hook_msgs := trigger_hook(
                         HookType.TOOL_EXECUTE_POST,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ Documentation = "https://gptme.org/docs/"
 Issues = "https://github.com/gptme/gptme/issues"
 
 [project.entry-points."gptme.plugins"]
+agent_devtools = "gptme.hooks.agent_devtools:plugin"
 auto_snapshots = "gptme.hooks.auto_snapshots:plugin"
 aw_watcher_agent = "gptme.hooks.aw_watcher_agent:plugin"
 

--- a/tests/test_execute_msg_hook_call_id.py
+++ b/tests/test_execute_msg_hook_call_id.py
@@ -103,6 +103,25 @@ def test_post_hook_message_does_not_get_call_id(fake_echo_tool, monkeypatch):
     )
 
 
+def test_post_hook_receives_single_message_tool_result(fake_echo_tool, monkeypatch):
+    """TOOL_EXECUTE_POST should receive result_msgs even for single-message tools."""
+    captured = {}
+
+    def fake_trigger(hook_type, data, **kwargs):
+        if hook_type == HookType.TOOL_EXECUTE_POST:
+            captured["result_msgs"] = data.result_msgs
+        return []
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", fake_trigger)
+
+    msg = Message("assistant", '@echo(call-single-result): {"text": "hello"}')
+    list(execute_msg(msg))
+
+    assert captured["result_msgs"] is not None
+    assert len(captured["result_msgs"]) == 1
+    assert captured["result_msgs"][0].content == "echo: hello"
+
+
 def test_pre_hook_message_does_not_get_call_id(fake_echo_tool, monkeypatch):
     """TOOL_EXECUTE_PRE hook messages must NOT inherit the tool's call_id either."""
     hook_msg = Message("system", "pre-hook notification")


### PR DESCRIPTION
## Summary
- add a built-in `agent_devtools` hook plugin that exports lifecycle, turn, tool, and generation events
- send privacy-safe trace envelopes to an optional HTTP sink with fail-open behavior
- document the minimal config and keep `TOOL_CONFIRM` as the blocking policy surface

Refs gptme/gptme#3548.

## Verification
- `PYTHONPATH=/tmp/worktrees/gptme-agent-devtools-trace-exporter-98a1 /home/bob/bob/.venv/bin/python -m pytest -q gptme/hooks/tests/test_agent_devtools.py tests/test_execute_msg_hook_call_id.py`
- `uv run ruff check gptme/hooks/agent_devtools.py gptme/hooks/tests/test_agent_devtools.py gptme/tools/base.py tests/test_execute_msg_hook_call_id.py`
- `PYTHONPATH=/tmp/worktrees/gptme-agent-devtools-trace-exporter-98a1 /home/bob/bob/.venv/bin/python -m py_compile gptme/hooks/agent_devtools.py`
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme` -> 94/100 OPEN
