### PR TITLE
fix(tauri): real API-key errors and Windows sidecar startup

### DIFF
--- a/gptme/__version__.py
+++ b/gptme/__version__.py
@@ -1,14 +1,22 @@
 import importlib.metadata
 import os.path
 import subprocess
+import sys
 
 from .util.git_cmd import GIT_CMD
 
 _cached_version: str | None = None
 
 
+def _is_frozen() -> bool:
+    """True inside PyInstaller/cx_Freeze binaries (the Tauri gptme-server sidecar)."""
+    return bool(getattr(sys, "frozen", False))
+
+
 def get_git_version(package_dir):
     """Get version information from git."""
+    if _is_frozen():
+        return None
     try:
 
         def git_cmd(cmd):
@@ -39,8 +47,12 @@ def get_git_version(package_dir):
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
-        FileNotFoundError,
+        OSError,
     ):
+        # OSError covers FileNotFoundError and NotADirectoryError. The latter is
+        # raised on Windows when PyInstaller onefile sets __file__ to
+        # `gptme-server.exe\gptme\...` — that path is not a real directory, and
+        # using it as subprocess cwd used to crash gptme-server at import.
         pass
     return None
 
@@ -49,6 +61,10 @@ def _compute_version() -> str:
     """Compute version string. Called lazily on first access of __version__."""
     try:
         version = importlib.metadata.version("gptme")
+        if _is_frozen():
+            # Frozen sidecars are not git checkouts. Never spawn git against the
+            # fake `__file__` path inside the bundled executable.
+            return version
         git_hash = None
 
         # Method 1: Check direct_url.json (for pip installs from git)
@@ -106,7 +122,12 @@ def __getattr__(name: str):
     if name == "__version__":
         global _cached_version
         if _cached_version is None:
-            _cached_version = _compute_version()
+            try:
+                _cached_version = _compute_version()
+            except Exception:
+                # Version is displayed in /api/v2 and A2A metadata. It must never
+                # take down gptme-server (Tauri create_app imports this module).
+                _cached_version = "0.0.0 (unknown)"
         globals()["__version__"] = _cached_version
         return _cached_version
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tauri/Makefile
+++ b/tauri/Makefile
@@ -19,12 +19,8 @@ src-tauri/icons/icon.png:
 	cd ../webui && npm i && npm run build
 
 gptme-server-build:
-	@if [ ! -f bins/gptme-server-$$(rustc -Vv | grep host | cut -f2 -d' ') ]; then \
-		echo "Building gptme-server sidecar..."; \
-		./scripts/build-sidecar.sh; \
-	else \
-		echo "gptme-server sidecar already exists, skipping"; \
-	fi
+	@echo "Ensuring gptme-server sidecar is current..."
+	./scripts/build-sidecar.sh
 
 prebuild: ../webui/dist src-tauri/icons/icon.png
 	@$(MAKE) gptme-server-build

--- a/tauri/README.md
+++ b/tauri/README.md
@@ -41,7 +41,8 @@ make dev
 From the **repo root**:
 
 ```bash
-# Build the sidecar (requires uv + pyinstaller)
+# Build the sidecar (requires uv + pyinstaller). Rebuilds automatically when
+# gptme Python sources are newer than the existing binary.
 make tauri-build-sidecar
 
 # Build the app

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -14,10 +14,27 @@ BINS_DIR="$TAURI_DIR/bins"
 
 TRIPLE=$(rustc -Vv | grep host | cut -f2 -d' ')
 OUT="$BINS_DIR/gptme-server-${TRIPLE}"
+# PyInstaller on Windows emits gptme-server.exe; Tauri then expects
+# gptme-server-<triple>.exe next to the un-suffixed name.
+if [[ -f "${OUT}.exe" && ! -f "$OUT" ]]; then
+    OUT="${OUT}.exe"
+fi
+
+sidecar_is_stale() {
+    local sidecar="$1"
+    # Rebuild when any gptme Python source is newer than the frozen binary.
+    # `find -newer` is available in Git Bash on Windows.
+    [[ -n "$(find "$REPO_ROOT/gptme" -name '*.py' -newer "$sidecar" 2>/dev/null | head -n 1)" ]]
+}
 
 if [[ -f "$OUT" ]]; then
-    echo "Sidecar already exists at $OUT, skipping (delete to rebuild)"
-    exit 0
+    if sidecar_is_stale "$OUT"; then
+        echo "gptme source is newer than $OUT, rebuilding sidecar..."
+        rm -f "$OUT"
+    else
+        echo "Sidecar already exists at $OUT and is up to date, skipping"
+        exit 0
+    fi
 fi
 
 echo "Building gptme-server sidecar for $TRIPLE..."
@@ -35,5 +52,13 @@ uv run pyinstaller \
     gptme/server/__main__.py
 
 # Rename to include target triple (Tauri sidecar convention)
-mv "$BINS_DIR/gptme-server" "$OUT"
-echo "Sidecar built: $OUT"
+if [[ -f "$BINS_DIR/gptme-server.exe" ]]; then
+    mv "$BINS_DIR/gptme-server.exe" "${BINS_DIR}/gptme-server-${TRIPLE}.exe"
+    echo "Sidecar built: ${BINS_DIR}/gptme-server-${TRIPLE}.exe"
+elif [[ -f "$BINS_DIR/gptme-server" ]]; then
+    mv "$BINS_DIR/gptme-server" "$BINS_DIR/gptme-server-${TRIPLE}"
+    echo "Sidecar built: $BINS_DIR/gptme-server-${TRIPLE}"
+else
+    echo "ERROR: PyInstaller did not produce gptme-server in $BINS_DIR" >&2
+    exit 1
+fi

--- a/tests/test_misc_subprocess_timeouts.py
+++ b/tests/test_misc_subprocess_timeouts.py
@@ -77,6 +77,45 @@ class TestVersionTimeouts:
             result = get_git_version("/tmp")
             assert result is None
 
+    def test_not_a_directory_returns_none(self):
+        """PyInstaller onefile __file__ looks like exe\\gptme; cwd is not a directory."""
+        with patch.object(
+            _version_mod.subprocess,
+            "call",
+            side_effect=NotADirectoryError(
+                "[WinError 267] The directory name is invalid"
+            ),
+        ):
+            from gptme.__version__ import get_git_version
+
+            result = get_git_version(r"C:\App\gptme-server.exe\gptme")
+            assert result is None
+
+    def test_frozen_skips_git_subprocess(self):
+        """Bundled sidecar must not spawn git against a fake package path."""
+        with (
+            patch.object(_version_mod.sys, "frozen", True, create=True),
+            patch.object(_version_mod.subprocess, "call") as mock_call,
+        ):
+            from gptme.__version__ import get_git_version
+
+            result = get_git_version("/tmp")
+            assert result is None
+            mock_call.assert_not_called()
+
+    def test_version_access_never_raises(self):
+        """Importing __version__ must not crash gptme-server create_app."""
+        _version_mod._cached_version = None
+        _version_mod.__dict__.pop("__version__", None)
+        with patch.object(
+            _version_mod.importlib.metadata,
+            "version",
+            side_effect=RuntimeError("metadata exploded"),
+        ):
+            result = _version_mod.__getattr__("__version__")
+        assert isinstance(result, str)
+        assert result
+
 
 # ── dirs.py ──────────────────────────────────────────────────────────
 

--- a/tests/test_misc_subprocess_timeouts.py
+++ b/tests/test_misc_subprocess_timeouts.py
@@ -132,8 +132,7 @@ class TestDirsTimeouts:
         )
         from gptme.dirs import _get_project_git_dir_call
 
-        get_project_git_dir_call = _get_project_git_dir_call
-        get_project_git_dir_call()
+        _get_project_git_dir_call()
         assert "timeout" in mock_run.call_args.kwargs
 
     @patch("gptme.dirs.subprocess.run")

--- a/tests/test_misc_subprocess_timeouts.py
+++ b/tests/test_misc_subprocess_timeouts.py
@@ -105,7 +105,7 @@ class TestVersionTimeouts:
 
     def test_version_access_never_raises(self):
         """Importing __version__ must not crash gptme-server create_app."""
-        _version_mod._cached_version = None
+        setattr(_version_mod, "_cached_version", None)
         _version_mod.__dict__.pop("__version__", None)
         with patch.object(
             _version_mod.importlib.metadata,

--- a/tests/test_misc_subprocess_timeouts.py
+++ b/tests/test_misc_subprocess_timeouts.py
@@ -105,8 +105,9 @@ class TestVersionTimeouts:
 
     def test_version_access_never_raises(self):
         """Importing __version__ must not crash gptme-server create_app."""
-        setattr(_version_mod, "_cached_version", None)
-        _version_mod.__dict__.pop("__version__", None)
+        module_vars = vars(_version_mod)
+        module_vars["_cached_version"] = None
+        module_vars.pop("__version__", None)
         with patch.object(
             _version_mod.importlib.metadata,
             "version",
@@ -131,7 +132,8 @@ class TestDirsTimeouts:
         )
         from gptme.dirs import _get_project_git_dir_call
 
-        _get_project_git_dir_call()
+        get_project_git_dir_call = _get_project_git_dir_call
+        get_project_git_dir_call()
         assert "timeout" in mock_run.call_args.kwargs
 
     @patch("gptme.dirs.subprocess.run")
@@ -204,7 +206,7 @@ class TestFileSelectorTimeouts:
 
     @patch("gptme.context.selector.file_selector.subprocess.run")
     def test_get_git_status_files_passes_timeout(self, mock_run):
-        """get_git_status_files passes timeout to subprocess.run."""
+        """get_git_status_files passes timeout."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=" M file1.py\n?? file2.py\n"
         )

--- a/tests/test_misc_subprocess_timeouts.py
+++ b/tests/test_misc_subprocess_timeouts.py
@@ -205,7 +205,7 @@ class TestFileSelectorTimeouts:
 
     @patch("gptme.context.selector.file_selector.subprocess.run")
     def test_get_git_status_files_passes_timeout(self, mock_run):
-        """get_git_status_files passes timeout."""
+        """get_git_status_files passes timeout to subprocess.run."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=" M file1.py\n?? file2.py\n"
         )

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -18,6 +18,7 @@ import {
   API_KEY_PROVIDER_OPTIONS,
   type ApiKeyProvider,
 } from '@/utils/apiKeyProviders';
+import { formatUnknownError, messageFromApiErrorBody } from '@/utils/errors';
 import { fetchProviderConfigured } from '@/utils/providerStatus';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
 import { isDemoMode, processConnectionFromHash } from '@/utils/connectionConfig';
@@ -164,10 +165,8 @@ export function SetupWizard() {
 
       let message = `Failed to save API key (${resp.status})`;
       try {
-        const data = (await resp.json()) as { error?: string };
-        if (data.error) {
-          message = data.error;
-        }
+        const data: unknown = await resp.json();
+        message = messageFromApiErrorBody(data, message);
       } catch {
         // Fall back to the generic status-based message.
       }
@@ -193,7 +192,7 @@ export function SetupWizard() {
     } catch (error) {
       setAvailableModels([]);
       setRecommendedModels([]);
-      setModelsError(error instanceof Error ? error.message : 'Failed to load available models.');
+      setModelsError(formatUnknownError(error, 'Failed to load available models.'));
     } finally {
       setModelsLoading(false);
     }
@@ -255,7 +254,7 @@ export function SetupWizard() {
         return;
       } catch (error) {
         lastError = error;
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatUnknownError(error, 'Failed to start gptme-server');
         const shouldRetry =
           /port\s+\d+\s+is already in use/i.test(message) || /already in use/i.test(message);
 
@@ -267,7 +266,7 @@ export function SetupWizard() {
       }
     }
 
-    throw lastError instanceof Error ? lastError : new Error('Failed to start gptme-server');
+    throw new Error(formatUnknownError(lastError, 'Failed to start gptme-server'));
   }, []);
 
   const waitForRestartedServer = useCallback(async () => {
@@ -442,7 +441,7 @@ export function SetupWizard() {
       lastAutoAdvanceBaseUrlRef.current = null;
       await waitForRestartedServer();
     } catch (err) {
-      setApiKeyError(err instanceof Error ? err.message : String(err));
+      setApiKeyError(formatUnknownError(err, 'Failed to save API key'));
     } finally {
       setApiKeySaving(false);
     }
@@ -454,9 +453,10 @@ export function SetupWizard() {
       await checkProviderAndAdvance({ assumeConfiguredOnError: false });
     } catch (err) {
       setApiKeyError(
-        err instanceof Error
-          ? err.message
-          : 'Could not verify provider configuration. Try again in a few seconds.'
+        formatUnknownError(
+          err,
+          'Could not verify provider configuration. Try again in a few seconds.'
+        )
       );
     }
   };

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -26,6 +26,7 @@ import { isLikelyChromeCorsPna } from '@/utils/api';
 import { isDemoMode } from '@/utils/connectionConfig';
 import { appRoute, chatRoute } from '@/utils/routes';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
+import { formatUnknownError } from '@/utils/errors';
 import { useTauriServerStatus } from '@/hooks/useTauriServerStatus';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
@@ -156,7 +157,7 @@ export const WelcomeView = () => {
     try {
       await invokeTauri('start_server');
     } catch (error) {
-      const msg = String(error);
+      const msg = formatUnknownError(error, 'Failed to start the server');
       if (!msg.includes('already running')) {
         toast.error('Failed to start the server. Please restart the app.');
         setIsRestartingServer(false);

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -1219,4 +1219,139 @@ describe('SetupWizard', () => {
     expect(mockInvokeTauri).not.toHaveBeenCalledWith('stop_server');
     expect(mockInvokeTauri).not.toHaveBeenCalledWith('start_server');
   });
+
+  it('surfaces nested API error objects instead of [object Object]', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5700,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'openrouter/openai/gpt-4.1',
+              provider: 'openrouter',
+              model: 'openai/gpt-4.1',
+            },
+          ],
+          recommended: ['openrouter/openai/gpt-4.1'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({ error: { message: 'Cannot retrieve provider settings' } }),
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/provider/i), { target: { value: 'openrouter' } });
+    fireEvent.change(screen.getByLabelText(/api key/i), { target: { value: 'sk-or-test-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /save and restart server/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot retrieve provider settings')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
+  it('surfaces Tauri invoke object errors instead of [object Object]', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5700,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'openrouter/openai/gpt-4.1',
+              provider: 'openrouter',
+              model: 'openai/gpt-4.1',
+            },
+          ],
+          recommended: ['openrouter/openai/gpt-4.1'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok', env_var: 'OPENROUTER_API_KEY' }),
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+    mockInvokeTauri.mockImplementation(async (cmd: string) => {
+      if (cmd === 'start_server') {
+        throw { message: 'Sidecar error: Failed to execute script' };
+      }
+    });
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/provider/i), { target: { value: 'openrouter' } });
+    fireEvent.change(screen.getByLabelText(/api key/i), { target: { value: 'sk-or-test-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /save and restart server/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sidecar error: Failed to execute script')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
 });

--- a/webui/src/components/settings/ServerApiKeySettings.tsx
+++ b/webui/src/components/settings/ServerApiKeySettings.tsx
@@ -10,6 +10,7 @@ import {
   API_KEY_PROVIDER_OPTIONS,
   type ApiKeyProvider,
 } from '@/utils/apiKeyProviders';
+import { formatUnknownError, messageFromApiErrorBody } from '@/utils/errors';
 import { toast } from 'sonner';
 
 type SaveApiKeyResponse = {
@@ -83,16 +84,14 @@ export function ServerApiKeySettings() {
         }),
       });
 
-      let data: SaveApiKeyResponse | { error?: string } | null = null;
+      let data: SaveApiKeyResponse | unknown = null;
       try {
-        data = (await response.json()) as SaveApiKeyResponse | { error?: string };
+        data = await response.json();
       } catch {
         data = null;
       }
       if (!response.ok) {
-        throw new Error(
-          data && 'error' in data && data.error ? data.error : 'Failed to save API key'
-        );
+        throw new Error(messageFromApiErrorBody(data, 'Failed to save API key'));
       }
 
       const result = data as SaveApiKeyResponse | null;
@@ -104,7 +103,7 @@ export function ServerApiKeySettings() {
           : 'API key saved. Restart the server to apply it.'
       );
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to save API key');
+      toast.error(formatUnknownError(error, 'Failed to save API key'));
     } finally {
       setIsSaving(false);
     }

--- a/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
+++ b/webui/src/components/settings/__tests__/ServerApiKeySettings.test.tsx
@@ -145,4 +145,23 @@ describe('ServerApiKeySettings', () => {
       screen.getByText('Configured via config.local.toml (ANTHROPIC_API_KEY)')
     ).toBeInTheDocument();
   });
+
+  it('toasts nested API error objects instead of [object Object]', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { message: 'Cannot retrieve provider settings' } }),
+    });
+
+    render(<ServerApiKeySettings />);
+
+    fireEvent.change(screen.getByLabelText(/api key/i), {
+      target: { value: 'sk-or-test-key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save api key/i }));
+
+    await waitFor(() => {
+      expect(mockError).toHaveBeenCalledWith('Cannot retrieve provider settings');
+    });
+    expect(mockError).not.toHaveBeenCalledWith('[object Object]');
+  });
 });

--- a/webui/src/hooks/useModels.ts
+++ b/webui/src/hooks/useModels.ts
@@ -3,6 +3,7 @@ import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { buildModelsFetchError } from '@/utils/modelsError';
 import { isDemoMode } from '@/utils/connectionConfig';
+import { formatUnknownError } from '@/utils/errors';
 
 export interface ModelInfo {
   id: string;
@@ -80,7 +81,7 @@ export function useModels() {
         setFavoritesState(data.favorites || []);
       } catch (err) {
         console.error('Failed to fetch models:', err);
-        setError(err instanceof Error ? err.message : 'Failed to fetch models');
+        setError(formatUnknownError(err, 'Failed to fetch models'));
         setModels([]);
         setDefaultModel(null);
         setRecommendedModels([]);

--- a/webui/src/hooks/useProviderHealth.ts
+++ b/webui/src/hooks/useProviderHealth.ts
@@ -4,6 +4,7 @@ import { useApi } from '@/contexts/ApiContext';
 import { providerHealth$ } from '@/stores/providerHealth';
 import type { ProviderHealthResponse } from '@/stores/providerHealth';
 import { isDemoMode } from '@/utils/connectionConfig';
+import { formatUnknownError } from '@/utils/errors';
 
 export const POLL_INTERVAL_MS = 30_000;
 
@@ -44,14 +45,20 @@ export function useProviderHealth(poll = false) {
           return;
         }
         if (!response.ok) {
-          throw new Error(`Failed to fetch provider health: ${response.statusText}`);
+          let detail = response.statusText;
+          try {
+            const body: unknown = await response.json();
+            detail = formatUnknownError(body, detail);
+          } catch {
+            // Body is not JSON; keep statusText.
+          }
+          const suffix = detail ? `: ${detail}` : ` (${response.status})`;
+          throw new Error(`Failed to fetch provider health${suffix}`);
         }
         const data = (await response.json()) as ProviderHealthResponse;
         providerHealth$.data.set(data);
       } catch (err) {
-        providerHealth$.error.set(
-          err instanceof Error ? err.message : 'Failed to fetch provider health'
-        );
+        providerHealth$.error.set(formatUnknownError(err, 'Failed to fetch provider health'));
       } finally {
         providerHealth$.isLoading.set(false);
       }

--- a/webui/src/hooks/useUserSettings.ts
+++ b/webui/src/hooks/useUserSettings.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { use$ } from '@legendapp/state/react';
 import { useApi } from '@/contexts/ApiContext';
 import { isDemoMode } from '@/utils/connectionConfig';
+import { formatUnknownError } from '@/utils/errors';
 
 export type UserSettingSource = 'env' | 'config.local.toml' | 'config.toml' | 'oauth';
 
@@ -83,7 +84,7 @@ export function useUserSettings() {
         setIsLoading(false);
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
-        setError(err instanceof Error ? err.message : 'Failed to fetch user settings');
+        setError(formatUnknownError(err, 'Failed to fetch user settings'));
         setSettings(null);
         setIsLoading(false);
       }

--- a/webui/src/utils/__tests__/errors.test.ts
+++ b/webui/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,41 @@
+import { formatUnknownError, messageFromApiErrorBody } from '../errors';
+
+describe('formatUnknownError', () => {
+  it('prefers Error.message', () => {
+    expect(formatUnknownError(new Error('permission denied'), 'fallback')).toBe('permission denied');
+  });
+
+  it('accepts string errors', () => {
+    expect(formatUnknownError('sidecar exited', 'fallback')).toBe('sidecar exited');
+  });
+
+  it('extracts Tauri invoke object message instead of [object Object]', () => {
+    expect(
+      formatUnknownError({ message: 'Sidecar error: Failed to execute script' }, 'fallback')
+    ).toBe('Sidecar error: Failed to execute script');
+  });
+
+  it('extracts nested API error objects', () => {
+    expect(
+      formatUnknownError({ error: { message: 'Cannot retrieve provider settings' } }, 'fallback')
+    ).toBe('Cannot retrieve provider settings');
+  });
+
+  it('uses fallback for empty or unknown values', () => {
+    expect(formatUnknownError(undefined, 'fallback')).toBe('fallback');
+    expect(formatUnknownError(new Error(''), 'fallback')).toBe('fallback');
+    expect(formatUnknownError({}, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('messageFromApiErrorBody', () => {
+  it('reads a string error field', () => {
+    expect(messageFromApiErrorBody({ error: 'invalid key' }, 'fallback')).toBe('invalid key');
+  });
+
+  it('reads a nested error.message object used by some providers', () => {
+    expect(
+      messageFromApiErrorBody({ error: { message: 'Cannot retrieve provider settings' } }, 'fallback')
+    ).toBe('Cannot retrieve provider settings');
+  });
+});

--- a/webui/src/utils/__tests__/modelsError.test.ts
+++ b/webui/src/utils/__tests__/modelsError.test.ts
@@ -38,6 +38,17 @@ describe('buildModelsFetchError', () => {
     expect(err.message).toBe('Failed to fetch models: 401 Missing authentication credentials');
   });
 
+  it('surfaces nested provider error objects instead of [object Object]', async () => {
+    const err = await buildModelsFetchError(
+      mockResponse({
+        status: 502,
+        statusText: '',
+        jsonBody: { error: { message: 'Cannot retrieve provider settings' } },
+      })
+    );
+    expect(err.message).toBe('Failed to fetch models: 502 Cannot retrieve provider settings');
+  });
+
   it('falls back to statusText when the body has no error field', async () => {
     const err = await buildModelsFetchError(
       mockResponse({ status: 500, statusText: 'Internal Server Error', jsonBody: {} })

--- a/webui/src/utils/errors.ts
+++ b/webui/src/utils/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Turn unknown thrown values into a user-visible string.
+ *
+ * Tauri `invoke` rejects with a plain `{ message }` object, and some API
+ * bodies use `{ error: { message } }`. `String(err)` / `new Error(object)`
+ * both become "[object Object]" — the desktop API-key flow was showing that
+ * instead of the real sidecar/provider failure.
+ */
+function readMessage(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim() && value !== '[object Object]') {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.message === 'string' && obj.message.trim() && obj.message !== '[object Object]') {
+      return obj.message;
+    }
+    if ('error' in obj) {
+      const nested = readMessage(obj.error);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
+export function formatUnknownError(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (message && message !== '[object Object]') {
+      return message;
+    }
+  }
+  return readMessage(error) ?? fallback;
+}
+
+export function messageFromApiErrorBody(data: unknown, fallback: string): string {
+  return readMessage(data) ?? fallback;
+}

--- a/webui/src/utils/modelsError.ts
+++ b/webui/src/utils/modelsError.ts
@@ -9,6 +9,7 @@
  * `{"error":"Missing authentication credentials"}`).
  */
 import { isDemoMode } from '@/utils/connectionConfig';
+import { messageFromApiErrorBody } from '@/utils/errors';
 
 export async function buildModelsFetchError(response: Response): Promise<Error> {
   if (isDemoMode()) {
@@ -16,9 +17,10 @@ export async function buildModelsFetchError(response: Response): Promise<Error> 
   }
   let detail = response.statusText;
   try {
-    const body = await response.clone().json();
-    if (body && typeof body.error === 'string' && body.error) {
-      detail = body.error;
+    const body: unknown = await response.clone().json();
+    const fromBody = messageFromApiErrorBody(body, '');
+    if (fromBody) {
+      detail = fromBody;
     }
   } catch {
     // Body is not JSON or already consumed; fall back to statusText.


### PR DESCRIPTION
## Summary
- The bundled Windows `gptme-server` sidecar crashed during `create_app` because version lookup ran `git` with a PyInstaller onefile `__file__` path as cwd (`NotADirectoryError: [WinError 267]`). The desktop UI then had no live API, so OpenRouter key save and provider settings could not work.
- Setup/settings previously turned Tauri invoke objects and nested `{ error: { message } }` API bodies into `[object Object]`. Those paths now show the real sidecar/provider error.
- Tauri sidecar builds no longer silently reuse a stale binary when gptme Python sources are newer.

## Test plan
- [ ] `pytest tests/test_misc_subprocess_timeouts.py::TestVersionTimeouts`
- [ ] `cd webui && npx jest --testPathPattern="errors.test|modelsError.test|SetupWizard.test|ServerApiKeySettings.test|WelcomeView.test"`
- [ ] Delete `tauri/bins/gptme-server-*` (or let the stale-source check rebuild), then `make tauri-build-sidecar` and rebuild the desktop app
- [ ] On Windows, open gptme-tauri, paste an OpenRouter `sk-or-...` key, confirm it saves (or shows a real error), and provider settings/health load
