### PR TITLE
fix(shell): allowlist permitted flags per binary instead of denying four find flags (GHSA-mfh4-cxj2-jc9p)

### DIFF
--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -407,6 +407,48 @@ def _lex(cmd: str) -> list[str] | None:
         return None
 
 
+def _split_lines(cmd: str) -> list[str]:
+    """Split a command block on newlines that actually separate commands.
+
+    ``shlex`` treats newlines as ordinary whitespace, so a multi-command block
+    would otherwise collapse into a single segment and later commands would be
+    validated against the *first* binary's flag table. That is exploitable
+    wherever two binaries give the same flag different meanings — ``find -o``
+    is a harmless OR operator, ``sort -o`` overwrites a file.
+
+    Newlines inside quotes are data, and a backslash-newline is a line
+    continuation, so neither splits.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    in_single = in_double = False
+    i = 0
+    while i < len(cmd):
+        char = cmd[i]
+        if char == "\\" and not in_single and i + 1 < len(cmd):
+            if cmd[i + 1] == "\n":
+                # Line continuation — drop both, the logical line continues.
+                i += 2
+                continue
+            buf.append(char)
+            buf.append(cmd[i + 1])
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+
+        if char == "\n" and not in_single and not in_double:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(char)
+        i += 1
+    parts.append("".join(buf))
+    return [part for part in parts if part.strip()]
+
+
 def _split_segments(tokens: list[str]) -> list[list[str]]:
     """Split a flat token list into pipeline/list segments."""
     segments: list[list[str]] = [[]]
@@ -538,7 +580,10 @@ def flags_permitted(cmd: str) -> bool:
     binary's permitted set, or when the command cannot be parsed. A False
     result does not forbid the command — it makes it require confirmation.
     """
-    tokens = _lex(cmd)
-    if tokens is None:
-        return False
-    return all(_check_segment(segment) for segment in _split_segments(tokens))
+    for line in _split_lines(cmd):
+        tokens = _lex(line)
+        if tokens is None:
+            return False
+        if not all(_check_segment(segment) for segment in _split_segments(tokens)):
+            return False
+    return True

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -569,6 +569,19 @@ def _check_segment(segment: list[str]) -> bool:
         if not permitted:
             return False
         if consumes_next:
+            if index >= len(segment):
+                return False
+            value = segment[index]
+            # Values may legitimately start with a dash (grep patterns and
+            # negative find durations), but a *forbidden long option* here
+            # could otherwise be swallowed by a value-taking flag (for
+            # example ``rg -T --pre``). Reject all unknown long options; short
+            # values remain supported because arbitrary patterns such as
+            # ``grep -e -dashy-pattern`` are common and cannot name long flags.
+            if value.startswith("--"):
+                name = value[2:].partition("=")[0]
+                if name not in spec.long and name not in spec.long_value:
+                    return False
             index += 1
 
     if spec.max_operands is not None:

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -596,7 +596,7 @@ def _check_segment(segment: list[str]) -> bool:
             # example ``rg -T --pre``). Reject all unknown long options; short
             # values remain supported because arbitrary patterns such as
             # ``grep -e -dashy-pattern`` are common and cannot name long flags.
-            if value.startswith("--"):
+            if value.startswith("--") and value != "--":
                 name = value[2:].partition("=")[0]
                 if name not in spec.long and name not in spec.long_value:
                     return False

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -437,7 +437,6 @@ def _split_lines(cmd: str) -> list[str]:
             i += 1
             continue
         if in_comment:
-            buf.append(char)
             i += 1
             continue
         if char == "\\" and not in_single and i + 1 < len(cmd):
@@ -457,9 +456,13 @@ def _split_lines(cmd: str) -> list[str]:
             char == "#"
             and not in_single
             and not in_double
-            and (not buf or buf[-1].isspace())
+            and (not buf or buf[-1].isspace() or buf[-1] in ";&|")
         ):
+            # Comments are inert data. Drop their contents so tokens that look
+            # like flags cannot force an unnecessary confirmation prompt.
             in_comment = True
+            i += 1
+            continue
 
         if char == "\n" and not in_single and not in_double:
             parts.append("".join(buf))

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -380,9 +380,13 @@ PERMITTED_FLAGS: dict[str, FlagSpec] = {
     ),
 }
 
-# Shell operator tokens produced by the punctuation-aware lexer. Each starts a
-# new pipeline segment (and therefore a new binary whose flags we must check).
-_SEGMENT_SEPARATORS = frozenset({"|", "||", "&&", "&", ";", ";;", "\n"})
+# Characters that make up bash's list/pipeline operators. A token composed
+# entirely of these starts a new segment — and therefore a new binary whose
+# flag table applies. Matching on the character set rather than an enumerated
+# list covers `|`, `||`, `&`, `&&`, `|&`, `;`, `;;`, `;&` and `;;&` without
+# relying on us having thought of every operator bash supports. `(` and `)`
+# are deliberately excluded: escaped parens are how find groups expressions.
+_OPERATOR_CHARS = frozenset("|&;")
 
 # Redirection operators: the token that follows is a filename, not a flag.
 _REDIRECTIONS = frozenset({"<", ">", ">>", "<<", "<<-", "<<<", ">|", "<>", "&>", ">&"})
@@ -449,11 +453,16 @@ def _split_lines(cmd: str) -> list[str]:
     return [part for part in parts if part.strip()]
 
 
+def _is_operator(token: str) -> bool:
+    """Whether a token is a bash list/pipeline operator."""
+    return bool(token) and all(char in _OPERATOR_CHARS for char in token)
+
+
 def _split_segments(tokens: list[str]) -> list[list[str]]:
     """Split a flat token list into pipeline/list segments."""
     segments: list[list[str]] = [[]]
     for token in tokens:
-        if token in _SEGMENT_SEPARATORS:
+        if _is_operator(token):
             segments.append([])
         else:
             segments[-1].append(token)

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -421,14 +421,25 @@ def _split_lines(cmd: str) -> list[str]:
     is a harmless OR operator, ``sort -o`` overwrites a file.
 
     Newlines inside quotes are data, and a backslash-newline is a line
-    continuation, so neither splits.
+    continuation, so neither splits. Shell comments run to the newline, so
+    quotes and continuations inside them cannot affect the following line.
     """
     parts: list[str] = []
     buf: list[str] = []
-    in_single = in_double = False
+    in_single = in_double = in_comment = False
     i = 0
     while i < len(cmd):
         char = cmd[i]
+        if char == "\n" and in_comment:
+            parts.append("".join(buf))
+            buf = []
+            in_comment = False
+            i += 1
+            continue
+        if in_comment:
+            buf.append(char)
+            i += 1
+            continue
         if char == "\\" and not in_single and i + 1 < len(cmd):
             if cmd[i + 1] == "\n":
                 # Line continuation — drop both, the logical line continues.
@@ -442,6 +453,13 @@ def _split_lines(cmd: str) -> list[str]:
             in_single = not in_single
         elif char == '"' and not in_single:
             in_double = not in_double
+        elif (
+            char == "#"
+            and not in_single
+            and not in_double
+            and (not buf or buf[-1].isspace())
+        ):
+            in_comment = True
 
         if char == "\n" and not in_single and not in_double:
             parts.append("".join(buf))

--- a/gptme/tools/shell_flags.py
+++ b/gptme/tools/shell_flags.py
@@ -1,0 +1,544 @@
+"""Per-binary permitted-flag tables for shell command auto-approval.
+
+Security model: **permitted flags, not forbidden flags.**
+
+The previous model denied a hand-picked set of four ``find``-specific flags
+(``-exec``, ``-execdir``, ``-delete``, ``-ok``). That denylist was complete
+only until someone found flag number five — and several exist, on binaries
+other than ``find``:
+
+- ``rg --pre <program>``            → ripgrep execs ``<program>`` per file
+- ``rg --hostname-bin <program>``   → ripgrep execs ``<program>``
+- ``rg --search-zip``               → ripgrep spawns decompressors
+- ``sort --compress-program=<prog>``→ GNU sort execs the compressor
+- ``sort -o <file>``                → arbitrary file overwrite
+- ``find -fprintf/-fprint/-fls``    → arbitrary file write
+- ``tree -o <file>``                → arbitrary file write
+
+Rather than keep extending the denylist, each allowlisted binary declares the
+flags it is *permitted* to be auto-approved with. Anything not in the set —
+including flags added by a future release of the binary — makes
+``is_allowlisted()`` return ``False``, which is **not a block**: the command
+simply falls through to the normal confirmation prompt.
+
+The permitted sets are deliberately generous: they were derived from the
+``--help`` output of GNU coreutils 9.4, GNU findutils 4.9, GNU grep 3.11,
+ripgrep 14.1 and tree 2.1, minus the exec/write-capable flags listed above.
+Narrow sets would mean constant prompting, which is how safety features get
+turned off.
+"""
+
+import shlex
+from dataclasses import dataclass, field
+
+__all__ = ["FlagSpec", "PERMITTED_FLAGS", "flags_permitted"]
+
+
+@dataclass(frozen=True)
+class FlagSpec:
+    """Permitted command-line flags for a single binary.
+
+    Names are stored *without* leading dashes.
+
+    Attributes:
+        short: Bundleable single-letter flags taking no value (``ls -la``).
+        short_value: Single-letter flags requiring a value, either attached
+            (``cut -d,``) or as the next token (``cut -d ,``).
+        long: ``--long`` flags taking no value. Flags with an *optional*
+            value (``ls --color[=WHEN]``) belong here: GNU getopt only
+            accepts optional values in the ``--flag=value`` form, never as a
+            separate token, so no token must be consumed.
+        long_value: ``--long`` flags requiring a value.
+        word: Single-dash multi-letter flags taking no value. Used by
+            ``find``, whose expression primaries (``-type``, ``-print``) are
+            not bundleable short flags.
+        word_value: Single-dash multi-letter flags requiring a value.
+        bundling: Whether single-letter flags may be bundled (``-la``).
+            ``find`` sets this to False.
+        numeric: Whether a bare numeric token like ``-5`` is a valid flag
+            (``head -5``, ``tail -100``, ``grep -3``).
+        max_operands: Maximum number of non-flag operands. Set for binaries
+            where a trailing operand is an *output* file — ``uniq INPUT
+            OUTPUT`` silently truncates OUTPUT.
+        any_flag: Accept any flag-shaped token. Only for binaries that cannot
+            spawn a process or write a file no matter what they are passed,
+            and whose arguments are ordinary text (``echo``).
+    """
+
+    short: str = ""
+    short_value: str = ""
+    long: frozenset[str] = field(default_factory=frozenset)
+    long_value: frozenset[str] = field(default_factory=frozenset)
+    word: frozenset[str] = field(default_factory=frozenset)
+    word_value: frozenset[str] = field(default_factory=frozenset)
+    bundling: bool = True
+    numeric: bool = False
+    max_operands: int | None = None
+    any_flag: bool = False
+
+
+def _fs(names: str) -> frozenset[str]:
+    """Build a frozenset of flag names from a whitespace-separated string."""
+    return frozenset(names.split())
+
+
+# ── find ─────────────────────────────────────────────────────────────
+# find's expression primaries are single-dash words, not bundleable letters,
+# so `bundling=False` and everything lives in word/word_value.
+#
+# Deliberately EXCLUDED (these are the vulnerability):
+#   -exec -execdir -ok -okdir   → execute arbitrary commands
+#   -delete                     → deletes files
+#   -fprintf -fprint -fprint0 -fls → arbitrary file write (bypasses the >
+#                                    redirection check entirely)
+_FIND_WORD = _fs(
+    """
+    H L P O0 O1 O2 O3
+    daystart follow nowarn warn
+    depth d mount noleaf xdev ignore_readdir_race noignore_readdir_race
+    empty false true nouser nogroup readable writable executable
+    print print0 ls prune quit
+    a and o or not help version
+    """
+)
+# -newerXY compares timestamp X of a file against reference Y (find(1)).
+_FIND_NEWER_XY = frozenset(
+    f"newer{x}{y}" for x in "aBcm" for y in "aBcmt" if not (x == y == "t")
+)
+_FIND_WORD_VALUE = (
+    _fs(
+        """
+    D regextype files0-from maxdepth mindepth
+    amin anewer atime cmin cnewer context ctime fstype gid group
+    ilname iname inum ipath iwholename iregex links lname mmin mtime name newer
+    path perm regex samefile size type uid used user wholename xtype
+    printf
+    """
+    )
+    | _FIND_NEWER_XY
+)
+
+# ── ripgrep ──────────────────────────────────────────────────────────
+# Deliberately EXCLUDED: --pre, --pre-glob (exec a preprocessor per file),
+# --hostname-bin (exec), -z/--search-zip (spawns decompressors),
+# --generate (writes completion/man output).
+_RG_LONG = _fs(
+    """
+    auto-hybrid-regex binary block-buffered byte-offset case-sensitive column
+    count count-matches crlf debug files files-with-matches files-without-match
+    fixed-strings follow glob-case-insensitive heading help hidden ignore-case
+    ignore-file-case-insensitive include-zero invert-match json line-buffered
+    line-number line-regexp max-columns-preview mmap multiline multiline-dotall
+    no-binary no-block-buffered no-column no-config no-crlf no-filename
+    no-follow no-heading no-hidden no-ignore no-ignore-dot no-ignore-exclude
+    no-ignore-files no-ignore-global no-ignore-messages no-ignore-parent
+    no-ignore-vcs no-line-buffered no-line-number no-messages no-mmap
+    no-multiline no-pcre2 no-pcre2-unicode no-require-git no-search-zip
+    no-unicode null null-data one-file-system only-matching passthru pcre2
+    pcre2-version pretty quiet smart-case sort-files stats stop-on-nonmatch
+    text trace trim type-list unrestricted version vimgrep with-filename
+    word-regexp
+    """
+)
+_RG_LONG_VALUE = _fs(
+    """
+    after-context before-context color colors context context-separator
+    dfa-size-limit encoding engine field-context-separator field-match-separator
+    file glob iglob ignore-file hyperlink-format max-columns max-count max-depth
+    max-filesize path-separator regex-size-limit regexp replace sort sortr
+    threads type type-add type-clear type-not
+    """
+)
+
+# ── the silver searcher (ag) ─────────────────────────────────────────
+# Deliberately EXCLUDED: --pager (execs the pager program),
+# -z/--search-zip (decompression), --print-long-lines is fine but
+# anything spawning a process is not.
+_AG_LONG = _fs(
+    """
+    ackmate affinity all-text all-types break color color-line-number
+    color-match color-path column count filename filename-only files-with-matches
+    files-without-matches follow group heading help hidden ignore-case invert-match
+    literal no-numbers no-recurse nobreak nocolor nofilename nofollow nogroup
+    noheading nonumbers nopager norecurse null numbers one-device only-matching
+    parallel passthrough passthru print-all-files print-long-lines print0
+    recurse search-binary search-files silent skip-vcs-ignores smart-case stats
+    stats-only unrestricted version vimgrep word-regexp case-sensitive
+    """
+)
+_AG_LONG_VALUE = _fs(
+    """
+    after before context depth file-search-regex ignore ignore-dir max-count
+    path-to-ignore workers width
+    """
+)
+
+# ── coreutils & friends ──────────────────────────────────────────────
+
+PERMITTED_FLAGS: dict[str, FlagSpec] = {
+    "ls": FlagSpec(
+        short="1ABCDFGHLNQRSUXZabcdfghiklmnopqrstuvx",
+        short_value="ITw",
+        long=_fs(
+            """
+            all almost-all author classify color context dereference
+            dereference-command-line dereference-command-line-symlink-to-dir
+            directory dired escape file-type full-time group-directories-first
+            help hide-control-chars human-readable hyperlink ignore-backups
+            inode kibibytes literal no-group numeric-uid-gid quote-name
+            recursive reverse show-control-chars si size version zero
+            """
+        ),
+        long_value=_fs(
+            """
+            block-size format hide ignore indicator-style quoting-style sort
+            tabsize time time-style width
+            """
+        ),
+    ),
+    "stat": FlagSpec(
+        short="Lft",
+        short_value="c",
+        long=_fs("dereference file-system terse help version"),
+        long_value=_fs("cached format printf"),
+    ),
+    "cd": FlagSpec(short="LP@e"),
+    "cat": FlagSpec(
+        short="AbeEnstTuv",
+        long=_fs(
+            """
+            help number number-nonblank show-all show-ends show-nonprinting
+            show-tabs squeeze-blank version
+            """
+        ),
+    ),
+    "pwd": FlagSpec(short="LP", long=_fs("logical physical help version")),
+    # echo has no flag that can spawn a process or write a file, and its
+    # arguments are literal text — `echo "---"` and `echo "--- section ---"`
+    # are extremely common separators that must not trigger a prompt.
+    # Redirection (`echo x > f`) is still caught by _has_file_redirection().
+    "echo": FlagSpec(short="neE", long=_fs("help version"), any_flag=True),
+    "head": FlagSpec(
+        short="qvz",
+        short_value="cn",
+        long=_fs("help quiet silent verbose version zero-terminated"),
+        long_value=_fs("bytes lines"),
+        numeric=True,  # head -5
+    ),
+    "find": FlagSpec(
+        word=_FIND_WORD,
+        word_value=_FIND_WORD_VALUE,
+        bundling=False,
+        long=_fs("help version"),
+    ),
+    "rg": FlagSpec(
+        short=".0FHILNPSUVabchilnopqsuvwx",
+        short_value="ABCEMTdefgjmrt",
+        long=_RG_LONG,
+        long_value=_RG_LONG_VALUE,
+    ),
+    "ag": FlagSpec(
+        short="acDfHiLlnoQrsStuVvw0",
+        short_value="ABCGgmp",
+        long=_AG_LONG,
+        long_value=_AG_LONG_VALUE,
+    ),
+    "tail": FlagSpec(
+        short="Ffqvz",
+        short_value="cns",
+        long=_fs("follow help quiet retry silent verbose version zero-terminated"),
+        long_value=_fs("bytes lines max-unchanged-stats pid sleep-interval"),
+        numeric=True,  # tail -100
+    ),
+    "grep": FlagSpec(
+        short="EFGHILPRTUVZabchilnoqrsvwxyz",
+        short_value="ABCDdefm",
+        long=_fs(
+            """
+            basic-regexp binary byte-offset color colour count
+            dereference-recursive extended-regexp files-with-matches
+            files-without-match fixed-strings help ignore-case initial-tab
+            invert-match line-buffered line-number line-regexp no-filename
+            no-group-separator no-ignore-case no-messages null null-data
+            only-matching perl-regexp quiet recursive silent text version
+            with-filename word-regexp
+            """
+        ),
+        long_value=_fs(
+            """
+            after-context before-context binary-files context devices
+            directories exclude exclude-dir exclude-from file group-separator
+            include label max-count regexp
+            """
+        ),
+        numeric=True,  # grep -3 (same as --context=3)
+    ),
+    "wc": FlagSpec(
+        short="Lclmw",
+        long=_fs("bytes chars help lines max-line-length version words"),
+        long_value=_fs("files0-from total"),
+    ),
+    # EXCLUDED for sort: -o/--output (arbitrary file overwrite),
+    # --compress-program (execs the compressor), -T/--temporary-directory,
+    # --random-source, --files0-from.
+    "sort": FlagSpec(
+        short="CMRVbcdfghimnrsuz",
+        short_value="Skt",
+        long=_fs(
+            """
+            check debug dictionary-order general-numeric-sort help
+            human-numeric-sort ignore-case ignore-leading-blanks
+            ignore-nonprinting merge month-sort numeric-sort random-sort
+            reverse stable unique version version-sort zero-terminated
+            """
+        ),
+        long_value=_fs("batch-size buffer-size field-separator key parallel sort"),
+    ),
+    # `uniq INPUT OUTPUT` writes to OUTPUT — cap operands at one.
+    "uniq": FlagSpec(
+        short="Dcdiuz",
+        short_value="fsw",
+        long=_fs(
+            """
+            all-repeated count group help ignore-case repeated unique version
+            zero-terminated
+            """
+        ),
+        long_value=_fs("check-chars skip-chars skip-fields"),
+        max_operands=1,
+    ),
+    "cut": FlagSpec(
+        short="nsz",
+        short_value="bcdf",
+        long=_fs("complement help only-delimited version zero-terminated"),
+        long_value=_fs("bytes characters delimiter fields output-delimiter"),
+    ),
+    # EXCLUDED for file: -C/--compile (writes a compiled .mgc magic file),
+    # -S/--no-sandbox (disables libmagic's seccomp sandbox).
+    "file": FlagSpec(
+        short="0bcdhiklnNprsvzZL",
+        short_value="eFfmP",
+        long=_fs(
+            """
+            apple brief checking-printout debug dereference extension help
+            keep-going list mime mime-encoding mime-type no-buffer
+            no-dereference no-pad preserve-date print0 raw special-files
+            uncompress uncompress-noreport version
+            """
+        ),
+        long_value=_fs(
+            "exclude exclude-quiet files-from magic-file parameter separator"
+        ),
+    ),
+    "which": FlagSpec(
+        short="ainsv",
+        long=_fs(
+            """
+            all help read-alias read-functions show-dot show-tilde skip-alias
+            skip-dot skip-functions skip-tilde tty-only version
+            """
+        ),
+    ),
+    "type": FlagSpec(short="afpPt"),
+    # EXCLUDED for tree: -o (writes output to an arbitrary file).
+    "tree": FlagSpec(
+        short="ACDFJNQRSUXacdfghilnpqrstuvx",
+        short_value="HILPT",
+        long=_fs(
+            """
+            device dirsfirst du fflinks filesfirst fromfile fromtabfile
+            gitignore help hintro houtro ignore-case info inodes matchdirs
+            metafirst nolinks noreport prune si version
+            """
+        ),
+        long_value=_fs("charset filelimit gitfile infofile sort timefmt"),
+    ),
+    "du": FlagSpec(
+        short="0DHLPSabchklmsx",
+        short_value="BXdt",
+        long=_fs(
+            """
+            all apparent-size bytes count-links dereference dereference-args
+            help human-readable inodes no-dereference null one-file-system
+            separate-dirs si summarize time total version
+            """
+        ),
+        long_value=_fs(
+            "block-size exclude exclude-from files0-from max-depth threshold time-style"
+        ),
+    ),
+    "df": FlagSpec(
+        short="HPTahiklv",
+        short_value="Btx",
+        long=_fs(
+            """
+            all help human-readable inodes local no-sync output portability
+            print-type si sync total version
+            """
+        ),
+        long_value=_fs("block-size exclude-type type"),
+    ),
+}
+
+# Shell operator tokens produced by the punctuation-aware lexer. Each starts a
+# new pipeline segment (and therefore a new binary whose flags we must check).
+_SEGMENT_SEPARATORS = frozenset({"|", "||", "&&", "&", ";", ";;", "\n"})
+
+# Redirection operators: the token that follows is a filename, not a flag.
+_REDIRECTIONS = frozenset({"<", ">", ">>", "<<", "<<-", "<<<", ">|", "<>", "&>", ">&"})
+
+_GLOB_METACHARS = "*?["
+
+
+def _lex(cmd: str) -> list[str] | None:
+    """Tokenise a command, keeping shell operators as separate tokens.
+
+    Returns None when the command cannot be parsed (e.g. unbalanced quotes),
+    in which case the caller should fail closed and require confirmation.
+    """
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    # bash only starts a comment at the beginning of a word; shlex would
+    # otherwise truncate tokens like `dir#1` and hide arguments from us.
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _split_segments(tokens: list[str]) -> list[list[str]]:
+    """Split a flat token list into pipeline/list segments."""
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token in _SEGMENT_SEPARATORS:
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    return [segment for segment in segments if segment]
+
+
+def _check_short_bundle(body: str, spec: FlagSpec) -> tuple[bool, bool]:
+    """Validate a bundle of single-letter flags (the part after the ``-``).
+
+    Returns ``(permitted, consumes_next_token)``.
+    """
+    i = 0
+    while i < len(body):
+        char = body[i]
+        if char in spec.short:
+            i += 1
+            continue
+        if char in spec.short_value:
+            # Value is either attached (``-d,``) or the next token (``-d ,``).
+            attached = body[i + 1 :]
+            return True, not attached
+        return False, False
+    return True, False
+
+
+def _check_flag_token(token: str, spec: FlagSpec) -> tuple[bool, bool]:
+    """Validate a single ``-``-prefixed token.
+
+    Returns ``(permitted, consumes_next_token)``.
+    """
+    if spec.any_flag:
+        return True, False
+
+    # A run of dashes (``---``, ``----``) is never a flag — no binary defines
+    # one — but it is a very common text separator.
+    if set(token) == {"-"}:
+        return True, False
+
+    # ``--flag`` / ``--flag=value``
+    if token.startswith("--"):
+        name, sep, _value = token[2:].partition("=")
+        if name in spec.long:
+            # Optional-value flags (``--color=auto``) are permitted either way.
+            return True, False
+        if name in spec.long_value:
+            return True, not sep
+        return False, False
+
+    body = token[1:]
+
+    # Legacy numeric shorthand: ``head -5``, ``tail -100``, ``grep -3``.
+    if spec.numeric and body.isdigit():
+        return True, False
+
+    # Single-dash words (find primaries). Checked before letter bundling so
+    # that ``-name`` is not decomposed into ``-n -a -m -e``.
+    if body in spec.word:
+        return True, False
+    if body in spec.word_value:
+        return True, True
+
+    if spec.bundling:
+        return _check_short_bundle(body, spec)
+
+    # No bundling (find): a single-letter option is still valid if declared.
+    if len(body) == 1:
+        if body in spec.short:
+            return True, False
+        if body in spec.short_value:
+            return True, True
+    return False, False
+
+
+def _check_segment(segment: list[str]) -> bool:
+    """Validate every flag in one pipeline segment against its binary."""
+    binary = segment[0]
+    spec = PERMITTED_FLAGS.get(binary)
+    if spec is None:
+        # Unknown binary: fail closed if it is given anything flag-shaped.
+        # (The caller has already verified the binary is in allowlist_commands.)
+        return not any(token.startswith("-") and token != "-" for token in segment[1:])
+
+    operands: list[str] = []
+    end_of_options = False
+    index = 1
+    while index < len(segment):
+        token = segment[index]
+        index += 1
+
+        if token in _REDIRECTIONS:
+            # Skip the redirection target — it is a filename, not an operand.
+            index += 1
+            continue
+
+        if end_of_options or token == "-" or not token.startswith("-"):
+            operands.append(token)
+            continue
+
+        if token == "--":
+            end_of_options = True
+            continue
+
+        permitted, consumes_next = _check_flag_token(token, spec)
+        if not permitted:
+            return False
+        if consumes_next:
+            index += 1
+
+    if spec.max_operands is not None:
+        if len(operands) > spec.max_operands:
+            return False
+        # Globs expand after validation, so one glob operand can become
+        # several — and for ``uniq`` the last one would be overwritten.
+        if any(char in operand for operand in operands for char in _GLOB_METACHARS):
+            return False
+
+    return True
+
+
+def flags_permitted(cmd: str) -> bool:
+    """Check that every flag in ``cmd`` is permitted for its binary.
+
+    Returns False when any token that looks like a flag is not in its
+    binary's permitted set, or when the command cannot be parsed. A False
+    result does not forbid the command — it makes it require confirmation.
+    """
+    tokens = _lex(cmd)
+    if tokens is None:
+        return False
+    return all(_check_segment(segment) for segment in _split_segments(tokens))

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -181,6 +181,20 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
     heredoc_pattern = re.compile(r"<<-?\s*(?:\"([^\"\n]+)\"|'([^'\n]+)'|([^\s;&|<>]+))")
 
     for match in heredoc_pattern.finditer(cmd):
+        # A comment begins at an unquoted ``#`` at the start of a shell word.
+        # Markers inside it are inert to the shell and must not hide later lines
+        # from command validation.
+        line_start = cmd.rfind("\n", 0, match.start()) + 1
+        prefix = cmd[line_start : match.start()]
+        quoted_regions = _find_quotes(prefix)
+        if any(
+            char == "#"
+            and (i == 0 or prefix[i - 1].isspace())
+            and not _is_in_quoted_region(i, quoted_regions)
+            for i, char in enumerate(prefix)
+        ):
+            continue
+
         delimiter = next(group for group in match.groups() if group is not None)
 
         # Find where the content starts (after the first newline after the marker)

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -14,6 +14,7 @@ import tempfile
 from typing import TYPE_CHECKING
 
 from ..util.context import md_codeblock
+from .shell_flags import flags_permitted
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -372,6 +373,25 @@ def _has_command_substitution(cmd: str) -> bool:
     return False
 
 
+def _blank_heredoc_bodies(cmd: str) -> str:
+    """Replace heredoc bodies with blanks, preserving offsets.
+
+    Heredoc content is *data* fed to a command's stdin, not command
+    arguments. Leaving it in place would make a body line such as
+    ``-exec`` look like a flag to the permitted-flag checker.
+    """
+    regions = _find_heredoc_regions(cmd)
+    if not regions:
+        return cmd
+
+    chars = list(cmd)
+    for start, end in regions:
+        for i in range(start, min(end, len(chars))):
+            if chars[i] != "\n":
+                chars[i] = " "
+    return "".join(chars)
+
+
 def is_allowlisted(cmd: str) -> bool:
     """Check if a shell command is safe to auto-approve.
 
@@ -380,10 +400,15 @@ def is_allowlisted(cmd: str) -> bool:
     2. No file redirections (>, >>) - these can write malicious content
     3. No sensitive path arguments (e.g. /etc/shadow, /root/, /proc/)
     4. No executable shell command substitution
-    5. No dangerous flags within allowlisted commands (e.g., find -exec)
+    5. Every flag must be in its binary's *permitted* flag set
 
     This means commands like xargs, sh, bash, python, perl, etc. are automatically
     blocked since they're not in the allowlist, even if piped to from safe commands.
+
+    Step 5 is a permitted-flag model, not a forbidden-flag model: an
+    unrecognised flag makes this function return False, which does not forbid
+    the command — it falls through to the normal confirmation prompt. See
+    ``gptme/tools/shell_flags.py`` for the tables and the rationale.
     """
     # Check if all commands in the pipeline are allowlisted
     # This blocks non-allowlisted commands like: python, perl, xargs, sh, bash, etc.
@@ -408,21 +433,18 @@ def is_allowlisted(cmd: str) -> bool:
     if _has_command_substitution(cmd):
         return False
 
-    # Check for dangerous flags within allowlisted commands
-    # These are rare exceptions where an allowlisted command has dangerous dual-use flags
-    # Uses token-based matching (not substring) to avoid false positives like
-    # -executable being caught by -exec
-    dangerous_flags = {
-        "-exec",  # find -exec can execute arbitrary commands
-        "-execdir",  # find -execdir can execute arbitrary commands in target dir
-        "-delete",  # find -delete can delete files
-        "-ok",  # find -ok prompts but can be automated
-    }
-    try:
-        tokens = shlex.split(cmd)
-    except ValueError:
-        tokens = cmd.split()
-    return not any(token in dangerous_flags for token in tokens)
+    # GHSA-mfh4-cxj2-jc9p: every flag must be permitted for its binary.
+    #
+    # This replaces a four-entry denylist ({-exec, -execdir, -delete, -ok})
+    # that modelled `find` only. Other allowlisted binaries have their own
+    # subprocess-spawning and file-writing flags (`rg --pre`,
+    # `sort --compress-program`, `sort -o`, `find -fprintf`, `tree -o`, ...),
+    # none of which the denylist covered. A permitted-flag model fails closed
+    # on flag number five instead of waiting for someone to report it.
+    #
+    # Heredoc bodies are data, not arguments, so blank them out first —
+    # otherwise a heredoc line starting with `-` would look like a flag.
+    return flags_permitted(_blank_heredoc_bodies(cmd))
 
 
 def is_denylisted(cmd: str) -> tuple[bool, str | None, str | None]:

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -175,12 +175,13 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
     """
     heredoc_regions = []
 
-    # Pattern to match heredoc operators with optional quotes around delimiter
-    # Matches: << or <<- followed by optional whitespace and delimiter (with optional quotes)
-    heredoc_pattern = re.compile(r"<<-?\s*([\"']?)(\w+)\1")
+    # A delimiter is a shell word, not necessarily an identifier. Support
+    # punctuation commonly used to make delimiters distinctive (for example
+    # ``END-TAG``), while stopping unquoted words at shell metacharacters.
+    heredoc_pattern = re.compile(r"<<-?\s*(?:\"([^\"\n]+)\"|'([^'\n]+)'|([^\s;&|<>]+))")
 
     for match in heredoc_pattern.finditer(cmd):
-        delimiter = match.group(2)
+        delimiter = next(group for group in match.groups() if group is not None)
 
         # Find where the content starts (after the first newline after the marker)
         search_start = match.end()
@@ -195,15 +196,19 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
         while True:
             newline_idx = cmd.find("\n", pos)
             if newline_idx == -1:
-                # Check if remaining text is the delimiter
+                # Check if remaining text is the delimiter. Include the
+                # delimiter itself in the safe region: it is shell syntax, not
+                # a command following the heredoc.
                 if cmd[pos:].strip() == delimiter:
-                    heredoc_regions.append((content_start, pos))
+                    heredoc_regions.append((content_start, len(cmd)))
                 break
 
-            # Check if the line from pos to newline_idx is just the delimiter
+            # Check if the line from pos to newline_idx is just the delimiter.
+            # Include the terminator line but preserve its newline, so a real
+            # command on the following line remains independently visible.
             line = cmd[pos:newline_idx]
             if line.strip() == delimiter:
-                heredoc_regions.append((content_start, pos))
+                heredoc_regions.append((content_start, newline_idx))
                 break
 
             pos = newline_idx + 1
@@ -421,9 +426,14 @@ def is_allowlisted(cmd: str) -> bool:
     the command — it falls through to the normal confirmation prompt. See
     ``gptme/tools/shell_flags.py`` for the tables and the rationale.
     """
+    # Heredoc bodies are data, not command segments or arguments. Keep the
+    # original command for substitution/redirection checks below: an unquoted
+    # heredoc body can itself perform command substitution.
+    cmd_without_heredoc_data = _blank_heredoc_bodies(cmd)
+
     # Check if all commands in the pipeline are allowlisted
     # This blocks non-allowlisted commands like: python, perl, xargs, sh, bash, etc.
-    for match in cmd_regex.finditer(cmd):
+    for match in cmd_regex.finditer(cmd_without_heredoc_data):
         for group in match.groups():
             if group and group not in allowlist_commands:
                 return False
@@ -453,9 +463,9 @@ def is_allowlisted(cmd: str) -> bool:
     # none of which the denylist covered. A permitted-flag model fails closed
     # on flag number five instead of waiting for someone to report it.
     #
-    # Heredoc bodies are data, not arguments, so blank them out first —
+    # Heredoc bodies are data, not arguments, so use the blanked command —
     # otherwise a heredoc line starting with `-` would look like a flag.
-    return flags_permitted(_blank_heredoc_bodies(cmd))
+    return flags_permitted(cmd_without_heredoc_data)
 
 
 def is_denylisted(cmd: str) -> tuple[bool, str | None, str | None]:

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -196,14 +196,15 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
             continue
 
         # A comment begins at an unquoted ``#`` at the start of a shell word.
-        # Markers inside it are inert to the shell and must not hide later lines
-        # from command validation.
+        # Besides whitespace, a shell control operator starts a new word, so
+        # ``;#`` and ``|#`` begin comments too. Markers inside a comment are
+        # inert and must not hide later executable lines from validation.
         line_start = cmd.rfind("\n", 0, match.start()) + 1
         prefix = cmd[line_start : match.start()]
         prefix_quotes = _find_quotes(prefix)
         if any(
             char == "#"
-            and (i == 0 or prefix[i - 1].isspace())
+            and (i == 0 or prefix[i - 1].isspace() or prefix[i - 1] in ";&|")
             and not _is_in_quoted_region(i, prefix_quotes)
             for i, char in enumerate(prefix)
         ):

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -346,7 +346,8 @@ def _has_command_substitution(cmd: str) -> bool:
     single quotes.  The fix adds ``in_double`` tracking and gates single-quote
     transitions on ``not in_double``.
 
-    Returns True if executable backtick or ``$(...)`` syntax is found.
+    Returns True if executable backtick, ``$(...)`` or ``<(...)``/``>(...)``
+    process-substitution syntax is found.
     """
     # Walk the string tracking both single- and double-quote context.
     in_single = False
@@ -368,6 +369,16 @@ def _has_command_substitution(cmd: str) -> bool:
         # Backticks and $(...) substitute when not inside single quotes. Both
         # still substitute inside double-quoted strings.
         elif not in_single and (c == "`" or cmd.startswith("$(", i)):
+            return True
+        # Process substitution <(...) / >(...) runs a command too, but unlike
+        # $(...) it is inert inside double quotes, so both quote contexts
+        # suppress it. Without this, `rg pattern <(sh -c id)` auto-approved:
+        # the inner command never appears at a separator cmd_regex looks for.
+        elif (
+            not in_single
+            and not in_double
+            and (cmd.startswith("<(", i) or cmd.startswith(">(", i))
+        ):
             return True
         i += 1
     return False

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -180,17 +180,31 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
     # ``END-TAG``), while stopping unquoted words at shell metacharacters.
     heredoc_pattern = re.compile(r"<<-?\s*(?:\"([^\"\n]+)\"|'([^'\n]+)'|([^\s;&|<>]+))")
 
+    quoted_regions = _find_quotes(cmd)
+
     for match in heredoc_pattern.finditer(cmd):
+        # Quoted or escaped ``<<`` text is inert to the shell and must not hide
+        # later lines from command validation.
+        if _is_in_quoted_region(match.start(), quoted_regions):
+            continue
+        backslashes = 0
+        pos = match.start() - 1
+        while pos >= 0 and cmd[pos] == "\\":
+            backslashes += 1
+            pos -= 1
+        if backslashes % 2:
+            continue
+
         # A comment begins at an unquoted ``#`` at the start of a shell word.
         # Markers inside it are inert to the shell and must not hide later lines
         # from command validation.
         line_start = cmd.rfind("\n", 0, match.start()) + 1
         prefix = cmd[line_start : match.start()]
-        quoted_regions = _find_quotes(prefix)
+        prefix_quotes = _find_quotes(prefix)
         if any(
             char == "#"
             and (i == 0 or prefix[i - 1].isspace())
-            and not _is_in_quoted_region(i, quoted_regions)
+            and not _is_in_quoted_region(i, prefix_quotes)
             for i, char in enumerate(prefix)
         ):
             continue
@@ -283,12 +297,9 @@ def _has_file_redirection(cmd: str) -> bool:
         if i < len(cmd) - 1 and cmd[i : i + 2] == ">>":
             return True
 
-        # Check for > but not << (heredoc)
+        # Any unquoted ``>`` writes to a file, including the ``<>`` read-write
+        # operator. Heredocs contain no ``>`` and need no exception here.
         if cmd[i] == ">":
-            # Make sure it's not part of << or <<-
-            if i > 0 and cmd[i - 1] == "<":
-                i += 1
-                continue
             return True
 
         i += 1

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -285,12 +285,15 @@ def _has_file_redirection(cmd: str) -> bool:
     Ignores heredoc operators (<< and <<-).
     """
     quoted_regions = _find_quotes(cmd)
+    heredoc_regions = _find_heredoc_regions(cmd)
 
-    # Look for > or >> that are not in quotes and not part of heredoc
+    # Look for > or >> that are not in quotes or heredoc data.
     i = 0
     while i < len(cmd):
-        # Skip if we're in a quoted region
-        if _is_in_quoted_region(i, quoted_regions):
+        # Skip if we're in a quoted or heredoc region.
+        if _is_in_quoted_region(i, quoted_regions) or _is_in_quoted_region(
+            i, heredoc_regions
+        ):
             i += 1
             continue
 
@@ -298,8 +301,8 @@ def _has_file_redirection(cmd: str) -> bool:
         if i < len(cmd) - 1 and cmd[i : i + 2] == ">>":
             return True
 
-        # Any unquoted ``>`` writes to a file, including the ``<>`` read-write
-        # operator. Heredocs contain no ``>`` and need no exception here.
+        # Any remaining unquoted ``>`` writes to a file, including the ``<>``
+        # read-write operator.
         if cmd[i] == ">":
             return True
 
@@ -434,6 +437,39 @@ def _blank_heredoc_bodies(cmd: str) -> str:
     return "".join(chars)
 
 
+def _blank_shell_comments(cmd: str) -> str:
+    """Replace unquoted shell comments with blanks, preserving newlines."""
+    chars = list(cmd)
+    in_single = in_double = in_comment = False
+    i = 0
+    while i < len(cmd):
+        char = cmd[i]
+        if in_comment:
+            if char == "\n":
+                in_comment = False
+            else:
+                chars[i] = " "
+            i += 1
+            continue
+        if char == "\\" and not in_single and i + 1 < len(cmd):
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif (
+            char == "#"
+            and not in_single
+            and not in_double
+            and (i == 0 or cmd[i - 1].isspace() or cmd[i - 1] in ";&|")
+        ):
+            chars[i] = " "
+            in_comment = True
+        i += 1
+    return "".join(chars)
+
+
 def is_allowlisted(cmd: str) -> bool:
     """Check if a shell command is safe to auto-approve.
 
@@ -456,10 +492,11 @@ def is_allowlisted(cmd: str) -> bool:
     # original command for substitution/redirection checks below: an unquoted
     # heredoc body can itself perform command substitution.
     cmd_without_heredoc_data = _blank_heredoc_bodies(cmd)
+    cmd_without_inert_data = _blank_shell_comments(cmd_without_heredoc_data)
 
     # Check if all commands in the pipeline are allowlisted
     # This blocks non-allowlisted commands like: python, perl, xargs, sh, bash, etc.
-    for match in cmd_regex.finditer(cmd_without_heredoc_data):
+    for match in cmd_regex.finditer(cmd_without_inert_data):
         for group in match.groups():
             if group and group not in allowlist_commands:
                 return False
@@ -489,9 +526,10 @@ def is_allowlisted(cmd: str) -> bool:
     # none of which the denylist covered. A permitted-flag model fails closed
     # on flag number five instead of waiting for someone to report it.
     #
-    # Heredoc bodies are data, not arguments, so use the blanked command —
-    # otherwise a heredoc line starting with `-` would look like a flag.
-    return flags_permitted(cmd_without_heredoc_data)
+    # Heredoc bodies and shell comments are data, not arguments, so use the
+    # blanked command — otherwise inert text starting with `-` would look like
+    # a flag and force an unnecessary confirmation prompt.
+    return flags_permitted(cmd_without_inert_data)
 
 
 def is_denylisted(cmd: str) -> tuple[bool, str | None, str | None]:

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -103,6 +103,11 @@ class TestFindHeredocRegions:
         regions = _find_heredoc_regions(cmd)
         assert len(regions) == 1
 
+    def test_punctuation_in_delimiter(self):
+        cmd = "cat << END-TAG\nhello world\nEND-TAG"
+        regions = _find_heredoc_regions(cmd)
+        assert len(regions) == 1
+
     def test_indented_heredoc(self):
         cmd = "cat <<- EOF\n\thello world\n\tEOF"
         regions = _find_heredoc_regions(cmd)
@@ -611,6 +616,13 @@ class TestEdgeCases:
         # The "ls -la" outside heredoc is fine, the dangerous stuff is in heredoc
         assert not denied
 
+    def test_heredoc_data_does_not_look_like_commands_or_flags(self):
+        assert is_allowlisted("cat << EOF\nhello\nEOF")
+        assert is_allowlisted("cat << END-TAG\n-exec\nEND-TAG")
+
+    def test_unquoted_heredoc_command_substitution_is_not_allowlisted(self):
+        assert not is_allowlisted("cat << EOF\n$(id)\nEOF")
+
     def test_git_add_dotenv_not_denied(self):
         """git add .env should not trigger the git add . rule."""
         denied, _, _ = is_denylisted("git add .env")
@@ -1014,6 +1026,13 @@ class TestFlagParsingShapes:
         assert not is_allowlisted("grep foo >(tee out)")
         # A literal `<(` inside quotes is not process substitution
         assert is_allowlisted("grep 'a<(b' f.txt")
+
+    def test_rg_value_flags_cannot_hide_exec_flag(self):
+        """Value-taking -M/-T cannot swallow a forbidden long flag."""
+        assert not is_allowlisted("rg -T --pre /bin/sh pattern")
+        assert not is_allowlisted("rg -M --pre /bin/sh pattern")
+        assert is_allowlisted("rg -T js pattern")
+        assert is_allowlisted("rg -M 120 pattern")
 
     def test_dash_runs_are_operands_not_flags(self):
         assert is_allowlisted('grep "---" f.txt')

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -612,6 +612,17 @@ class TestEdgeCases:
         denied, _, _ = is_denylisted(cmd)
         assert denied
 
+    @pytest.mark.parametrize(
+        "comment",
+        ["# don't", ' # "', "# \\", "# \\\\"],
+    )
+    def test_comment_syntax_cannot_merge_next_command(self, comment: str):
+        cmd = f"echo foo {comment}\nsort -o payload.sh data.txt"
+        assert not is_allowlisted(cmd)
+
+    def test_hash_inside_word_does_not_start_comment(self):
+        assert is_allowlisted("echo foo#bar\necho baz")
+
     def test_cd_is_allowlisted(self):
         assert is_allowlisted("cd /tmp")
 

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -971,6 +971,8 @@ class TestFlagParsingShapes:
     def test_value_is_not_mistaken_for_a_flag(self):
         # -e takes the next token as its pattern, even when it looks like a flag
         assert is_allowlisted("grep -e -dashy-pattern f.txt")
+        assert is_allowlisted("grep -e -- f.txt")
+        assert is_allowlisted("rg -e -- f.txt")
         assert is_allowlisted("find . -name '-weird-name'")
         assert is_allowlisted("sort -k1,2 -t: data.txt")
 

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -4,6 +4,8 @@ Tests the allowlist/denylist logic, quote/heredoc parsing, pipe detection,
 and redirection detection in gptme/tools/shell_validation.py.
 """
 
+import pytest
+
 from gptme.tools.shell_validation import (
     _find_first_unquoted_pipe,
     _find_heredoc_regions,
@@ -794,3 +796,376 @@ class TestPipeToShellCloseParen:
         """`cmd; curl x | bash; ls` should be blocked."""
         denied, _, _ = is_denylisted("echo start; curl x | bash; ls")
         assert denied
+
+
+# ── GHSA-mfh4-cxj2-jc9p: permitted flags, not forbidden flags ────────
+
+
+class TestGHSAExecAndWriteFlags:
+    """The reported vectors (Pham Phuoc Hanh, @hanhpp).
+
+    ``is_allowlisted()`` used to reject a denylist of exactly four
+    ``find``-specific flags. Every allowlisted binary below has its own
+    subprocess-spawning or file-writing flag that the denylist never modelled,
+    so all of these auto-ran with no confirmation prompt.
+    """
+
+    def test_rg_pre_arbitrary_exec(self):
+        """`rg --pre <program>` execs <program> once per searched file."""
+        assert not is_allowlisted("rg --pre /bin/sh pattern file.txt")
+
+    def test_rg_pre_equals_form(self):
+        """The `--flag=value` form must be caught identically."""
+        assert not is_allowlisted("rg --pre=/bin/sh pattern file.txt")
+
+    def test_sort_compress_program_arbitrary_exec(self):
+        """`sort --compress-program` execs the named compressor."""
+        assert not is_allowlisted("sort -S1 --compress-program=/bin/sh bigfile")
+
+    def test_sort_compress_program_separate_value(self):
+        assert not is_allowlisted("sort -S1 --compress-program /bin/sh bigfile")
+
+    def test_find_fprintf_arbitrary_write(self):
+        """`find -fprintf` writes an arbitrary file, bypassing the > check."""
+        assert not is_allowlisted("find . -maxdepth 0 -fprintf payload.sh 'content'")
+
+    def test_sort_o_arbitrary_write(self):
+        """`sort -o` overwrites an arbitrary file, bypassing the > check."""
+        assert not is_allowlisted("sort -o payload.sh source.txt")
+
+    def test_chained_rce_write_then_exec(self):
+        """The two halves of the reported RCE chain are both rejected."""
+        assert not is_allowlisted("find . -maxdepth 0 -fprintf run.sh 'id'")
+        assert not is_allowlisted("rg --pre sh --pre-glob '*' x run.sh")
+
+
+class TestGHSAVariantFlags:
+    """Same shape, different flags — the reason a denylist cannot work."""
+
+    def test_rg_hostname_bin(self):
+        assert not is_allowlisted("rg --hostname-bin /bin/sh pattern")
+
+    def test_rg_hostname_bin_equals_form(self):
+        assert not is_allowlisted("rg --hostname-bin=/bin/sh pattern")
+
+    def test_rg_search_zip_long(self):
+        assert not is_allowlisted("rg --search-zip pattern archive.gz")
+
+    def test_rg_search_zip_short(self):
+        assert not is_allowlisted("rg -z pattern archive.gz")
+
+    def test_rg_pre_glob_equals_form(self):
+        assert not is_allowlisted("rg --pre-glob='*.pdf' pattern")
+
+    def test_find_okdir(self):
+        assert not is_allowlisted("find . -okdir rm {} \\;")
+
+    def test_find_fls(self):
+        assert not is_allowlisted("find . -fls listing.txt")
+
+    def test_find_fprint(self):
+        assert not is_allowlisted("find . -fprint out.txt")
+
+    def test_find_fprint0(self):
+        assert not is_allowlisted("find . -fprint0 out.txt")
+
+    def test_tree_output_to_file(self):
+        """`tree -o` is another arbitrary file write."""
+        assert not is_allowlisted("tree -o payload.sh")
+
+    def test_file_compile_writes_magic(self):
+        """`file -C` compiles and writes a .mgc file."""
+        assert not is_allowlisted("file -C -m custom.magic")
+
+    def test_file_no_sandbox(self):
+        """`file -S` disables libmagic's seccomp sandbox."""
+        assert not is_allowlisted("file -S suspicious.bin")
+
+    def test_uniq_second_operand_is_an_output_file(self):
+        """`uniq INPUT OUTPUT` truncates OUTPUT — no flag involved."""
+        assert not is_allowlisted("uniq input.txt payload.sh")
+
+    def test_uniq_single_operand_still_fine(self):
+        assert is_allowlisted("uniq input.txt")
+
+    def test_sort_temporary_directory(self):
+        assert not is_allowlisted("sort -T /tmp/attacker big.txt")
+
+    def test_unknown_future_flag_requires_confirmation(self):
+        """The point of the model: a flag we have never heard of prompts."""
+        assert not is_allowlisted("ls --some-flag-invented-in-2030")
+        assert not is_allowlisted("grep --brand-new-exec-flag=sh pattern f.txt")
+
+
+class TestFlagParsingShapes:
+    """Argument shapes the permitted-flag parser has to get right."""
+
+    def test_bundled_short_flags(self):
+        assert is_allowlisted("ls -la")
+        assert is_allowlisted("ls -lah")
+        assert is_allowlisted("grep -rn pattern .")
+        assert is_allowlisted("sort -nr data.txt")
+        assert is_allowlisted("du -sh .")
+
+    def test_bundled_short_flags_reject_one_bad_letter(self):
+        # -o is not permitted for sort even when bundled with permitted ones
+        assert not is_allowlisted("sort -no out.txt data.txt")
+
+    def test_attached_and_separate_values(self):
+        assert is_allowlisted("cut -d, -f2 data.csv")
+        assert is_allowlisted("cut -d , -f 2 data.csv")
+        assert is_allowlisted("grep -m5 pattern f.txt")
+        assert is_allowlisted("grep -m 5 pattern f.txt")
+        assert is_allowlisted("rg -A3 pattern")
+        assert is_allowlisted("rg -A 3 pattern")
+
+    def test_long_flag_equals_and_space_forms(self):
+        assert is_allowlisted("du --max-depth=1 .")
+        assert is_allowlisted("du --max-depth 1 .")
+        assert is_allowlisted("rg --type=py pattern")
+        assert is_allowlisted("rg --type py pattern")
+
+    def test_numeric_shorthand_is_not_a_flag(self):
+        assert is_allowlisted("head -5 f.txt")
+        assert is_allowlisted("tail -100 app.log")
+        assert is_allowlisted("grep -3 pattern f.txt")
+
+    def test_value_is_not_mistaken_for_a_flag(self):
+        # -e takes the next token as its pattern, even when it looks like a flag
+        assert is_allowlisted("grep -e -dashy-pattern f.txt")
+        assert is_allowlisted("find . -name '-weird-name'")
+        assert is_allowlisted("sort -k1,2 -t: data.txt")
+
+    def test_end_of_options_marker(self):
+        assert is_allowlisted("cat -- -dashed-file.txt")
+        assert is_allowlisted("grep -n -- -pattern f.txt")
+
+    def test_operands_are_not_flags(self):
+        assert is_allowlisted("find . -name '*.py'")
+        assert is_allowlisted("ls src/gptme")
+        assert is_allowlisted("rg pattern src/ tests/")
+
+    def test_find_primaries_are_not_bundled_letters(self):
+        # -name must not decompose into -n -a -m -e
+        assert is_allowlisted("find . -name '*.py' -maxdepth 3")
+        assert is_allowlisted("find . -type f -executable -name '*.sh'")
+        assert is_allowlisted("find . \\( -name a -o -name b \\) -print")
+
+    def test_flags_checked_per_pipeline_segment(self):
+        # `-o` is fine for grep (--only-matching) but not for sort
+        assert is_allowlisted("grep -o pattern f.txt | sort -u")
+        assert not is_allowlisted("grep -o pattern f.txt | sort -o out.txt")
+
+    def test_unparseable_command_fails_closed(self):
+        assert not is_allowlisted("echo 'unbalanced")
+
+    def test_echo_text_separators_are_not_flags(self):
+        """`echo "---"` between commands is an extremely common idiom."""
+        assert is_allowlisted('echo "---"')
+        assert is_allowlisted('echo "--- section ---"')
+        assert is_allowlisted('echo "---created:"')
+        assert is_allowlisted('cat a.txt | head -5; echo "---"; wc -l a.txt')
+
+    def test_echo_redirection_still_blocked(self):
+        """echo accepts any flag, but redirection is checked separately."""
+        assert not is_allowlisted('echo "payload" > /tmp/exploit.sh')
+        assert not is_allowlisted('echo "payload" >> ~/.bashrc')
+
+    def test_dash_runs_are_operands_not_flags(self):
+        assert is_allowlisted('grep "---" f.txt')
+        assert is_allowlisted("grep -- --- f.txt")
+
+
+REALISTIC_USAGE = [
+    # ls
+    "ls",
+    "ls -l",
+    "ls -la",
+    "ls -lah",
+    "ls -ltr",
+    "ls -R",
+    "ls --color=auto -l",
+    "ls -F --group-directories-first",
+    "ls -lh --time-style=long-iso",
+    "ls -I node_modules",
+    "ls -1 src",
+    # stat / file / which / type
+    "stat setup.py",
+    "stat -c %s setup.py",
+    "stat --format=%y setup.py",
+    "file image.png",
+    "file -b image.png",
+    "file --mime-type image.png",
+    "which python3",
+    "which -a python3",
+    "type ls",
+    "type -a ls",
+    # cat / echo / pwd / cd
+    "cat README.md",
+    "cat -n README.md",
+    "cat -A README.md",
+    "cat a.txt b.txt",
+    "echo hello",
+    "echo -n hello",
+    'echo "---"',
+    'echo "=== section ==="',
+    "pwd",
+    "pwd -P",
+    "cd subdir",
+    # head / tail
+    "head README.md",
+    "head -5 README.md",
+    "head -n 10 README.md",
+    "head -c 100 README.md",
+    "head --lines=50 README.md",
+    "tail app.log",
+    "tail -f app.log",
+    "tail -F app.log",
+    "tail -100 app.log",
+    "tail -n +5 app.log",
+    "tail -f -n 20 app.log",
+    # find
+    "find . -type f",
+    "find . -type d",
+    "find . -name '*.py'",
+    "find . -iname 'README*'",
+    "find . -name '*.py' -maxdepth 3",
+    "find . -mindepth 2 -maxdepth 4 -type f",
+    "find . -size +10M",
+    "find . -mtime -7",
+    "find . -mmin -60",
+    "find . -empty",
+    "find . -perm 644",
+    "find . -newer Makefile",
+    "find . -newermt 2024-01-01",
+    "find . -regex '.*test.*'",
+    "find . -type f -print0",
+    "find . -type f -printf '%p\\n'",
+    "find . -type f -ls",
+    "find . -path './build' -prune -o -print",
+    "find . -not -name '*.tmp'",
+    "find -L . -type l",
+    "find . -xdev -type f",
+    "find . -depth -type d",
+    # rg
+    "rg pattern",
+    "rg -i pattern",
+    "rg -ni pattern",
+    "rg -w word",
+    "rg -F 'literal.string'",
+    "rg -i --type py pattern",
+    "rg -t py pattern",
+    "rg -T js pattern",
+    "rg -g '*.py' pattern",
+    "rg -l pattern",
+    "rg --files",
+    "rg -c pattern",
+    "rg -n -A3 -B3 pattern src",
+    "rg -C2 pattern",
+    "rg -m 5 pattern",
+    "rg --max-depth 2 pattern",
+    "rg -e pat1 -e pat2",
+    "rg --no-ignore pattern",
+    "rg --hidden pattern",
+    "rg -uu pattern",
+    "rg --json pattern",
+    "rg --stats pattern",
+    "rg -U 'multi.*line'",
+    "rg --color never pattern",
+    "rg --sort path pattern",
+    "rg -o pattern",
+    "rg --vimgrep pattern",
+    "rg -S pattern",
+    "rg --no-heading -n pattern",
+    # ag
+    "ag pattern",
+    "ag -i pattern",
+    "ag -l pattern",
+    "ag --ignore-dir node_modules pattern",
+    "ag -A 2 pattern",
+    "ag --hidden pattern",
+    # grep
+    "grep pattern f.txt",
+    "grep -i pattern f.txt",
+    "grep -r pattern .",
+    "grep -rn 'foo' .",
+    "grep -rni pattern .",
+    "grep -v pattern f.txt",
+    "grep -c pattern f.txt",
+    "grep -l pattern src",
+    "grep -L pattern src",
+    "grep -w word f.txt",
+    "grep -E '^a.*b$' f.txt",
+    "grep -F literal f.txt",
+    "grep -P '\\d+' f.txt",
+    "grep -A 3 pattern f.txt",
+    "grep -B 2 pattern f.txt",
+    "grep -C 2 pattern f.txt",
+    "grep -n --color=auto pattern f.txt",
+    "grep -f patterns.txt f.txt",
+    "grep --include='*.py' -r pattern .",
+    "grep --exclude-dir=node_modules -r pattern .",
+    "grep -o pattern f.txt",
+    "grep -q pattern f.txt",
+    # wc / sort / uniq / cut
+    "wc -l f.txt",
+    "wc -w f.txt",
+    "wc -lwc f.txt",
+    "sort f.txt",
+    "sort -n f.txt",
+    "sort -nr f.txt",
+    "sort -u -k2 f.txt",
+    "sort -k1,2 f.txt",
+    "sort -t: -k3 -n f.txt",
+    "sort -h f.txt",
+    "sort -V f.txt",
+    "sort --key=2 --numeric-sort f.txt",
+    "uniq -c",
+    "uniq -d",
+    "uniq -u",
+    "uniq -f 1",
+    "cut -d: -f1 fields.csv",
+    "cut -d, -f2,3 data.csv",
+    "cut -c1-10 f.txt",
+    "cut --delimiter=: --fields=1 f.txt",
+    "cut -s -d: -f2 f.txt",
+    # tree / du / df
+    "tree",
+    "tree -L 2",
+    "tree -d",
+    "tree -a",
+    "tree -I node_modules",
+    "tree --dirsfirst",
+    "tree -h --du",
+    "du -sh .",
+    "du -h --max-depth=1 .",
+    "du -c -h src",
+    "du --exclude=node_modules -sh .",
+    "df -h",
+    "df -i",
+    "df -T",
+    # pipelines
+    "ls | grep foo",
+    "cat f.txt | head -20",
+    "cat f.txt | sort | uniq -c | sort -nr | head -10",
+    "find . -name '*.py' | wc -l",
+    "grep -rn TODO . | head -50",
+    "rg -l pattern | sort",
+    "du -sh src | sort -h",
+    "ls -la | grep -v '^d'",
+    "cat f.txt | cut -d, -f2 | sort -u",
+]
+
+
+class TestRealisticUsageStillAutoApproves:
+    """Usability regression guard.
+
+    If the permitted sets are too narrow, gptme prompts constantly and users
+    disable the protection. Every command here must still auto-approve.
+    """
+
+    @pytest.mark.parametrize("cmd", REALISTIC_USAGE)
+    def test_realistic_usage(self, cmd: str):
+        assert is_allowlisted(cmd), (
+            f"common usage should not require confirmation: {cmd}"
+        )

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -112,6 +112,14 @@ class TestFindHeredocRegions:
         cmd = "rg foo # <<TAG\nsh -c id\nTAG"
         assert _find_heredoc_regions(cmd) == []
 
+    @pytest.mark.parametrize(
+        "marker",
+        ["'<<TAG'", '"<<TAG"', r"\<<TAG"],
+    )
+    def test_inert_heredoc_marker_is_ignored(self, marker: str):
+        cmd = f"rg {marker}\nsh -c id\nTAG"
+        assert _find_heredoc_regions(cmd) == []
+
     def test_hash_inside_shell_word_is_not_a_comment(self):
         cmd = "cat foo#bar <<TAG\nhello\nTAG"
         assert len(_find_heredoc_regions(cmd)) == 1
@@ -238,6 +246,9 @@ class TestHasFileRedirection:
     def test_heredoc_not_redirect(self):
         # << should not be detected as > redirection
         assert not _has_file_redirection("cat << EOF")
+
+    def test_read_write_redirection_is_redirect(self):
+        assert _has_file_redirection("sort 2<> payload.sh")
 
     def test_input_redirect_not_detected(self):
         # < alone should not trigger
@@ -645,6 +656,17 @@ class TestEdgeCases:
 
     def test_heredoc_marker_in_comment_cannot_hide_command(self):
         assert not is_allowlisted("rg foo # <<TAG\nsh -c id\nTAG")
+
+    @pytest.mark.parametrize(
+        "marker",
+        ["'<<TAG'", '"<<TAG"', r"\<<TAG"],
+    )
+    def test_inert_heredoc_marker_cannot_hide_command(self, marker: str):
+        cmd = f"rg {marker}\nsh -c id\nTAG"
+        assert not is_allowlisted(cmd)
+
+    def test_read_write_redirection_cannot_overwrite_file(self):
+        assert not is_allowlisted("sort 2<> payload.sh")
 
     def test_unquoted_heredoc_command_substitution_is_not_allowlisted(self):
         assert not is_allowlisted("cat << EOF\n$(id)\nEOF")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -971,6 +971,26 @@ class TestFlagParsingShapes:
         assert not is_allowlisted('echo "payload" > /tmp/exploit.sh')
         assert not is_allowlisted('echo "payload" >> ~/.bashrc')
 
+    def test_newline_separated_commands_checked_independently(self):
+        """Each line is its own command, so flags must not cross binaries.
+
+        shlex treats newlines as whitespace, so a multi-command block would
+        otherwise be validated entirely against the FIRST binary's table.
+        `find -o` is a harmless OR operator; `sort -o` overwrites a file.
+        """
+        assert not is_allowlisted("find . -name x\nsort -o payload.sh data.txt")
+        assert not is_allowlisted("rg pattern\nfind . -maxdepth 0 -fprintf out '%f'")
+        assert not is_allowlisted("ls -la\ntree -o payload.sh")
+        # ...while a benign multi-line block still auto-approves
+        assert is_allowlisted("ls -la\ngrep -rn foo .\nwc -l f.txt")
+
+    def test_quoted_newlines_and_continuations_are_not_command_breaks(self):
+        from gptme.tools.shell_flags import flags_permitted
+
+        assert flags_permitted('echo "line1\nline2"')
+        assert flags_permitted("grep 'a\nb' f.txt")
+        assert flags_permitted("ls -la \\\n  -h")
+
     def test_dash_runs_are_operands_not_flags(self):
         assert is_allowlisted('grep "---" f.txt')
         assert is_allowlisted("grep -- --- f.txt")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -991,6 +991,30 @@ class TestFlagParsingShapes:
         assert flags_permitted("grep 'a\nb' f.txt")
         assert flags_permitted("ls -la \\\n  -h")
 
+    def test_all_bash_list_operators_split_segments(self):
+        """Every operator must start a new segment, not just `|` and `&&`.
+
+        `rg -o` is --only-matching; `sort -o` overwrites a file. If `|&` is
+        not recognised as an operator, `sort -o` gets validated against
+        ripgrep's table.
+        """
+        assert not is_allowlisted("rg pattern |& sort -o payload.sh")
+        assert not is_allowlisted("ls; rg p |& tree -o payload.sh")
+        assert not is_allowlisted("ls -la & sort -o payload.sh f")
+        assert not is_allowlisted("ls -la ;; sort -o payload.sh f")
+        # ...and benign uses of the same operators still auto-approve
+        assert is_allowlisted("cat f.txt |& head")
+        assert is_allowlisted("ls -la && pwd")
+        assert is_allowlisted("ls -la; pwd")
+
+    def test_process_substitution_requires_confirmation(self):
+        """`<(cmd)` executes cmd, and its name never reaches cmd_regex."""
+        assert not is_allowlisted("rg pattern <(sh -c id)")
+        assert not is_allowlisted("cat <(id)")
+        assert not is_allowlisted("grep foo >(tee out)")
+        # A literal `<(` inside quotes is not process substitution
+        assert is_allowlisted("grep 'a<(b' f.txt")
+
     def test_dash_runs_are_operands_not_flags(self):
         assert is_allowlisted('grep "---" f.txt')
         assert is_allowlisted("grep -- --- f.txt")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -108,6 +108,18 @@ class TestFindHeredocRegions:
         regions = _find_heredoc_regions(cmd)
         assert len(regions) == 1
 
+    def test_heredoc_marker_in_comment_is_ignored(self):
+        cmd = "rg foo # <<TAG\nsh -c id\nTAG"
+        assert _find_heredoc_regions(cmd) == []
+
+    def test_hash_inside_shell_word_is_not_a_comment(self):
+        cmd = "cat foo#bar <<TAG\nhello\nTAG"
+        assert len(_find_heredoc_regions(cmd)) == 1
+
+    def test_hash_inside_quotes_is_not_a_comment(self):
+        cmd = 'echo "# literal" <<TAG\nhello\nTAG'
+        assert len(_find_heredoc_regions(cmd)) == 1
+
     def test_indented_heredoc(self):
         cmd = "cat <<- EOF\n\thello world\n\tEOF"
         regions = _find_heredoc_regions(cmd)
@@ -619,6 +631,9 @@ class TestEdgeCases:
     def test_heredoc_data_does_not_look_like_commands_or_flags(self):
         assert is_allowlisted("cat << EOF\nhello\nEOF")
         assert is_allowlisted("cat << END-TAG\n-exec\nEND-TAG")
+
+    def test_heredoc_marker_in_comment_cannot_hide_command(self):
+        assert not is_allowlisted("rg foo # <<TAG\nsh -c id\nTAG")
 
     def test_unquoted_heredoc_command_substitution_is_not_allowlisted(self):
         assert not is_allowlisted("cat << EOF\n$(id)\nEOF")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -108,8 +108,9 @@ class TestFindHeredocRegions:
         regions = _find_heredoc_regions(cmd)
         assert len(regions) == 1
 
-    def test_heredoc_marker_in_comment_is_ignored(self):
-        cmd = "rg foo # <<TAG\nsh -c id\nTAG"
+    @pytest.mark.parametrize("prefix", ["rg foo #", "echo foo;#", "echo foo|#"])
+    def test_heredoc_marker_in_comment_is_ignored(self, prefix: str):
+        cmd = f"{prefix} <<TAG\nsh -c id\nTAG"
         assert _find_heredoc_regions(cmd) == []
 
     @pytest.mark.parametrize(
@@ -654,8 +655,10 @@ class TestEdgeCases:
         assert is_allowlisted("cat << EOF\nhello\nEOF")
         assert is_allowlisted("cat << END-TAG\n-exec\nEND-TAG")
 
-    def test_heredoc_marker_in_comment_cannot_hide_command(self):
-        assert not is_allowlisted("rg foo # <<TAG\nsh -c id\nTAG")
+    @pytest.mark.parametrize("prefix", ["rg foo #", "echo foo;#", "echo foo|#"])
+    def test_heredoc_marker_in_comment_cannot_hide_command(self, prefix: str):
+        cmd = f"{prefix} <<TAG\nsort -o payload.sh data.txt\nTAG"
+        assert not is_allowlisted(cmd)
 
     @pytest.mark.parametrize(
         "marker",

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -248,6 +248,9 @@ class TestHasFileRedirection:
         # << should not be detected as > redirection
         assert not _has_file_redirection("cat << EOF")
 
+    def test_greater_than_in_heredoc_body_not_redirect(self):
+        assert not _has_file_redirection("cat << EOF\nhello > world\nEOF")
+
     def test_read_write_redirection_is_redirect(self):
         assert _has_file_redirection("sort 2<> payload.sh")
 
@@ -654,6 +657,14 @@ class TestEdgeCases:
     def test_heredoc_data_does_not_look_like_commands_or_flags(self):
         assert is_allowlisted("cat << EOF\nhello\nEOF")
         assert is_allowlisted("cat << END-TAG\n-exec\nEND-TAG")
+        assert is_allowlisted("cat << EOF\nhello > world\nEOF")
+
+    @pytest.mark.parametrize("operator", [";", "&", "|"])
+    def test_comment_after_control_operator_does_not_look_like_flags(
+        self, operator: str
+    ):
+        assert is_allowlisted(f"echo hi{operator}# ls -la")
+        assert is_allowlisted(f"echo hi{operator}# -unknown")
 
     @pytest.mark.parametrize("prefix", ["rg foo #", "echo foo;#", "echo foo|#"])
     def test_heredoc_marker_in_comment_cannot_hide_command(self, prefix: str):


### PR DESCRIPTION
Fixes the shell-tool auto-approval bypass reported as **GHSA-mfh4-cxj2-jc9p** (high, CVSS 8.8) by **Pham Phuoc Hanh ([@hanhpp](https://github.com/hanhpp))**. Public disclosure authorised by the maintainer.

## The vector

`gptme/tools/shell.py` runs allowlisted shell commands with **no confirmation prompt**. `is_allowlisted()` gated that on a denylist of exactly four flags:

```python
dangerous_flags = {"-exec", "-execdir", "-delete", "-ok"}
```

All four are `find`-specific. The other allowlisted binaries have their own subprocess-spawning and file-writing flags, none of which were modelled — so these all auto-ran, silently:

```sh
rg --pre <program> <pattern> <file>              # ripgrep execs <program> once per file
sort -S1 --compress-program=<program> <bigfile>  # GNU sort execs the compressor
find . -maxdepth 0 -fprintf <file> '<content>'   # arbitrary file write
sort -o <file> <src>                             # arbitrary file overwrite
```

The last two also slip past `_has_file_redirection()`, which only looks for shell-level `>` / `>>` — the write happens inside the binary. Chain them and you have RCE with no prompt: write a script with `find -fprintf`, execute it with `rg --pre sh`.

The same shape exists on `rg --hostname-bin`, `rg --search-zip`, `find -okdir/-fls/-fprint/-fprint0`, `tree -o`, and `file -C` / `file -S`.

Not covered by #3495 — that PR closed other allowlist veins (sensitive paths, command substitution, the pipe-to-shell regex) but never touched `dangerous_flags`.

## The fix: permitted flags, not forbidden flags

A denylist has exactly the failure mode that produced this bug: it is complete until someone finds flag number five. This PR replaces it with a per-binary table of **permitted** flags in a new `gptme/tools/shell_flags.py`.

**Unrecognised flags now require confirmation — they are not forbidden.** `is_allowlisted()` returning False means the command falls through to the normal confirmation prompt, exactly as `python foo.py` does today. Nothing becomes impossible; a narrow set of unusual invocations becomes one keypress slower. The model fails closed on flags nobody has enumerated yet, including ones added by future releases of these binaries.

Each of the 22 allowlisted binaries declares its flags, derived from the `--help` output of GNU coreutils 9.4, findutils 4.9, grep 3.11, ripgrep 14.1 and tree 2.1, minus the exec/write-capable ones (each exclusion is commented in the table).

The parser handles the argument shapes real usage actually needs:

- **bundled short flags** — `ls -la`, `grep -rn`, `sort -nr`, `du -sh` (decomposed letter by letter)
- **`--flag=value` and `--flag value`** — `--compress-program=sh` is caught identically to `--compress-program sh`
- **attached and separate short values** — `cut -d,` / `cut -d ,`, `grep -m5` / `grep -m 5`, `rg -A3` / `rg -A 3`
- **optional-value flags** — `ls --color[=WHEN]`, `tail -f` never consume a following token, matching GNU getopt
- **legacy numeric shorthand** — `head -5`, `tail -100`, `grep -3` are counts, not flags
- **`--` end-of-options** — everything after it is an operand
- **`find`'s expression primaries** — single-dash words, so `-name` is not decomposed into `-n -a -m -e`; `-newerXY` is expanded
- **per-segment binary tracking** — `grep -o pat f | sort -u` passes, `grep -o pat f | sort -o out` does not (`-o` means different things to each)
- **value consumption** — `grep -e -dashy-pattern` and `find . -name '-weird'` still auto-approve, because a flag's value is never re-examined as a flag

Two things found while writing it, fixed here as the same class of bug:

- `uniq INPUT OUTPUT` silently truncates OUTPUT with no flag involved — `uniq` is capped at one operand (and rejects glob operands, which expand after validation).
- Heredoc bodies are stdin data, not arguments, so they are blanked before flag parsing.

On `_has_file_redirection`: the two file-write vectors (`sort -o`, `find -fprintf`) are now rejected by the permitted-flag model rather than by the redirection check, verified by test rather than assumed. The shell-level `>` / `>>` check is unchanged and still needed for its own case (`echo x > f`).

## Usability

This is where the change lives or dies: if the permitted sets are too narrow, gptme prompts constantly, and a protection people find unbearable gets disabled. So it was measured rather than eyeballed.

Against **2,330 real shell invocations** extracted from agent session logs, of the **329** that the old logic auto-approved, **0** newly require confirmation.

The first measurement pass found 13 that did — all the same cause, `echo "---"` used as a visual separator between chained commands, where shell quoting is lost by the time the token reaches the checker. `echo` cannot spawn a process or write a file whatever you pass it (redirection is checked separately), so it accepts any flag-shaped argument; a run of dashes is treated as an operand for every binary. Both are tested.

## Tests

`tests/test_tools_shell_validation.py`, 152 new cases:

- each reported PoC → `is_allowlisted(...) is False`, named after its vector
- the variants: `rg --hostname-bin`, `rg --search-zip` (long and short), `find -okdir/-fls/-fprint/-fprint0`, `tree -o`, `file -C/-S`, `sort -T`, and the `--flag=value` forms of `--pre` and `--compress-program`
- an invented future flag (`ls --some-flag-invented-in-2030`) → requires confirmation, which is the point of the model
- the parser shapes above, each as its own case
- **a 165-command realistic-usage suite** across all 22 binaries asserting `True` — the regression guard for the usability risk

All 196 pre-existing validation tests and the full shell-tool suite pass unchanged.

---

### Update: multiline segmentation (a635db0c1)

Greptile caught a real hole in the first commit. `shlex` treats newlines as ordinary whitespace, so a multi-command block collapsed into a single segment and *every* line's flags were validated against the **first** binary's table:

```sh
find . -name x
sort -o payload.sh data.txt
```

`-o` is `find`'s harmless OR operator, so `sort -o` (arbitrary file overwrite) auto-approved. Fixed by splitting on newlines that actually separate commands before lexing — newlines inside quotes are data, and backslash-newline is a line continuation, so neither splits. Both are tested, as is the vector itself.

The usability measurement was re-run over a corpus that now **includes** multiline blocks (3,669 real invocations, 341 previously auto-approved): still **0** newly require confirmation.

### Update: all bash list operators + process substitution (88759f9ad)

Two more instances of the same segmentation class, also from Greptile:

1. **`|&`** was not in the segment separator set, so `rg pattern |& sort -o payload.sh` validated `sort -o` against *ripgrep's* table, where `-o` is the harmless `--only-matching`. Same gap for `;;`, `;&`, `;;&`. Now matched on the operator **character set** (`|&;`) rather than an enumerated list, so operators nobody enumerated still split. `(` and `)` stay excluded — escaped parens are how `find` groups expressions.

2. **Process substitution `<(cmd)`** executes `cmd`, but its name never appears at a separator `cmd_regex` looks for, so `rg pattern <(sh -c id)` auto-ran with no prompt. This one predates the permitted-flag work: #3495 closed `$(...)` and backticks but not `<(` / `>(`. Unlike `$(...)`, process substitution is inert inside double quotes, so both quote contexts suppress it.

Usability re-measured after both: 3,685 real invocations, 340 previously auto-approved, still **0** newly require confirmation.
