### PR TITLE
fix(android): enable mobile cloud sign-in

### DIFF
--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -40,6 +40,11 @@
   },
   "plugins": {
     "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["gptme"]
+        }
+      ],
       "desktop": {
         "schemes": ["gptme"]
       }

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -117,7 +117,6 @@ export function SetupWizard() {
   const externalStep = use$(setupWizard$.step);
   const isRemoteOnlyTauri = isTauri && managesLocalServer === false;
   const isDeterminingTauriMode = isTauri && isLoadingTauriStatus;
-  const cloudSetupSupported = !isRemoteOnlyTauri;
   const canManageApiKeyInApp = isTauri && managesLocalServer === true;
   const [remoteBaseUrl, setRemoteBaseUrl] = useState(
     connectionConfig.baseUrl === 'http://127.0.0.1:5700' ? '' : connectionConfig.baseUrl
@@ -587,18 +586,13 @@ export function SetupWizard() {
               </button>
               <button
                 onClick={() => setStep('cloud')}
-                disabled={!cloudSetupSupported}
-                className="flex items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
+                className="flex items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-accent"
               >
                 <Cloud className="mt-0.5 h-6 w-6 shrink-0" />
                 <div>
-                  <div className="font-medium">
-                    {cloudSetupSupported ? 'Cloud' : 'Cloud (coming soon on mobile)'}
-                  </div>
+                  <div className="font-medium">Cloud</div>
                   <div className="text-sm text-muted-foreground">
-                    {cloudSetupSupported
-                      ? 'Connect to gptme.ai for a managed experience. No setup required.'
-                      : 'Not ready on this mobile build yet. Use a server URL for now.'}
+                    Connect to gptme.ai for a managed experience. No setup required.
                   </div>
                 </div>
               </button>
@@ -633,8 +627,8 @@ export function SetupWizard() {
               ) : isRemoteOnlyTauri ? (
                 <div className="flex flex-col gap-3">
                   <p className="text-sm text-muted-foreground">
-                    Enter the URL for a remote gptme server. Cloud sign-in is not ready on this
-                    mobile build yet, so use Bob or another hosted gptme server for now.
+                    Enter the URL for a remote gptme server. Use Cloud instead if you want the
+                    managed <code>gptme.ai</code> sign-in flow.
                   </p>
                   <Input
                     autoComplete="url"
@@ -756,19 +750,16 @@ export function SetupWizard() {
             <DialogHeader>
               <DialogTitle>Cloud setup</DialogTitle>
               <DialogDescription>
-                {cloudSetupSupported
-                  ? 'Sign in to gptme.ai for a fully managed experience.'
-                  : 'Cloud sign-in is not available on this mobile build yet.'}
+                Sign in to gptme.ai for a fully managed experience.
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-4 py-4">
               <div className="flex flex-col gap-3">
                 <p className="text-sm text-muted-foreground">
-                  {cloudSetupSupported
-                    ? "You'll be redirected to gptme.ai to sign in. After authentication, you'll be connected automatically."
-                    : 'Use the Remote server path for now and connect to Bob or another hosted gptme server by URL.'}
+                  You&apos;ll be redirected to gptme.ai to sign in. After authentication,
+                  you&apos;ll be connected automatically.
                 </p>
-                {cloudSetupSupported && cloudLoginStarted && !isConnected && (
+                {cloudLoginStarted && !isConnected && (
                   <div className="rounded-lg border border-border/70 bg-muted px-3 py-2 text-sm text-muted-foreground">
                     Waiting for sign-in to complete… This window will update automatically once the
                     app connects.
@@ -779,7 +770,7 @@ export function SetupWizard() {
                     {connectError}
                   </div>
                 )}
-                {cloudSetupSupported && isTauri && (
+                {isTauri && (
                   <p className="text-xs text-muted-foreground">
                     The app will handle the login callback via the <code>gptme://</code> deep link.
                   </p>
@@ -790,19 +781,17 @@ export function SetupWizard() {
               <Button
                 variant="outline"
                 onClick={() => {
-                  setStep(cloudSetupSupported ? 'mode' : 'local');
+                  setStep('mode');
                   setCloudLoginStarted(false);
                   setConnectError(null);
                 }}
               >
-                {cloudSetupSupported ? 'Back' : 'Use Remote server'}
+                Back
               </Button>
-              {cloudSetupSupported && (
-                <Button onClick={handleCloudLogin} className="gap-2">
-                  Sign in to gptme.ai
-                  <ExternalLink className="h-4 w-4" />
-                </Button>
-              )}
+              <Button onClick={handleCloudLogin} className="gap-2">
+                Sign in to gptme.ai
+                <ExternalLink className="h-4 w-4" />
+              </Button>
             </DialogFooter>
           </>
         )}

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -692,7 +692,7 @@ describe('SetupWizard', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('disables cloud setup on remote-only tauri builds', () => {
+  it('supports cloud setup on remote-only tauri builds', async () => {
     mockIsTauriEnvironment.mockReturnValue(true);
     mockUseTauriServerStatus.mockReturnValue({
       isLoading: false,
@@ -714,61 +714,14 @@ describe('SetupWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /get started/i }));
 
     const cloudButton = screen.getByRole('button', { name: /cloud/i });
-    expect(cloudButton).toBeDisabled();
-    expect(screen.getByText(/not ready on this mobile build yet/i)).toBeInTheDocument();
+    expect(cloudButton).toBeEnabled();
+    expect(screen.queryByText(/not ready on this mobile build yet/i)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /remote server/i }));
+    fireEvent.click(cloudButton);
+    fireEvent.click(screen.getByRole('button', { name: /sign in to gptme.ai/i }));
 
-    expect(
-      screen.getByText(/cloud sign-in is not ready on this mobile build yet/i)
-    ).toBeInTheDocument();
-  });
-
-  it('falls back to remote-server guidance when cloud step is opened on remote-only tauri', async () => {
-    mockIsTauriEnvironment.mockReturnValue(true);
-    mockUseTauriServerStatus.mockReturnValue({
-      isLoading: false,
-      managesLocalServer: false,
-      serverStatus: {
-        running: false,
-        port: 5700,
-        port_available: false,
-        manages_local_server: false,
-      },
-    });
-    localStorage.setItem('gptme-settings', JSON.stringify({ hasCompletedSetup: true }));
-
-    const { rerender } = render(
-      <SettingsProvider>
-        <SetupWizard />
-      </SettingsProvider>
-    );
-
-    act(() => {
-      setupWizard$.step.set('cloud');
-      setupWizard$.open.set(true);
-    });
-
-    rerender(
-      <SettingsProvider>
-        <SetupWizard />
-      </SettingsProvider>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /cloud setup/i })).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText(/cloud sign-in is not available on this mobile build yet/i)
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /sign in to gptme.ai/i })).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /use remote server/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /remote server setup/i })).toBeInTheDocument();
-    });
+    expect(mockOpen).toHaveBeenCalledWith(CLOUD_AUTH_URL, '_blank');
+    expect(screen.getByText(/waiting for sign-in to complete/i)).toBeInTheDocument();
   });
 
   it('connects to a remote server during tauri mobile setup', async () => {


### PR DESCRIPTION
## Problem

The cloud and app-side handoff work from gptme/gptme-cloud#264 and gptme/gptme#2624 is live, but Android still cannot use it: `SetupWizard` preserves the temporary May fallback from gptme/gptme#2454 and disables Cloud on remote-only Tauri builds. The Android manifest also has no `gptme://` intent filter because the deep-link plugin only declares the desktop scheme.

## Changes

- enable the Cloud onboarding choice for remote-only Tauri/mobile builds
- remove the stale "coming soon on mobile" fallback copy
- declare `gptme` as a mobile deep-link scheme so Android generates the callback intent filter
- replace the obsolete disabled-path tests with a mobile cloud-auth regression test

## Verification

- `cd webui && npm test -- --runInBand src/components/__tests__/SetupWizard.test.tsx` — 27/27 passed
- `cd webui && npm run typecheck` — passed
- pre-commit hooks — passed
- `git diff --check` — passed

## Scope

This restores the already-shipped cloud auth handoff on Android. It does not add Play Store distribution or change desktop/local-server behavior.
