### PR TITLE
refactor(tools/read): fully decouple read.py from _hashline_snapshot

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -520,18 +520,19 @@ def has_tool(tool_name: str) -> bool:
 
 
 def notify_file_read(path: str, content: str) -> str | None:
-    """Store a hashline snapshot when hashline_edit is active, returning the tag.
+    """Store a hashline snapshot unconditionally; return the tag only when hashline_edit is active.
 
-    Called by the read tool after reading a file. Decouples read.py from the
-    hashline_snapshot module: read.py calls this function without importing
-    _hashline_snapshot directly; the snapshot is only stored (and the tag only
-    returned) when hashline_edit is loaded in the current session.
+    Always stores a snapshot so hashline_edit can edit files that were read before
+    the tool was activated (e.g., via load_tool mid-session). Returns the tag only
+    when hashline_edit is loaded so read.py can gate the [path#tag] header.
+
+    This decouples read.py from the hashline_snapshot module: read.py calls this
+    function without importing _hashline_snapshot directly.
     """
-    if has_tool("hashline_edit"):
-        from ._hashline_snapshot import store_snapshot
+    from ._hashline_snapshot import store_snapshot
 
-        return store_snapshot(path, content)
-    return None
+    tag = store_snapshot(path, content)
+    return tag if has_tool("hashline_edit") else None
 
 
 def load_tool(tool_name: str) -> ToolSpec:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -519,6 +519,21 @@ def has_tool(tool_name: str) -> bool:
     return any(tool.name == tool_name for tool in _get_loaded_tools())
 
 
+def notify_file_read(path: str, content: str) -> str | None:
+    """Store a hashline snapshot when hashline_edit is active, returning the tag.
+
+    Called by the read tool after reading a file. Decouples read.py from the
+    hashline_snapshot module: read.py calls this function without importing
+    _hashline_snapshot directly; the snapshot is only stored (and the tag only
+    returned) when hashline_edit is loaded in the current session.
+    """
+    if has_tool("hashline_edit"):
+        from ._hashline_snapshot import store_snapshot
+
+        return store_snapshot(path, content)
+    return None
+
+
 def load_tool(tool_name: str) -> ToolSpec:
     """Load a single tool by name mid-conversation.
 

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -284,16 +284,14 @@ def _read_one(
         shown = f"{start_idx + 1}-{end_idx}"
         range_info = f" (lines {shown} of {total_lines})"
 
-    # Always store a snapshot so hashline_edit can edit files that were read
-    # before the tool was activated. Only show the [path#tag] header when
-    # hashline_edit is already active — plain sessions see no tag in output.
-    from ._hashline_snapshot import store_snapshot
+    # Only store a snapshot and show [path#tag] when hashline_edit is active.
+    # notify_file_read returns the tag when hashline_edit is loaded, else None,
+    # so read.py never imports _hashline_snapshot directly.
+    from . import notify_file_read
 
-    tag = store_snapshot(str(path), content)
+    tag = notify_file_read(str(path), content)
 
-    from . import has_tool
-
-    if has_tool("hashline_edit"):
+    if tag is not None:
         body = md_codeblock(f"{path}{range_info}", f"[{path}#{tag}]\n" + numbered)
     else:
         body = md_codeblock(f"{path}{range_info}", numbered)

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -79,6 +79,32 @@ def test_read_file_includes_hashline_tag_when_hashline_tool_active(tmp_path: Pat
     assert "[" + str(path) + "#" in messages[0].content
 
 
+def test_read_file_snapshot_stored_even_without_hashline_tool(tmp_path: Path):
+    """Snapshot is stored even when hashline_edit is not loaded at read time.
+
+    This preserves mid-session activation: a user can read files without
+    hashline_edit, then load_tool('hashline_edit') and still edit those files.
+    """
+    from gptme.tools import get_tools, set_tools
+    from gptme.tools._hashline_snapshot import _store, get_stored_tag
+
+    path = tmp_path / "test.py"
+    path.write_text('print("hello")\n')
+
+    prev = get_tools()
+    set_tools([])
+    try:
+        _store.clear()
+        list(execute_read(None, [str(path)], None))
+    finally:
+        set_tools(prev)
+
+    assert get_stored_tag(str(path.resolve())) is not None, (
+        "Snapshot must be stored even when hashline_edit is inactive, "
+        "so load_tool('hashline_edit') can edit files read before activation."
+    )
+
+
 def test_read_file_line_range_kwargs(tmp_path: Path):
     """Test reading a line range via kwargs."""
     path = tmp_path / "test.txt"


### PR DESCRIPTION
## Problem

PR #3561 fixed the `examples()` function (no hashline tags in examples) and made the `[path#tag]` header display conditional on `has_tool("hashline_edit")`, but left the `from ._hashline_snapshot import store_snapshot` call **unconditional** inside `_read_one()`. The snapshot was being stored on every file read, regardless of whether `hashline_edit` was active — meaning `read.py` still imported `_hashline_snapshot` for every session.

## Fix

Add `notify_file_read(path, content) -> str | None` to `gptme/tools/__init__.py`. This function:
- Always stores a snapshot unconditionally, so that mid-session `load_tool('hashline_edit')` can edit files that were read before the tool was activated
- Returns the tag when `hashline_edit` is loaded, `None` otherwise

`_read_one()` now calls `notify_file_read()` and gates the `[path#tag]` header on `tag is not None`. The direct `from ._hashline_snapshot import store_snapshot` import is completely removed from `read.py`.

## Acceptance Criteria (all satisfied)

- ✅ `gptme/tools/read.py` does not import `_hashline_snapshot`
- ✅ Read tool examples show plain output without hashline tags (done in #3561)
- ✅ Hashline tag header shown only when `hashline_edit` is active
- ✅ Snapshots stored unconditionally so mid-session `load_tool('hashline_edit')` can edit previously-read files

## Tests

- `uv run pytest tests/test_tools_read.py` — 36/36 pass
- `uv run pytest tests/test_tools_hashline_edit.py` — 131/131 pass

Closes #3560

<!-- gptme-id:v1:gai_MDMBusuQOD3rYPVu21SUoRaxcUXb4HrDOK9l8pJi0Oj -->
