### PR TITLE
docs: fix providers.rst structure, nest provider/browser pages, add Tool Formats guide

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,7 +62,7 @@ Here is an example:
     #OPENAI_BASE_URL = "http://localhost:11434/v1"
 
     # Uncomment to change tool configuration
-    #TOOL_FORMAT = "markdown" # Select the tool formal. One of `markdown`, `xml`, `tool`
+    #TOOL_FORMAT = "markdown" # Select the tool format. One of `markdown`, `xml`, `tool` (see docs: Tool Formats)
     #TOOL_ALLOWLIST = "save,append,patch,ipython,shell,browser"  # Comma separated list of allowed tools
     #TOOL_MODULES = "gptme.tools,custom.tools" # List of python comma separated python module path
 
@@ -376,7 +376,7 @@ The variable name is derived from the parameter name in uppercase.
 Common examples:
 
 - ``GPTME_MODEL`` - Set the model (equivalent to ``--model``)
-- ``GPTME_TOOL_FORMAT`` - Set the tool format (equivalent to ``--tool-format``)
+- ``GPTME_TOOL_FORMAT`` - Set the tool format (equivalent to ``--tool-format``), see :doc:`tool-formats`
 - ``GPTME_WORKSPACE`` - Set the workspace (equivalent to ``--workspace``)
 - ``GPTME_TOOL_ALLOWLIST`` - Set allowed tools (equivalent to ``--tools``)
 

--- a/docs/evals.rst
+++ b/docs/evals.rst
@@ -30,7 +30,7 @@ Decent alternatives include:
 - DeepSeek V3 (``deepseek/deepseek-chat``)
 - DeepSeek R1 (``deepseek/deepseek-reasoner``)
 
-Note that some models may perform better or worse with different ``--tool-format`` options (``markdown``, ``xml``, or ``tool`` for native tool-calling).
+Note that some models may perform better or worse with different ``--tool-format`` options (``markdown``, ``xml``, or ``tool`` for native tool-calling). See :doc:`tool-formats` for what each format does and how to choose one.
 
 Note that many providers on OpenRouter have poor performance and reliability, so be sure to test your chosen model/provider combination before committing to it. This is especially true for open weight models which any provider can host at any quality. You can choose a specific provider by appending with ``:provider``, e.g. ``openrouter/qwen/qwen3-coder:alibaba/opensource``.
 
@@ -50,7 +50,7 @@ The table below shows pass rates across our eval suites for each model (best too
 
 **Notes:**
 
-- *Format* shows the best-performing ``--tool-format`` for each model.
+- *Format* shows the best-performing ``--tool-format`` for each model (see :doc:`tool-formats`).
 - *Basic* tests cover fundamental tool use (file I/O, shell, git, Python).
 - *Practical* tests cover real-world programming tasks (APIs, data processing, refactoring).
 - Models with fewer than 4 tests are excluded.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,13 +32,11 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    cookbook
    howto/index
    tools
-   browser
    commands
    cli
    tui
    config
    providers
-   providers-custom
    provider-integration
    model-routing
    security
@@ -82,7 +80,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    design/ptc-tool-interface
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: About
 
    alternatives

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -5,14 +5,12 @@ We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter,
 
 .. note::
 
-    We are in the process of adding support for configurable `custom providers <providers-custom>`_.
+    We are in the process of adding support for configurable :doc:`custom providers <providers-custom>`.
 
 You can find our model recommendations on the :doc:`evals` page.
 
-.. toctree::
-   :maxdepth: 2
-
-   providers-custom
+Selecting a provider and model
+------------------------------
 
 To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag set to ``<provider>/<model>``, for example:
 
@@ -30,6 +28,12 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m gptme/claude-sonnet-4-6
 
 You can list the models known to gptme using ``gptme '/models' - '/exit'``.
+
+Which tool format a model performs best with also varies by provider and model —
+see :doc:`tool-formats` for how to choose one.
+
+Configuring credentials
+-----------------------
 
 To configure provider credentials interactively, run ``/account`` inside gptme:
 
@@ -53,7 +57,8 @@ You can still use the ``[env]`` section in the :ref:`global-config` file to stor
 - ``GROQ_API_KEY="your-api-key"``
 - ``DEEPSEEK_API_KEY="your-api-key"``
 
-.. rubric:: OpenAI Platform
+OpenAI Platform
+---------------
 
 Use the direct OpenAI Platform provider with ``openai/<model>``:
 
@@ -92,7 +97,8 @@ falsy values.
     ``openai-subscription`` provider uses its own Responses API path by
     default.
 
-.. rubric:: OpenRouter
+OpenRouter
+----------
 
 `OpenRouter <https://openrouter.ai/>`_ provides access to 100+ models through a single API key. gptme applies sensible defaults for OpenRouter requests:
 
@@ -117,7 +123,8 @@ falsy values.
     # Common values: fp16, bf16, fp8, int8, int4, unknown
     OPENROUTER_QUANTIZATION = "fp16,bf16"
 
-.. rubric:: Requesty
+Requesty
+--------
 
 `Requesty <https://requesty.ai/>`_ is an OpenAI-compatible LLM gateway that routes to many models through a single API key, using the same ``provider/model`` naming as OpenRouter (e.g. ``requesty/openai/gpt-4o-mini``, ``requesty/anthropic/claude-sonnet-4-5``). It is reached through the standard OpenAI-compatible client path.
 
@@ -131,7 +138,8 @@ falsy values.
 
 Get an API key at https://app.requesty.ai/api-keys. See https://docs.requesty.ai for details.
 
-.. rubric:: Groq
+Groq
+----
 
 `Groq <https://groq.com/>`_ provides fast inference for open-source models via its own API key — **not** through the ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` pattern.
 
@@ -166,7 +174,8 @@ Popular Groq models:
 - ``groq/llama-3.3-70b-versatile`` — fast 70B Llama 3.3
 - ``groq/llama-3.1-8b-instant`` — fastest, smallest
 
-.. rubric:: OpenAI Subscription
+OpenAI Subscription
+-------------------
 
 You can use your existing ChatGPT Plus/Pro subscription with gptme. This uses the ChatGPT backend API (Codex endpoint) instead of the OpenAI Platform API, allowing you to leverage your subscription for development.
 
@@ -213,7 +222,8 @@ You can also append reasoning levels: ``:low``, ``:medium``, ``:high``, or ``:xh
     For production or multi-user applications, use the OpenAI Platform API.
     OAuth credentials are stored locally and access tokens are refreshed automatically.
 
-.. rubric:: gptme Managed Service
+gptme Managed Service
+---------------------
 
 The ``gptme`` provider connects to the `gptme.ai <https://gptme.ai>`_ managed service, which acts as an OpenAI-compatible LLM proxy/gateway. This gives you access to multiple model providers (Anthropic, OpenAI, etc.) through a single account.
 
@@ -250,7 +260,8 @@ Models are pass-through: ``gptme/<model>`` proxies to the corresponding backend 
     gptme-auth status              # Show current login status
     gptme-auth logout              # Remove stored credentials
 
-.. rubric:: Provider Plugins (Entry Points)
+Provider Plugins (Entry Points)
+-------------------------------
 
 Third-party packages can register LLM providers via Python entry points, making them available immediately after ``pip install`` without any configuration changes.
 
@@ -317,7 +328,8 @@ Plugin providers are auto-initialised on first use and routed through the OpenAI
 
    For new plugins, consider using the :ref:`unified plugin system <unified-plugins>` (``gptme.plugins`` entry-point group) instead. It lets a single package provide tools, hooks, commands, **and** a provider together. The ``gptme.providers`` group still works and is supported for backward compatibility.
 
-.. rubric:: Local
+Local
+-----
 
 You can use local LLM models using any OpenAI API-compatible server.
 
@@ -332,3 +344,10 @@ To achieve that with ``ollama``, install it then run:
 .. note::
 
     Small models won't work well with tools, severely limiting the usefulness of gptme. You can find an overview of how different models perform on the :doc:`evals` page.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: More about providers
+
+   providers-custom
+   tool-formats

--- a/docs/tool-formats.rst
+++ b/docs/tool-formats.rst
@@ -1,0 +1,268 @@
+Tool Formats
+============
+
+gptme can hand tools to a model in three different ways, selected with
+``--tool-format``:
+
+- ``markdown`` — fenced code blocks (the default)
+- ``xml`` — XML-tagged blocks
+- ``tool`` — the provider's native tool/function-calling API
+
+This page explains what each one does and how to pick one. For the architectural
+rationale behind the non-native formats, see the "Tool Interface Architecture"
+section of :doc:`tools` and the :doc:`design/ptc-tool-interface` design document.
+
+Why there is more than one
+--------------------------
+
+gptme predates native tool/function calling being widely available and reliable,
+so its original — and still default — interface is **Programmatic Tool Calling
+(PTC)**: the model writes a fenced code block, and gptme executes it. No JSON
+schemas are sent to the model, and no JSON-structured response is parsed.
+
+Native tool calling later became available on most providers, and gptme supports
+it as the ``tool`` format. It is not automatically the best choice. Native tool
+calling gives you provider-side routing, constrained decoding against a schema,
+and (on some providers) parallel tool calls. In exchange, every tool definition
+is serialized into the request as JSON schema, and tool results accumulate as
+structured blocks rather than plain text.
+
+The practical upshot: **a good model should work reasonably well in all three
+formats**, and which one wins is an empirical question per model. The
+:doc:`evals` leaderboard reports the best-performing format per model from actual
+eval runs — that table is the most reliable answer for any model listed there.
+
+The three formats
+-----------------
+
+``markdown`` (default)
+^^^^^^^^^^^^^^^^^^^^^^
+
+The model emits a fenced code block whose language tag is a tool name:
+
+.. code-block:: text
+
+    ```patch test.txt
+    <<<<<<< ORIGINAL
+    old
+    =======
+    new
+    >>>>>>> UPDATED
+    ```
+
+**Strengths.** Nothing is sent as JSON schema, so tool definitions cost little
+context and are described in prose the model was heavily post-trained on. Writing
+code in fenced blocks is the single most common thing in any code model's
+training data, so instruction adherence tends to be high even for smaller models.
+It degrades gracefully: a slightly malformed block is still often recoverable.
+
+**Weaknesses.** Parsing is heuristic rather than schema-validated. Nested fenced
+code blocks are the classic failure mode — gptme handles variable-length fences
+(three or more backticks) and matches closing fences by length, but a
+model that emits mismatched fences can truncate its own tool call. There is no
+constrained decoding to stop the model inventing an argument.
+
+``xml``
+^^^^^^^
+
+The same calls, wrapped in XML tags:
+
+.. code-block:: xml
+
+    <tool-use>
+    <patch args="test.txt">
+    ...
+    </patch>
+    </tool-use>
+
+**Strengths.** Explicit delimiters make the boundary of a tool call unambiguous,
+which sidesteps the nested-code-block problem entirely. Models that were
+post-trained heavily on XML-tagged tool use (notably some Anthropic models) often
+adhere better here than in markdown. The system prompt is also emitted
+XML-sectioned in this mode.
+
+**Weaknesses.** More verbose, and content must be XML-escaped. Crucially,
+**in ``xml`` mode gptme does not parse markdown code blocks at all** — if the
+model falls back to a fenced block, the call is silently not executed. That makes
+``xml`` a poor fit for models that are inconsistent about which shape they emit.
+
+``tool`` (native)
+^^^^^^^^^^^^^^^^^
+
+Tools are sent to the provider as JSON-schema function definitions, and the
+provider returns structured tool calls, which gptme renders back into the log as:
+
+.. code-block:: text
+
+    @patch(call_abc123): {
+      "path": "test.txt",
+      "patch": "..."
+    }
+
+**Strengths.** Constrained decoding means arguments validate against the schema,
+so malformed calls are largely eliminated. Providers that support **parallel tool
+calls** can emit several calls in one response. On OpenAI Chat Completions, models
+that support **strict tool schemas** (structured outputs) get an additional
+guarantee that arguments conform exactly — gptme enables this only when every
+parameter of the tool is required.
+
+**Weaknesses.** Every enabled tool's schema is serialized into every request,
+which costs context and grows with your tool allowlist. Tool descriptions are
+truncated at 1024 characters (an OpenAI limit), so long tool instructions have to
+be shortened for this format. Accuracy is also more sensitive to context rot in
+long sessions — see the benchmark cited in :doc:`tools`.
+
+Note that ``tool`` mode still parses markdown code blocks in addition to native
+tool calls, so ``/impersonate`` and hand-written blocks keep working.
+
+**Not every provider supports it.** On the OpenAI-compatible chat-completions
+path, native tools are only accepted for ``openai``, ``azure``, ``openrouter``,
+``deepseek``, ``moonshot``, ``local``, and custom providers. Selecting
+``--tool-format tool`` on e.g. ``gemini``, ``xai``, ``groq``, ``nvidia`` or
+``requesty`` raises an error rather than silently degrading. Anthropic, the
+OpenAI Responses API, and ``openai-subscription`` all support it.
+
+Choosing a format
+-----------------
+
+Start with the :doc:`evals` leaderboard: it lists the best-performing format per
+model as measured, and that beats any rule of thumb.
+
+Absent eval data for your model, these heuristics hold up:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Situation
+     - Suggested format
+   * - Frontier model, long autonomous sessions
+     - ``markdown`` — best resilience to context rot, cheapest in context
+   * - Model that reliably emits XML tool use, or markdown fences keep breaking
+     - ``xml``
+   * - You want parallel tool calls or schema-validated arguments
+     - ``tool`` (check the model supports it — see below)
+   * - Small / weakly instruction-tuned local model
+     - Try ``xml`` first, then ``markdown``; ``tool`` usually needs a 7B+
+       instruction-tuned model
+   * - Model ignores tools or hallucinates arguments
+     - ``tool`` if the provider supports it, to get constrained decoding
+
+The considerations that actually differentiate models here are: support for
+parallel tool calling, support for tool-calling schemas and constrained decoding,
+and how much tool-use post-training the model received (which drives instruction
+adherence). A model can be excellent in general and still be limited by any one
+of these.
+
+Setting the format
+------------------
+
+.. code-block:: sh
+
+    gptme --tool-format xml "hello"
+
+Or via environment variable / config:
+
+.. code-block:: sh
+
+    export GPTME_TOOL_FORMAT=xml
+
+.. code-block:: toml
+
+    # ~/.config/gptme/config.toml
+    [env]
+    TOOL_FORMAT = "xml"
+
+Resolution order, highest priority first:
+
+1. The ``--tool-format`` CLI flag.
+
+2. The ``tool_format`` saved in a resumed conversation's chat config (it is
+   sticky across ``--resume``).
+
+3. ``GPTME_TOOL_FORMAT`` / ``TOOL_FORMAT``, from the process environment or an
+   ``[env]`` section in chat, project, or user config (in that order).
+
+4. The model's ``default_tool_format`` from its metadata, if set.
+
+5. ``markdown``.
+
+Switching model at runtime with ``/model`` also switches to that model's
+``default_tool_format`` if it declares one.
+
+.. _tool-format-model-metadata:
+
+Model metadata
+--------------
+
+``ModelMeta`` (``gptme/llm/models/types.py``) carries per-model fields that
+describe tool-calling capability. They are worth knowing about because they change
+behaviour silently:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Field
+     - Meaning
+   * - ``default_tool_format``
+     - Preferred tool format for this model, used as a fallback when nothing
+       higher-priority sets one (step 4 above).
+   * - ``supports_parallel_tool_calls``
+     - The model can emit multiple tool calls in a single response. When this is
+       ``False``, gptme stops generation as soon as one complete tool call is
+       seen, so at most one call per assistant message runs. Override with
+       ``GPTME_BREAK_ON_TOOLUSE``.
+   * - ``supports_strict_tools``
+     - The model supports ``strict=True`` tool schemas (OpenAI structured
+       outputs). Only used on the OpenAI chat-completions path, and only for tools
+       whose parameters are all required.
+   * - ``preferred_edit_format``
+     - Hint for code edits — ``"diff"`` (patch/morph) or ``"whole"`` (save).
+       Derived from Aider's empirical per-model edit-format registry. Not a tool
+       format; listed here because it is adjacent and equally undocumented.
+
+**How well populated is this?** Unevenly, and it is worth being explicit about:
+
+- ``default_tool_format`` is set for the ``openai-subscription`` models only
+  (they default to ``tool``). No other model in the bundled registry declares
+  one, so for almost every model step 4 above is a no-op and you land on
+  ``markdown``.
+
+- ``supports_parallel_tool_calls`` is set on the Claude Opus/Sonnet 4.x families,
+  their OpenRouter aliases, Kimi K3, and the GPT-4.1/GPT-5 families — roughly 30
+  entries. Deliberate omissions are meaningful: Claude Haiku 4.5 carries an
+  explicit comment that it does *not* emit multiple tool calls per response.
+
+- ``supports_strict_tools`` is set on the OpenAI models (GPT-4o/4.1/5 families,
+  o-series) and Kimi K3.
+
+So this is not a complete capability matrix, and an absent flag means "not
+recorded", not "not supported". If a model you use is missing a flag it should
+have, that is a worthwhile contribution.
+
+The :doc:`evals` leaderboard is the natural source for populating
+``default_tool_format``: it already reports the best-performing format per model
+from measured runs.
+
+Troubleshooting
+---------------
+
+**"Provider doesn't support tools API"** — you selected ``--tool-format tool`` on
+a provider that is not on the native-tools allowlist above. Use ``markdown`` or
+``xml``.
+
+**The model narrates a tool call but nothing runs** — in ``xml`` mode, markdown
+code blocks are not parsed. Either switch to ``markdown`` or steer the model back
+to XML.
+
+**Tool calls truncate mid-content** — usually nested fenced code blocks in
+``markdown`` mode. Try ``xml``.
+
+**Only one tool runs per turn** — expected unless the model declares
+``supports_parallel_tool_calls``. Set ``GPTME_BREAK_ON_TOOLUSE=false`` to
+override, at the risk of the model emitting calls the provider will not accept.
+
+**A small local model ignores tools entirely** — see the troubleshooting section
+in :doc:`providers-custom`; small models often need ``xml`` and a 7B+
+instruction-tuned base.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -739,3 +739,9 @@ spawning subagents programmatically:
     # gptme.toml
     [env]
     TOOL_ALLOWLIST = "shell,patch,save,read,hint:read-only"
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tool guides
+
+   browser


### PR DESCRIPTION
Fixes the structural defects in `docs/providers.rst` that Erik flagged ("providers.html looks a bit messy... the toc is still misplaced and doesn't include the rubric headings"), tidies the site TOC, and fills the largest content gap in the docs: `--tool-format` had no dedicated page.

## A. `providers.rst` was structurally broken

The page had exactly **one** real section heading (`Providers`). All eight others were `.. rubric::`. Sphinx rubrics are non-section headings by design — they never enter a toctree or the in-page TOC, and they render as a bare `<p class="rubric">` with **no `id`**. So there was no `#openrouter` anchor, nothing could deep-link to a provider section, and "the TOC doesn't include the rubric headings" was guaranteed by the directive choice, not a TOC bug.

- Promoted all 8 rubrics to real sections. **Markup only** — no prose moved, no sections reordered (the ordering from 6e3529153 is untouched).
- Moved the `toctree` out of the middle of the prose to the end of the page.
- Added `Selecting a provider and model` / `Configuring credentials` headings so the ~50-line lead-in is navigable and citable too.
- Fixed `` `custom providers <providers-custom>`_ `` — that was rendering as a link to an external URL `providers-custom`; now a proper `:doc:` reference.

## B. TOC hierarchy

- `providers-custom` was listed **twice** (inline in `providers.rst` *and* top-level in `index.rst`), which is the duplicated "Custom and Local Providers" in the sidebar. Now nested under Providers only.
- `browser` nested under `tools` instead of being its own top-level sibling.
- About toctree set to `:maxdepth: 1`. The landing page was inlining all **54** release entries under Changelog; now zero.

## C. New page: Tool Formats

`--tool-format` is central to gptme — it predates native tool/function calling and is load-bearing for model compatibility — but had no dedicated documentation. Every mention was incidental: one line in `config.rst`, a parenthetical in `evals.rst`, two troubleshooting rows in `providers-custom.rst`. Nothing explained what the formats are or how to choose.

`docs/tool-formats.rst` is a **choosing guide**, not a flag reference:

- What `markdown` / `xml` / `tool` each emit and parse, with examples.
- Why the non-native formats exist and still matter, and their trade-offs: context cost of JSON schemas, constrained decoding, parallel tool calls, and how much tool-use post-training a model got (instruction adherence). A good model works ~well in all three; which one wins is empirical per model.
- Gotchas that bite in practice: `xml` mode does not parse markdown code blocks at all; `tool` mode still does; native tools hard-fail (not degrade) on providers outside the allowlist.
- The full resolution order: CLI flag → resumed chat config → `GPTME_TOOL_FORMAT`/`TOOL_FORMAT` → model `default_tool_format` → `markdown`.
- Troubleshooting section.

Linked from `providers.rst`, `config.rst`, and `evals.rst`.

### ModelMeta fields, documented honestly

The page also documents `default_tool_format`, `supports_parallel_tool_calls`, `supports_strict_tools`, and `preferred_edit_format` — previously undocumented — including **how unevenly they are populated**:

- `default_tool_format` is set in exactly one place: a bulk assignment over the `openai-subscription` models. No other model in the registry declares one, so for almost every model that resolution step is a no-op.
- `supports_parallel_tool_calls` / `supports_strict_tools` cover roughly 30 and 23 entries respectively (Claude 4.x families + OpenRouter aliases + Kimi K3; GPT-4o/4.1/5 + o-series).

The page states that an absent flag means "not recorded", not "not supported", and notes that the evals leaderboard already reports the best-performing format per model and is the natural source for populating `default_tool_format` later. **That population is a code change and deliberately not in this PR.**

## Verified in the rendered HTML, not just the source

This whole bug class is "the source looks fine, the render doesn't", so:

- `providers.html` now emits section anchors for all ten sections: `#selecting-a-provider-and-model`, `#configuring-credentials`, `#openai-platform`, `#openrouter`, `#requesty`, `#groq`, `#openai-subscription`, `#gptme-managed-service`, `#provider-plugins-entry-points`, `#local`. Previously: **none of them existed**.
- All ten appear in the in-page TOC. Zero `class="rubric"` nodes remain.
- Sidebar: "Custom and Local Providers" appears once (was twice), "Browser Tool" is nested under Tools, "Tool Formats" is nested under Providers.
- `index.html` body: 54 → 0 inlined release links.
- Sphinx warning set diffed against a build of master: **no new warnings**, zero `problematic` nodes on the new page.

## Deliberately left out

- **Merging Cookbook into How-To Guides.** They are the same thing but in different markup languages (`cookbook.rst`, 429 lines RST vs `docs/howto/`, 10 Markdown files). That is a large content-motion diff and would make this one unreviewable.
- **Re-homing `provider-integration` and `model-routing`** into that guides group. They stay flat top-level siblings for now, since their right home depends on the guides consolidation above.
- **Auditing the rest of the docs for rubric-as-heading.** `examples.rst`, `config.rst`, `demos.rst`, `usage.rst`, and `projects.rst` all use rubrics as de-facto headings and have the same missing-anchor problem. Same fix, separate PR — keeping this one scoped to the page that was reported.
- **Populating the ModelMeta fields** from eval data (code change).
