### PR TITLE
refactor(tests): move hashline snapshot test out of test_tools_read.py

### DIFF
--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -796,6 +796,38 @@ class TestReadIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Read tool integration — snapshot stored even without hashline active
+# ---------------------------------------------------------------------------
+
+
+class TestReadIntegrationWithoutHashline:
+    """Snapshot behavior when hashline_edit is NOT active at read time."""
+
+    def test_snapshot_stored_even_without_hashline_tool(self, tmp_path: Path):
+        """Snapshot is stored even when hashline_edit is not loaded at read time.
+
+        This preserves mid-session activation: a user can read files without
+        hashline_edit, then load_tool('hashline_edit') and still edit those files.
+        """
+        from gptme.tools import get_tools, set_tools
+
+        path = tmp_path / "test.py"
+        path.write_text('print("hello")\n')
+
+        prev = get_tools()
+        set_tools([])  # no hashline_edit active
+        try:
+            list(execute_read(None, [str(path)], None))
+        finally:
+            set_tools(prev)
+
+        assert get_stored_tag(str(path.resolve())) is not None, (
+            "Snapshot must be stored even when hashline_edit is inactive, "
+            "so load_tool('hashline_edit') can edit files read before activation."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Block resolution (_resolve_block_end)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -79,32 +79,6 @@ def test_read_file_includes_hashline_tag_when_hashline_tool_active(tmp_path: Pat
     assert "[" + str(path) + "#" in messages[0].content
 
 
-def test_read_file_snapshot_stored_even_without_hashline_tool(tmp_path: Path):
-    """Snapshot is stored even when hashline_edit is not loaded at read time.
-
-    This preserves mid-session activation: a user can read files without
-    hashline_edit, then load_tool('hashline_edit') and still edit those files.
-    """
-    from gptme.tools import get_tools, set_tools
-    from gptme.tools._hashline_snapshot import _store, get_stored_tag
-
-    path = tmp_path / "test.py"
-    path.write_text('print("hello")\n')
-
-    prev = get_tools()
-    set_tools([])
-    try:
-        _store.clear()
-        list(execute_read(None, [str(path)], None))
-    finally:
-        set_tools(prev)
-
-    assert get_stored_tag(str(path.resolve())) is not None, (
-        "Snapshot must be stored even when hashline_edit is inactive, "
-        "so load_tool('hashline_edit') can edit files read before activation."
-    )
-
-
 def test_read_file_line_range_kwargs(tmp_path: Path):
     """Test reading a line range via kwargs."""
     path = tmp_path / "test.txt"


### PR DESCRIPTION
## Problem

The final acceptance criterion from #3560 was unmet after PR #3562 merged:
`tests/test_tools_read.py` still imported `_hashline_snapshot` directly via
`test_read_file_snapshot_stored_even_without_hashline_tool`.

## Fix

Move that test into `test_tools_hashline_edit.py` as a new
`TestReadIntegrationWithoutHashline` class. It belongs there because it
exercises hashline-specific snapshot behaviour (unconditional storage so
mid-session `load_tool('hashline_edit')` can edit pre-read files).

## Acceptance Criteria (all now satisfied)

- ✅ `gptme/tools/read.py` does not import `_hashline_snapshot` (done in #3562)
- ✅ `tests/test_tools_read.py` does not import `_hashline_snapshot` (this PR)
- ✅ Read tool examples show plain output without hashline tags (done in #3561)
- ✅ Hashline tag header shown only when `hashline_edit` is active (done in #3562)

## Tests

- `poetry run pytest tests/test_tools_read.py tests/test_tools_hashline_edit.py` — 168/168 pass

Closes #3560

<!-- gptme-id:v1:gai_KsyLejyuojuE5oeUFaWUU6GjhMGpbHOKWQD3rZm207H -->