### PR TITLE
feat(shell): opt-in per-shell memory ceiling via GPTME_SHELL_MEMORY_LIMIT

### DIFF
--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -237,7 +238,10 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     # Persistent shell form: re-exec the shell so the limit applies to it and
     # every child it spawns.  Clear BASH_ENV first so any user script that
     # resets ulimits cannot bypass the configured ceiling in the exec'd shell.
-    return [cmd[0], "-c", f"{prefix}BASH_ENV='' exec {cmd[0]}"]
+    # Preserve all original arguments (e.g. --norc) in the exec'd shell so the
+    # function honours its contract for any future caller that passes extra flags.
+    exec_cmd = " ".join(shlex.quote(a) for a in cmd)
+    return [cmd[0], "-c", f"{prefix}BASH_ENV='' exec {exec_cmd}"]
 
 
 def verify_memory_limit(limit: int) -> None:

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -212,8 +212,12 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     the sandbox rather than limiting the sandbox launcher itself.
 
     Two forms are supported:
-      - ``["bash"]``            → ``["bash", "-c", "ulimit -v N; exec bash"]``
-      - ``["bash", "-c", "..."]`` → ``["bash", "-c", "ulimit -v N; ..."]``
+      - ``["bash"]``            → ``["bash", "-c", "ulimit -v N && BASH_ENV='' exec bash"]``
+      - ``["bash", "-c", "..."]`` → ``["bash", "-c", "ulimit -v N && { ...; }"]``
+
+    The persistent shell form clears ``BASH_ENV`` before exec so that any
+    user ``$BASH_ENV`` script that resets limits (e.g. ``ulimit -v unlimited``)
+    cannot silently bypass the configured ceiling in the replacement shell.
     """
     if limit is None or not cmd:
         return cmd
@@ -231,8 +235,9 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
         # comment out the closing brace.
         return [cmd[0], cmd[1], prefix + "{ " + cmd[2] + "\n}", *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and
-    # every child it spawns (the semantic we want for a long-lived shell).
-    return [cmd[0], "-c", f"{prefix}exec {cmd[0]}"]
+    # every child it spawns.  Clear BASH_ENV first so any user script that
+    # resets ulimits cannot bypass the configured ceiling in the exec'd shell.
+    return [cmd[0], "-c", f"{prefix}BASH_ENV='' exec {cmd[0]}"]
 
 
 def verify_memory_limit(limit: int) -> None:

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -217,7 +217,9 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     """
     if limit is None or not cmd:
         return cmd
-    kib = max(1, limit // 1024)  # ulimit -v is expressed in KiB
+    kib = max(
+        1, (limit + 1023) // 1024
+    )  # ulimit -v is in KiB; ceil so applied limit ≥ requested
     # Use && so that a failed ulimit prevents the command from running unrestricted.
     prefix = f"ulimit -v {kib} && "
     if len(cmd) >= 3 and cmd[1] == "-c":

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -227,7 +227,9 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     if len(cmd) >= 3 and cmd[1] == "-c":
         # Wrap in a group so && gates the entire user script, not just its first
         # statement (shell parses `ulimit -v N && a; b` as `(ulimit && a); b`).
-        return [cmd[0], cmd[1], prefix + "{ " + cmd[2] + "; }", *cmd[3:]]
+        # Use a newline before } so a trailing # comment in cmd[2] doesn't
+        # comment out the closing brace.
+        return [cmd[0], cmd[1], prefix + "{ " + cmd[2] + "\n}", *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and
     # every child it spawns (the semantic we want for a long-lived shell).
     return [cmd[0], "-c", f"{prefix}exec {cmd[0]}"]

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -220,8 +220,9 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     kib = max(
         1, (limit + 1023) // 1024
     )  # ulimit -v is in KiB; ceil so applied limit ≥ requested
-    # Use && so that a failed ulimit prevents the command from running unrestricted.
-    prefix = f"ulimit -v {kib} && "
+    # Best-effort: if ulimit -v is unavailable or the limit exceeds the hard limit,
+    # warn and continue without the ceiling rather than silently killing the shell.
+    prefix = f"ulimit -v {kib} 2>/dev/null || echo 'WARNING: GPTME_SHELL_MEMORY_LIMIT ignored: ulimit -v failed' >&2; "
     if len(cmd) >= 3 and cmd[1] == "-c":
         return [cmd[0], cmd[1], prefix + cmd[2], *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -212,13 +212,22 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     before ``wrap_shell_cmd`` so firejail/bwrap run the limited shell inside
     the sandbox rather than limiting the sandbox launcher itself.
 
-    Two forms are supported:
-      - ``["bash"]``            → ``["bash", "-c", "ulimit -v N && BASH_ENV='' exec bash"]``
-      - ``["bash", "-c", "..."]`` → ``["bash", "-c", "ulimit -v N && { ...; }"]``
+    Both forms are prefixed with ``env -u BASH_ENV`` so that bash starts with
+    ``BASH_ENV`` unset in its process environment.  This prevents any user
+    startup script referenced by ``$BASH_ENV`` from running *before* the
+    ``ulimit -v`` command in the ``-c`` script, which would otherwise allow the
+    startup code to execute outside the configured ceiling.
 
-    The persistent shell form clears ``BASH_ENV`` before exec so that any
-    user ``$BASH_ENV`` script that resets limits (e.g. ``ulimit -v unlimited``)
-    cannot silently bypass the configured ceiling in the replacement shell.
+    Two forms are supported:
+      - ``["bash"]``            → ``["env", "-u", "BASH_ENV", "bash", "-c",
+                                    "ulimit -v N && BASH_ENV='' exec bash"]``
+      - ``["bash", "-c", "..."]`` → ``["env", "-u", "BASH_ENV", "bash", "-c",
+                                       "ulimit -v N && { ...; }"]``
+
+    The persistent shell form additionally clears ``BASH_ENV`` inline before
+    exec so the replacement shell also inherits a clean environment (belt and
+    suspenders: env handles the outer shell, the inline assignment handles the
+    exec'd shell).
     """
     if limit is None or not cmd:
         return cmd
@@ -229,19 +238,24 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     # running unrestricted.  Call verify_memory_limit() before spawning so
     # failures surface at the Python level with a clear message.
     prefix = f"ulimit -v {kib} && "
+    # Prepend `env -u BASH_ENV` so bash starts with BASH_ENV unset at the
+    # process-environment level.  Bash sources BASH_ENV before executing any
+    # -c script, so without this, startup code in $BASH_ENV would run before
+    # ulimit is installed and could allocate memory outside the ceiling.
+    env_prefix = ["env", "-u", "BASH_ENV"]
     if len(cmd) >= 3 and cmd[1] == "-c":
         # Wrap in a group so && gates the entire user script, not just its first
         # statement (shell parses `ulimit -v N && a; b` as `(ulimit && a); b`).
         # Use a newline before } so a trailing # comment in cmd[2] doesn't
         # comment out the closing brace.
-        return [cmd[0], cmd[1], prefix + "{ " + cmd[2] + "\n}", *cmd[3:]]
+        return [*env_prefix, cmd[0], cmd[1], prefix + "{ " + cmd[2] + "\n}", *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and
-    # every child it spawns.  Clear BASH_ENV first so any user script that
-    # resets ulimits cannot bypass the configured ceiling in the exec'd shell.
+    # every child it spawns.  Clear BASH_ENV inline before exec as well so the
+    # replacement shell also has no BASH_ENV to source on startup.
     # Preserve all original arguments (e.g. --norc) in the exec'd shell so the
     # function honours its contract for any future caller that passes extra flags.
     exec_cmd = " ".join(shlex.quote(a) for a in cmd)
-    return [cmd[0], "-c", f"{prefix}BASH_ENV='' exec {exec_cmd}"]
+    return [*env_prefix, cmd[0], "-c", f"{prefix}BASH_ENV='' exec {exec_cmd}"]
 
 
 def verify_memory_limit(limit: int) -> None:

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -220,14 +220,38 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     kib = max(
         1, (limit + 1023) // 1024
     )  # ulimit -v is in KiB; ceil so applied limit ≥ requested
-    # Best-effort: if ulimit -v is unavailable or the limit exceeds the hard limit,
-    # warn and continue without the ceiling rather than silently killing the shell.
-    prefix = f"ulimit -v {kib} 2>/dev/null || echo 'WARNING: GPTME_SHELL_MEMORY_LIMIT ignored: ulimit -v failed' >&2; "
+    # Hard-gate: if ulimit -v fails at runtime the shell aborts rather than
+    # running unrestricted.  Call verify_memory_limit() before spawning so
+    # failures surface at the Python level with a clear message.
+    prefix = f"ulimit -v {kib} && "
     if len(cmd) >= 3 and cmd[1] == "-c":
         return [cmd[0], cmd[1], prefix + cmd[2], *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and
     # every child it spawns (the semantic we want for a long-lived shell).
     return [cmd[0], "-c", f"{prefix}exec {cmd[0]}"]
+
+
+def verify_memory_limit(limit: int) -> None:
+    """Verify that ``ulimit -v`` can apply *limit* bytes on this system.
+
+    Raises ``ValueError`` if the limit cannot be applied (e.g. it exceeds the
+    hard limit or ``ulimit -v`` is unavailable).  Call this before spawning a
+    shell so failures surface at the Python level — an informative error —
+    rather than silently leaving the shell unrestricted.
+    """
+    kib = max(1, (limit + 1023) // 1024)
+    result = subprocess.run(
+        ["bash", "-c", f"ulimit -v {kib}"],
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"GPTME_SHELL_MEMORY_LIMIT cannot be enforced: "
+            f"'ulimit -v {kib}' exited {result.returncode}. "
+            f"Check your system's ulimit hard limit or reduce the configured value."
+        )
 
 
 def build_env(config: SandboxConfig) -> dict[str, str] | None:

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -193,9 +193,12 @@ def _parse_size(value: str) -> int:
     factor = units.get(suffix, 1)
     number = value[:-1] if suffix in units else value
     try:
-        return int(number) * factor
+        result = int(number) * factor
     except ValueError as exc:
         raise ValueError(f"invalid size: {value!r}") from exc
+    if result <= 0:
+        raise ValueError(f"size must be positive: {value!r}")
+    return result
 
 
 def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
@@ -215,7 +218,8 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     if limit is None or not cmd:
         return cmd
     kib = max(1, limit // 1024)  # ulimit -v is expressed in KiB
-    prefix = f"ulimit -v {kib}; "
+    # Use && so that a failed ulimit prevents the command from running unrestricted.
+    prefix = f"ulimit -v {kib} && "
     if len(cmd) >= 3 and cmd[1] == "-c":
         return [cmd[0], cmd[1], prefix + cmd[2], *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -179,6 +179,50 @@ def wrap_shell_cmd(config: SandboxConfig, cmd: list[str]) -> list[str]:
     return cmd
 
 
+def _parse_size(value: str) -> int:
+    """Parse a human-readable size string into bytes.
+
+    Accepts a plain integer (bytes) or an integer with a binary unit suffix
+    (``K``/``M``/``G``/``T``, case-insensitive), e.g. ``"512M"`` → 536870912.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("empty size")
+    units = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    suffix = value[-1].upper()
+    factor = units.get(suffix, 1)
+    number = value[:-1] if suffix in units else value
+    try:
+        return int(number) * factor
+    except ValueError as exc:
+        raise ValueError(f"invalid size: {value!r}") from exc
+
+
+def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
+    """Cap the address space of a bash invocation via ``ulimit -v``.
+
+    ``limit`` is in bytes (``None`` → no limit, returns ``cmd`` unchanged).
+    POSIX-only: ``ulimit`` is a bash builtin, so callers skip this on Windows.
+
+    Composes with the sandbox wrapper: apply it to the *inner* bash command
+    before ``wrap_shell_cmd`` so firejail/bwrap run the limited shell inside
+    the sandbox rather than limiting the sandbox launcher itself.
+
+    Two forms are supported:
+      - ``["bash"]``            → ``["bash", "-c", "ulimit -v N; exec bash"]``
+      - ``["bash", "-c", "..."]`` → ``["bash", "-c", "ulimit -v N; ..."]``
+    """
+    if limit is None or not cmd:
+        return cmd
+    kib = max(1, limit // 1024)  # ulimit -v is expressed in KiB
+    prefix = f"ulimit -v {kib}; "
+    if len(cmd) >= 3 and cmd[1] == "-c":
+        return [cmd[0], cmd[1], prefix + cmd[2], *cmd[3:]]
+    # Persistent shell form: re-exec the shell so the limit applies to it and
+    # every child it spawns (the semantic we want for a long-lived shell).
+    return [cmd[0], "-c", f"{prefix}exec {cmd[0]}"]
+
+
 def build_env(config: SandboxConfig) -> dict[str, str] | None:
     """Return sanitized environment dict, or None to inherit current env.
 

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -234,10 +234,13 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     kib = max(
         1, (limit + 1023) // 1024
     )  # ulimit -v is in KiB; ceil so applied limit ≥ requested
-    # Hard-gate: if ulimit -v fails at runtime the shell aborts rather than
-    # running unrestricted.  Call verify_memory_limit() before spawning so
-    # failures surface at the Python level with a clear message.
-    prefix = f"ulimit -v {kib} && "
+    # Set both the hard and soft RLIMIT_AS so subprocesses cannot raise the
+    # soft limit back to unlimited via `ulimit -v unlimited`.  The hard limit
+    # is lowered first (best-effort; suppressed if it is already below kib, in
+    # which case verify_memory_limit will have caught the unsatisfiable config
+    # before we get here).  The soft limit is then set to the same value and
+    # gates the user command via &&.
+    prefix = f"ulimit -H -v {kib} 2>/dev/null; ulimit -v {kib} && "
     # Prepend `env -u BASH_ENV` so bash starts with BASH_ENV unset at the
     # process-environment level.  Bash sources BASH_ENV before executing any
     # -c script, so without this, startup code in $BASH_ENV would run before
@@ -259,16 +262,18 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
 
 
 def verify_memory_limit(limit: int) -> None:
-    """Verify that ``ulimit -v`` can apply *limit* bytes on this system.
+    """Verify that both the hard and soft ``ulimit -v`` can be applied on this system.
 
-    Raises ``ValueError`` if the limit cannot be applied (e.g. it exceeds the
-    hard limit or ``ulimit -v`` is unavailable).  Call this before spawning a
-    shell so failures surface at the Python level — an informative error —
-    rather than silently leaving the shell unrestricted.
+    Sets the hard limit first (best-effort) then the soft limit so the check
+    mirrors the actual prefix used in ``apply_memory_limit``.  Raises
+    ``ValueError`` if either step fails — for example, if *limit* exceeds the
+    current system hard limit and we cannot lower it.  Call this before
+    spawning a shell so failures surface at the Python level — an informative
+    error — rather than silently leaving the shell unrestricted.
     """
     kib = max(1, (limit + 1023) // 1024)
     result = subprocess.run(
-        ["bash", "-c", f"ulimit -v {kib}"],
+        ["bash", "-c", f"ulimit -H -v {kib} 2>/dev/null; ulimit -v {kib}"],
         capture_output=True,
         timeout=5,
         check=False,

--- a/gptme/sandbox.py
+++ b/gptme/sandbox.py
@@ -225,7 +225,9 @@ def apply_memory_limit(cmd: list[str], limit: int | None) -> list[str]:
     # failures surface at the Python level with a clear message.
     prefix = f"ulimit -v {kib} && "
     if len(cmd) >= 3 and cmd[1] == "-c":
-        return [cmd[0], cmd[1], prefix + cmd[2], *cmd[3:]]
+        # Wrap in a group so && gates the entire user script, not just its first
+        # statement (shell parses `ulimit -v N && a; b` as `(ulimit && a); b`).
+        return [cmd[0], cmd[1], prefix + "{ " + cmd[2] + "; }", *cmd[3:]]
     # Persistent shell form: re-exec the shell so the limit applies to it and
     # every child it spawns (the semantic we want for a long-lived shell).
     return [cmd[0], "-c", f"{prefix}exec {cmd[0]}"]

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -8,6 +8,12 @@ Configuration:
         - Invalid values default to 1200 seconds (20 minutes)
         - If not set, defaults to 1200 seconds (20 minutes)
 
+    GPTME_SHELL_MEMORY_LIMIT: Optional per-shell address-space ceiling (POSIX only,
+        off by default). Accepts a plain byte count or a binary suffix (e.g.
+        "512M", "1G"). Applies to the persistent shell and any command it runs
+        via `ulimit -v`, so a runaway build fails with an allocation error
+        instead of stalling the session.
+
     GPTME_SHELL_TRUNC_PRE_TOKENS / GPTME_SHELL_TRUNC_POST_TOKENS: Override the
     head/tail token budget for stdout truncation. Defaults: 2000 / 8000.
     GPTME_SHELL_TRUNC_STDERR_PRE_TOKENS / GPTME_SHELL_TRUNC_STDERR_POST_TOKENS:
@@ -34,7 +40,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..message import Message
-from ..sandbox import SandboxConfig, build_env, wrap_shell_cmd
+from ..sandbox import (
+    SandboxConfig,
+    _parse_size,
+    apply_memory_limit,
+    build_env,
+    wrap_shell_cmd,
+)
 from ..util import get_installed_programs
 from ..util.ask_execute import execute_with_confirmation
 from ..util.context import md_codeblock
@@ -253,6 +265,28 @@ def examples(tool_format):
 """.strip()
 
 
+def _get_memory_limit() -> int | None:
+    """Read the opt-in shell memory ceiling in bytes, or None if unset.
+
+    Knob is ``GPTME_SHELL_MEMORY_LIMIT`` (env) or ``[env] SHELL_MEMORY_LIMIT``
+    (config.toml). The value is a byte count or a binary-suffixed size (e.g.
+    ``"512M"``). Unparseable values are logged and treated as unset.
+    """
+    from ..config import get_config  # deferred: avoid import cycle
+
+    raw = get_config().get_env("SHELL_MEMORY_LIMIT")
+    if not raw:
+        return None
+    try:
+        return _parse_size(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid GPTME_SHELL_MEMORY_LIMIT=%r (expected e.g. '512M')",
+            raw,
+        )
+        return None
+
+
 class ShellSession:
     process: subprocess.Popen
     stdout_fd: int
@@ -260,9 +294,11 @@ class ShellSession:
     delimiter: str
     start_marker: str  # Fix for Issue #408: Add start marker to prevent output mixing
     _cwd: str | None  # Workspace directory for this session (thread-safe)
+    _memory_limit: int | None  # Address-space ceiling in bytes (None = off)
 
     def __init__(self, cwd: str | None = None) -> None:
         self._cwd = cwd
+        self._memory_limit = _get_memory_limit()
         self._init()
 
         # close on exit
@@ -278,6 +314,8 @@ class ShellSession:
             popen_kwargs = {
                 "start_new_session": True,  # Create new process group for proper signal handling
             }
+            if self._memory_limit is not None:
+                shell_cmd = apply_memory_limit(shell_cmd, self._memory_limit)
 
         # Apply sandbox wrapper if GPTME_SANDBOX is set
         sandbox = SandboxConfig.from_env(
@@ -408,8 +446,11 @@ class ShellSession:
                     "PYTHONUNBUFFERED": "1",
                 }
             )
+            shell_cmd = ["bash", "-c", command]
+            if self._memory_limit is not None:
+                shell_cmd = apply_memory_limit(shell_cmd, self._memory_limit)
             proc = subprocess.Popen(
-                ["bash", "-c", command],
+                shell_cmd,
                 stdin=tty_stdin,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -271,7 +271,9 @@ def _get_memory_limit() -> int | None:
 
     Knob is ``GPTME_SHELL_MEMORY_LIMIT`` (env) or ``[env] SHELL_MEMORY_LIMIT``
     (config.toml). The value is a byte count or a binary-suffixed size (e.g.
-    ``"512M"``). Unparseable values are logged and treated as unset.
+    ``"512M"``). Unparseable values and unenforceable limits (e.g. the value
+    exceeds the system hard ulimit) are both logged as warnings and treated as
+    unset so a misconfiguration never breaks the shell tool entirely.
 
     POSIX-only: returns None on Windows because ``ulimit -v`` is not available.
     """
@@ -293,11 +295,16 @@ def _get_memory_limit() -> int | None:
     try:
         verify_memory_limit(limit)
     except ValueError as exc:
-        raise RuntimeError(
-            f"Cannot start shell: GPTME_SHELL_MEMORY_LIMIT is set but cannot be "
-            f"enforced on this system. Either unset the variable or reduce the value. "
-            f"Details: {exc}"
-        ) from exc
+        # Treat an unenforceable limit as unset rather than crashing the shell.
+        # A misconfigured ceiling (e.g. 4G on a system with a 2G hard ulimit)
+        # should not prevent every shell command from working.
+        logger.warning(
+            "GPTME_SHELL_MEMORY_LIMIT=%r cannot be enforced on this system "
+            "(running without memory ceiling). Details: %s",
+            raw,
+            exc,
+        )
+        return None
     return limit
 
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1714,10 +1714,11 @@ def execute_shell(
 
     if bg_line_idx is not None:
         # Found a bg command
+        _bg_memory_limit = _get_memory_limit()
         if bg_line_idx == 0 and len(lines) == 1:
             # Simple case: bg is the only command
             bg_cmd = cmd_stripped[3:].strip()
-            yield from execute_bg_command(bg_cmd)
+            yield from execute_bg_command(bg_cmd, memory_limit=_bg_memory_limit)
             return
         elif bg_line_idx > 0:
             # bg is on a later line - execute preceding commands first (Issue #992)
@@ -1728,7 +1729,7 @@ def execute_shell(
             # Now execute the bg command
             bg_line = lines[bg_line_idx].strip()
             bg_cmd = bg_line[3:].strip()  # Remove "bg " prefix
-            yield from execute_bg_command(bg_cmd)
+            yield from execute_bg_command(bg_cmd, memory_limit=_bg_memory_limit)
             # Execute any remaining commands after bg (unlikely but handle it)
             if bg_line_idx < len(lines) - 1:
                 remaining_cmds = "\n".join(lines[bg_line_idx + 1 :])
@@ -1740,7 +1741,7 @@ def execute_shell(
             # Start bg job, then execute remaining commands
             bg_line = lines[0].strip()
             bg_cmd = bg_line[3:].strip()
-            yield from execute_bg_command(bg_cmd)
+            yield from execute_bg_command(bg_cmd, memory_limit=_bg_memory_limit)
             remaining_cmds = "\n".join(lines[1:])
             if remaining_cmds.strip():
                 yield from execute_shell(remaining_cmds, None, None)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -278,8 +278,8 @@ def _get_memory_limit() -> int | None:
     if not raw:
         return None
     try:
-        return _parse_size(raw)
-    except ValueError:
+        return _parse_size(str(raw))
+    except (ValueError, AttributeError):
         logger.warning(
             "Ignoring invalid GPTME_SHELL_MEMORY_LIMIT=%r (expected e.g. '512M')",
             raw,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -272,7 +272,11 @@ def _get_memory_limit() -> int | None:
     Knob is ``GPTME_SHELL_MEMORY_LIMIT`` (env) or ``[env] SHELL_MEMORY_LIMIT``
     (config.toml). The value is a byte count or a binary-suffixed size (e.g.
     ``"512M"``). Unparseable values are logged and treated as unset.
+
+    POSIX-only: returns None on Windows because ``ulimit -v`` is not available.
     """
+    if _is_windows:
+        return None  # ulimit -v is a POSIX-only bash builtin; skip silently
     from ..config import get_config  # deferred: avoid import cycle
 
     raw = get_config().get_env("SHELL_MEMORY_LIMIT")

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -45,6 +45,7 @@ from ..sandbox import (
     _parse_size,
     apply_memory_limit,
     build_env,
+    verify_memory_limit,
     wrap_shell_cmd,
 )
 from ..util import get_installed_programs
@@ -278,13 +279,22 @@ def _get_memory_limit() -> int | None:
     if not raw:
         return None
     try:
-        return _parse_size(str(raw))
+        limit = _parse_size(str(raw))
     except (ValueError, AttributeError):
         logger.warning(
             "Ignoring invalid GPTME_SHELL_MEMORY_LIMIT=%r (expected e.g. '512M')",
             raw,
         )
         return None
+    try:
+        verify_memory_limit(limit)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Cannot start shell: GPTME_SHELL_MEMORY_LIMIT is set but cannot be "
+            f"enforced on this system. Either unset the variable or reduce the value. "
+            f"Details: {exc}"
+        ) from exc
+    return limit
 
 
 class ShellSession:

--- a/gptme/tools/shell_background.py
+++ b/gptme/tools/shell_background.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ..message import Message
+from ..sandbox import apply_memory_limit
 from ..util.context import md_codeblock
 
 _is_windows = os.name == "nt"
@@ -172,7 +173,9 @@ def _get_next_job_id() -> int:
         return job_id
 
 
-def start_background_job(command: str) -> BackgroundJob:
+def start_background_job(
+    command: str, memory_limit: int | None = None
+) -> BackgroundJob:
     """Start a command as a background job (thread-safe)."""
     # Proactively clean up finished jobs to prevent memory accumulation
     cleanup_finished_jobs()
@@ -181,10 +184,13 @@ def start_background_job(command: str) -> BackgroundJob:
 
     # Start process with separate stdout/stderr pipes
     popen_kwargs: dict = {}
+    shell_cmd: list[str] = ["bash", "-c", command]
     if not _is_windows:
         popen_kwargs["start_new_session"] = True
+        if memory_limit is not None:
+            shell_cmd = apply_memory_limit(shell_cmd, memory_limit)
     process = subprocess.Popen(
-        ["bash", "-c", command],
+        shell_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.DEVNULL,
@@ -247,7 +253,9 @@ atexit.register(reset_background_jobs)
 # Background command handlers
 
 
-def execute_bg_command(command: str) -> Generator[Message, None, None]:
+def execute_bg_command(
+    command: str, memory_limit: int | None = None
+) -> Generator[Message, None, None]:
     """Start a command as a background job."""
     from .shell_validation import is_denylisted
 
@@ -263,7 +271,7 @@ def execute_bg_command(command: str) -> Generator[Message, None, None]:
         )
         return
 
-    job = start_background_job(command)
+    job = start_background_job(command, memory_limit=memory_limit)
     yield Message(
         "system",
         f"Started background job **#{job.id}**: `{command}`\n\n"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -994,6 +994,14 @@ class TestApplyMemoryLimit:
         exec_pos = script.index("exec")
         assert ulimit_pos < bash_env_pos < exec_pos
 
+    def test_persistent_form_preserves_extra_flags(self):
+        # apply_memory_limit(["bash", "--norc"], N) must not drop --norc so the
+        # function honours its contract for callers that pass startup flags.
+        result = apply_memory_limit(["bash", "--norc"], 512 * 1024**2)
+        assert result[0] == "bash"
+        assert result[1] == "-c"
+        assert "exec bash --norc" in result[2]
+
 
 # ---------------------------------------------------------------------------
 # verify_memory_limit

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -942,6 +942,9 @@ class TestApplyMemoryLimit:
         assert result[1] == "-c"
         assert "ulimit -v 1024" in result[2]
         assert "echo hi" in result[2]
+        # Script must be wrapped in a group so && gates the entire script, not
+        # just its first statement (e.g. `ulimit && a; b` runs b even if ulimit fails).
+        assert "{ echo hi; }" in result[2]
 
     def test_empty_cmd_returns_unchanged(self):
         assert apply_memory_limit([], 1024) == []

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -942,3 +942,9 @@ class TestApplyMemoryLimit:
     def test_small_limit_rounds_up_to_one_kib(self):
         result = apply_memory_limit(["bash"], 1)
         assert result == ["bash", "-c", "ulimit -v 1 && exec bash"]
+
+    def test_non_kib_aligned_limit_rounds_up(self):
+        # 2000 bytes is not KiB-aligned; floor gives 1 KiB (under-allocates),
+        # ceiling gives 2 KiB (at least the requested amount).
+        result = apply_memory_limit(["bash"], 2000)
+        assert result == ["bash", "-c", "ulimit -v 2 && exec bash"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1013,6 +1013,27 @@ class TestApplyMemoryLimit:
             "one-shot form missing env -u BASH_ENV prefix"
         )
 
+    def test_hard_limit_set_before_soft_limit(self):
+        # Both forms must set the hard limit (ulimit -H -v) before the soft
+        # limit so subprocesses cannot raise the soft limit back to unlimited
+        # via `ulimit -v unlimited`.  Hard-limit lowering is best-effort
+        # (suppressed with 2>/dev/null) so pre-existing lower hard limits are
+        # respected; the soft-limit command still fails fast if kib > hard.
+        persistent = apply_memory_limit(["bash"], 512 * 1024**2)
+        one_shot = apply_memory_limit(["bash", "-c", "echo hi"], 512 * 1024**2)
+        for name, result in (("persistent", persistent), ("one-shot", one_shot)):
+            script = result[-1]
+            hard_pos = script.index("ulimit -H -v ")
+            soft_pos = script.index("ulimit -v ", hard_pos + 1)
+            assert hard_pos < soft_pos, (
+                f"{name} form: hard-limit command must precede soft-limit command"
+            )
+            # Hard limit is best-effort (2>/dev/null) so a pre-existing lower
+            # hard limit doesn't crash the shell; the soft ulimit gates the &&.
+            assert "2>/dev/null" in script[hard_pos:soft_pos], (
+                f"{name} form: ulimit -H -v must be followed by 2>/dev/null"
+            )
+
     def test_persistent_form_clears_bash_env(self):
         # The -c script must also clear BASH_ENV inline before exec so the
         # replacement shell inherits a clean environment (belt-and-suspenders:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -928,23 +928,39 @@ class TestApplyMemoryLimit:
         assert apply_memory_limit(cmd, None) is cmd
 
     def test_persistent_shell_form(self):
-        # 512 MiB → 524288 KiB
+        # 512 MiB → 524288 KiB; best-effort fallback prefix used
         result = apply_memory_limit(["bash"], 512 * 1024**2)
-        assert result == ["bash", "-c", "ulimit -v 524288 && exec bash"]
+        assert result[0] == "bash"
+        assert result[1] == "-c"
+        assert "ulimit -v 524288" in result[2]
+        assert "exec bash" in result[2]
 
     def test_command_form_prepends_ulimit(self):
         result = apply_memory_limit(["bash", "-c", "echo hi"], 1024 * 1024)
-        assert result == ["bash", "-c", "ulimit -v 1024 && echo hi"]
+        assert result[0] == "bash"
+        assert result[1] == "-c"
+        assert "ulimit -v 1024" in result[2]
+        assert "echo hi" in result[2]
 
     def test_empty_cmd_returns_unchanged(self):
         assert apply_memory_limit([], 1024) == []
 
     def test_small_limit_rounds_up_to_one_kib(self):
         result = apply_memory_limit(["bash"], 1)
-        assert result == ["bash", "-c", "ulimit -v 1 && exec bash"]
+        assert "ulimit -v 1" in result[2]
+        assert "exec bash" in result[2]
 
     def test_non_kib_aligned_limit_rounds_up(self):
         # 2000 bytes is not KiB-aligned; floor gives 1 KiB (under-allocates),
         # ceiling gives 2 KiB (at least the requested amount).
         result = apply_memory_limit(["bash"], 2000)
-        assert result == ["bash", "-c", "ulimit -v 2 && exec bash"]
+        assert "ulimit -v 2" in result[2]
+        assert "exec bash" in result[2]
+
+    def test_ulimit_failure_falls_back_gracefully(self):
+        # The prefix must not use && — a failed ulimit should not prevent the shell
+        # from starting. Verify the separator is not && alone.
+        result = apply_memory_limit(["bash"], 512 * 1024**2)
+        script = result[2]
+        # The ulimit invocation should fall back (|| or ;) rather than hard-gate (&&).
+        assert " && exec" not in script

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -908,6 +908,14 @@ class TestParseSize:
         with pytest.raises(ValueError, match="invalid size"):
             _parse_size("abc")
 
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            _parse_size("0")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            _parse_size("-1")
+
 
 # ---------------------------------------------------------------------------
 # apply_memory_limit
@@ -922,15 +930,15 @@ class TestApplyMemoryLimit:
     def test_persistent_shell_form(self):
         # 512 MiB → 524288 KiB
         result = apply_memory_limit(["bash"], 512 * 1024**2)
-        assert result == ["bash", "-c", "ulimit -v 524288; exec bash"]
+        assert result == ["bash", "-c", "ulimit -v 524288 && exec bash"]
 
     def test_command_form_prepends_ulimit(self):
         result = apply_memory_limit(["bash", "-c", "echo hi"], 1024 * 1024)
-        assert result == ["bash", "-c", "ulimit -v 1024; echo hi"]
+        assert result == ["bash", "-c", "ulimit -v 1024 && echo hi"]
 
     def test_empty_cmd_returns_unchanged(self):
         assert apply_memory_limit([], 1024) == []
 
     def test_small_limit_rounds_up_to_one_kib(self):
         result = apply_memory_limit(["bash"], 1)
-        assert result == ["bash", "-c", "ulimit -v 1; exec bash"]
+        assert result == ["bash", "-c", "ulimit -v 1 && exec bash"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -989,6 +989,24 @@ class TestApplyMemoryLimit:
 # ---------------------------------------------------------------------------
 
 
+class TestGetMemoryLimitWindowsGuard:
+    """_get_memory_limit() must return None on Windows without calling the verifier."""
+
+    def test_returns_none_on_windows_without_calling_verifier(self, monkeypatch):
+        """When _is_windows is True the function exits early; verify_memory_limit
+        is never called, so FileNotFoundError from missing bash never surfaces."""
+        monkeypatch.setenv("GPTME_SHELL_MEMORY_LIMIT", "256M")
+        with (
+            patch("gptme.tools.shell._is_windows", True),
+            patch("gptme.tools.shell.verify_memory_limit") as mock_verify,
+        ):
+            from gptme.tools.shell import _get_memory_limit
+
+            result = _get_memory_limit()
+        assert result is None
+        mock_verify.assert_not_called()
+
+
 class TestVerifyMemoryLimit:
     def test_raises_when_ulimit_fails(self):
         from unittest.mock import MagicMock

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -20,6 +20,7 @@ from gptme.sandbox import (
     build_env,
     sandbox_exec_python,
     sandbox_exec_wasmtime,
+    verify_memory_limit,
     wrap_shell_cmd,
 )
 
@@ -928,7 +929,7 @@ class TestApplyMemoryLimit:
         assert apply_memory_limit(cmd, None) is cmd
 
     def test_persistent_shell_form(self):
-        # 512 MiB → 524288 KiB; best-effort fallback prefix used
+        # 512 MiB → 524288 KiB; hard-gate (&&) so a failed ulimit aborts the shell
         result = apply_memory_limit(["bash"], 512 * 1024**2)
         assert result[0] == "bash"
         assert result[1] == "-c"
@@ -957,10 +958,36 @@ class TestApplyMemoryLimit:
         assert "ulimit -v 2" in result[2]
         assert "exec bash" in result[2]
 
-    def test_ulimit_failure_falls_back_gracefully(self):
-        # The prefix must not use && — a failed ulimit should not prevent the shell
-        # from starting. Verify the separator is not && alone.
+    def test_uses_hard_gate_not_soft_fallback(self):
+        # The prefix must use && so a failed ulimit aborts the shell rather than
+        # running it unrestricted.  verify_memory_limit() surfaces failures at
+        # the Python level before the shell is spawned.
         result = apply_memory_limit(["bash"], 512 * 1024**2)
         script = result[2]
-        # The ulimit invocation should fall back (|| or ;) rather than hard-gate (&&).
-        assert " && exec" not in script
+        assert " && exec" in script
+
+
+# ---------------------------------------------------------------------------
+# verify_memory_limit
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyMemoryLimit:
+    def test_raises_when_ulimit_fails(self):
+        from unittest.mock import MagicMock
+
+        result = MagicMock()
+        result.returncode = 1
+        with (
+            patch("gptme.sandbox.subprocess.run", return_value=result),
+            pytest.raises(ValueError, match="cannot be enforced"),
+        ):
+            verify_memory_limit(512 * 1024**2)
+
+    def test_succeeds_when_ulimit_works(self):
+        from unittest.mock import MagicMock
+
+        result = MagicMock()
+        result.returncode = 0
+        with patch("gptme.sandbox.subprocess.run", return_value=result):
+            verify_memory_limit(512 * 1024**2)  # should not raise

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -944,7 +944,21 @@ class TestApplyMemoryLimit:
         assert "echo hi" in result[2]
         # Script must be wrapped in a group so && gates the entire script, not
         # just its first statement (e.g. `ulimit && a; b` runs b even if ulimit fails).
-        assert "{ echo hi; }" in result[2]
+        assert "{ echo hi" in result[2]
+        assert result[2].endswith("}")
+
+    def test_command_form_trailing_comment_not_swallowed(self):
+        # A script ending with a # comment must not comment out the closing }.
+        # Before fix: `{ echo hi  # note; }` → `; }` commented out, bash error.
+        # After fix:  `{ echo hi  # note\n}` → } on its own line, always executes.
+        result = apply_memory_limit(
+            ["bash", "-c", "echo hi  # trailing comment"], 1024 * 1024
+        )
+        script = result[2]
+        assert "# trailing comment" in script
+        # The closing brace must be on its own line, not on the comment line.
+        lines = script.splitlines()
+        assert lines[-1].strip() == "}"
 
     def test_empty_cmd_returns_unchanged(self):
         assert apply_memory_limit([], 1024) == []

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -15,6 +15,8 @@ from gptme.sandbox import (
     _bwrap_cmd,
     _ensure_python_wasm,
     _firejail_cmd,
+    _parse_size,
+    apply_memory_limit,
     build_env,
     sandbox_exec_python,
     sandbox_exec_wasmtime,
@@ -872,3 +874,63 @@ class TestWasmtimeExecUnit:
 
         assert (stdout, rc) == ("", 1)
         assert "Wasmtime error" in stderr
+
+
+# ---------------------------------------------------------------------------
+# _parse_size
+# ---------------------------------------------------------------------------
+
+
+class TestParseSize:
+    def test_plain_bytes(self):
+        assert _parse_size("1024") == 1024
+
+    def test_kilobytes_suffix(self):
+        assert _parse_size("4K") == 4 * 1024
+
+    def test_megabytes_suffix(self):
+        assert _parse_size("512M") == 512 * 1024**2
+
+    def test_gigabytes_suffix_case_insensitive(self):
+        assert _parse_size("1g") == 1024**3
+
+    def test_terabytes_suffix(self):
+        assert _parse_size("2T") == 2 * 1024**4
+
+    def test_strips_whitespace(self):
+        assert _parse_size("  8M ") == 8 * 1024**2
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty size"):
+            _parse_size("")
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="invalid size"):
+            _parse_size("abc")
+
+
+# ---------------------------------------------------------------------------
+# apply_memory_limit
+# ---------------------------------------------------------------------------
+
+
+class TestApplyMemoryLimit:
+    def test_none_limit_returns_unchanged(self):
+        cmd = ["bash"]
+        assert apply_memory_limit(cmd, None) is cmd
+
+    def test_persistent_shell_form(self):
+        # 512 MiB → 524288 KiB
+        result = apply_memory_limit(["bash"], 512 * 1024**2)
+        assert result == ["bash", "-c", "ulimit -v 524288; exec bash"]
+
+    def test_command_form_prepends_ulimit(self):
+        result = apply_memory_limit(["bash", "-c", "echo hi"], 1024 * 1024)
+        assert result == ["bash", "-c", "ulimit -v 1024; echo hi"]
+
+    def test_empty_cmd_returns_unchanged(self):
+        assert apply_memory_limit([], 1024) == []
+
+    def test_small_limit_rounds_up_to_one_kib(self):
+        result = apply_memory_limit(["bash"], 1)
+        assert result == ["bash", "-c", "ulimit -v 1; exec bash"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -924,28 +924,42 @@ class TestParseSize:
 
 
 class TestApplyMemoryLimit:
+    # apply_memory_limit now prepends ["env", "-u", "BASH_ENV"] to every
+    # returned command so that bash starts with BASH_ENV unset at the
+    # process-environment level.  The returned list is always:
+    #   ["env", "-u", "BASH_ENV", <bash>, "-c", <script>, ...]
+    # so result[0:3] == ["env", "-u", "BASH_ENV"], result[3] is the bash
+    # binary, result[4] == "-c", and result[5] (or result[-1]) is the script.
+    ENV_PREFIX = ["env", "-u", "BASH_ENV"]
+
     def test_none_limit_returns_unchanged(self):
         cmd = ["bash"]
         assert apply_memory_limit(cmd, None) is cmd
 
     def test_persistent_shell_form(self):
-        # 512 MiB → 524288 KiB; hard-gate (&&) so a failed ulimit aborts the shell
+        # 512 MiB → 524288 KiB; hard-gate (&&) so a failed ulimit aborts the shell.
+        # Result: ["env", "-u", "BASH_ENV", "bash", "-c", "ulimit -v 524288 && BASH_ENV='' exec bash"]
         result = apply_memory_limit(["bash"], 512 * 1024**2)
-        assert result[0] == "bash"
-        assert result[1] == "-c"
-        assert "ulimit -v 524288" in result[2]
-        assert "exec bash" in result[2]
+        assert result[:3] == self.ENV_PREFIX
+        assert result[3] == "bash"
+        assert result[4] == "-c"
+        script = result[5]
+        assert "ulimit -v 524288" in script
+        assert "exec bash" in script
 
     def test_command_form_prepends_ulimit(self):
+        # Result: ["env", "-u", "BASH_ENV", "bash", "-c", "ulimit -v 1024 && { echo hi\n}"]
         result = apply_memory_limit(["bash", "-c", "echo hi"], 1024 * 1024)
-        assert result[0] == "bash"
-        assert result[1] == "-c"
-        assert "ulimit -v 1024" in result[2]
-        assert "echo hi" in result[2]
+        assert result[:3] == self.ENV_PREFIX
+        assert result[3] == "bash"
+        assert result[4] == "-c"
+        script = result[5]
+        assert "ulimit -v 1024" in script
+        assert "echo hi" in script
         # Script must be wrapped in a group so && gates the entire script, not
         # just its first statement (e.g. `ulimit && a; b` runs b even if ulimit fails).
-        assert "{ echo hi" in result[2]
-        assert result[2].endswith("}")
+        assert "{ echo hi" in script
+        assert script.endswith("}")
 
     def test_command_form_trailing_comment_not_swallowed(self):
         # A script ending with a # comment must not comment out the closing }.
@@ -954,7 +968,7 @@ class TestApplyMemoryLimit:
         result = apply_memory_limit(
             ["bash", "-c", "echo hi  # trailing comment"], 1024 * 1024
         )
-        script = result[2]
+        script = result[-1]
         assert "# trailing comment" in script
         # The closing brace must be on its own line, not on the comment line.
         lines = script.splitlines()
@@ -965,29 +979,47 @@ class TestApplyMemoryLimit:
 
     def test_small_limit_rounds_up_to_one_kib(self):
         result = apply_memory_limit(["bash"], 1)
-        assert "ulimit -v 1" in result[2]
-        assert "exec bash" in result[2]
+        script = result[-1]
+        assert "ulimit -v 1" in script
+        assert "exec bash" in script
 
     def test_non_kib_aligned_limit_rounds_up(self):
         # 2000 bytes is not KiB-aligned; floor gives 1 KiB (under-allocates),
         # ceiling gives 2 KiB (at least the requested amount).
         result = apply_memory_limit(["bash"], 2000)
-        assert "ulimit -v 2" in result[2]
-        assert "exec bash" in result[2]
+        script = result[-1]
+        assert "ulimit -v 2" in script
+        assert "exec bash" in script
 
     def test_uses_hard_gate_not_soft_fallback(self):
         # The prefix must use && so a failed ulimit aborts the shell rather than
         # running it unrestricted.  verify_memory_limit() surfaces failures at
         # the Python level before the shell is spawned.
         result = apply_memory_limit(["bash"], 512 * 1024**2)
-        script = result[2]
+        script = result[-1]
         assert " && " in script and "exec" in script
 
+    def test_both_forms_use_env_u_bash_env(self):
+        # Both forms must prepend env -u BASH_ENV so that bash starts with
+        # BASH_ENV unset at the OS-environment level.  Bash sources BASH_ENV
+        # before executing any -c script; without this, startup code in
+        # $BASH_ENV runs before ulimit is installed.
+        persistent = apply_memory_limit(["bash"], 512 * 1024**2)
+        one_shot = apply_memory_limit(["bash", "-c", "echo hi"], 512 * 1024**2)
+        assert persistent[:3] == self.ENV_PREFIX, (
+            "persistent form missing env -u BASH_ENV prefix"
+        )
+        assert one_shot[:3] == self.ENV_PREFIX, (
+            "one-shot form missing env -u BASH_ENV prefix"
+        )
+
     def test_persistent_form_clears_bash_env(self):
-        # BASH_ENV must be cleared before exec so a user $BASH_ENV script that
-        # resets ulimits (e.g. `ulimit -v unlimited`) cannot bypass the ceiling.
+        # The -c script must also clear BASH_ENV inline before exec so the
+        # replacement shell inherits a clean environment (belt-and-suspenders:
+        # env handles the outer shell, the inline assignment handles the exec'd
+        # shell which may have started with its own environment).
         result = apply_memory_limit(["bash"], 512 * 1024**2)
-        script = result[2]
+        script = result[-1]
         # BASH_ENV='' must appear between ulimit and exec
         ulimit_pos = script.index("ulimit")
         bash_env_pos = script.index("BASH_ENV=''")
@@ -998,9 +1030,10 @@ class TestApplyMemoryLimit:
         # apply_memory_limit(["bash", "--norc"], N) must not drop --norc so the
         # function honours its contract for callers that pass startup flags.
         result = apply_memory_limit(["bash", "--norc"], 512 * 1024**2)
-        assert result[0] == "bash"
-        assert result[1] == "-c"
-        assert "exec bash --norc" in result[2]
+        assert result[:3] == self.ENV_PREFIX
+        assert result[3] == "bash"
+        assert result[4] == "-c"
+        assert "exec bash --norc" in result[-1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -981,7 +981,18 @@ class TestApplyMemoryLimit:
         # the Python level before the shell is spawned.
         result = apply_memory_limit(["bash"], 512 * 1024**2)
         script = result[2]
-        assert " && exec" in script
+        assert " && " in script and "exec" in script
+
+    def test_persistent_form_clears_bash_env(self):
+        # BASH_ENV must be cleared before exec so a user $BASH_ENV script that
+        # resets ulimits (e.g. `ulimit -v unlimited`) cannot bypass the ceiling.
+        result = apply_memory_limit(["bash"], 512 * 1024**2)
+        script = result[2]
+        # BASH_ENV='' must appear between ulimit and exec
+        ulimit_pos = script.index("ulimit")
+        bash_env_pos = script.index("BASH_ENV=''")
+        exec_pos = script.index("exec")
+        assert ulimit_pos < bash_env_pos < exec_pos
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shell_memory_limit.py
+++ b/tests/test_shell_memory_limit.py
@@ -57,7 +57,10 @@ def test_memory_limit_allows_small_allocation(monkeypatch):
 def test_integer_config_value_does_not_raise():
     """Integer TOML config values (e.g. SHELL_MEMORY_LIMIT = 536870912) must not
     raise AttributeError via value.strip() — they should be coerced to str first."""
-    with patch("gptme.config.get_config") as mock_cfg:
+    with (
+        patch("gptme.config.get_config") as mock_cfg,
+        patch("gptme.tools.shell.verify_memory_limit"),
+    ):
         mock_env = mock_cfg.return_value
         mock_env.get_env.return_value = 536870912  # integer, not string
         result = _get_memory_limit()

--- a/tests/test_shell_memory_limit.py
+++ b/tests/test_shell_memory_limit.py
@@ -1,0 +1,53 @@
+"""Integration tests for the opt-in shell memory ceiling (GPTME_SHELL_MEMORY_LIMIT).
+
+Idea #1128: a per-shell RLIMIT_AS ceiling so a runaway command fails with an
+allocation error instead of taking the session (or host) down with it.
+"""
+
+import os
+
+import pytest
+
+from gptme.tools.shell import ShellSession
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="ulimit -v is POSIX-only (no resource module on Windows)"
+)
+
+
+def _make_shell():
+    return ShellSession()
+
+
+def test_memory_limit_unset_keeps_behavior(monkeypatch):
+    """With no limit set, a moderate allocation succeeds as before."""
+    monkeypatch.delenv("GPTME_SHELL_MEMORY_LIMIT", raising=False)
+    shell = _make_shell()
+    try:
+        code, stdout, stderr = shell.run("python3 -c 'bytearray(64 * 1024 * 1024)'")
+        assert code == 0, f"stderr: {stderr}"
+    finally:
+        shell.close()
+
+
+def test_memory_limit_blocks_overallocation(monkeypatch):
+    """With a 256 MiB ceiling, a 1 GiB allocation fails with MemoryError."""
+    monkeypatch.setenv("GPTME_SHELL_MEMORY_LIMIT", "256M")
+    shell = _make_shell()
+    try:
+        code, stdout, stderr = shell.run("python3 -c 'bytearray(1024 * 1024 * 1024)'")
+        assert code != 0, f"stdout: {stdout}\nstderr: {stderr}"
+        assert "MemoryError" in stderr
+    finally:
+        shell.close()
+
+
+def test_memory_limit_allows_small_allocation(monkeypatch):
+    """The ceiling permits allocations comfortably under the limit."""
+    monkeypatch.setenv("GPTME_SHELL_MEMORY_LIMIT", "256M")
+    shell = _make_shell()
+    try:
+        code, stdout, stderr = shell.run("python3 -c 'bytearray(1024 * 1024)'")
+        assert code == 0, f"stderr: {stderr}"
+    finally:
+        shell.close()

--- a/tests/test_shell_memory_limit.py
+++ b/tests/test_shell_memory_limit.py
@@ -23,6 +23,13 @@ def _make_shell():
 def test_memory_limit_unset_keeps_behavior(monkeypatch):
     """With no limit set, a moderate allocation succeeds as before."""
     monkeypatch.delenv("GPTME_SHELL_MEMORY_LIMIT", raising=False)
+    # Also block any [env] SHELL_MEMORY_LIMIT from config.toml so the test is
+    # hermetic in environments that have that key set.
+    from unittest.mock import MagicMock
+
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = None
+    monkeypatch.setattr("gptme.config.get_config", lambda: mock_cfg)
     shell = _make_shell()
     try:
         code, stdout, stderr = shell.run("python3 -c 'bytearray(64 * 1024 * 1024)'")

--- a/tests/test_shell_memory_limit.py
+++ b/tests/test_shell_memory_limit.py
@@ -5,10 +5,11 @@ allocation error instead of taking the session (or host) down with it.
 """
 
 import os
+from unittest.mock import patch
 
 import pytest
 
-from gptme.tools.shell import ShellSession
+from gptme.tools.shell import ShellSession, _get_memory_limit
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="ulimit -v is POSIX-only (no resource module on Windows)"
@@ -51,3 +52,13 @@ def test_memory_limit_allows_small_allocation(monkeypatch):
         assert code == 0, f"stderr: {stderr}"
     finally:
         shell.close()
+
+
+def test_integer_config_value_does_not_raise():
+    """Integer TOML config values (e.g. SHELL_MEMORY_LIMIT = 536870912) must not
+    raise AttributeError via value.strip() — they should be coerced to str first."""
+    with patch("gptme.config.get_config") as mock_cfg:
+        mock_env = mock_cfg.return_value
+        mock_env.get_env.return_value = 536870912  # integer, not string
+        result = _get_memory_limit()
+    assert result == 536870912, f"Expected 512MiB in bytes, got {result}"

--- a/tests/test_shell_memory_limit.py
+++ b/tests/test_shell_memory_limit.py
@@ -72,3 +72,20 @@ def test_integer_config_value_does_not_raise():
         mock_env.get_env.return_value = 536870912  # integer, not string
         result = _get_memory_limit()
     assert result == 536870912, f"Expected 512MiB in bytes, got {result}"
+
+
+def test_unenforceable_limit_warns_and_returns_none():
+    """When the system hard ulimit is below the configured ceiling,
+    _get_memory_limit() must log a warning and return None rather than raise
+    RuntimeError — a misconfiguration should not crash every shell invocation."""
+    with (
+        patch("gptme.config.get_config") as mock_cfg,
+        patch(
+            "gptme.tools.shell.verify_memory_limit",
+            side_effect=ValueError("hard limit exceeded"),
+        ),
+    ):
+        mock_env = mock_cfg.return_value
+        mock_env.get_env.return_value = "4G"  # exceeds hypothetical hard limit
+        result = _get_memory_limit()
+    assert result is None


### PR DESCRIPTION
## Problem

A shell command run by gptme can consume unbounded memory and take the session — or the host — down with it. There is no per-tool ceiling anywhere in gptme today. Bob mitigates this *outside* gptme via `systemd-run -p MemoryMax`, which protects no other gptme user. Claude Code shipped the equivalent as an opt-in memory cgroup (`CLAUDE_CODE_TOOL_MEMORY_LIMIT`) specifically so "a runaway build can't stall the session."

## Change

Adds an opt-in, off-by-default `RLIMIT_AS` ceiling to the shell tool.

- `apply_memory_limit()` wraps the bash invocation with `ulimit -v` (no `preexec_fn`, which CPython documents as thread-unsafe). It composes with the existing `wrap_shell_cmd` sandbox wrapper — the limit is applied to the *inner* shell so firejail/bwrap run the limited shell inside the sandbox.
- Wired at **both** Popen sites: the persistent shell (`_init`) and the one-shot TTY path (`_run_with_tty`). POSIX-only; skipped on Windows (`ulimit` is a bash builtin).
- Knob: `GPTME_SHELL_MEMORY_LIMIT` env var, or `[env] SHELL_MEMORY_LIMIT` in `config.toml` (via the existing `get_env` idiom). Accepts a plain byte count or a binary suffix (`512M`, `1G`).
- Defaults to **off**; unparseable values are logged and treated as unset.

## Why `ulimit -v` over cgroups

`RLIMIT_AS` caps *address space*, not RSS, so it over-counts for anything that maps large files or reserves virtual memory (JVM, Go runtimes, some builds). A cgroup would be more accurate but needs privileges gptme can't assume. This tradeoff is documented on the knob.

## Tests

- Unit tests for `_parse_size` and `apply_memory_limit` (both bash forms, suffixes, rounding).
- Integration tests (POSIX-only, auto-skipped on Windows): limit unset → behavior unchanged; limit set → a 1 GiB allocation under a 256 MiB ceiling fails with `MemoryError`; a small allocation still succeeds.

## Out of scope

- No default-on behavior — this is strictly opt-in.
- No cgroup backend (see above).
- No Windows support (`resource`/`ulimit` are POSIX-only).

Refs: ErikBjare/bob#1128 (idea), `knowledge/strategic/2026-08-agent-harness-gap-scan.md`.
