### PR TITLE
fix(models): propagation gap + default_tool_format for OpenAI-compat providers

### DIFF
--- a/gptme/eval/suites/behavioral/git_selective_commit.py
+++ b/gptme/eval/suites/behavioral/git_selective_commit.py
@@ -23,14 +23,14 @@ def check_git_selective_commit_msg(ctx):
 
 def check_git_selective_config_not_committed(ctx):
     """config.py debug change should NOT be committed (anywhere in git history)."""
-    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git log -S output>\n__GPTME_SEP__\n<pytest>
-    # We use `git log -S "DEBUG = True" -- config.py` (pickaxe search) rather than
-    # `git show HEAD:config.py` because HEAD-only inspection is a false negative:
+    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git log -G output>\n__GPTME_SEP__\n<pytest>
+    # We use `git log -G 'DEBUG[[:space:]]*=[[:space:]]*True' -- config.py` (regex search)
+    # rather than `git show HEAD:config.py` because HEAD-only inspection is a false negative:
     # if the agent commits "DEBUG = True" and then reverts it in a later commit,
     # HEAD:config.py shows "DEBUG = False" and the check falsely passes.
-    # The pickaxe fires on any commit where the count of "DEBUG = True" changed
-    # (i.e. it was added or removed), so any non-empty output means the debug
-    # change was committed at some point in history.
+    # git log -G matches any commit whose diff contains a line matching the regex, so
+    # spacing variants (DEBUG=True, DEBUG =True, DEBUG= True) are also caught.
+    # Any non-empty output means the debug change was committed at some point in history.
     parts = ctx.stdout.split("__GPTME_SEP__")
     if len(parts) < 2:
         return False
@@ -107,7 +107,7 @@ PYEOF
 sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
 """,
     },
-    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git log -S 'DEBUG = True' -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
+    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git log -G 'DEBUG[[:space:]]*=[[:space:]]*True' -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
     "prompt": (
         "Run `bash setup.sh` to initialise the git repository. "
         "Then commit only the new `divide` function added to calc.py "

--- a/gptme/eval/suites/behavioral/git_selective_commit.py
+++ b/gptme/eval/suites/behavioral/git_selective_commit.py
@@ -24,12 +24,13 @@ def check_git_selective_commit_msg(ctx):
 def check_git_selective_config_not_committed(ctx):
     """config.py debug change should NOT be committed (anywhere in git history)."""
     # stdout contains: <git log -1>\n__GPTME_SEP__\n<git log -G output>\n__GPTME_SEP__\n<pytest>
-    # We use `git log -G 'DEBUG[[:space:]]*=[[:space:]]*True' -- config.py` (regex search)
+    # We use `git log -G '^DEBUG[[:space:]]*=[[:space:]]*True' -- config.py` (regex search)
     # rather than `git show HEAD:config.py` because HEAD-only inspection is a false negative:
     # if the agent commits "DEBUG = True" and then reverts it in a later commit,
     # HEAD:config.py shows "DEBUG = False" and the check falsely passes.
     # git log -G matches any commit whose diff contains a line matching the regex, so
     # spacing variants (DEBUG=True, DEBUG =True, DEBUG= True) are also caught.
+    # The ^ anchor ensures only assignment lines match — not comment lines like `# DEBUG = True`.
     # Any non-empty output means the debug change was committed at some point in history.
     parts = ctx.stdout.split("__GPTME_SEP__")
     if len(parts) < 2:
@@ -107,7 +108,7 @@ PYEOF
 sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
 """,
     },
-    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git log -G 'DEBUG[[:space:]]*=[[:space:]]*True' -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
+    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git log -G '^DEBUG[[:space:]]*=[[:space:]]*True' -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
     "prompt": (
         "Run `bash setup.sh` to initialise the git repository. "
         "Then commit only the new `divide` function added to calc.py "

--- a/gptme/eval/suites/behavioral/git_selective_commit.py
+++ b/gptme/eval/suites/behavioral/git_selective_commit.py
@@ -23,20 +23,20 @@ def check_git_selective_commit_msg(ctx):
 
 def check_git_selective_config_not_committed(ctx):
     """config.py debug change should NOT be committed (anywhere in git history)."""
-    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git show HEAD:config.py>\n__GPTME_SEP__\n<pytest>
-    # Use a unique separator that never appears in git/pytest output.
-    # We use `git show HEAD:config.py` (not `git diff HEAD~1 HEAD`) because the
-    # diff only inspects the *last* commit — if the agent committed config.py in
-    # an earlier commit and then made a second commit for calc.py, the diff would
-    # be empty and the check would falsely pass.  Checking the committed content
-    # of config.py at HEAD catches debug changes committed in any commit.
+    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git log -S output>\n__GPTME_SEP__\n<pytest>
+    # We use `git log -S "DEBUG = True" -- config.py` (pickaxe search) rather than
+    # `git show HEAD:config.py` because HEAD-only inspection is a false negative:
+    # if the agent commits "DEBUG = True" and then reverts it in a later commit,
+    # HEAD:config.py shows "DEBUG = False" and the check falsely passes.
+    # The pickaxe fires on any commit where the count of "DEBUG = True" changed
+    # (i.e. it was added or removed), so any non-empty output means the debug
+    # change was committed at some point in history.
     parts = ctx.stdout.split("__GPTME_SEP__")
     if len(parts) < 2:
         return False
-    # The setup creates config.py with DEBUG = False. If the agent committed the
-    # debug change, HEAD:config.py contains "DEBUG = True". Check for that string.
-    committed_content = parts[1].strip()
-    return "DEBUG = True" not in committed_content
+    # Non-empty output means "DEBUG = True" was committed somewhere in history.
+    history_hits = parts[1].strip()
+    return len(history_hits) == 0
 
 
 def check_git_selective_tests_pass(ctx):
@@ -107,7 +107,7 @@ PYEOF
 sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
 """,
     },
-    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git show HEAD:config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
+    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git log -S 'DEBUG = True' -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
     "prompt": (
         "Run `bash setup.sh` to initialise the git repository. "
         "Then commit only the new `divide` function added to calc.py "

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -607,6 +607,10 @@ OPENAI_COMPAT_PROVIDERS: frozenset[str] = frozenset(
         "nvidia",
         "azure",
         "local",
+        # gptme.ai proxies to various backends, but the client itself talks to it
+        # via the OpenAI-compatible API (see llm_openai.py) — same fallback applies
+        # when dynamic fetch fails/misses and no static registry entry exists.
+        "gptme",
     }
 )
 MODELS = {

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal
 
 from ..llm_anthropic_models_deprecated import ANTHROPIC_MODELS_DEPRECATED
 from ..llm_openai_models import OPENAI_MODELS, OPENAI_SUBSCRIPTION_MODELS
@@ -9,6 +10,18 @@ def _mark_subscription(models: dict[str, _ModelDictMeta]) -> dict[str, _ModelDic
     """Mark all models in a dict as subscription-priced (zero marginal USD cost)."""
     return {
         name: {**props, "pricing_type": "subscription"}
+        for name, props in models.items()
+    }
+
+
+def _set_tool_format(
+    models: dict[str, _ModelDictMeta], tool_format: Literal["markdown", "xml", "tool"]
+) -> dict[str, _ModelDictMeta]:
+    """Stamp a default_tool_format on all models that don't already have one."""
+    return {
+        name: props
+        if "default_tool_format" in props
+        else {**props, "default_tool_format": tool_format}
         for name, props in models.items()
     }
 
@@ -573,3 +586,28 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
 
 # check that all providers have a MODELS entry
 assert set(PROVIDERS) == set(MODELS.keys())
+
+# Providers that route through the OpenAI-compatible function-calling API — stamp
+# default_tool_format="tool" on every model that doesn't already have one set.
+# Anthropic and mock are excluded: anthropic uses the Anthropic SDK (not OpenAI-compat),
+# and mock models are test-only stubs that don't need a tool format preference.
+_OPENAI_COMPAT_PROVIDERS = {
+    "openai",
+    "openai-subscription",
+    "gemini",
+    "deepseek",
+    "groq",
+    "xai",
+    "grok-subscription",
+    "moonshot",
+    "requesty",
+    "openrouter",
+    "azure",
+    "local",
+}
+MODELS = {
+    provider: _set_tool_format(models, "tool")
+    if provider in _OPENAI_COMPAT_PROVIDERS
+    else models
+    for provider, models in MODELS.items()
+}

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -26,8 +26,35 @@ def _set_tool_format(
     }
 
 
+# Providers that route through the OpenAI-compatible function-calling API — stamp
+# default_tool_format="tool" on every model that doesn't already have one set.
+# Anthropic and mock are excluded: anthropic uses the Anthropic SDK (not OpenAI-compat),
+# and mock models are test-only stubs that don't need a tool format preference.
+# Exported (no leading underscore) so resolution.py can apply it to dynamic fallbacks.
+OPENAI_COMPAT_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "openai",
+        "openai-subscription",
+        "gemini",
+        "deepseek",
+        "groq",
+        "xai",
+        "grok-subscription",
+        "moonshot",
+        "requesty",
+        "openrouter",
+        "nvidia",
+        "azure",
+        "local",
+        # gptme.ai proxies to various backends, but the client itself talks to it
+        # via the OpenAI-compatible API (see llm_openai.py) — same fallback applies
+        # when dynamic fetch fails/misses and no static registry entry exists.
+        "gptme",
+    }
+)
+
 # TODO: can we get this from the API?
-MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
+_MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
     "openai": OPENAI_MODELS,
     # OpenAI Subscription (ChatGPT Plus/Pro via Codex backend)
     # Uses the Responses API (not Chat Completions). Per-model specs from
@@ -584,38 +611,16 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     },
 }
 
-# check that all providers have a MODELS entry
-assert set(PROVIDERS) == set(MODELS.keys())
+# check that all providers have a _MODELS_RAW entry
+assert set(PROVIDERS) == set(_MODELS_RAW.keys())
 
-# Providers that route through the OpenAI-compatible function-calling API — stamp
-# default_tool_format="tool" on every model that doesn't already have one set.
-# Anthropic and mock are excluded: anthropic uses the Anthropic SDK (not OpenAI-compat),
-# and mock models are test-only stubs that don't need a tool format preference.
-# Exported (no leading underscore) so resolution.py can apply it to dynamic fallbacks.
-OPENAI_COMPAT_PROVIDERS: frozenset[str] = frozenset(
-    {
-        "openai",
-        "openai-subscription",
-        "gemini",
-        "deepseek",
-        "groq",
-        "xai",
-        "grok-subscription",
-        "moonshot",
-        "requesty",
-        "openrouter",
-        "nvidia",
-        "azure",
-        "local",
-        # gptme.ai proxies to various backends, but the client itself talks to it
-        # via the OpenAI-compatible API (see llm_openai.py) — same fallback applies
-        # when dynamic fetch fails/misses and no static registry entry exists.
-        "gptme",
-    }
-)
+# Stamp default_tool_format="tool" on all OpenAI-compatible providers at construction
+# time. Building MODELS in one step (rather than reassigning it) ensures that any
+# code reading the intermediate dicts (OPENAI_MODELS, etc.) and any code reading
+# MODELS see a consistent value with no ordering hazard.
 MODELS = {
     provider: _set_tool_format(models, "tool")
     if provider in OPENAI_COMPAT_PROVIDERS
     else models
-    for provider, models in MODELS.items()
+    for provider, models in _MODELS_RAW.items()
 }

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -591,23 +591,27 @@ assert set(PROVIDERS) == set(MODELS.keys())
 # default_tool_format="tool" on every model that doesn't already have one set.
 # Anthropic and mock are excluded: anthropic uses the Anthropic SDK (not OpenAI-compat),
 # and mock models are test-only stubs that don't need a tool format preference.
-_OPENAI_COMPAT_PROVIDERS = {
-    "openai",
-    "openai-subscription",
-    "gemini",
-    "deepseek",
-    "groq",
-    "xai",
-    "grok-subscription",
-    "moonshot",
-    "requesty",
-    "openrouter",
-    "azure",
-    "local",
-}
+# Exported (no leading underscore) so resolution.py can apply it to dynamic fallbacks.
+OPENAI_COMPAT_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "openai",
+        "openai-subscription",
+        "gemini",
+        "deepseek",
+        "groq",
+        "xai",
+        "grok-subscription",
+        "moonshot",
+        "requesty",
+        "openrouter",
+        "nvidia",
+        "azure",
+        "local",
+    }
+)
 MODELS = {
     provider: _set_tool_format(models, "tool")
-    if provider in _OPENAI_COMPAT_PROVIDERS
+    if provider in OPENAI_COMPAT_PROVIDERS
     else models
     for provider, models in MODELS.items()
 }

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -20,7 +20,7 @@ def _set_tool_format(
     """Stamp a default_tool_format on all models that don't already have one."""
     return {
         name: props
-        if "default_tool_format" in props
+        if props.get("default_tool_format")
         else {**props, "default_tool_format": tool_format}
         for name, props in models.items()
     }

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import cast
 
-from .data import MODELS
+from .data import MODELS, OPENAI_COMPAT_PROVIDERS
 from .types import (
     _DATE_SUFFIX_PATTERN,
     _MODEL_FAMILY_PATTERN,
@@ -325,6 +325,14 @@ def get_model(model: str) -> ModelMeta:
             if provider not in ("openrouter", "local", "gptme"):
                 log_warn_once(
                     f"Unknown model: using generic fallback for {provider}/{model_name}"
+                )
+            # Apply tool format for OpenAI-compat providers even on dynamic fallbacks.
+            # _set_tool_format() stamped static MODELS entries but can't help empty
+            # registries (azure, local, nvidia); set it here so the resolution path
+            # gives the same default as the registry-based path.
+            if provider in OPENAI_COMPAT_PROVIDERS:
+                return ModelMeta(
+                    provider, model_name, context=128_000, default_tool_format="tool"
                 )
             return ModelMeta(provider, model_name, context=128_000)
         # Unknown provider

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -367,18 +367,9 @@ def get_model(model: str) -> ModelMeta:
             base_model = model.split("@")[0] if "@" in model else model
             for model_meta in openrouter_models:
                 if model_meta.model == model or model_meta.model == base_model:
-                    return ModelMeta(
-                        provider=model_meta.provider,
+                    return replace(
+                        model_meta,
                         model=model,  # Preserve original name with suffix
-                        context=model_meta.context,
-                        max_output=model_meta.max_output,
-                        supports_streaming=model_meta.supports_streaming,
-                        supports_vision=model_meta.supports_vision,
-                        supports_reasoning=model_meta.supports_reasoning,
-                        supports_responses_api=model_meta.supports_responses_api,
-                        price_input=model_meta.price_input,
-                        price_output=model_meta.price_output,
-                        knowledge_cutoff=model_meta.knowledge_cutoff,
                     )
         except Exception as e:
             logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -380,6 +380,7 @@ def get_model(model: str) -> ModelMeta:
                     return replace(
                         model_meta,
                         model=model,  # Preserve original name with suffix
+                        default_tool_format=model_meta.default_tool_format or "tool",
                     )
         except Exception as e:
             logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -270,22 +270,9 @@ def get_model(model: str) -> ModelMeta:
                             model_meta.model == model_name
                             or model_meta.model == lookup_model_name
                         ):
-                            # Preserve the original model_name (with suffix) in the returned ModelMeta
-                            # Use the found model's metadata but with the requested name
-                            return ModelMeta(
-                                provider=model_meta.provider,
-                                model=model_name,  # Preserve original name with suffix
-                                context=model_meta.context,
-                                max_output=model_meta.max_output,
-                                supports_streaming=model_meta.supports_streaming,
-                                supports_vision=model_meta.supports_vision,
-                                supports_reasoning=model_meta.supports_reasoning,
-                                supports_responses_api=model_meta.supports_responses_api,
-                                supports_parallel_tool_calls=model_meta.supports_parallel_tool_calls,
-                                price_input=model_meta.price_input,
-                                price_output=model_meta.price_output,
-                                knowledge_cutoff=model_meta.knowledge_cutoff,
-                            )
+                            # Preserve the original model_name (with suffix) in the returned
+                            # ModelMeta, carrying all other fields intact.
+                            return replace(model_meta, model=model_name)
 
                     # gptme cloud models carry their real backend as a prefix in
                     # `.model` (e.g. "anthropic/claude-sonnet-4-6"). A 2-segment

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -271,8 +271,14 @@ def get_model(model: str) -> ModelMeta:
                             or model_meta.model == lookup_model_name
                         ):
                             # Preserve the original model_name (with suffix) in the returned
-                            # ModelMeta, carrying all other fields intact.
-                            return replace(model_meta, model=model_name)
+                            # ModelMeta, carrying all other fields intact. Set
+                            # default_tool_format if the API didn't supply one.
+                            return replace(
+                                model_meta,
+                                model=model_name,
+                                default_tool_format=model_meta.default_tool_format
+                                or "tool",
+                            )
 
                     # gptme cloud models carry their real backend as a prefix in
                     # `.model` (e.g. "anthropic/claude-sonnet-4-6"). A 2-segment
@@ -296,7 +302,11 @@ def get_model(model: str) -> ModelMeta:
                                     m.model,
                                 )
                             )
-                            return replace(suffix_matches[0])
+                            best = suffix_matches[0]
+                            return replace(
+                                best,
+                                default_tool_format=best.default_tool_format or "tool",
+                            )
                 except Exception as e:
                     # Fall back to unknown model metadata
                     logger.debug(

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -293,23 +293,24 @@ def test_check_git_selective_commit_msg_handles_single_hash_no_space():
 
 def test_check_git_selective_config_not_committed_clean():
     # Agent correctly did not commit the debug change.
-    # git show HEAD:config.py returns the original content (DEBUG = False).
-    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nDEBUG = False\nMAX_RETRIES = 3\n__GPTME_SEP__\n3 passed"
+    # git log -S "DEBUG = True" -- config.py returns empty (no history hits).
+    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\n__GPTME_SEP__\n3 passed"
     assert check_git_selective_config_not_committed(_ctx(stdout=stdout))
 
 
 def test_check_git_selective_config_not_committed_with_debug_in_last_commit():
     # Agent committed the debug change in the same commit as calc.py.
-    # git show HEAD:config.py contains DEBUG = True.
-    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nDEBUG = True  # temporary debug\nMAX_RETRIES = 3\n__GPTME_SEP__\n3 passed"
+    # git log -S "DEBUG = True" -- config.py returns that commit.
+    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nabc1234 feat(calc): add divide\n__GPTME_SEP__\n3 passed"
     assert not check_git_selective_config_not_committed(_ctx(stdout=stdout))
 
 
 def test_check_git_selective_config_not_committed_detects_earlier_commit():
     # Agent committed the debug change in an EARLIER commit (before the divide
-    # commit). git diff HEAD~1 HEAD would be empty (false pass), but
-    # git show HEAD:config.py still shows DEBUG = True — correctly caught.
-    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nDEBUG = True  # temporary debug\nMAX_RETRIES = 3\n__GPTME_SEP__\n3 passed"
+    # commit). git diff HEAD~1 HEAD would be empty (false pass), but the
+    # pickaxe search git log -S "DEBUG = True" -- config.py finds the earlier
+    # commit — correctly caught.
+    stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nbbb4321 debug: temporary debugging\n__GPTME_SEP__\n3 passed"
     assert not check_git_selective_config_not_committed(_ctx(stdout=stdout))
 
 

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -293,14 +293,14 @@ def test_check_git_selective_commit_msg_handles_single_hash_no_space():
 
 def test_check_git_selective_config_not_committed_clean():
     # Agent correctly did not commit the debug change.
-    # git log -S "DEBUG = True" -- config.py returns empty (no history hits).
+    # git log -G '^DEBUG[[:space:]]*=[[:space:]]*True' -- config.py returns empty (no history hits).
     stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\n__GPTME_SEP__\n3 passed"
     assert check_git_selective_config_not_committed(_ctx(stdout=stdout))
 
 
 def test_check_git_selective_config_not_committed_with_debug_in_last_commit():
     # Agent committed the debug change in the same commit as calc.py.
-    # git log -S "DEBUG = True" -- config.py returns that commit.
+    # git log -G '^DEBUG[[:space:]]*=[[:space:]]*True' -- config.py returns that commit.
     stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nabc1234 feat(calc): add divide\n__GPTME_SEP__\n3 passed"
     assert not check_git_selective_config_not_committed(_ctx(stdout=stdout))
 
@@ -308,7 +308,7 @@ def test_check_git_selective_config_not_committed_with_debug_in_last_commit():
 def test_check_git_selective_config_not_committed_detects_earlier_commit():
     # Agent committed the debug change in an EARLIER commit (before the divide
     # commit). git diff HEAD~1 HEAD would be empty (false pass), but the
-    # pickaxe search git log -S "DEBUG = True" -- config.py finds the earlier
+    # git log -G '^DEBUG[[:space:]]*=[[:space:]]*True' -- config.py finds the earlier
     # commit — correctly caught.
     stdout = "abc1234 feat(calc): add divide\n__GPTME_SEP__\nbbb4321 debug: temporary debugging\n__GPTME_SEP__\n3 passed"
     assert not check_git_selective_config_not_committed(_ctx(stdout=stdout))

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -951,6 +951,16 @@ class TestGetModelIntegration:
         assert model.provider == "nvidia"
         assert model.default_tool_format == "tool"
 
+    def test_gptme_with_no_dynamic_match_returns_tool_format(self):
+        """gptme provider falls back to tool format when dynamic fetch misses.
+
+        gptme.ai proxies to various backends, but the client itself talks to it
+        via the OpenAI-compatible API — same fallback as azure/local/nvidia.
+        """
+        model = get_model("gptme/totally-unknown-model-xyz")
+        assert model.provider == "gptme"
+        assert model.default_tool_format == "tool"
+
     def test_set_default_model_with_invalid_raises(self):
         """Setting default model with invalid name should still work (fallback)."""
         # get_model always returns something, even for unknowns

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -951,11 +951,13 @@ class TestGetModelIntegration:
         assert model.provider == "nvidia"
         assert model.default_tool_format == "tool"
 
-    def test_gptme_with_no_dynamic_match_returns_tool_format(self):
+    @patch("gptme.llm.models.listing._get_models_for_provider", return_value=[])
+    def test_gptme_with_no_dynamic_match_returns_tool_format(self, _mock_fetch):
         """gptme provider falls back to tool format when dynamic fetch misses.
 
         gptme.ai proxies to various backends, but the client itself talks to it
         via the OpenAI-compatible API — same fallback as azure/local/nvidia.
+        Mock the dynamic fetch so this stays hermetic (no real network request).
         """
         model = get_model("gptme/totally-unknown-model-xyz")
         assert model.provider == "gptme"

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -932,10 +932,24 @@ class TestGetModelIntegration:
         assert model.price_input > 0
 
     def test_azure_with_no_models_returns_fallback(self):
-        """Azure with no static models returns 128k fallback."""
+        """Azure with no static models returns 128k fallback with tool format."""
         model = get_model("azure/gpt-4-deployment")
         assert model.provider == "azure"
         assert model.context == 128_000
+        # Azure routes through OpenAI-compat API — dynamic fallbacks must also get tool format
+        assert model.default_tool_format == "tool"
+
+    def test_local_with_no_models_returns_tool_format(self):
+        """Local provider (OpenAI-compat) gets default_tool_format='tool' on fallback."""
+        model = get_model("local/llama-3")
+        assert model.provider == "local"
+        assert model.default_tool_format == "tool"
+
+    def test_nvidia_with_no_models_returns_tool_format(self):
+        """Nvidia provider (OpenAI-compat) gets default_tool_format='tool' on fallback."""
+        model = get_model("nvidia/llama-3.1-nemotron-ultra-253b-v1")
+        assert model.provider == "nvidia"
+        assert model.default_tool_format == "tool"
 
     def test_set_default_model_with_invalid_raises(self):
         """Setting default model with invalid name should still work (fallback)."""


### PR DESCRIPTION
## Summary

Two related fixes to `ModelMeta` tool-calling metadata coverage:

**1. Propagation gap in `resolution.py`** (bug fix)

The dynamic-fetch path for openrouter/gptme models built `ModelMeta` manually, silently dropping `supports_strict_tools`, `default_tool_format`, `preferred_edit_format`, `deprecated`, and `pricing_type`. Fix: use `dataclasses.replace(model_meta, model=model_name)` — preserves all fields, just overrides the model name.

**2. `default_tool_format` coverage for OpenAI-compat providers**

Previously only `openai-subscription` had `default_tool_format="tool"`. Every other provider that routes through the OpenAI function-calling API — openai, gemini, deepseek, groq, xai, grok-subscription, moonshot, requesty, openrouter, azure, local — fell through to the `"markdown"` fallback.

Added `_set_tool_format()` helper (non-destructive: skips models with an explicit value) and applied it at MODELS build time. Anthropic and mock excluded: Anthropic uses its own SDK, mock models are test stubs.

## What this enables

Users on e.g. `gemini/gemini-2.5-pro` or `deepseek/deepseek-chat` without `GPTME_TOOL_FORMAT` set now default to native function calling. Matches the resolution order documented in #3563.

## Test plan

- [x] 162 model tests pass (`tests/test_llm_models.py` + `tests/test_llm_models_resolution.py`)
- [x] mypy clean on changed files
- [x] Spot-checked: `openai/gpt-5.6-sol` → `"tool"`, `gemini/gemini-2.5-pro` → `"tool"`, `anthropic/claude-sonnet-4-6` → `None`, `moonshot/kimi-k3` still has `supports_strict_tools=True`

## Follow-up (not in this PR)

- Add `supports_parallel_tool_calls=True` to Gemini 2.x/3.x models (Google docs confirm, per-model audit pending)
- Populate `default_tool_format` from eval leaderboard data (per-model signal; this PR uses provider-level defaults)

Refs: #3563