### PR TITLE
feat(autocompact): add keep_head to protect task context from compaction

### DIFF
--- a/gptme/eval/suites/behavioral/git_selective_commit.py
+++ b/gptme/eval/suites/behavioral/git_selective_commit.py
@@ -22,15 +22,16 @@ def check_git_selective_commit_msg(ctx):
 
 
 def check_git_selective_config_not_committed(ctx):
-    """config.py should NOT appear in the last commit (diff is non-empty means not committed)."""
-    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git show HEAD -- config.py>\n__GPTME_SEP__\n<pytest>
+    """config.py debug change should NOT be committed (anywhere in git history)."""
+    # stdout contains: <git log -1>\n__GPTME_SEP__\n<git show HEAD:config.py>\n__GPTME_SEP__\n<pytest>
     # Use a unique separator that never appears in git/pytest output.
     parts = ctx.stdout.split("__GPTME_SEP__")
     if len(parts) < 2:
         return False
-    # git show HEAD -- config.py is empty if not committed
+    # The setup creates config.py with DEBUG = False. If the agent committed the
+    # debug change, HEAD:config.py contains "DEBUG = True". Check for that string.
     committed_content = parts[1].strip()
-    return committed_content == ""
+    return "DEBUG = True" not in committed_content
 
 
 def check_git_selective_tests_pass(ctx):
@@ -101,7 +102,7 @@ PYEOF
 sed -i 's/DEBUG = False/DEBUG = True  # temporary debug/' config.py
 """,
     },
-    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git show HEAD -- config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
+    "run": "git log --oneline -1 && echo __GPTME_SEP__ && git show HEAD:config.py && echo __GPTME_SEP__ && python3 -m pytest test_calc.py -q 2>&1",
     "prompt": (
         "Run `bash setup.sh` to initialise the git repository. "
         "Then commit only the new `divide` function added to calc.py "

--- a/gptme/tools/autocompact/config.py
+++ b/gptme/tools/autocompact/config.py
@@ -37,7 +37,13 @@ def _get_keep_head() -> int:
     raw = get_config().get_env("GPTME_AUTOCOMPACT_KEEP_HEAD")
     if raw is not None:
         try:
-            return max(0, int(raw))
+            val = int(raw)
+            if val < 0:
+                logger.warning(
+                    f"Invalid GPTME_AUTOCOMPACT_KEEP_HEAD={raw!r} (negative), using default {cfg.keep_head}"
+                )
+                return cfg.keep_head
+            return val
         except ValueError:
             logger.warning(
                 f"Invalid GPTME_AUTOCOMPACT_KEEP_HEAD={raw!r}, using default {cfg.keep_head}"

--- a/gptme/tools/autocompact/config.py
+++ b/gptme/tools/autocompact/config.py
@@ -4,7 +4,10 @@ Settings here control how aggressive compaction is and whether the head of the
 conversation (the system prompt and original task) is protected from reduction.
 """
 
+import logging
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -20,3 +23,23 @@ class AutoCompactConfig:
 
     keep_head: int = 2
     """Number of messages at the start of the log to protect from compaction."""
+
+
+def _get_keep_head() -> int:
+    """Resolve the number of head messages to protect from compaction.
+
+    Priority: ``GPTME_AUTOCOMPACT_KEEP_HEAD`` env var > :class:`AutoCompactConfig`
+    default. Invalid/negative values fall back to the configured default.
+    """
+    from ...config import get_config
+
+    cfg = AutoCompactConfig()
+    raw = get_config().get_env("GPTME_AUTOCOMPACT_KEEP_HEAD")
+    if raw is not None:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            logger.warning(
+                f"Invalid GPTME_AUTOCOMPACT_KEEP_HEAD={raw!r}, using default {cfg.keep_head}"
+            )
+    return cfg.keep_head

--- a/gptme/tools/autocompact/config.py
+++ b/gptme/tools/autocompact/config.py
@@ -1,0 +1,22 @@
+"""Configuration for the auto-compact tool.
+
+Settings here control how aggressive compaction is and whether the head of the
+conversation (the system prompt and original task) is protected from reduction.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AutoCompactConfig:
+    """Configuration for auto-compaction behavior.
+
+    ``keep_head`` protects the first ``N`` messages (by position) of the log from
+    any compaction — reasoning stripping, tool-result truncation, and assistant
+    compression all skip them. The default of 2 protects the system prompt and
+    the first user message, which typically carry the original task. Set to 0 to
+    disable head retention (pre-existing behavior).
+    """
+
+    keep_head: int = 2
+    """Number of messages at the start of the log to protect from compaction."""

--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -110,7 +110,12 @@ def auto_compact_log(
         and not needs_compacting
         and not needs_phase3_compression
     ):
-        yield from log
+        # Pin protected head messages even on early return so downstream
+        # limit_log (e.g. in prepare_messages) cannot drop them.
+        yield from (
+            m.replace(pinned=True) if keep_head > 0 and idx < keep_head else m
+            for idx, m in enumerate(log)
+        )
         return
 
     if needs_compacting:
@@ -300,7 +305,13 @@ def auto_compact_log(
             f"({reduction_pct:.1f}% reduction, saved {total_saved:,} tokens) "
             f"[{breakdown_str}]"
         )
-        yield from compacted_log
+        # Pin protected head messages so a downstream limit_log call (e.g. in
+        # prepare_messages) cannot drop them — limit_log only preserves pinned
+        # or initial-system messages, not arbitrary index positions.
+        yield from (
+            m.replace(pinned=True) if keep_head > 0 and idx < keep_head else m
+            for idx, m in enumerate(compacted_log)
+        )
         return
 
     # If still over limit, fall back to regular reduction.

--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -303,7 +303,17 @@ def auto_compact_log(
         yield from compacted_log
         return
 
-    # If still over limit, fall back to regular reduction
+    # If still over limit, fall back to regular reduction.
+    # Protected head messages are yielded verbatim; reduce_log only sees the tail
+    # so it cannot remove or truncate task context the caller marked as protected.
     logger.info("Auto-compacting not sufficient, falling back to regular reduction")
 
-    yield from reduce_log(compacted_log, limit)
+    if keep_head > 0 and keep_head < len(compacted_log):
+        head_msgs = compacted_log[:keep_head]
+        tail_msgs = compacted_log[keep_head:]
+        head_tokens = len_tokens(head_msgs, model.model)
+        tail_limit = max(0, limit - head_tokens)
+        yield from head_msgs
+        yield from reduce_log(tail_msgs, tail_limit)
+    else:
+        yield from reduce_log(compacted_log, limit)

--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -304,12 +304,13 @@ def auto_compact_log(
         return
 
     # If still over limit, fall back to regular reduction.
-    # Protected head messages are yielded verbatim; reduce_log only sees the tail
-    # so it cannot remove or truncate task context the caller marked as protected.
+    # Protected head messages are yielded with pinned=True so any downstream
+    # reduce_log call (e.g. in prepare_messages) also skips them — it only
+    # respects the pinned flag, not the keep_head index.
     logger.info("Auto-compacting not sufficient, falling back to regular reduction")
 
     if keep_head > 0 and keep_head < len(compacted_log):
-        head_msgs = compacted_log[:keep_head]
+        head_msgs = [m.replace(pinned=True) for m in compacted_log[:keep_head]]
         tail_msgs = compacted_log[keep_head:]
         head_tokens = len_tokens(head_msgs, model.model)
         tail_limit = max(0, limit - head_tokens)
@@ -317,12 +318,13 @@ def auto_compact_log(
         yield from reduce_log(tail_msgs, tail_limit)
     elif keep_head >= len(compacted_log):
         # All messages are protected — accept the budget overshoot verbatim.
-        # Per documented behavior: if the head alone exceeds the limit,
-        # compaction accepts the overshoot rather than corrupting task context.
+        # Pin every message so that if the result is still over the model's
+        # context limit, a downstream reduce_log in prepare_messages cannot
+        # summarize or drop task context.
         logger.info(
-            "keep_head covers all %d messages; yielding verbatim (accepting budget overshoot)",
+            "keep_head covers all %d messages; yielding pinned verbatim (accepting budget overshoot)",
             len(compacted_log),
         )
-        yield from compacted_log
+        yield from (m.replace(pinned=True) for m in compacted_log)
     else:
         yield from reduce_log(compacted_log, limit)

--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -31,6 +31,7 @@ def auto_compact_log(
     max_tool_result_tokens: int = 2000,
     reasoning_strip_age_threshold: int = 5,
     logdir: Path | None = None,
+    keep_head: int = 0,
 ) -> Generator[Message, None, None]:
     """
     Auto-compact log for conversations with massive tool results.
@@ -56,6 +57,11 @@ def auto_compact_log(
         max_tool_result_tokens: Maximum tokens allowed in a tool result before removal
         reasoning_strip_age_threshold: Strip reasoning from messages >N positions back
         logdir: Path to conversation directory for saving removed outputs
+        keep_head: Number of messages at the start of the log to protect from all
+            compaction (default 0 = no protection, existing behavior). Protected
+            head messages are yielded verbatim and count toward the token budget but
+            are never reduced. If the head alone exceeds the limit, compaction accepts
+            the overshoot rather than reducing the protected task context.
     """
 
     # Build master context index for byte-range references
@@ -120,7 +126,7 @@ def auto_compact_log(
     reasoning_tokens_saved = 0
 
     for idx, msg in enumerate(log):
-        if msg.pinned:
+        if msg.pinned or idx < keep_head:
             compacted_log.append(msg)
             continue
 
@@ -153,7 +159,7 @@ def auto_compact_log(
         # Identify all candidate tool results for truncation (with original indices)
         candidates: list[tuple[int, int, Message]] = []  # (idx, tokens, msg)
         for idx, msg in enumerate(compacted_log):
-            if msg.pinned:
+            if msg.pinned or idx < keep_head:
                 continue
             if msg.role == "system":
                 msg_tokens = len_tokens(msg.content, model.model)
@@ -214,7 +220,7 @@ def auto_compact_log(
     # Phase 3: Extractive compression for long assistant messages
     compacted_log_len = len(compacted_log)
     for idx, msg in enumerate(compacted_log):
-        if msg.pinned:
+        if msg.pinned or idx < keep_head:
             continue
 
         distance_from_end = compacted_log_len - idx - 1

--- a/gptme/tools/autocompact/engine.py
+++ b/gptme/tools/autocompact/engine.py
@@ -315,5 +315,14 @@ def auto_compact_log(
         tail_limit = max(0, limit - head_tokens)
         yield from head_msgs
         yield from reduce_log(tail_msgs, tail_limit)
+    elif keep_head >= len(compacted_log):
+        # All messages are protected — accept the budget overshoot verbatim.
+        # Per documented behavior: if the head alone exceeds the limit,
+        # compaction accepts the overshoot rather than corrupting task context.
+        logger.info(
+            "keep_head covers all %d messages; yielding verbatim (accepting budget overshoot)",
+            len(compacted_log),
+        )
+        yield from compacted_log
     else:
         yield from reduce_log(compacted_log, limit)

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from ...llm.models import get_default_model
 from ...logmanager import Log
 from ...message import Message, len_tokens
+from .config import AutoCompactConfig
 from .decision import should_auto_compact
 from .engine import auto_compact_log
 from .resume import _resume_via_llm
@@ -45,7 +46,11 @@ def _compact_auto(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
         return
 
     # Apply auto-compacting
-    compacted_msgs = list(auto_compact_log(msgs, logdir=ctx.manager.logdir))
+    compacted_msgs = list(
+        auto_compact_log(
+            msgs, logdir=ctx.manager.logdir, keep_head=AutoCompactConfig().keep_head
+        )
+    )
 
     # Calculate reduction stats
     original_count = len(msgs)

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from ...llm.models import get_default_model
 from ...logmanager import Log
 from ...message import Message, len_tokens
-from .config import AutoCompactConfig
+from .config import _get_keep_head
 from .decision import should_auto_compact
 from .engine import auto_compact_log
 from .resume import _resume_via_llm
@@ -47,9 +47,7 @@ def _compact_auto(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
 
     # Apply auto-compacting
     compacted_msgs = list(
-        auto_compact_log(
-            msgs, logdir=ctx.manager.logdir, keep_head=AutoCompactConfig().keep_head
-        )
+        auto_compact_log(msgs, logdir=ctx.manager.logdir, keep_head=_get_keep_head())
     )
 
     # Calculate reduction stats

--- a/gptme/tools/autocompact/hook.py
+++ b/gptme/tools/autocompact/hook.py
@@ -11,10 +11,12 @@ from collections.abc import Generator
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from ...config import get_config
 from ...hooks import HookType, StopPropagation, trigger_hook
 from ...llm.models import get_default_model
 from ...message import Message, len_tokens
 from ..base import ToolSpec
+from .config import AutoCompactConfig
 from .decision import should_auto_compact
 from .engine import auto_compact_log
 from .handlers import cmd_compact_handler
@@ -28,6 +30,24 @@ logger = logging.getLogger(__name__)
 # Reentrancy guard to prevent infinite loops
 _last_autocompact_time = 0.0
 _autocompact_min_interval = 60  # Minimum 60 seconds between autocompact attempts
+
+
+def _get_keep_head() -> int:
+    """Resolve the number of head messages to protect from compaction.
+
+    Priority: ``GPTME_AUTOCOMPACT_KEEP_HEAD`` env var > :class:`AutoCompactConfig`
+    default. Invalid/negative values fall back to the configured default.
+    """
+    cfg = AutoCompactConfig()
+    raw = get_config().get_env("GPTME_AUTOCOMPACT_KEEP_HEAD")
+    if raw is not None:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            logger.warning(
+                f"Invalid GPTME_AUTOCOMPACT_KEEP_HEAD={raw!r}, using default {cfg.keep_head}"
+            )
+    return cfg.keep_head
 
 
 def _get_compacted_name(conversation_name: str) -> str:
@@ -116,7 +136,13 @@ def autocompact_hook(
 
         # Apply auto-compacting to get compacted messages
         try:
-            compacted_msgs = list(auto_compact_log(messages, logdir=manager.logdir))
+            compacted_msgs = list(
+                auto_compact_log(
+                    messages,
+                    logdir=manager.logdir,
+                    keep_head=_get_keep_head(),
+                )
+            )
 
             # Calculate reduction stats
             m = get_default_model()

--- a/gptme/tools/autocompact/hook.py
+++ b/gptme/tools/autocompact/hook.py
@@ -11,12 +11,11 @@ from collections.abc import Generator
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from ...config import get_config
 from ...hooks import HookType, StopPropagation, trigger_hook
 from ...llm.models import get_default_model
 from ...message import Message, len_tokens
 from ..base import ToolSpec
-from .config import AutoCompactConfig
+from .config import _get_keep_head
 from .decision import should_auto_compact
 from .engine import auto_compact_log
 from .handlers import cmd_compact_handler
@@ -30,24 +29,6 @@ logger = logging.getLogger(__name__)
 # Reentrancy guard to prevent infinite loops
 _last_autocompact_time = 0.0
 _autocompact_min_interval = 60  # Minimum 60 seconds between autocompact attempts
-
-
-def _get_keep_head() -> int:
-    """Resolve the number of head messages to protect from compaction.
-
-    Priority: ``GPTME_AUTOCOMPACT_KEEP_HEAD`` env var > :class:`AutoCompactConfig`
-    default. Invalid/negative values fall back to the configured default.
-    """
-    cfg = AutoCompactConfig()
-    raw = get_config().get_env("GPTME_AUTOCOMPACT_KEEP_HEAD")
-    if raw is not None:
-        try:
-            return max(0, int(raw))
-        except ValueError:
-            logger.warning(
-                f"Invalid GPTME_AUTOCOMPACT_KEEP_HEAD={raw!r}, using default {cfg.keep_head}"
-            )
-    return cfg.keep_head
 
 
 def _get_compacted_name(conversation_name: str) -> str:

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -504,6 +504,11 @@ def _drop_orphaned_tool_pairs(
 
             if msg.role == "system" and msg.call_id:
                 # Case 1: walk backward to find nearest non-system anchor.
+                # Pinned tool results are never dropped, even if the anchor
+                # was excluded — keep_head may protect results whose assistant
+                # anchor lies outside the protected window.
+                if msg.pinned:
+                    continue
                 for j in range(idx - 1, -1, -1):
                     if original[j].role != "system":
                         if id(original[j]) not in kept_ids:

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -533,7 +533,7 @@ def limit_log(log: list[Message]) -> list[Message]:
     """
     Picks messages until the total number of tokens exceeds limit,
     then removes the last message to get below the limit.
-    Will always pick the first few system messages.
+    Will always pick the first few system messages and any pinned messages.
     """
     model = get_default_model()
     assert model, "No model loaded"
@@ -545,19 +545,34 @@ def limit_log(log: list[Message]) -> list[Message]:
             break
         initial_system_msgs.append(msg)
 
-    # Pick the messages in latest-first order
+    # Also always include pinned messages beyond the initial system block
+    # (e.g. keep_head-protected task context marked pinned by auto_compact_log).
+    extra_pinned = [m for m in log[len(initial_system_msgs) :] if m.pinned]
+    extra_pinned_ids = {id(m) for m in extra_pinned}
+
+    # Reserve budget for always-included messages.
+    always_tokens = len_tokens(initial_system_msgs + extra_pinned, model.model)
+    tail_budget = max(0, model.context - always_tokens)
+
+    # Pick the non-pinned messages in latest-first order within the remaining budget.
     msgs = []
     for msg in reversed(log[len(initial_system_msgs) :]):
+        if id(msg) in extra_pinned_ids:
+            continue  # already included
         msgs.append(msg)
-        if len_tokens(msgs, model.model) > model.context:
+        if len_tokens(msgs, model.model) > tail_budget:
             break
 
     # Remove the message that put us over the limit
-    if len_tokens(msgs, model.model) > model.context:
+    if len_tokens(msgs, model.model) > tail_budget:
         # skip the last message
         msgs.pop()
 
-    result = initial_system_msgs + list(reversed(msgs))
+    # Reconstruct in original log order, preserving initial + pinned + tail selection.
+    kept_ids = (
+        {id(m) for m in initial_system_msgs} | extra_pinned_ids | {id(m) for m in msgs}
+    )
+    result = [m for m in log if id(m) in kept_ids]
 
     # Pass 1 — drop non-call_id system messages whose anchor was removed.
     # These are gptme-native tool results (markdown format, no call_id).

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -547,8 +547,22 @@ def limit_log(log: list[Message]) -> list[Message]:
 
     # Also always include pinned messages beyond the initial system block
     # (e.g. keep_head-protected task context marked pinned by auto_compact_log).
-    extra_pinned = [m for m in log[len(initial_system_msgs) :] if m.pinned]
-    extra_pinned_ids = {id(m) for m in extra_pinned}
+    # For pinned assistant messages, extend protection to their immediately following
+    # call_id tool results so _drop_orphaned_tool_pairs doesn't remove the pinned
+    # assistant when its result was excluded from the tail budget.
+    log_tail = log[len(initial_system_msgs) :]
+    extra_pinned_ids: set[int] = set()
+    for i, m in enumerate(log_tail):
+        if m.pinned:
+            extra_pinned_ids.add(id(m))
+            if m.role == "assistant":
+                for j in range(i + 1, len(log_tail)):
+                    nxt = log_tail[j]
+                    if nxt.role == "system" and nxt.call_id:
+                        extra_pinned_ids.add(id(nxt))
+                    elif nxt.role != "system":
+                        break
+    extra_pinned = [m for m in log_tail if id(m) in extra_pinned_ids]
 
     # Reserve budget for always-included messages.
     always_tokens = len_tokens(initial_system_msgs + extra_pinned, model.model)
@@ -556,7 +570,7 @@ def limit_log(log: list[Message]) -> list[Message]:
 
     # Pick the non-pinned messages in latest-first order within the remaining budget.
     msgs = []
-    for msg in reversed(log[len(initial_system_msgs) :]):
+    for msg in reversed(log_tail):
         if id(msg) in extra_pinned_ids:
             continue  # already included
         msgs.append(msg)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -558,9 +558,12 @@ def limit_log(log: list[Message]) -> list[Message]:
             if m.role == "assistant":
                 for j in range(i + 1, len(log_tail)):
                     nxt = log_tail[j]
-                    if nxt.role == "system" and nxt.call_id:
+                    if nxt.role == "system":
+                        # Include ALL consecutive system messages (both call_id
+                        # and markdown/no-call_id tool results) so orphan-drop
+                        # passes never strip the result of a pinned tool call.
                         extra_pinned_ids.add(id(nxt))
-                    elif nxt.role != "system":
+                    else:
                         break
     extra_pinned = [m for m in log_tail if id(m) in extra_pinned_ids]
 
@@ -597,7 +600,11 @@ def limit_log(log: list[Message]) -> list[Message]:
     initial_id_set = {id(m) for m in initial_system_msgs}
 
     def _is_orphaned(msg: Message) -> bool:
-        if msg.role != "system" or id(msg) in initial_id_set:
+        if (
+            msg.role != "system"
+            or id(msg) in initial_id_set
+            or id(msg) in extra_pinned_ids
+        ):
             return False
         idx = log_by_id.get(id(msg))
         if idx is None or idx == 0:

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1195,3 +1195,51 @@ def test_get_keep_head_negative_falls_back_to_default(monkeypatch):
     assert result == 2, (
         f"Negative GPTME_AUTOCOMPACT_KEEP_HEAD=-1 should fall back to default 2, got {result}"
     )
+
+
+def test_keep_head_success_path_pins_head_messages():
+    """keep_head messages must be pinned on ALL yield paths, including early-return and success.
+
+    Two paths previously missed pinning:
+    1. Early-return path (log already fits in budget — no compaction needed).
+    2. Success path (compaction brought final_tokens <= limit).
+
+    Without pinning, a downstream limit_log call (e.g. in prepare_messages)
+    could still drop the protected head messages because limit_log only preserves
+    initial-system and pinned=True messages.
+
+    Fix: pin the first keep_head messages on every yield path.
+    """
+    from gptme.tools.autocompact.engine import auto_compact_log
+
+    model = get_default_model() or get_model("gpt-4")
+    # Build a log with a massive tool result that phase-2 truncates, bringing
+    # final_tokens <= limit so the SUCCESS path fires (not the fallback).
+    target_tokens = max(2100, int(0.85 * model.context))
+    words = [f"file_{i}.txt" for i in range(target_tokens // 2)]
+    massive = "\n".join(words)
+    head1 = "SYSTEM PROMPT — must be pinned"
+    head2 = "USER TASK — must be pinned"
+
+    messages = [
+        Message("system", head1, datetime.now(tz=timezone.utc)),
+        Message("user", head2, datetime.now(tz=timezone.utc)),
+        Message("assistant", "running", datetime.now(tz=timezone.utc)),
+        Message("system", massive, datetime.now(tz=timezone.utc)),
+    ]
+
+    # Phase-2 truncates the massive tail; final_tokens <= limit → success path
+    compacted = list(auto_compact_log(messages, keep_head=2))
+
+    assert len(compacted) >= 2
+    assert compacted[0].content == head1
+    assert compacted[1].content == head2
+    assert compacted[0].pinned, (
+        "head[0] must be pinned so downstream limit_log skips it"
+    )
+    assert compacted[1].pinned, (
+        "head[1] must be pinned so downstream limit_log skips it"
+    )
+    # Non-head messages must NOT be pinned
+    for m in compacted[2:]:
+        assert not m.pinned, f"non-head message should not be pinned: {m.content[:30]}"

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1071,3 +1071,76 @@ def test_keep_head_zero_is_default_behavior():
     explicit = list(auto_compact_log(messages, keep_head=0))
 
     assert default == explicit
+
+
+def test_keep_head_survives_reduce_log_fallback():
+    """Protected head messages must not be touched by the reduce_log fallback.
+
+    Passes a limit of 1 token so all three primary phases are guaranteed to
+    fail to reach the limit and the fallback fires.  The head message must
+    come out identical despite reduce_log being called on the tail.
+    """
+    head_content = "SYSTEM PROMPT — task context that must survive compaction"
+    messages = [
+        Message("system", head_content, datetime.now(tz=timezone.utc)),
+        Message("user", "word " * 500, datetime.now(tz=timezone.utc)),
+        Message("assistant", "word " * 500, datetime.now(tz=timezone.utc)),
+    ]
+
+    # limit=1 guarantees phases 1-3 leave us over-limit, triggering the fallback
+    compacted = list(auto_compact_log(messages, limit=1, keep_head=1))
+
+    # Head message must be yielded verbatim
+    assert compacted[0].content == head_content
+
+
+def test_compact_auto_handler_honors_env_keep_head(monkeypatch):
+    """The /compact auto handler must use _get_keep_head(), not a hardcoded default.
+
+    When GPTME_AUTOCOMPACT_KEEP_HEAD differs from the AutoCompactConfig default,
+    the handler must pass the env value — not the dataclass default — to
+    auto_compact_log.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import _compact_auto
+
+    # Set up a mock context
+    mock_logdir = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.manager.logdir = mock_logdir
+
+    msgs = [
+        Message("system", "System prompt"),
+        Message("user", "word " * 200),
+        Message("system", "tool result " * 200),
+    ]
+
+    captured_keep_head = {}
+
+    def fake_auto_compact_log(log, logdir=None, keep_head=0, **kw):
+        captured_keep_head["value"] = keep_head
+        yield from log
+
+    with (
+        patch(
+            "gptme.tools.autocompact.handlers.should_auto_compact",
+            return_value="rule_based",
+        ),
+        patch(
+            "gptme.tools.autocompact.handlers.auto_compact_log",
+            side_effect=fake_auto_compact_log,
+        ),
+        patch("gptme.tools.autocompact.handlers.get_default_model", return_value=None),
+        patch("gptme.config.get_config") as mock_get_config,
+    ):
+        # Simulate env var returning "5"
+        mock_cfg = MagicMock()
+        mock_cfg.get_env.return_value = "5"
+        mock_get_config.return_value = mock_cfg
+
+        list(_compact_auto(mock_ctx, msgs))
+
+    assert captured_keep_head.get("value") == 5, (
+        f"Expected keep_head=5 from env override, got {captured_keep_head.get('value')}"
+    )

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1094,6 +1094,28 @@ def test_keep_head_survives_reduce_log_fallback():
     assert compacted[0].content == head_content
 
 
+def test_keep_head_fully_protected_log_yields_verbatim():
+    """When keep_head >= message count, all messages are protected.
+
+    The fallback must yield the entire log verbatim rather than passing it to
+    reduce_log (which has no knowledge of keep_head and would truncate the
+    "protected" head messages).
+    """
+    head1 = "SYSTEM PROMPT — must survive"
+    head2 = "USER TASK — must survive"
+    messages = [
+        Message("system", head1, datetime.now(tz=timezone.utc)),
+        Message("user", head2, datetime.now(tz=timezone.utc)),
+    ]
+
+    # keep_head=2 covers all 2 messages; limit=1 forces the fallback
+    compacted = list(auto_compact_log(messages, limit=1, keep_head=2))
+
+    assert len(compacted) == 2
+    assert compacted[0].content == head1
+    assert compacted[1].content == head2
+
+
 def test_compact_auto_handler_honors_env_keep_head(monkeypatch):
     """The /compact auto handler must use _get_keep_head(), not a hardcoded default.
 

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1178,3 +1178,20 @@ def test_compact_auto_handler_honors_env_keep_head(monkeypatch):
     assert captured_keep_head.get("value") == 5, (
         f"Expected keep_head=5 from env override, got {captured_keep_head.get('value')}"
     )
+
+
+def test_get_keep_head_negative_falls_back_to_default(monkeypatch):
+    """_get_keep_head must treat negative env values as invalid and return the configured default.
+
+    A user setting GPTME_AUTOCOMPACT_KEEP_HEAD=-1 might expect head retention to fall
+    back to the default (2), not to be silently disabled. The old code returned
+    max(0, int(raw)) = 0 for negatives, defeating head protection.
+    """
+    from gptme.tools.autocompact.config import _get_keep_head
+
+    monkeypatch.setenv("GPTME_AUTOCOMPACT_KEEP_HEAD", "-1")
+    result = _get_keep_head()
+
+    assert result == 2, (
+        f"Negative GPTME_AUTOCOMPACT_KEEP_HEAD=-1 should fall back to default 2, got {result}"
+    )

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1090,8 +1090,12 @@ def test_keep_head_survives_reduce_log_fallback():
     # limit=1 guarantees phases 1-3 leave us over-limit, triggering the fallback
     compacted = list(auto_compact_log(messages, limit=1, keep_head=1))
 
-    # Head message must be yielded verbatim
+    # Head message must be yielded verbatim and pinned so downstream reduce_log
+    # (e.g. in prepare_messages) cannot summarize or remove it.
     assert compacted[0].content == head_content
+    assert compacted[0].pinned, (
+        "head message must be pinned to survive downstream reduce_log"
+    )
 
 
 def test_keep_head_fully_protected_log_yields_verbatim():
@@ -1114,6 +1118,12 @@ def test_keep_head_fully_protected_log_yields_verbatim():
     assert len(compacted) == 2
     assert compacted[0].content == head1
     assert compacted[1].content == head2
+    assert compacted[0].pinned, (
+        "head messages must be pinned to survive downstream reduce_log"
+    )
+    assert compacted[1].pinned, (
+        "head messages must be pinned to survive downstream reduce_log"
+    )
 
 
 def test_compact_auto_handler_honors_env_keep_head(monkeypatch):

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1000,3 +1000,74 @@ def test_resume_via_llm_with_view_branch():
     # Status messages should be hidden
     for msg in results:
         assert msg.hide is True
+
+
+def test_keep_head_protects_head_messages_from_reasoning_strip():
+    """Test that keep_head messages are not modified by reasoning stripping."""
+    messages = [
+        Message(
+            "user",
+            "Original task <think>old reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "assistant",
+            "Reply <think>old reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "user", "Later <think>old reasoning</think>", datetime.now(tz=timezone.utc)
+        ),
+        Message(
+            "assistant",
+            "Final <think>old reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+    ]
+
+    # With keep_head=1, the first message (system prompt / task) must be untouched
+    compacted = list(
+        auto_compact_log(messages, reasoning_strip_age_threshold=0, keep_head=1)
+    )
+
+    # Head message preserved verbatim
+    assert compacted[0].content == messages[0].content
+    assert "<think>" in compacted[0].content
+
+    # Later messages still get reasoning stripped
+    for msg in compacted[1:]:
+        assert "<think>" not in msg.content
+
+
+def test_keep_head_protects_head_messages_from_tool_truncation():
+    """Test that keep_head messages are not truncated even when over the limit."""
+    model = get_default_model() or get_model("gpt-4")
+    target_tokens = int(0.85 * model.context)
+
+    words = [f"file_{i}.txt" for i in range(target_tokens // 2)]
+    massive = "\n".join(words)
+    head_content = "HEAD TASK CONTENT that must be preserved verbatim"
+    tail_content = f"Ran command: `find /usr -type f`\n{massive}"
+
+    messages = [
+        Message("system", head_content, datetime.now(tz=timezone.utc)),
+        Message("assistant", "running", datetime.now(tz=timezone.utc)),
+        Message("system", tail_content, datetime.now(tz=timezone.utc)),
+    ]
+
+    compacted = list(auto_compact_log(messages, keep_head=1))
+
+    # Head message preserved verbatim despite massive tail triggering truncation
+    assert compacted[0].content == head_content
+    # Tail was truncated
+    assert "[Large tool output removed" in compacted[2].content
+
+
+def test_keep_head_zero_is_default_behavior():
+    """Test that keep_head=0 (default) gives identical output to no param."""
+    messages = create_test_conversation()
+
+    default = list(auto_compact_log(messages))
+    explicit = list(auto_compact_log(messages, keep_head=0))
+
+    assert default == explicit

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1042,7 +1042,9 @@ def test_keep_head_protects_head_messages_from_reasoning_strip():
 def test_keep_head_protects_head_messages_from_tool_truncation():
     """Test that keep_head messages are not truncated even when over the limit."""
     model = get_default_model() or get_model("gpt-4")
-    target_tokens = int(0.85 * model.context)
+    # Clamp to at least 2100 so the tail always exceeds max_tool_result_tokens=2000,
+    # ensuring phase-2 truncation fires regardless of the model's context size.
+    target_tokens = max(2100, int(0.85 * model.context))
 
     words = [f"file_{i}.txt" for i in range(target_tokens // 2)]
     massive = "\n".join(words)

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -489,6 +489,54 @@ def test_limit_log_preserves_pinned_head():
         )
 
 
+def test_limit_log_preserves_pinned_tool_call_pair():
+    """limit_log must not drop a pinned assistant tool-call when its result is clipped.
+
+    Scenario: keep_head pins an assistant message that contains a tool call, but the
+    immediately following tool result is not pinned and falls outside the tail budget.
+    _drop_orphaned_tool_pairs would remove the orphaned assistant — but the result
+    should also be included in the always-reserved set to maintain pair atomicity.
+
+    With the fix: extra_pinned is extended to include immediately following call_id
+    results of pinned assistant messages, so the pair is always preserved together.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Budget: context=5 tokens.
+        # Messages: system(1) + assistant-with-call(2) + system-result(1) + newest(3)
+        # Without fix: system+newest=4 fits; pinned assistant-call kept but its result
+        # excluded from tail → _drop_orphaned_tool_pairs removes assistant.
+        # With fix: assistant-call + its result both in extra_pinned (reserved budget).
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=7)
+        set_default_model(tiny_model)
+
+        tool_call_msg = Message("assistant", "tool call", pinned=True)
+        tool_result_msg = Message("system", "result", call_id="abc123")
+        msgs = [
+            Message("system", "system"),  # 1 tok — initial system
+            tool_call_msg,  # 2 tok — pinned tool call
+            tool_result_msg,  # 1 tok — tool result (not pinned, but must be kept)
+            Message("user", "newest message"),  # 2 tok — recent context
+        ]
+
+        result = limit_log(msgs)
+        result_contents = [m.content for m in result]
+
+        assert "tool call" in result_contents, (
+            "Pinned assistant tool call must be preserved"
+        )
+        assert "result" in result_contents, (
+            "Tool result of pinned call must be preserved (atomicity)"
+        )
+        assert "system" in result_contents, "Initial system message must be preserved"
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tests for proactive_summarize_log
 # ---------------------------------------------------------------------------

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -443,6 +443,52 @@ def test_limit_log_partial_call_id_results_dropped():
         )
 
 
+def test_limit_log_preserves_pinned_head():
+    """limit_log must not drop pinned messages even when they are oldest and non-system.
+
+    Scenario: auto_compact_log marks the first N messages as pinned=True to protect
+    task context. If the compacted log still exceeds the model context, prepare_messages
+    calls limit_log, which builds tail-first and would normally drop the oldest
+    non-system messages — exactly the pinned head messages.
+
+    With the fix: pinned messages are always included (like initial system messages),
+    and the remaining budget is filled from the newest non-pinned messages.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Token counts (gpt-4 tokenizer):
+        #   "system" = 1 tok, "task" = 1 tok, "older reply" = 2 tok, "newest message" = 3 tok.
+        # Context=5: system(1) + task(1) + newest(3) = 5, fits.
+        # With old code: system + newest alone = 4, pinned "task" dropped.
+        # With fix: task is always included; tail_budget = 3, newest(3) fits, older(2)+newest(3)=5>3 → only newest.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=5)
+        set_default_model(tiny_model)
+
+        msgs = [
+            Message("system", "system"),  # 1 tok — initial system, always kept
+            Message("user", "task", pinned=True),  # 1 tok — pinned head
+            Message("assistant", "older reply"),  # 2 tok — old, non-pinned
+            Message("user", "newest message"),  # 2 tok — new, non-pinned
+        ]
+
+        result = limit_log(msgs)
+        result_contents = [m.content for m in result]
+
+        # The pinned "task" message must survive despite being older than "newest".
+        assert "task" in result_contents, "Pinned head message must be preserved"
+        assert "system" in result_contents, "Initial system message must be preserved"
+        # "older reply" should be dropped in favour of pinned head + newest.
+        assert "older reply" not in result_contents, (
+            "Non-pinned older message should be dropped when budget is tight"
+        )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tests for proactive_summarize_log
 # ---------------------------------------------------------------------------

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1104,3 +1104,100 @@ def test_proactive_summarize_error_falls_back(monkeypatch):
         set_default_model(original_model) if original_model else _default_model_var.set(
             None
         )
+
+
+def test_limit_log_preserves_pinned_markdown_tool_result():
+    """limit_log must also protect non-call_id (markdown) tool results of pinned assistant.
+
+    Scenario: a pinned assistant message contains a tool call, and the immediately
+    following system message is a gptme-native markdown result (no call_id).  The
+    old code only added call_id system messages to extra_pinned_ids, leaving the
+    markdown result eligible for budget exclusion.  When excluded, _is_orphaned
+    does NOT catch it (no call_id), so the pinned assistant survives with no result
+    — producing an incoherent log.
+
+    With the fix: ALL consecutive system messages after a pinned assistant tool-use
+    are added to extra_pinned_ids, so the markdown result is always reserved.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Budget: context=5 tokens.
+        # Messages: system(1) + pinned-assistant-tool(2) + markdown-result(1) + newest(3)
+        # Without fix: system+newest=4 fits; pinned assistant kept but markdown result
+        # excluded from tail → log has dangling tool call with no result.
+        # With fix: markdown result also in extra_pinned; always reserved.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=6)
+        set_default_model(tiny_model)
+
+        # Markdown tool result: system message with no call_id
+        tool_call_msg = Message("assistant", "tool call", pinned=True)
+        markdown_result_msg = Message("system", "markdown result")  # no call_id
+
+        msgs = [
+            Message("system", "system"),  # 1 tok — initial system
+            tool_call_msg,  # 2 tok — pinned tool call
+            markdown_result_msg,  # 2 tok — markdown result (no call_id)
+            Message("user", "newest"),  # 1 tok — recent context
+        ]
+
+        result = limit_log(msgs)
+        result_contents = [m.content for m in result]
+
+        assert "tool call" in result_contents, (
+            "Pinned assistant tool call must be preserved"
+        )
+        assert "markdown result" in result_contents, (
+            "Markdown tool result of pinned call must be preserved (no call_id path)"
+        )
+        assert "system" in result_contents, "Initial system message must be preserved"
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+
+
+def test_limit_log_pinned_system_not_orphaned():
+    """_is_orphaned must not drop a pinned system message even when its anchor is excluded.
+
+    Scenario: a pinned system message's preceding non-system message is NOT in the
+    tail budget selection.  The old _is_orphaned would walk back to that absent anchor
+    and return True, removing the pinned message — defeating the pin guarantee.
+
+    With the fix: _is_orphaned skips messages whose id is in extra_pinned_ids.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+
+    original_model = _default_model_var.get()
+    try:
+        # Budget: context=4 tokens.
+        # Messages: system(1) + assistant-anchor(2) + pinned-result(1) + user(1)
+        # always = system(1) + pinned-result(1) = 2; tail_budget=2; newest is user(1).
+        # assistant-anchor(2) > remaining(1) so it's dropped.
+        # Old _is_orphaned: pinned-result walks back to absent assistant → orphaned → dropped.
+        # New _is_orphaned: pinned-result is in extra_pinned_ids → exempt → kept.
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=4)
+        set_default_model(tiny_model)
+
+        anchor_msg = Message("assistant", "anchor msg")  # 2 tok — non-pinned anchor
+        pinned_result = Message("system", "pinned result", pinned=True)  # 1 tok
+
+        msgs = [
+            Message("system", "system"),  # 1 tok — initial system
+            anchor_msg,  # 2 tok — anchor (will be budget-excluded)
+            pinned_result,  # 1 tok — pinned system result
+            Message("user", "newest"),  # 1 tok — newest
+        ]
+
+        result = limit_log(msgs)
+        result_contents = [m.content for m in result]
+
+        assert "pinned result" in result_contents, (
+            "Pinned system message must not be dropped by _is_orphaned even when anchor is excluded"
+        )
+        assert "system" in result_contents, "Initial system message must be preserved"
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1201,3 +1201,32 @@ def test_limit_log_pinned_system_not_orphaned():
         set_default_model(original_model) if original_model else _default_model_var.set(
             None
         )
+
+
+def test_drop_orphaned_tool_pairs_preserves_pinned_tool_result():
+    """_drop_orphaned_tool_pairs must not drop a pinned system tool result.
+
+    When a system message with call_id is pinned, its anchor assistant may have
+    been excluded from the pruned set by limit_log. Previously _drop_orphaned_tool_pairs
+    would detect the missing anchor and remove the pinned result too. The fix: skip
+    Case 1 removal if the system message has pinned=True.
+
+    Regression test for: _drop_orphaned_tool_pairs ignoring pinned flag.
+    """
+    from gptme.util.reduce import _drop_orphaned_tool_pairs
+
+    anchor = Message("assistant", "fn call", call_id="call_abc")
+    pinned_result = Message("system", "fn result", pinned=True, call_id="call_abc")
+    user = Message("user", "follow up")
+
+    original = [anchor, pinned_result, user]
+
+    # Pruned: anchor was excluded (budget or index), only result + user remain
+    pruned = [pinned_result, user]
+
+    result = _drop_orphaned_tool_pairs(original, pruned)
+    result_contents = [m.content for m in result]
+
+    assert "fn result" in result_contents, (
+        "Pinned tool result must survive _drop_orphaned_tool_pairs even when anchor is absent"
+    )


### PR DESCRIPTION
## Summary

Adds a `keep_head: int` parameter to `auto_compact_log()` so the head of a conversation (system prompt + original task) is protected from all three compaction phases. Prevents **task amnesia** in long agent sessions where compaction strips away what the agent was originally asked to do.

Design: `knowledge/technical-designs/2026-07-25-context-auto-summarization-head-retention.md` (Bob workspace, idea #819).

## Changes

- `gptme/tools/autocompact/engine.py`: add `keep_head: int = 0` param; all three phase loops (reasoning strip, tool-result truncation, assistant compression) skip messages where `idx < keep_head`. Default 0 = no behavioral change.
- `gptme/tools/autocompact/config.py` (new): `AutoCompactConfig` dataclass with `keep_head: int = 2`.
- `gptme/tools/autocompact/hook.py`: thread `keep_head` from config into the hook call, with `GPTME_AUTOCOMPACT_KEEP_HEAD` env override.
- `gptme/tools/autocompact/handlers.py`: `/compact auto` uses the same config value.
- `tests/test_auto_compact.py`: 3 new tests — head protected from reasoning strip, head protected from tool truncation, keep_head=0 equals default behavior.

## How to reproduce / verify

```bash
uv run pytest tests/test_auto_compact.py -k keep_head -v
```

Head messages are preserved verbatim even when the tail is massive/truncatable.

## Notes

- Protected head counts toward the token budget but is never reduced. If the head alone exceeds the limit, compaction accepts the overshoot (documented in docstring).
- Cross-harness demand: Aider#5440, Cline#12468.

