### PR TITLE
feat(cli): fatal error envelope + exit taxonomy for non-interactive mode

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1554,8 +1554,11 @@ def main(
                 logger.error(
                     f"  at {last_frame.filename}:{last_frame.lineno} in {last_frame.name}"
                 )
-        error_class, exit_code = _classify_fatal_error(e)
-        _write_terminal_error_to_log(logdir, error_class, exit_code, str(e))
+        if not config.chat.interactive:
+            error_class, exit_code = _classify_fatal_error(e)
+            _write_terminal_error_to_log(logdir, error_class, exit_code, str(e))
+        else:
+            exit_code = 1
         sys.exit(exit_code)
     finally:
         shutdown_telemetry()
@@ -1729,22 +1732,23 @@ def _classify_fatal_error(e: BaseException) -> tuple[str, int]:
             "rate" in emsg_lower
             or "usage_limit_reached" in emsg_lower
             or "quota" in emsg_lower
+            or "too many requests" in emsg_lower
         )
     ):
         return "rate_limit", EXIT_RATE_LIMIT
 
     # Authentication / permission denied — needs credential update (exit 76)
     if etype in ("AuthenticationError", "PermissionDeniedError", "GptmeAuthError") or (
-        ("401" in emsg or "403" in emsg) and "api error" in emsg_lower
+        "401" in emsg or "403" in emsg
     ):
         return "auth_error", EXIT_AUTH_ERROR
 
-    # Model / service unavailable — 404 or 503 response (exit 77)
-    # SDK-native exceptions (openai.NotFoundError, openai.InternalServerError, etc.)
-    # are matched by type name; string-based fallback handles bare HTTP error messages.
-    if etype in ("NotFoundError", "ServiceUnavailableError", "InternalServerError") or (
-        ("404" in emsg or "503" in emsg or "model_unavailable" in emsg_lower)
-        and "api error" in emsg_lower
+    # Model / service unavailable — 404 or 503 response (exit 77).
+    # SDK-native: NotFoundError (404) and ServiceUnavailableError (503) match by type
+    # name.  InternalServerError covers HTTP 500/502/504 — those are generic server
+    # errors, not a predictable availability failure, so they fall through to exit 1.
+    if etype in ("NotFoundError", "ServiceUnavailableError") or (
+        "404" in emsg or "503" in emsg or "model_unavailable" in emsg_lower
     ):
         return "model_unavailable", EXIT_MODEL_UNAVAIL
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import importlib
 import importlib.metadata as _ilm
+import json
 import logging
 import os
 import select
@@ -1553,7 +1554,9 @@ def main(
                 logger.error(
                     f"  at {last_frame.filename}:{last_frame.lineno} in {last_frame.name}"
                 )
-        sys.exit(1)
+        error_class, exit_code = _classify_fatal_error(e)
+        _write_terminal_error_to_log(logdir, error_class, exit_code, str(e))
+        sys.exit(exit_code)
     finally:
         shutdown_telemetry()
         if get_config().get_env_bool("GPTME_EXIT_STATS"):
@@ -1699,6 +1702,79 @@ def _cleanup_aborted_new_logdir(logdir: Path, *, preexisting: bool) -> None:
         shutil.rmtree(logdir)
     except OSError:
         pass
+
+
+# Exit codes for non-interactive fatal failures (documented in docs/cli.rst).
+# These mirror POSIX sysexits.h conventions where applicable.
+EXIT_RATE_LIMIT = 75  # EX_TEMPFAIL — quota exhausted, retry later
+EXIT_AUTH_ERROR = 76  # EX_PROTOCOL — credential / permission problem
+EXIT_MODEL_UNAVAIL = 77  # EX_NOPERM   — model/service not reachable
+
+
+def _classify_fatal_error(e: BaseException) -> tuple[str, int]:
+    """Classify a fatal exception into (error_class, exit_code).
+
+    Returns a string class name and an exit code.  The default for
+    unclassified exceptions is ("generic", 1) to preserve the existing
+    behaviour.
+    """
+    etype = type(e).__name__
+    emsg = str(e)
+    emsg_lower = emsg.lower()
+
+    # Rate-limit / quota exhausted — temporary, retry later (exit 75)
+    if etype == "RateLimitError" or (
+        "429" in emsg
+        and (
+            "rate" in emsg_lower
+            or "usage_limit_reached" in emsg_lower
+            or "quota" in emsg_lower
+        )
+    ):
+        return "rate_limit", EXIT_RATE_LIMIT
+
+    # Authentication / permission denied — needs credential update (exit 76)
+    if etype in ("AuthenticationError", "PermissionDeniedError", "GptmeAuthError") or (
+        ("401" in emsg or "403" in emsg) and "api error" in emsg_lower
+    ):
+        return "auth_error", EXIT_AUTH_ERROR
+
+    # Model / service unavailable — 404 or 503 response (exit 77)
+    if (
+        "404" in emsg or "503" in emsg or "model_unavailable" in emsg_lower
+    ) and "api error" in emsg_lower:
+        return "model_unavailable", EXIT_MODEL_UNAVAIL
+
+    return "generic", 1
+
+
+def _write_terminal_error_to_log(
+    logdir: Path, error_class: str, exit_code: int, message: str
+) -> None:
+    """Append a terminal error system message to the conversation log.
+
+    This gives machine-readable evidence of the failure in the same
+    ``conversation.jsonl`` that callers inspect for assistant output, instead
+    of silently ending the log at the user prompt.
+    """
+    log_file = logdir / "conversation.jsonl"
+    if not logdir.exists():
+        return
+    event = {
+        "role": "system",
+        "content": f"error: {error_class}\n{message}",
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "metadata": {
+            "error": True,
+            "error_class": error_class,
+            "exit_code": exit_code,
+        },
+    }
+    try:
+        with open(log_file, "a") as f:
+            f.write(json.dumps(event) + "\n")
+    except OSError:
+        pass  # best-effort — don't mask the original failure
 
 
 def _read_stdin() -> str:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1740,9 +1740,12 @@ def _classify_fatal_error(e: BaseException) -> tuple[str, int]:
         return "auth_error", EXIT_AUTH_ERROR
 
     # Model / service unavailable — 404 or 503 response (exit 77)
-    if (
-        "404" in emsg or "503" in emsg or "model_unavailable" in emsg_lower
-    ) and "api error" in emsg_lower:
+    # SDK-native exceptions (openai.NotFoundError, openai.InternalServerError, etc.)
+    # are matched by type name; string-based fallback handles bare HTTP error messages.
+    if etype in ("NotFoundError", "ServiceUnavailableError", "InternalServerError") or (
+        ("404" in emsg or "503" in emsg or "model_unavailable" in emsg_lower)
+        and "api error" in emsg_lower
+    ):
         return "model_unavailable", EXIT_MODEL_UNAVAIL
 
     return "generic", 1

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -740,10 +740,12 @@ class TestCLI:
             assert result.exit_code == 0
             assert "No agents installed" in result.output
 
-    def test_scan_shows_active_agents(self, runner, mocker):
+    def test_scan_shows_active_agents(self, runner, monkeypatch):
         """Test scan command exposes the shared live-agent scanner."""
         agent = _make_scanned_agent()
-        mocker.patch("gptme.hooks.workspace_agents.scan_agents", return_value=[agent])
+        monkeypatch.setattr(
+            "gptme.hooks.workspace_agents.scan_agents", lambda **_: [agent]
+        )
 
         result = runner.invoke(main, ["scan"])
 

--- a/tests/test_cli_fatal_error_envelope.py
+++ b/tests/test_cli_fatal_error_envelope.py
@@ -106,17 +106,37 @@ def _setup_cli_mocks(
             "model_unavailable",
             cli.EXIT_MODEL_UNAVAIL,
         ),
+        # Rate limit via bare "429 Too Many Requests" (no keyword suffix)
+        (
+            ValueError("429 Too Many Requests"),
+            "rate_limit",
+            cli.EXIT_RATE_LIMIT,
+        ),
+        # Auth error via bare "401 Client Error: Unauthorized" (no "api error" phrase)
+        (
+            ValueError(
+                "401 Client Error: Unauthorized for url: https://api.example.com"
+            ),
+            "auth_error",
+            cli.EXIT_AUTH_ERROR,
+        ),
         # Model unavailable via SDK-native exception type (openai/anthropic style)
         (
             type("NotFoundError", (Exception,), {})("model not found"),
             "model_unavailable",
             cli.EXIT_MODEL_UNAVAIL,
         ),
-        # InternalServerError also maps to model_unavailable
+        # ServiceUnavailableError (503) maps to model_unavailable
         (
-            type("InternalServerError", (Exception,), {})("upstream error"),
+            type("ServiceUnavailableError", (Exception,), {})("service down"),
             "model_unavailable",
             cli.EXIT_MODEL_UNAVAIL,
+        ),
+        # InternalServerError (HTTP 500/502/504) falls through to generic exit 1
+        (
+            type("InternalServerError", (Exception,), {})("upstream 500"),
+            "generic",
+            1,
         ),
         # Generic fallback
         (

--- a/tests/test_cli_fatal_error_envelope.py
+++ b/tests/test_cli_fatal_error_envelope.py
@@ -100,9 +100,21 @@ def _setup_cli_mocks(
             "auth_error",
             cli.EXIT_AUTH_ERROR,
         ),
-        # Model unavailable via 503
+        # Model unavailable via 503 in message
         (
             ValueError("Codex API error 503: service unavailable"),
+            "model_unavailable",
+            cli.EXIT_MODEL_UNAVAIL,
+        ),
+        # Model unavailable via SDK-native exception type (openai/anthropic style)
+        (
+            type("NotFoundError", (Exception,), {})("model not found"),
+            "model_unavailable",
+            cli.EXIT_MODEL_UNAVAIL,
+        ),
+        # InternalServerError also maps to model_unavailable
+        (
+            type("InternalServerError", (Exception,), {})("upstream error"),
             "model_unavailable",
             cli.EXIT_MODEL_UNAVAIL,
         ),

--- a/tests/test_cli_fatal_error_envelope.py
+++ b/tests/test_cli_fatal_error_envelope.py
@@ -1,0 +1,240 @@
+"""Tests for non-interactive fatal error envelope and exit taxonomy.
+
+When gptme --non-interactive encounters a fatal LLM startup error, it should:
+1. Append a terminal error event to conversation.jsonl
+2. Exit with a class-specific code (75/76/77/1)
+"""
+
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import gptme.cli.main as cli
+
+# ---------------------------------------------------------------------------
+# Minimal fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def runner(tmp_data_dir: Path) -> CliRunner:
+    return CliRunner()
+
+
+def _fake_config(tmp_path: Path) -> Any:
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            agent_config=None,
+            tools=["shell", "read"],
+            interactive=False,
+            tool_format="markdown",
+            model="local/test",
+            workspace=tmp_path,
+            stream=False,
+            agent=None,
+            gear=None,
+            no_confirm=True,
+        ),
+        project=None,
+    )
+
+
+def _setup_cli_mocks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, chat_raises: Exception
+) -> None:
+    """Patch the minimal set of dependencies so the CLI reaches the chat() call."""
+    config = _fake_config(tmp_path)
+    monkeypatch.setattr("gptme.config.setup_config_from_cli", lambda **_: config)
+    monkeypatch.setattr("gptme.tools.init_tools", lambda _: [])
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **_: None)
+    monkeypatch.setattr("gptme.telemetry.shutdown_telemetry", lambda: None)
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise chat_raises
+
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", _raise)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _classify_fatal_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_class", "expected_code"),
+    [
+        # Rate limit via ValueError from subscription LLM (the concrete production case)
+        (
+            ValueError("Codex API error 429: usage_limit_reached"),
+            "rate_limit",
+            cli.EXIT_RATE_LIMIT,
+        ),
+        # Rate limit via openai-style exception type name
+        (
+            type("RateLimitError", (Exception,), {})("too many requests"),
+            "rate_limit",
+            cli.EXIT_RATE_LIMIT,
+        ),
+        # Auth error via type name
+        (
+            type("AuthenticationError", (Exception,), {})("invalid key"),
+            "auth_error",
+            cli.EXIT_AUTH_ERROR,
+        ),
+        # Auth error via 401 in message
+        (
+            ValueError("Codex API error 401: unauthorized"),
+            "auth_error",
+            cli.EXIT_AUTH_ERROR,
+        ),
+        # Model unavailable via 503
+        (
+            ValueError("Codex API error 503: service unavailable"),
+            "model_unavailable",
+            cli.EXIT_MODEL_UNAVAIL,
+        ),
+        # Generic fallback
+        (
+            RuntimeError("something unexpected"),
+            "generic",
+            1,
+        ),
+    ],
+)
+def test_classify_fatal_error(
+    exc: Exception, expected_class: str, expected_code: int
+) -> None:
+    error_class, exit_code = cli._classify_fatal_error(exc)
+    assert error_class == expected_class
+    assert exit_code == expected_code
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _write_terminal_error_to_log
+# ---------------------------------------------------------------------------
+
+
+def test_write_terminal_error_creates_jsonl_event(tmp_path: Path) -> None:
+    """_write_terminal_error_to_log appends a valid JSON event to conversation.jsonl."""
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    log_file = logdir / "conversation.jsonl"
+
+    cli._write_terminal_error_to_log(logdir, "rate_limit", 75, "quota exhausted")
+
+    assert log_file.exists()
+    event = json.loads(log_file.read_text().strip())
+    assert event["role"] == "system"
+    assert "rate_limit" in event["content"]
+    assert "quota exhausted" in event["content"]
+    assert event["metadata"]["error"] is True
+    assert event["metadata"]["error_class"] == "rate_limit"
+    assert event["metadata"]["exit_code"] == 75
+
+
+def test_write_terminal_error_appends_to_existing_log(tmp_path: Path) -> None:
+    """_write_terminal_error_to_log appends without truncating existing content."""
+    logdir = tmp_path / "conv"
+    logdir.mkdir()
+    log_file = logdir / "conversation.jsonl"
+    log_file.write_text('{"role":"user","content":"ping"}\n')
+
+    cli._write_terminal_error_to_log(logdir, "auth_error", 76, "bad token")
+
+    lines = log_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+    user_event = json.loads(lines[0])
+    assert user_event["role"] == "user"
+    err_event = json.loads(lines[1])
+    assert err_event["metadata"]["error_class"] == "auth_error"
+
+
+def test_write_terminal_error_missing_logdir_is_silent(tmp_path: Path) -> None:
+    """_write_terminal_error_to_log does not raise if logdir doesn't exist."""
+    logdir = tmp_path / "nonexistent"
+    cli._write_terminal_error_to_log(logdir, "generic", 1, "boom")
+    # Should complete without raising
+
+
+# ---------------------------------------------------------------------------
+# Integration: CLI exit codes and conversation log
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_exits_75_and_writes_error_event(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """A 429 usage_limit_reached exception → exit 75 + terminal error in conversation.jsonl."""
+    _setup_cli_mocks(
+        monkeypatch,
+        tmp_path,
+        chat_raises=ValueError("Codex API error 429: usage_limit_reached"),
+    )
+    result = runner.invoke(
+        cli.main, ["--non-interactive", "--name", "test-rate-limit", "ping"]
+    )
+
+    assert result.exit_code == cli.EXIT_RATE_LIMIT, result.output
+
+    # The conversation log should contain the terminal error event
+    log_file = cli.get_logs_dir() / "test-rate-limit" / "conversation.jsonl"
+    assert log_file.exists(), f"conversation.jsonl not found at {log_file}"
+    events = [
+        json.loads(line) for line in log_file.read_text().strip().splitlines() if line
+    ]
+    error_events = [e for e in events if e.get("metadata", {}).get("error")]
+    assert error_events, "No error event written to conversation.jsonl"
+    assert error_events[-1]["metadata"]["error_class"] == "rate_limit"
+    assert error_events[-1]["metadata"]["exit_code"] == cli.EXIT_RATE_LIMIT
+
+
+def test_auth_error_exits_76(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """A 401 error → exit 76."""
+    _setup_cli_mocks(
+        monkeypatch,
+        tmp_path,
+        chat_raises=ValueError("Codex API error 401: unauthorized"),
+    )
+    result = runner.invoke(
+        cli.main, ["--non-interactive", "--name", "test-auth-err", "ping"]
+    )
+    assert result.exit_code == cli.EXIT_AUTH_ERROR
+
+
+def test_generic_error_exits_1(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """An unclassified exception still exits 1 (backward-compatible default)."""
+    _setup_cli_mocks(
+        monkeypatch,
+        tmp_path,
+        chat_raises=RuntimeError("unexpected internal failure"),
+    )
+    result = runner.invoke(
+        cli.main, ["--non-interactive", "--name", "test-generic-err", "ping"]
+    )
+    assert result.exit_code == 1


### PR DESCRIPTION
## Problem

When `gptme --non-interactive` encounters a fatal LLM startup error (e.g. `429 usage_limit_reached` from the OpenAI subscription backend), it:
- Logs via `logger.error` only to stderr
- Exits with code `1` regardless of failure class
- Leaves `conversation.jsonl` ending at the user prompt with no machine-readable error record

Callers capturing stderr to a file see a bare exit `1` and cannot tell rate-limit exhaustion from a bad credential from a service outage. Bob's retry policy has to guess from stderr text.

Friction source: internal dogfood draft `02f11e982c2c` (2026-08-04).

## Changes

**`gptme/cli/main.py`**
- `_classify_fatal_error(e)` — classifies an exception into `(error_class, exit_code)` based on exception type name and message:
  - `rate_limit` → exit **75** (`EX_TEMPFAIL` — temporary, retry later)
  - `auth_error` → exit **76** (`EX_PROTOCOL` — credential update needed)
  - `model_unavailable` → exit **77** (`EX_NOPERM` — 404/503)
  - `generic` → exit **1** (unchanged default, backward-compatible)
- `_write_terminal_error_to_log(logdir, ...)` — appends a `system` message to `conversation.jsonl` with `error_class` and `exit_code` in `metadata`, so callers can inspect the log without parsing stderr
- Top-level exception handler now calls both before `sys.exit()`

**`tests/test_cli_fatal_error_envelope.py`** (new)
- 6 parametrized unit tests for `_classify_fatal_error`
- 3 unit tests for `_write_terminal_error_to_log` (creates, appends, silent on missing dir)
- 3 integration tests via `CliRunner` covering exit codes 75, 76, and 1, with the rate-limit test also asserting the JSONL event is written

## Test plan

- [x] 12/12 new tests pass locally
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI green