### PR TITLE
feat(server): BYOK key validation — warn not block when provider unreachable

### DIFF
--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -84,14 +84,18 @@ def validate_api_key(
     Returns:
         Tuple of (is_valid, error_message)
         - (True, "") if valid
-        - (False, "error description") if invalid
+        - (True, "warning message") if provider unreachable (warn but allow)
+        - (False, "error description") if definitively invalid
     """
     status, message = validate_api_key_status(api_key, provider, timeout=timeout)
     # UNSUPPORTED providers (azure, local, custom) historically counted as
     # valid because there is no key to reject — preserve that for CLI callers.
+    # UNREACHABLE also counts as "allow" — a transient network blip must not
+    # lock a CLI user out of saving a key they know is good.
     return status in (
         ApiKeyValidationStatus.VALID,
         ApiKeyValidationStatus.UNSUPPORTED,
+        ApiKeyValidationStatus.UNREACHABLE,
     ), message
 
 

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -74,6 +74,13 @@ def validate_api_key(
         - (True, "") if valid
         - (True, "warning message") if provider unreachable (warn but allow)
         - (False, "error description") if definitively invalid
+
+    Note:
+        Callers MUST check the second element and surface any non-empty warning
+        to the user; a non-empty message with is_valid=True means the key was
+        saved without being confirmed reachable, and the user should be notified.
+        (All current built-in CLI callers — setup, doctor, onboard, account —
+        already do this.)
     """
     status, message = validate_api_key_status(api_key, provider, timeout=timeout)
     # UNSUPPORTED providers (azure, local, custom) historically counted as

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -160,11 +160,11 @@ def validate_api_key_status(
     except requests.exceptions.HTTPError as e:
         # 408/5xx from the provider — server is reachable but broken; not a key rejection.
         status_code = e.response.status_code if e.response is not None else "unknown"
-        return (
-            ApiKeyValidationStatus.UNREACHABLE,
+        message = (
             f"{VALIDATION_PROVIDER_ERROR_PREFIX} Provider returned server error "
-            f"{status_code}. Please try again later.",
+            f"{status_code}. Please try again later."
         )
+        return ApiKeyValidationStatus.UNREACHABLE, message
     except requests.exceptions.RequestException as e:
         logger.exception(f"Unexpected error validating {provider} API key")
         return (

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -47,25 +47,13 @@ PROVIDER_DOCS: dict[str, str] = {
 # Providers that use OAuth instead of API keys
 OAUTH_PROVIDERS: set[str] = {"openai-subscription", "grok-subscription"}
 
-# Stable messages used by callers to distinguish provider availability failures from
-# credential failures without parsing provider-specific responses.
+# Error message constants returned by validate_api_key / validate_api_key_status.
+# Callers that need to distinguish transient connectivity failures from definitive
+# key rejections can compare against these instead of hard-coding message strings.
 VALIDATION_TIMEOUT_ERROR = "Request timed out. Please check your network connection."
 VALIDATION_CONNECTION_ERROR = "Could not connect to the API. Please check your network."
-VALIDATION_PROVIDER_ERROR_PREFIX = "Validation failed:"
-
-
-def _http_status_error(status_code: int) -> tuple[bool, str]:
-    """Map an unexpected HTTP status to a validation error tuple.
-
-    5xx responses mean the provider is down, not that the key is bad, so they
-    use VALIDATION_PROVIDER_ERROR_PREFIX so api_v2 can return 502 instead of 422.
-    """
-    if status_code >= 500:
-        return (
-            False,
-            f"{VALIDATION_PROVIDER_ERROR_PREFIX} Provider unavailable (HTTP {status_code})",
-        )
-    return False, f"API returned status {status_code}"
+# Prefix for server-side errors (full message: "Provider returned server error <code>. …")
+VALIDATION_PROVIDER_ERROR_PREFIX = "Provider returned server error"
 
 
 def validate_api_key(
@@ -82,7 +70,7 @@ def validate_api_key(
         timeout: Request timeout in seconds
 
     Returns:
-        Tuple of (is_valid, error_message)
+        Tuple of (is_valid, message)
         - (True, "") if valid
         - (True, "warning message") if provider unreachable (warn but allow)
         - (False, "error description") if definitively invalid
@@ -136,12 +124,22 @@ def validate_api_key_status(
         elif provider == "xai":
             is_valid, message = _validate_xai(api_key, timeout)
         elif provider == "azure":
-            # Azure requires endpoint configuration, skip validation
+            # Azure requires endpoint configuration, skip live validation
             logger.info("Azure API key validation skipped (requires endpoint config)")
-            return ApiKeyValidationStatus.UNSUPPORTED, ""
-        elif provider in ("nvidia", "local"):
-            # Local models don't need API key validation
-            logger.info(f"{provider} provider doesn't require API key validation")
+            return (
+                ApiKeyValidationStatus.UNSUPPORTED,
+                "Key accepted without live validation — Azure requires endpoint configuration to validate",
+            )
+        elif provider == "nvidia":
+            # NVIDIA validation would need an org-specific endpoint, skip
+            logger.info("NVIDIA API key validation skipped (requires org endpoint)")
+            return (
+                ApiKeyValidationStatus.UNSUPPORTED,
+                "Key accepted without live validation — NVIDIA keys are checked on first use",
+            )
+        elif provider == "local":
+            # Local models typically use a placeholder key or none at all
+            logger.info("Local provider doesn't require API key validation")
             return ApiKeyValidationStatus.UNSUPPORTED, ""
         else:
             # Unknown or custom provider, skip validation
@@ -151,21 +149,15 @@ def validate_api_key_status(
             return ApiKeyValidationStatus.VALID, message
         return ApiKeyValidationStatus.INVALID, message
     except requests.exceptions.Timeout:
-        return (
-            ApiKeyValidationStatus.UNREACHABLE,
-            "Request timed out. Please check your network connection.",
-        )
+        return ApiKeyValidationStatus.UNREACHABLE, VALIDATION_TIMEOUT_ERROR
     except requests.exceptions.ConnectionError:
-        return (
-            ApiKeyValidationStatus.UNREACHABLE,
-            "Could not connect to the API. Please check your network.",
-        )
+        return ApiKeyValidationStatus.UNREACHABLE, VALIDATION_CONNECTION_ERROR
     except requests.exceptions.HTTPError as e:
-        # 5xx from the provider — server is reachable but broken; not a key rejection.
+        # 408/5xx from the provider — server is reachable but broken; not a key rejection.
         status_code = e.response.status_code if e.response is not None else "unknown"
         return (
             ApiKeyValidationStatus.UNREACHABLE,
-            f"Provider returned server error {status_code}. Please try again later.",
+            f"{VALIDATION_PROVIDER_ERROR_PREFIX} {status_code}. Please try again later.",
         )
     except requests.exceptions.RequestException as e:
         logger.exception(f"Unexpected error validating {provider} API key")
@@ -295,7 +287,7 @@ def _validate_openai_compatible(
         return False, "API key forbidden. It may lack required permissions."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -47,13 +47,11 @@ PROVIDER_DOCS: dict[str, str] = {
 # Providers that use OAuth instead of API keys
 OAUTH_PROVIDERS: set[str] = {"openai-subscription", "grok-subscription"}
 
-# Error message constants returned by validate_api_key / validate_api_key_status.
-# Callers that need to distinguish transient connectivity failures from definitive
-# key rejections can compare against these instead of hard-coding message strings.
+# Stable messages retained for callers of the legacy boolean API. New callers should
+# use ApiKeyValidationStatus instead of parsing these strings.
 VALIDATION_TIMEOUT_ERROR = "Request timed out. Please check your network connection."
 VALIDATION_CONNECTION_ERROR = "Could not connect to the API. Please check your network."
-# Prefix for server-side errors (full message: "Provider returned server error <code>. …")
-VALIDATION_PROVIDER_ERROR_PREFIX = "Provider returned server error"
+VALIDATION_PROVIDER_ERROR_PREFIX = "Validation failed:"
 
 
 def validate_api_key(
@@ -164,11 +162,15 @@ def validate_api_key_status(
         status_code = e.response.status_code if e.response is not None else "unknown"
         return (
             ApiKeyValidationStatus.UNREACHABLE,
-            f"{VALIDATION_PROVIDER_ERROR_PREFIX} {status_code}. Please try again later.",
+            f"{VALIDATION_PROVIDER_ERROR_PREFIX} Provider returned server error "
+            f"{status_code}. Please try again later.",
         )
     except requests.exceptions.RequestException as e:
         logger.exception(f"Unexpected error validating {provider} API key")
-        return ApiKeyValidationStatus.UNREACHABLE, f"Validation failed: {e}"
+        return (
+            ApiKeyValidationStatus.UNREACHABLE,
+            f"{VALIDATION_PROVIDER_ERROR_PREFIX} {e}",
+        )
 
 
 def _validate_openai(api_key: str, timeout: int) -> tuple[bool, str]:

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -183,7 +183,7 @@ def _validate_openai(api_key: str, timeout: int) -> tuple[bool, str]:
     if response.status_code == 429:
         # Rate limited but key is valid
         return True, ""
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -245,7 +245,7 @@ def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
     if response.status_code == 429:
         # Rate limited but key is valid
         return True, ""
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -268,7 +268,7 @@ def _validate_openrouter(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -317,7 +317,7 @@ def _validate_google(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "API key forbidden. It may lack required permissions."
     if response.status_code == 429:
         return True, ""
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -336,7 +336,7 @@ def _validate_groq(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -355,7 +355,7 @@ def _validate_deepseek(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"
 
@@ -374,6 +374,6 @@ def _validate_xai(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    if response.status_code >= 500:
+    if response.status_code == 408 or response.status_code >= 500:
         response.raise_for_status()
     return False, f"API returned status {response.status_code}"

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -156,6 +156,13 @@ def validate_api_key_status(
             ApiKeyValidationStatus.UNREACHABLE,
             "Could not connect to the API. Please check your network.",
         )
+    except requests.exceptions.HTTPError as e:
+        # 5xx from the provider — server is reachable but broken; not a key rejection.
+        status_code = e.response.status_code if e.response is not None else "unknown"
+        return (
+            ApiKeyValidationStatus.UNREACHABLE,
+            f"Provider returned server error {status_code}. Please try again later.",
+        )
     except requests.exceptions.RequestException as e:
         logger.exception(f"Unexpected error validating {provider} API key")
         return ApiKeyValidationStatus.UNREACHABLE, f"Validation failed: {e}"
@@ -176,7 +183,9 @@ def _validate_openai(api_key: str, timeout: int) -> tuple[bool, str]:
     if response.status_code == 429:
         # Rate limited but key is valid
         return True, ""
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -236,7 +245,9 @@ def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
     if response.status_code == 429:
         # Rate limited but key is valid
         return True, ""
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_openrouter(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -257,7 +268,9 @@ def _validate_openrouter(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_openai_compatible(
@@ -278,7 +291,9 @@ def _validate_openai_compatible(
         return False, "API key forbidden. It may lack required permissions."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_google(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -302,7 +317,9 @@ def _validate_google(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "API key forbidden. It may lack required permissions."
     if response.status_code == 429:
         return True, ""
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_groq(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -319,7 +336,9 @@ def _validate_groq(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_deepseek(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -336,7 +355,9 @@ def _validate_deepseek(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"
 
 
 def _validate_xai(api_key: str, timeout: int) -> tuple[bool, str]:
@@ -353,4 +374,6 @@ def _validate_xai(api_key: str, timeout: int) -> tuple[bool, str]:
         return False, "Invalid API key. Please check your key and try again."
     if response.status_code == 429:
         return True, ""  # Rate limited but key is valid
-    return _http_status_error(response.status_code)
+    if response.status_code >= 500:
+        response.raise_for_status()
+    return False, f"API returned status {response.status_code}"

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -1,10 +1,29 @@
 """API key validation utilities for gptme."""
 
 import logging
+from enum import Enum
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+class ApiKeyValidationStatus(str, Enum):
+    """Result of validating a provider API key.
+
+    Distinct from a boolean because a network failure (provider unreachable)
+    is not the same as the key being definitively rejected — a first-run save
+    flow must not lock a user out of saving a key they know is good just
+    because of a transient network blip.
+    """
+
+    VALID = "valid"
+    INVALID = "invalid"  # provider explicitly rejected the key (401/403)
+    UNREACHABLE = "unreachable"  # could not reach provider (timeout / connection / 5xx)
+    UNSUPPORTED = (
+        "unsupported"  # provider has no validation path (azure, local, custom)
+    )
+
 
 # Provider documentation URLs
 PROVIDER_DOCS: dict[str, str] = {
@@ -67,57 +86,79 @@ def validate_api_key(
         - (True, "") if valid
         - (False, "error description") if invalid
     """
+    status, message = validate_api_key_status(api_key, provider, timeout=timeout)
+    # UNSUPPORTED providers (azure, local, custom) historically counted as
+    # valid because there is no key to reject — preserve that for CLI callers.
+    return status in (
+        ApiKeyValidationStatus.VALID,
+        ApiKeyValidationStatus.UNSUPPORTED,
+    ), message
+
+
+def validate_api_key_status(
+    api_key: str,
+    provider: str,
+    timeout: int = 10,
+) -> tuple[ApiKeyValidationStatus, str]:
+    """Validate an API key, returning a tri-state status distinct from a boolean.
+
+    Unlike :func:`validate_api_key`, this distinguishes a definitively-rejected
+    key (``INVALID``) from a provider that could not be reached
+    (``UNREACHABLE``). Callers that gate a first-run save on validation should
+    block on ``INVALID`` but only warn on ``UNREACHABLE`` so a transient network
+    blip never locks the user out of saving a key they know is good.
+    """
     try:
         if provider == "openai":
-            return _validate_openai(api_key, timeout)
-        if provider == "anthropic":
-            return _validate_anthropic(api_key, timeout)
-        if provider == "openrouter":
-            return _validate_openrouter(api_key, timeout)
-        if provider == "requesty":
-            return _validate_openai_compatible(
+            is_valid, message = _validate_openai(api_key, timeout)
+        elif provider == "anthropic":
+            is_valid, message = _validate_anthropic(api_key, timeout)
+        elif provider == "openrouter":
+            is_valid, message = _validate_openrouter(api_key, timeout)
+        elif provider == "requesty":
+            is_valid, message = _validate_openai_compatible(
                 api_key, timeout, "https://router.requesty.ai/v1"
             )
-        if provider == "moonshot":
-            return _validate_openai_compatible(
+        elif provider == "moonshot":
+            is_valid, message = _validate_openai_compatible(
                 api_key, timeout, "https://api.moonshot.ai/v1"
             )
-        if provider in ("google", "gemini"):
-            return _validate_google(api_key, timeout)
-        if provider == "groq":
-            return _validate_groq(api_key, timeout)
-        if provider == "deepseek":
-            return _validate_deepseek(api_key, timeout)
-        if provider == "xai":
-            return _validate_xai(api_key, timeout)
-        if provider == "azure":
-            # Azure requires endpoint configuration, skip live validation
+        elif provider in ("google", "gemini"):
+            is_valid, message = _validate_google(api_key, timeout)
+        elif provider == "groq":
+            is_valid, message = _validate_groq(api_key, timeout)
+        elif provider == "deepseek":
+            is_valid, message = _validate_deepseek(api_key, timeout)
+        elif provider == "xai":
+            is_valid, message = _validate_xai(api_key, timeout)
+        elif provider == "azure":
+            # Azure requires endpoint configuration, skip validation
             logger.info("Azure API key validation skipped (requires endpoint config)")
-            return (
-                True,
-                "Key accepted without live validation — Azure requires endpoint configuration to validate",
-            )
-        if provider == "nvidia":
-            # NVIDIA validation would need an org-specific endpoint, skip
-            logger.info("NVIDIA API key validation skipped (requires org endpoint)")
-            return (
-                True,
-                "Key accepted without live validation — NVIDIA keys are checked on first use",
-            )
-        if provider == "local":
-            # Local models typically use a placeholder key or none at all
-            logger.info("Local provider doesn't require API key validation")
-            return True, ""
-        # Unknown or custom provider, skip validation
-        logger.info(f"No validation available for provider: {provider}")
-        return True, ""
+            return ApiKeyValidationStatus.UNSUPPORTED, ""
+        elif provider in ("nvidia", "local"):
+            # Local models don't need API key validation
+            logger.info(f"{provider} provider doesn't require API key validation")
+            return ApiKeyValidationStatus.UNSUPPORTED, ""
+        else:
+            # Unknown or custom provider, skip validation
+            logger.info(f"No validation available for provider: {provider}")
+            return ApiKeyValidationStatus.UNSUPPORTED, ""
+        if is_valid:
+            return ApiKeyValidationStatus.VALID, message
+        return ApiKeyValidationStatus.INVALID, message
     except requests.exceptions.Timeout:
-        return False, VALIDATION_TIMEOUT_ERROR
+        return (
+            ApiKeyValidationStatus.UNREACHABLE,
+            "Request timed out. Please check your network connection.",
+        )
     except requests.exceptions.ConnectionError:
-        return False, VALIDATION_CONNECTION_ERROR
+        return (
+            ApiKeyValidationStatus.UNREACHABLE,
+            "Could not connect to the API. Please check your network.",
+        )
     except requests.exceptions.RequestException as e:
         logger.exception(f"Unexpected error validating {provider} API key")
-        return False, f"{VALIDATION_PROVIDER_ERROR_PREFIX} {e}"
+        return ApiKeyValidationStatus.UNREACHABLE, f"Validation failed: {e}"
 
 
 def _validate_openai(api_key: str, timeout: int) -> tuple[bool, str]:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -3075,7 +3075,7 @@ def api_user():
         "Persist a provider API key into the user's global gptme config. "
         "The key is checked against the provider before it is written, so an "
         "invalid key is rejected with 422 rather than saved; "
-        "provider connectivity failures return 502. "
+        "provider connectivity failures save the key with a 200 and a warning field. "
         "Intended for first-run onboarding flows; callers should restart the "
         "server after a successful write if they need the running process to "
         "pick the key up immediately."

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -3136,11 +3136,20 @@ def api_user_api_key():
     # We use the tri-state status rather than the boolean so an unreachable
     # provider is a warning, not a hard block: a transient network blip must not
     # lock a first-run user out of saving a key they know is good.
-    validation_status, validation_error = validate_api_key_status(
-        trimmed_api_key, provider
-    )
-    if validation_status is ApiKeyValidationStatus.INVALID:
-        return flask.jsonify({"error": validation_error}), 400
+    # skip_validation=True is for offline/test use where live network calls aren't available.
+    key_warning: str | None = None
+    if not skip_validation:
+        try:
+            validation_status, validation_msg = validate_api_key_status(
+                trimmed_api_key, provider
+            )
+        except Exception:
+            logger.exception("Unexpected error validating %s API key", provider)
+            return flask.jsonify({"error": "Provider validation failed"}), 502
+        if validation_status is ApiKeyValidationStatus.INVALID:
+            return flask.jsonify({"error": validation_msg}), 422
+        if validation_msg:
+            key_warning = validation_msg
 
     env_var = PROVIDER_API_KEYS[provider]
     set_config_value(f"env.{env_var}", trimmed_api_key, reload=False, local=True)
@@ -3160,8 +3169,8 @@ def api_user_api_key():
         "env_var": env_var,
         "restart_required": False,
     }
-    if validation_status is ApiKeyValidationStatus.UNREACHABLE:
-        response["warning"] = validation_error
+    if key_warning:
+        response["warning"] = key_warning
 
     logger.info(
         "Saved %s to user config via /api/v2/user/api-key (applied live)", env_var

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -54,10 +54,8 @@ from gptme.llm.models import (
 )
 from gptme.llm.models.types import is_custom_provider
 from gptme.llm.validate import (
-    VALIDATION_CONNECTION_ERROR,
-    VALIDATION_PROVIDER_ERROR_PREFIX,
-    VALIDATION_TIMEOUT_ERROR,
-    validate_api_key,
+    ApiKeyValidationStatus,
+    validate_api_key_status,
 )
 from gptme.prompts import get_prompt
 
@@ -3129,26 +3127,20 @@ def api_user_api_key():
         return flask.jsonify({"error": str(exc)}), 400
 
     # Check the key with the provider before writing it. `/account setup` has always
-    # done this (gptme/commands/account.py); this endpoint did not. Same validator, so
-    # both paths agree on what "valid" means: rate-limited or quota-exhausted keys are
-    # valid, and providers without a check (azure, nvidia, local) are skipped.
-    # skip_validation=True is for offline/test use where live network calls aren't available.
-    key_warning: str | None = None
-    if not skip_validation:
-        try:
-            is_valid, validation_msg = validate_api_key(trimmed_api_key, provider)
-        except Exception:
-            logger.exception("Unexpected error validating %s API key", provider)
-            return flask.jsonify({"error": "Provider validation failed"}), 502
-        if not is_valid:
-            if validation_msg in {
-                VALIDATION_TIMEOUT_ERROR,
-                VALIDATION_CONNECTION_ERROR,
-            } or validation_msg.startswith(VALIDATION_PROVIDER_ERROR_PREFIX):
-                return flask.jsonify({"error": validation_msg}), 502
-            return flask.jsonify({"error": validation_msg}), 422
-        if validation_msg:
-            key_warning = validation_msg
+    # done this (gptme/commands/account.py); this endpoint did not, so onboarding
+    # accepted a bad key, reported "status": "ok", and the user only found out when
+    # the first generation came back with a raw provider auth error. Same validator,
+    # so both onboarding paths agree on what "valid" means: a rate-limited or
+    # quota-exhausted key is valid, and providers without a check are skipped.
+    #
+    # We use the tri-state status rather than the boolean so an unreachable
+    # provider is a warning, not a hard block: a transient network blip must not
+    # lock a first-run user out of saving a key they know is good.
+    validation_status, validation_error = validate_api_key_status(
+        trimmed_api_key, provider
+    )
+    if validation_status is ApiKeyValidationStatus.INVALID:
+        return flask.jsonify({"error": validation_error}), 400
 
     env_var = PROVIDER_API_KEYS[provider]
     set_config_value(f"env.{env_var}", trimmed_api_key, reload=False, local=True)
@@ -3162,18 +3154,19 @@ def api_user_api_key():
     if trimmed_model is not None:
         os.environ["MODEL"] = trimmed_model
 
-    logger.info(
-        "Saved %s to user config via /api/v2/user/api-key (applied live)", env_var
-    )
-    resp: dict = {
+    response: dict = {
         "status": "ok",
         "provider": provider,
         "env_var": env_var,
         "restart_required": False,
     }
-    if key_warning:
-        resp["warning"] = key_warning
-    return flask.jsonify(resp)
+    if validation_status is ApiKeyValidationStatus.UNREACHABLE:
+        response["warning"] = validation_error
+
+    logger.info(
+        "Saved %s to user config via /api/v2/user/api-key (applied live)", env_var
+    )
+    return flask.jsonify(response)
 
 
 @v2_api.route("/api/v2/user/default-model", methods=["POST"])

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -25,7 +25,7 @@ from gptme.__version__ import __version__
 # Increment CONTRACT_REVISION for additive (backward-compatible) changes;
 # increment API_VERSION and update the URL prefix for breaking changes.
 API_VERSION = 2
-CONTRACT_REVISION = 1
+CONTRACT_REVISION = 2
 
 logger = logging.getLogger(__name__)
 

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -25,6 +25,14 @@ from gptme.__version__ import __version__
 # Increment CONTRACT_REVISION for additive (backward-compatible) changes;
 # increment API_VERSION and update the URL prefix for breaking changes.
 API_VERSION = 2
+# Revision 2 — BYOK warn-not-block: the /user/api-key endpoint now returns 200
+# with an optional "warning" field for UNREACHABLE providers instead of 502.
+# This is CONTRACT_REVISION (not API_VERSION) because:
+#   - HTTP success/failure semantics are preserved: 200 = save accepted, 4xx = rejected.
+#   - The "warning" field is optional and additive; existing clients that do not read
+#     it continue to work (they just lose the UNREACHABLE notification).
+#   - The 502 path was itself new in revision 1 (PR #3555) and had no stable consumers
+#     outside the SetupWizard, which is updated in this PR to handle the new field.
 CONTRACT_REVISION = 2
 
 logger = logging.getLogger(__name__)

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -249,7 +249,7 @@ class UserApiKeySaveResponse(BaseModel):
     )
     warning: str | None = Field(
         None,
-        description="Optional non-fatal warning (e.g. quota exhausted but key is valid)",
+        description="Non-blocking warning when the key was saved but could not be verified (e.g. provider unreachable)",
     )
 
 

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -389,3 +389,23 @@ class TestValidateApiKeyStatus:
         """Providers without validation should map to UNSUPPORTED."""
         status, _ = validate_api_key_status("some-key", "azure")
         assert status is ApiKeyValidationStatus.UNSUPPORTED
+
+    @patch("gptme.llm.validate._validate_openai")
+    def test_server_error_returns_unreachable(self, mock_validate):
+        """A 5xx from the provider should map to UNREACHABLE, not INVALID.
+
+        A provider outage is not proof that the key is bad — the save must not
+        be blocked.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 503
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            response=mock_response
+        )
+        mock_validate.return_value = (False, "API returned status 503")
+        # The helper would call raise_for_status() and propagate HTTPError;
+        # simulate that path directly.
+        mock_validate.side_effect = requests.HTTPError(response=mock_response)
+        status, message = validate_api_key_status("sk-key", "openai")
+        assert status is ApiKeyValidationStatus.UNREACHABLE
+        assert "503" in message

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -8,7 +8,6 @@ import requests
 from gptme.llm.validate import (
     PROVIDER_DOCS,
     ApiKeyValidationStatus,
-    VALIDATION_PROVIDER_ERROR_PREFIX,
     _validate_anthropic,
     _validate_google,
     _validate_openai,
@@ -125,12 +124,11 @@ class TestValidateGoogle:
         assert error == ""
 
     @patch("gptme.llm.validate.requests.get")
-    def test_provider_unavailable_returns_502_prefix(self, mock_get):
-        """5xx responses should return provider-unavailable prefix, not auth failure."""
+    def test_provider_unavailable_raises_http_error(self, mock_get):
+        """5xx responses raise HTTPError so the tri-state wrapper maps them to UNREACHABLE."""
         mock_get.return_value = Mock(status_code=500)
-        is_valid, error = _validate_google("some-key", 10)
-        assert not is_valid
-        assert VALIDATION_PROVIDER_ERROR_PREFIX in error
+        with pytest.raises(requests.HTTPError):
+            _validate_google("some-key", 10)
 
 
 class TestValidateAnthropic:
@@ -294,9 +292,6 @@ class TestValidateOpenAICompatible:
             (401, False, "Invalid API key"),
             (403, False, "forbidden"),
             (429, True, ""),
-            # 5xx → provider-unavailable error, not a credential failure
-            (500, False, VALIDATION_PROVIDER_ERROR_PREFIX),
-            (503, False, VALIDATION_PROVIDER_ERROR_PREFIX),
         ],
     )
     @patch("gptme.llm.validate.requests.get")
@@ -315,6 +310,13 @@ class TestValidateOpenAICompatible:
             headers={"Authorization": "Bearer test-key"},
             timeout=10,
         )
+
+    @patch("gptme.llm.validate.requests.get")
+    def test_5xx_raises_http_error(self, mock_get):
+        """A 5xx must raise HTTPError so the tri-state wrapper maps it to UNREACHABLE."""
+        mock_get.return_value = Mock(status_code=503)
+        with pytest.raises(requests.HTTPError):
+            _validate_openai_compatible("test-key", 10, "https://example.com/v1/")
 
 
 class TestUnvalidatableProviders:

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -65,6 +65,17 @@ class TestValidateApiKey:
             "moonshot-test", 10, "https://api.moonshot.ai/v1"
         )
 
+    @patch("gptme.llm.validate._validate_openai", side_effect=requests.ConnectionError)
+    def test_unreachable_provider_returns_true(self, mock_validate):
+        """UNREACHABLE must map to True in the boolean wrapper.
+
+        A transient network blip must not lock a CLI user out of saving a key
+        they know is good — the same policy the server BYOK endpoint applies.
+        """
+        is_valid, message = validate_api_key("sk-ok", "openai")
+        assert is_valid, "UNREACHABLE should allow save (warn but not block)"
+        assert "network" in message.lower() or "connect" in message.lower()
+
 
 class TestValidateOpenAI:
     """Tests for OpenAI API key validation."""

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -126,7 +126,9 @@ class TestValidateGoogle:
     @patch("gptme.llm.validate.requests.get")
     def test_provider_unavailable_raises_http_error(self, mock_get):
         """5xx responses raise HTTPError so the tri-state wrapper maps them to UNREACHABLE."""
-        mock_get.return_value = Mock(status_code=500)
+        mock_response = Mock(status_code=500)
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
+        mock_get.return_value = mock_response
         with pytest.raises(requests.HTTPError):
             _validate_google("some-key", 10)
 
@@ -314,7 +316,9 @@ class TestValidateOpenAICompatible:
     @patch("gptme.llm.validate.requests.get")
     def test_5xx_raises_http_error(self, mock_get):
         """A 5xx must raise HTTPError so the tri-state wrapper maps it to UNREACHABLE."""
-        mock_get.return_value = Mock(status_code=503)
+        mock_response = Mock(status_code=503)
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
+        mock_get.return_value = mock_response
         with pytest.raises(requests.HTTPError):
             _validate_openai_compatible("test-key", 10, "https://example.com/v1/")
 

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -3,9 +3,11 @@
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from gptme.llm.validate import (
     PROVIDER_DOCS,
+    ApiKeyValidationStatus,
     VALIDATION_PROVIDER_ERROR_PREFIX,
     _validate_anthropic,
     _validate_google,
@@ -13,6 +15,7 @@ from gptme.llm.validate import (
     _validate_openai_compatible,
     _validate_openrouter,
     validate_api_key,
+    validate_api_key_status,
 )
 
 
@@ -349,3 +352,40 @@ class TestProviderDocs:
         for provider in expected_providers:
             assert provider in PROVIDER_DOCS
             assert PROVIDER_DOCS[provider].startswith("https://")
+
+
+class TestValidateApiKeyStatus:
+    """Tests for the tri-state validate_api_key_status function."""
+
+    @patch("gptme.llm.validate._validate_openai")
+    def test_valid_returns_valid_status(self, mock_validate):
+        """A valid key should map to the VALID status."""
+        mock_validate.return_value = (True, "")
+        status, message = validate_api_key_status("sk-ok", "openai")
+        assert status is ApiKeyValidationStatus.VALID
+        assert message == ""
+
+    @patch("gptme.llm.validate._validate_openai")
+    def test_invalid_returns_invalid_status(self, mock_validate):
+        """A provider-rejected key should map to the INVALID status."""
+        mock_validate.return_value = (False, "Invalid API key. Please check your key.")
+        status, message = validate_api_key_status("sk-bad", "openai")
+        assert status is ApiKeyValidationStatus.INVALID
+        assert "Invalid API key" in message
+
+    @patch("gptme.llm.validate._validate_openai", side_effect=requests.ConnectionError)
+    def test_connection_error_returns_unreachable(self, mock_validate):
+        """A network failure should map to UNREACHABLE, not INVALID."""
+        status, _ = validate_api_key_status("sk-key", "openai")
+        assert status is ApiKeyValidationStatus.UNREACHABLE
+
+    @patch("gptme.llm.validate._validate_openai", side_effect=requests.Timeout)
+    def test_timeout_returns_unreachable(self, mock_validate):
+        """A request timeout should map to UNREACHABLE, not INVALID."""
+        status, _ = validate_api_key_status("sk-key", "openai")
+        assert status is ApiKeyValidationStatus.UNREACHABLE
+
+    def test_unsupported_provider_returns_unsupported(self):
+        """Providers without validation should map to UNSUPPORTED."""
+        status, _ = validate_api_key_status("some-key", "azure")
+        assert status is ApiKeyValidationStatus.UNSUPPORTED

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -433,9 +433,9 @@ class TestValidateApiKeyStatus:
         mock_response.raise_for_status.side_effect = requests.HTTPError(
             response=mock_response
         )
-        mock_validate.return_value = (False, "API returned status 503")
-        # The helper would call raise_for_status() and propagate HTTPError;
-        # simulate that path directly.
+        # The helper calls raise_for_status() and propagates HTTPError;
+        # side_effect makes the mock raise directly (return_value is unused
+        # when side_effect is set, so only side_effect is configured here).
         mock_validate.side_effect = requests.HTTPError(response=mock_response)
         status, message = validate_api_key_status("sk-key", "openai")
         assert status is ApiKeyValidationStatus.UNREACHABLE

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -7,6 +7,7 @@ import requests
 
 from gptme.llm.validate import (
     PROVIDER_DOCS,
+    VALIDATION_PROVIDER_ERROR_PREFIX,
     ApiKeyValidationStatus,
     _validate_anthropic,
     _validate_google,
@@ -420,6 +421,8 @@ class TestValidateApiKeyStatus:
         mock_validate.side_effect = requests.HTTPError(response=mock_response)
         status, message = validate_api_key_status("sk-key", "openai")
         assert status is ApiKeyValidationStatus.UNREACHABLE
+        assert message.startswith(VALIDATION_PROVIDER_ERROR_PREFIX)
+        assert "408" in message
 
     @patch("gptme.llm.validate._validate_openai")
     def test_server_error_returns_unreachable(self, mock_validate):
@@ -439,4 +442,5 @@ class TestValidateApiKeyStatus:
         mock_validate.side_effect = requests.HTTPError(response=mock_response)
         status, message = validate_api_key_status("sk-key", "openai")
         assert status is ApiKeyValidationStatus.UNREACHABLE
+        assert message.startswith(VALIDATION_PROVIDER_ERROR_PREFIX)
         assert "503" in message

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -391,6 +391,20 @@ class TestValidateApiKeyStatus:
         assert status is ApiKeyValidationStatus.UNSUPPORTED
 
     @patch("gptme.llm.validate._validate_openai")
+    def test_408_request_timeout_returns_unreachable(self, mock_validate):
+        """HTTP 408 (Request Timeout) must map to UNREACHABLE, not INVALID.
+
+        A server-side timeout is a transient condition — it does not mean the
+        key is bad.  Without this fix, 408 fell through the status branches and
+        returned False → INVALID, blocking the save with a 400 error.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 408
+        mock_validate.side_effect = requests.HTTPError(response=mock_response)
+        status, message = validate_api_key_status("sk-key", "openai")
+        assert status is ApiKeyValidationStatus.UNREACHABLE
+
+    @patch("gptme.llm.validate._validate_openai")
     def test_server_error_returns_unreachable(self, mock_validate):
         """A 5xx from the provider should map to UNREACHABLE, not INVALID.
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -13,6 +13,7 @@ import tomlkit
 
 from gptme.config import ChatConfig, MCPConfig
 from gptme.llm.models import ModelMeta, get_default_model
+from gptme.llm.validate import ApiKeyValidationStatus
 from gptme.prompts import get_prompt
 from gptme.tools import get_toolchain
 
@@ -603,9 +604,9 @@ def test_v2_user_api_key_rejects_invalid_key_via_provider(
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(
-        "gptme.server.api_v2.validate_api_key",
+        "gptme.server.api_v2.validate_api_key_status",
         lambda key, provider, **kw: (
-            False,
+            ApiKeyValidationStatus.INVALID,
             "Invalid API key. Please check your key and try again.",
         ),
     )
@@ -625,54 +626,22 @@ def test_v2_user_api_key_rejects_invalid_key_via_provider(
     assert not local_file.exists()
 
 
-@pytest.mark.parametrize(
-    "validation_error",
-    [
-        "Request timed out. Please check your network connection.",
-        "Could not connect to the API. Please check your network.",
-        "Validation failed: provider returned malformed response",
-        # 5xx provider responses now produce this prefix too — must be 502, not 422
-        "Validation failed: Provider unavailable (HTTP 500)",
-    ],
-)
-def test_v2_user_api_key_returns_bad_gateway_when_provider_unreachable(
-    client: FlaskClient, tmp_path, monkeypatch, validation_error
-):
-    """Connectivity failures should return 502 without persisting the key."""
-    import gptme.config.user as user_mod
-
-    config_file = tmp_path / "config.toml"
-    monkeypatch.setattr(user_mod, "config_path", str(config_file))
-    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
-    monkeypatch.setattr(
-        "gptme.server.api_v2.validate_api_key",
-        lambda key, provider: (False, validation_error),
-    )
-
-    response = client.post(
-        "/api/v2/user/api-key",
-        json={"provider": "anthropic", "api_key": "sk-ant-test"},
-    )
-
-    assert response.status_code == 502
-    assert response.get_json() == {"error": validation_error}
-    assert not (tmp_path / "config.local.toml").exists()
-
-
 def test_v2_user_api_key_handles_validator_exception(
     client: FlaskClient, tmp_path, monkeypatch
 ):
-    """A provider outage should return JSON without persisting the key."""
+    """An unexpected validator exception should return 502 without persisting the key."""
     import gptme.config.user as user_mod
 
     config_file = tmp_path / "config.toml"
     monkeypatch.setattr(user_mod, "config_path", str(config_file))
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
 
-    def raise_provider_error(key, provider):
+    def raise_provider_error(key, provider, timeout=10):
         raise RuntimeError("provider unavailable")
 
-    monkeypatch.setattr("gptme.server.api_v2.validate_api_key", raise_provider_error)
+    monkeypatch.setattr(
+        "gptme.server.api_v2.validate_api_key_status", raise_provider_error
+    )
 
     response = client.post(
         "/api/v2/user/api-key",
@@ -695,8 +664,8 @@ def test_v2_user_api_key_accepts_valid_key_via_provider(
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(
-        "gptme.server.api_v2.validate_api_key",
-        lambda key, provider, **kw: (True, ""),
+        "gptme.server.api_v2.validate_api_key_status",
+        lambda key, provider, **kw: (ApiKeyValidationStatus.VALID, ""),
     )
 
     response = client.post(
@@ -725,8 +694,11 @@ def test_v2_user_api_key_warns_on_quota_exhausted(
     monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(
-        "gptme.server.api_v2.validate_api_key",
-        lambda key, provider, **kw: (True, "API quota exhausted — resets in 3 days"),
+        "gptme.server.api_v2.validate_api_key_status",
+        lambda key, provider, **kw: (
+            ApiKeyValidationStatus.VALID,
+            "API quota exhausted — resets in 3 days",
+        ),
     )
 
     response = client.post(
@@ -780,9 +752,12 @@ def test_v2_user_api_key_skip_validation_bypasses_live_check(
 
     def fake_validate(key, provider, **kw):
         called.append((key, provider))
-        return (False, "Invalid API key")  # would fail if called
+        return (
+            ApiKeyValidationStatus.INVALID,
+            "Invalid API key",
+        )  # would fail if called
 
-    monkeypatch.setattr("gptme.server.api_v2.validate_api_key", fake_validate)
+    monkeypatch.setattr("gptme.server.api_v2.validate_api_key_status", fake_validate)
 
     response = client.post(
         "/api/v2/user/api-key",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -356,16 +356,26 @@ def test_webui_deploy_trigger_dispatches_workflow(client: FlaskClient, monkeypat
     }
 
 
-def stub_key_validation(monkeypatch, *, valid: bool = True, message: str = ""):
+def stub_key_validation(
+    monkeypatch,
+    *,
+    status: str = "VALID",
+    message: str = "",
+):
     """Stand in for the live provider call /api/v2/user/api-key makes.
 
     The endpoint checks the key with the provider before persisting it, so
-    every save test has to say what the provider would answer.
+    every save test has to say what the provider would answer. ``status`` is
+    one of the ``ApiKeyValidationStatus`` values: VALID (default), INVALID
+    (block the save), or UNREACHABLE (save but warn).
     Patch at the api_v2 import site so the function uses the stub.
     """
+    from gptme.llm.validate import ApiKeyValidationStatus
+
+    validation_status = ApiKeyValidationStatus[status]
     monkeypatch.setattr(
-        "gptme.server.api_v2.validate_api_key",
-        lambda api_key, provider, timeout=10: (valid, message),
+        "gptme.server.api_v2.validate_api_key_status",
+        lambda api_key, provider, timeout=10: (validation_status, message),
     )
 
 
@@ -489,7 +499,7 @@ def test_v2_user_api_key_rejects_invalid_key(
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     stub_key_validation(
         monkeypatch,
-        valid=False,
+        status="INVALID",
         message="Invalid API key. Please check your key and try again.",
     )
 
@@ -539,6 +549,36 @@ def test_v2_user_api_key_saves_when_validation_is_non_fatal(
 
     saved = tomlkit.loads((tmp_path / "config.local.toml").read_text()).unwrap()
     assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-out-of-credit"
+
+
+def test_v2_user_api_key_unreachable_warns_but_saves(
+    client: FlaskClient, tmp_path, monkeypatch
+):
+    """An unreachable provider must not block the save; it returns a warning."""
+    import gptme.config.user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setattr("gptme.config.core.reload_config", lambda: None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    stub_key_validation(
+        monkeypatch,
+        status="UNREACHABLE",
+        message="Request timed out. Please check your network connection.",
+    )
+
+    response = client.post(
+        "/api/v2/user/api-key",
+        json={"provider": "anthropic", "api_key": "sk-ant-live-key"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["warning"] == "Request timed out. Please check your network connection."
+
+    saved = tomlkit.loads((tmp_path / "config.local.toml").read_text()).unwrap()
+    assert saved["env"]["ANTHROPIC_API_KEY"] == "sk-ant-live-key"
 
 
 def test_v2_user_api_key_rejects_unknown_provider(client: FlaskClient):

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -145,7 +145,11 @@ export function SetupWizard() {
   );
 
   const saveApiKeyToServer = useCallback(
-    async (provider: ApiKeyProvider, apiKeyValue: string, model?: string) => {
+    async (
+      provider: ApiKeyProvider,
+      apiKeyValue: string,
+      model?: string
+    ): Promise<{ warning?: string }> => {
       const resp = await fetch(`${connectionConfig.baseUrl}/api/v2/user/api-key`, {
         method: 'POST',
         headers: withAuthHeaders(api.authHeader, {
@@ -159,7 +163,15 @@ export function SetupWizard() {
       });
 
       if (resp.ok) {
-        return;
+        // A successful save may still carry a non-blocking warning (e.g. the
+        // provider could not be reached for key validation). Surface it so the
+        // user knows the key was saved but not confirmed.
+        try {
+          const data = (await resp.json()) as { warning?: string };
+          return { warning: data.warning };
+        } catch {
+          return {};
+        }
       }
 
       let message = `Failed to save API key (${resp.status})`;
@@ -429,7 +441,16 @@ export function SetupWizard() {
     setApiKeySaving(true);
     setApiKeyError(null);
     try {
-      await saveApiKeyToServer(apiKeyProvider, trimmed, apiKeyModel || undefined);
+      const { warning } = await saveApiKeyToServer(
+        apiKeyProvider,
+        trimmed,
+        apiKeyModel || undefined
+      );
+      if (warning) {
+        // The save succeeds, so we proceed to the completion step — surface the
+        // unverified-key notice as a toast so it is not hidden by that transition.
+        toast.warning(warning);
+      }
       try {
         await invokeTauri('stop_server');
       } catch {

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -176,7 +176,7 @@ jest.mock('lucide-react', () => ({
 }));
 
 jest.mock('sonner', () => ({
-  toast: { success: jest.fn(), error: jest.fn() },
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
 }));
 
 describe('SetupWizard', () => {
@@ -225,6 +225,7 @@ describe('SetupWizard', () => {
     });
     (toast.success as jest.Mock).mockClear();
     (toast.error as jest.Mock).mockClear();
+    (toast.warning as jest.Mock).mockClear();
   });
 
   it('stays closed in demo mode even for first-time users', () => {
@@ -1171,6 +1172,83 @@ describe('SetupWizard', () => {
     expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
     expect(mockInvokeTauri).not.toHaveBeenCalledWith('stop_server');
     expect(mockInvokeTauri).not.toHaveBeenCalledWith('start_server');
+  });
+
+  it('surfaces a non-blocking warning when the provider is unreachable', async () => {
+    mockIsTauriEnvironment.mockReturnValue(true);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: true,
+      serverStatus: {
+        running: true,
+        port: 5700,
+        port_available: false,
+        manages_local_server: true,
+      },
+    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          models: [
+            {
+              id: 'anthropic/claude-sonnet-4-7',
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-7',
+            },
+          ],
+          recommended: ['anthropic/claude-sonnet-4-7'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: 'ok',
+          env_var: 'ANTHROPIC_API_KEY',
+          warning: 'Request timed out. Please check your network connection.',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ provider_configured: true }),
+      });
+    mockConnect.mockImplementation(async () => {
+      isConnected$.set(true);
+    });
+    mockInvokeTauri.mockResolvedValue(undefined);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /monitor local/i }));
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /configure a provider/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/api key/i), { target: { value: 'sk-good' } });
+    fireEvent.click(screen.getByRole('button', { name: /save and restart server/i }));
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledWith(
+        'Request timed out. Please check your network connection.'
+      );
+    });
+    expect(mockInvokeTauri).toHaveBeenCalledWith('stop_server');
+    expect(mockInvokeTauri).toHaveBeenCalledWith('start_server');
   });
 
   it('surfaces nested API error objects instead of [object Object]', async () => {


### PR DESCRIPTION
Refines the provider-key validation landed in #3555. That PR wires `validate_api_key` into the BYOK save endpoint and returns 400 for any invalid answer — including an **unreachable provider**, which hard-blocks the save.

This PR extends validation with a tri-state `ApiKeyValidationStatus` so the two failure classes are handled differently, matching the non-goal in the task: *a network blip must not lock a user out of saving a key they know is good*.

- **INVALID** (401/403): block the save with the provider's specific error (the user sees it in the BYOK UI at setup time, not on the first generation).
- **UNREACHABLE** (timeout / connection error / 5xx): save the key anyway and return a `warning` field.
- **VALID / UNSUPPORTED**: save normally.

The Desktop SetupWizard surfaces the `warning` as a toast so the notice is not hidden when the wizard advances to the "You're all set" step.

Closes #3545.

## Changes
- `gptme/llm/validate.py` — add `ApiKeyValidationStatus` + `validate_api_key_status` (tri-state); keep `validate_api_key` as the boolean wrapper for CLI callers (`setup`, `doctor`, `onboard`, `account`).
- `gptme/server/api_v2.py` — use `validate_api_key_status` in `/api/v2/user/api-key`; block on INVALID, warn on UNREACHABLE.
- `gptme/server/openapi_docs.py` — add optional `warning` to `UserApiKeySaveResponse`.
- `webui/src/components/SetupWizard.tsx` — surface the warning via `toast.warning`.
- Tests for all three statuses (server + validate module + SetupWizard).
