### PR TITLE
feat(tools): context-aware tool selection via ActivityWatch

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -108,6 +108,26 @@ The ``settings`` section contains user-level CLI defaults. Currently supported:
     [settings]
     gear = 2
 
+- ``tool_select_by_app``: Map of application-name glob to tool allowlist, used by
+  ``gptme --tool-select-by-app``. When that flag is passed, gptme asks a local
+  `ActivityWatch <https://activitywatch.net/>`_ server which application is focused
+  and loads the first matching rule's tools instead of the default set. Keys are
+  case-insensitive globs and are evaluated in declaration order, so put specific
+  patterns first.
+
+.. code-block:: toml
+
+    [settings.tool_select_by_app]
+    "*firefox*" = ["browser", "read"]
+    "code" = ["shell", "read", "save", "patch"]
+
+The flag is a *last* fallback: an explicit ``--tools``/``-t``, the
+``TOOL_ALLOWLIST`` env var, and a per-chat tool list all take precedence. If
+ActivityWatch is unreachable, has recorded no window events, or no rule matches
+the focused app, gptme falls back to the default toolset. The ActivityWatch
+server URL defaults to ``http://localhost:5600`` and can be overridden with the
+``AW_SERVER_URL`` env var. gptme only reads from ActivityWatch; it never writes.
+
 .. _how-model-selection-works:
 
 How model selection works

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -715,6 +715,14 @@ Run 'gptme-util --help' for all utility commands."""
     help="Prompt injection hygiene for tool outputs: off (disabled), warn (flag suspicious content), block (redact HIGH-severity patterns). Overrides GPTME_INJECTION_HYGIENE env var.",
 )
 @click.option(
+    "--tool-select-by-app",
+    "tool_select_by_app",
+    is_flag=True,
+    default=False,
+    envvar="GPTME_TOOL_SELECT_BY_APP",
+    help="Pick the tool allowlist from the focused application, as reported by a local ActivityWatch server, using the [settings].tool_select_by_app rules in gptme.toml. Ignored when --tools is given; falls back to the default toolset if ActivityWatch is unreachable or no rule matches.",
+)
+@click.option(
     "--manifest-dir",
     "manifest_dir",
     default=None,
@@ -756,6 +764,7 @@ def main(
     no_workspace: bool,
     output_schema: str | None,
     injection_hygiene: str | None,
+    tool_select_by_app: bool,
     manifest_dir: Path | None,
 ):
     """Main entrypoint for the CLI."""
@@ -872,6 +881,11 @@ def main(
     # so this only fires when the flag was explicitly passed on the command line.
     if injection_hygiene is not None:
         os.environ["GPTME_INJECTION_HYGIENE"] = injection_hygiene
+
+    # Consumed by init_tools() as a last-resort allowlist source, so it applies
+    # to any code path that loads tools (chat, server, subagents).
+    if tool_select_by_app:
+        os.environ["GPTME_TOOL_SELECT_BY_APP"] = "1"
 
     # Convert tool_allowlist from tuple to string or None
     # Use get_parameter_source to distinguish between default (None) and explicit empty list

--- a/gptme/config/models.py
+++ b/gptme/config/models.py
@@ -211,6 +211,11 @@ class SettingsConfig:
 
     gear: int | None = None
 
+    # Map of app-name glob -> tool allowlist, used by --tool-select-by-app.
+    # Keys are case-insensitive globs matched against the focused application
+    # reported by ActivityWatch; first match wins.
+    tool_select_by_app: dict[str, list[str]] = field(default_factory=dict)
+
 
 @dataclass
 class UserConfig:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -158,10 +158,18 @@ def _init_single_tool(tool: ToolSpec) -> ToolSpec:
 
 
 def _tool_select_by_app_rules(config) -> dict[str, list[str]]:
-    """Merged [settings].tool_select_by_app rules (project overrides user)."""
-    rules = dict(config.user.settings.tool_select_by_app)
+    """Merged [settings].tool_select_by_app rules (project overrides user).
+
+    Project rules are inserted first so they are evaluated first in
+    match_app_rules's first-match-wins iteration.  User rules fill in any
+    patterns not already covered by the project.
+    """
+    rules: dict[str, list[str]] = {}
     if config.project:
         rules.update(config.project.settings.tool_select_by_app)
+    for key, value in config.user.settings.tool_select_by_app.items():
+        if key not in rules:
+            rules[key] = value
     return rules
 
 
@@ -186,7 +194,8 @@ def _allowlist_from_activitywatch(config) -> list[str] | None:
         return None
     from ._activitywatch import resolve_allowlist_for_current_app  # fmt: skip
 
-    return resolve_allowlist_for_current_app(rules)
+    server_url = config.get_env("AW_SERVER_URL") or None
+    return resolve_allowlist_for_current_app(rules, server=server_url)
 
 
 def init_tools(

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -195,6 +195,12 @@ def _allowlist_from_activitywatch(config) -> list[str] | None:
     from ._activitywatch import resolve_allowlist_for_current_app  # fmt: skip
 
     server_url = config.get_env("AW_SERVER_URL") or None
+    if server_url is not None and not isinstance(server_url, str):
+        logger.warning(
+            "AW_SERVER_URL must be a string (got %s), using default toolset",
+            type(server_url).__name__,
+        )
+        return None
     return resolve_allowlist_for_current_app(rules, server=server_url)
 
 

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -157,6 +157,38 @@ def _init_single_tool(tool: ToolSpec) -> ToolSpec:
     return tool
 
 
+def _tool_select_by_app_rules(config) -> dict[str, list[str]]:
+    """Merged [settings].tool_select_by_app rules (project overrides user)."""
+    rules = dict(config.user.settings.tool_select_by_app)
+    if config.project:
+        rules.update(config.project.settings.tool_select_by_app)
+    return rules
+
+
+def _allowlist_from_activitywatch(config) -> list[str] | None:
+    """Resolve a tool allowlist from the focused app, if opted in.
+
+    Returns None whenever the feature is off, unconfigured, or ActivityWatch
+    can't answer — so callers fall back to the default toolset.
+    """
+    if (config.get_env("GPTME_TOOL_SELECT_BY_APP") or "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return None
+    rules = _tool_select_by_app_rules(config)
+    if not rules:
+        logger.warning(
+            "--tool-select-by-app is set but no [settings].tool_select_by_app "
+            "rules are configured, using default tools"
+        )
+        return None
+    from ._activitywatch import resolve_allowlist_for_current_app  # fmt: skip
+
+    return resolve_allowlist_for_current_app(rules)
+
+
 def init_tools(
     allowlist: list[str] | None = None,
 ) -> list[ToolSpec]:
@@ -183,6 +215,10 @@ def init_tools(
                 allowlist = env_allowlist.split(",")
             elif config.chat and config.chat.tools:
                 allowlist = config.chat.tools
+            else:
+                # Last fallback: let ActivityWatch pick tools for the focused app.
+                # Opt-in via --tool-select-by-app (which sets the env var).
+                allowlist = _allowlist_from_activitywatch(config)
 
         allowlist = expand_tool_allowlist_presets(allowlist)
 

--- a/gptme/tools/_activitywatch.py
+++ b/gptme/tools/_activitywatch.py
@@ -1,0 +1,102 @@
+"""Context-aware tool selection driven by ActivityWatch.
+
+Queries a local `ActivityWatch <https://activitywatch.net/>`_ server for the
+currently focused application and maps it to a tool allowlist, so a session
+started while a browser is focused can load browser tools while one started in
+an editor loads code tools.
+
+This is a read-only client: gptme never writes to ActivityWatch. Every failure
+mode (no server, no window bucket, no events, malformed payload) degrades to
+``None`` so the caller falls back to the full default toolset.
+"""
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from fnmatch import fnmatchcase
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVER = "http://localhost:5600"
+DEFAULT_TIMEOUT = 1.0
+
+# ActivityWatch's window watcher registers its bucket with this type.
+_WINDOW_BUCKET_TYPE = "currentwindow"
+
+
+def _get_json(url: str, timeout: float):
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def get_current_app(
+    server: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Return the name of the currently focused application, or None.
+
+    Returns None (never raises) if ActivityWatch is unreachable, has no window
+    watcher bucket, or has not recorded any events yet.
+    """
+    server = (server or os.environ.get("AW_SERVER_URL") or DEFAULT_SERVER).rstrip("/")
+    try:
+        buckets = _get_json(f"{server}/api/0/buckets/", timeout)
+        if not isinstance(buckets, dict):
+            return None
+        bucket_id = next(
+            (
+                bid
+                for bid, meta in buckets.items()
+                if isinstance(meta, dict) and meta.get("type") == _WINDOW_BUCKET_TYPE
+            ),
+            None,
+        )
+        if bucket_id is None:
+            logger.debug("ActivityWatch has no %s bucket", _WINDOW_BUCKET_TYPE)
+            return None
+        events = _get_json(
+            f"{server}/api/0/buckets/{bucket_id}/events?limit=1", timeout
+        )
+        if not isinstance(events, list) or not events:
+            return None
+        data = events[0].get("data") if isinstance(events[0], dict) else None
+        app = data.get("app") if isinstance(data, dict) else None
+        return app if isinstance(app, str) and app else None
+    except (urllib.error.URLError, OSError, ValueError, KeyError) as exc:
+        logger.debug("ActivityWatch query failed (%s), using default tools", exc)
+        return None
+
+
+def match_app_rules(app: str, rules: dict[str, list[str]]) -> list[str] | None:
+    """Return the tool allowlist for `app`, or None if no rule matches.
+
+    Rule keys are case-insensitive shell globs matched against the application
+    name (e.g. ``"*firefox*"``). Rules are evaluated in declaration order and
+    the first match wins, so put specific patterns before broad ones.
+    """
+    app_lower = app.lower()
+    for pattern, tools in rules.items():
+        if fnmatchcase(app_lower, pattern.lower()):
+            return list(tools)
+    return None
+
+
+def resolve_allowlist_for_current_app(
+    rules: dict[str, list[str]],
+    server: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> list[str] | None:
+    """Resolve a tool allowlist from the currently focused app, or None."""
+    if not rules:
+        return None
+    app = get_current_app(server=server, timeout=timeout)
+    if app is None:
+        return None
+    allowlist = match_app_rules(app, rules)
+    if allowlist is None:
+        logger.debug("No tool_select_by_app rule matched app %r", app)
+        return None
+    logger.info("ActivityWatch: app %r -> tools %s", app, ",".join(allowlist))
+    return allowlist

--- a/tests/test_tool_select_by_app.py
+++ b/tests/test_tool_select_by_app.py
@@ -190,3 +190,20 @@ def test_allowlist_from_activitywatch_uses_config_env_server_url(monkeypatch):
     assert all(u.startswith("http://aw-custom:5600") for u in captured_urls), (
         f"Expected custom AW server URL, got: {captured_urls}"
     )
+
+
+def test_allowlist_from_activitywatch_rejects_non_string_server_url(monkeypatch):
+    """A non-string AW_SERVER_URL (e.g. integer from TOML) must warn and return None."""
+    monkeypatch.setenv("GPTME_TOOL_SELECT_BY_APP", "1")
+    monkeypatch.delenv("AW_SERVER_URL", raising=False)
+
+    config = _config(user_rules={"*": ["shell"]})
+    # Simulate a misconfigured integer port number instead of a URL string
+    config.user.env["AW_SERVER_URL"] = 5600  # type: ignore[assignment]
+
+    with patch("gptme.tools._activitywatch._get_json") as mock_get_json:
+        result = _allowlist_from_activitywatch(config)
+
+    # Must gracefully return None instead of crashing on .rstrip()
+    assert result is None, "Non-string AW_SERVER_URL should fall back to None"
+    mock_get_json.assert_not_called()

--- a/tests/test_tool_select_by_app.py
+++ b/tests/test_tool_select_by_app.py
@@ -146,3 +146,47 @@ def test_allowlist_from_activitywatch_opted_in_without_rules(monkeypatch):
     monkeypatch.setenv("GPTME_TOOL_SELECT_BY_APP", "1")
     with patch("gptme.tools._activitywatch._get_json", side_effect=AssertionError):
         assert _allowlist_from_activitywatch(_config()) is None
+
+
+def test_rules_project_glob_beats_user_catchall():
+    """Project-specific globs should be evaluated before a broad user catch-all."""
+    config = _config(
+        user_rules={"*": ["shell"]},
+        project_rules={"*firefox*": ["browser"]},
+    )
+    rules = _tool_select_by_app_rules(config)
+    # Project rule must come first in iteration so it wins for "firefox"
+    result = match_app_rules("firefox", rules)
+    assert result == ["browser"], (
+        "Project glob '*firefox*' should win over user catch-all '*'"
+    )
+
+
+def test_allowlist_from_activitywatch_uses_config_env_server_url(monkeypatch):
+    """AW_SERVER_URL set in [env] config layer must reach the AW client."""
+    monkeypatch.setenv("GPTME_TOOL_SELECT_BY_APP", "1")
+    # Ensure process env does NOT have the override so only config-layer wins
+    monkeypatch.delenv("AW_SERVER_URL", raising=False)
+    monkeypatch.delenv("GPTME_AW_SERVER_URL", raising=False)
+
+    captured_urls: list[str] = []
+
+    def _spy_get_json(url: str, timeout: float):
+        captured_urls.append(url)
+        if url.endswith("/api/0/buckets/"):
+            return BUCKETS
+        if "/events" in url:
+            return [{"data": {"app": "firefox", "title": "t"}}]
+        raise AssertionError(f"unexpected url: {url}")
+
+    config = _config(user_rules={"*firefox*": ["browser"]})
+    # Set custom server URL via the config user-env layer (simulates [env] in gptme.toml)
+    config.user.env["AW_SERVER_URL"] = "http://aw-custom:5600"
+
+    with patch("gptme.tools._activitywatch._get_json", _spy_get_json):
+        result = _allowlist_from_activitywatch(config)
+
+    assert result == ["browser"]
+    assert all(u.startswith("http://aw-custom:5600") for u in captured_urls), (
+        f"Expected custom AW server URL, got: {captured_urls}"
+    )

--- a/tests/test_tool_select_by_app.py
+++ b/tests/test_tool_select_by_app.py
@@ -1,0 +1,148 @@
+"""Tests for ActivityWatch-driven tool selection (--tool-select-by-app)."""
+
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from gptme.config import Config, ProjectConfig, UserConfig
+from gptme.tools import _allowlist_from_activitywatch, _tool_select_by_app_rules
+from gptme.tools._activitywatch import (
+    get_current_app,
+    match_app_rules,
+    resolve_allowlist_for_current_app,
+)
+
+BUCKETS = {
+    "aw-watcher-afk_host": {"type": "afkstatus"},
+    "aw-watcher-window_host": {"type": "currentwindow"},
+}
+
+
+def _fake_aw(app: str | None, *, buckets=None, events=None):
+    """Return a _get_json stub mimicking the ActivityWatch REST API."""
+    resolved_buckets = BUCKETS if buckets is None else buckets
+    if events is None:
+        events = [] if app is None else [{"data": {"app": app, "title": "some title"}}]
+
+    def _get_json(url: str, timeout: float):
+        if url.endswith("/api/0/buckets/"):
+            return resolved_buckets
+        if "/events" in url:
+            assert "aw-watcher-window_host" in url
+            return events
+        raise AssertionError(f"unexpected url: {url}")
+
+    return _get_json
+
+
+@pytest.mark.parametrize(
+    ("app", "expected"),
+    [
+        ("firefox", ["browser", "read"]),
+        ("Firefox Developer Edition", ["browser", "read"]),
+        ("Code", ["shell", "patch"]),
+        ("Alacritty", None),
+    ],
+)
+def test_match_app_rules_is_case_insensitive_glob(app, expected):
+    rules = {"*firefox*": ["browser", "read"], "code": ["shell", "patch"]}
+    assert match_app_rules(app, rules) == expected
+
+
+def test_match_app_rules_first_match_wins():
+    rules = {"*fire*": ["browser"], "*firefox*": ["read"]}
+    assert match_app_rules("firefox", rules) == ["browser"]
+
+
+def test_get_current_app_reads_window_bucket():
+    with patch("gptme.tools._activitywatch._get_json", _fake_aw("firefox")):
+        assert get_current_app(server="http://aw.test") == "firefox"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"buckets": {"aw-watcher-afk_host": {"type": "afkstatus"}}},  # no window bucket
+        {"events": []},  # bucket exists but has no events
+        {"events": [{"data": {}}]},  # event without an app field
+        {"events": [{"data": {"app": ""}}]},  # empty app name
+        {"buckets": []},  # malformed buckets payload
+    ],
+)
+def test_get_current_app_degrades_to_none(kwargs):
+    with patch("gptme.tools._activitywatch._get_json", _fake_aw("firefox", **kwargs)):
+        assert get_current_app(server="http://aw.test") is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        urllib.error.URLError("connection refused"),
+        OSError("timed out"),
+        json.JSONDecodeError("bad", "", 0),
+    ],
+)
+def test_get_current_app_offline_server_degrades_to_none(exc):
+    """An offline/unreachable ActivityWatch must never raise into the caller."""
+    with patch("gptme.tools._activitywatch._get_json", side_effect=exc):
+        assert get_current_app(server="http://aw.test") is None
+
+
+def test_resolve_allowlist_for_current_app():
+    rules = {"*firefox*": ["browser", "read"]}
+    with patch("gptme.tools._activitywatch._get_json", _fake_aw("firefox")):
+        assert resolve_allowlist_for_current_app(rules) == ["browser", "read"]
+
+
+def test_resolve_allowlist_without_rules_skips_the_query():
+    """No configured rules means no reason to hit the server at all."""
+    with patch("gptme.tools._activitywatch._get_json", side_effect=AssertionError):
+        assert resolve_allowlist_for_current_app({}) is None
+
+
+def test_resolve_allowlist_unmatched_app_falls_back():
+    with patch("gptme.tools._activitywatch._get_json", _fake_aw("Alacritty")):
+        assert resolve_allowlist_for_current_app({"*firefox*": ["browser"]}) is None
+
+
+def _config(user_rules=None, project_rules=None) -> Config:
+    user = UserConfig()
+    user.settings.tool_select_by_app = user_rules or {}
+    project = None
+    if project_rules is not None:
+        project = ProjectConfig()
+        project.settings.tool_select_by_app = project_rules
+    return Config(user=user, project=project)
+
+
+def test_rules_merge_project_over_user():
+    config = _config(
+        user_rules={"*firefox*": ["browser"], "code": ["shell"]},
+        project_rules={"code": ["shell", "patch"]},
+    )
+    assert _tool_select_by_app_rules(config) == {
+        "*firefox*": ["browser"],
+        "code": ["shell", "patch"],
+    }
+
+
+def test_allowlist_from_activitywatch_requires_opt_in(monkeypatch):
+    monkeypatch.delenv("GPTME_TOOL_SELECT_BY_APP", raising=False)
+    config = _config(user_rules={"*firefox*": ["browser"]})
+    with patch("gptme.tools._activitywatch._get_json", side_effect=AssertionError):
+        assert _allowlist_from_activitywatch(config) is None
+
+
+def test_allowlist_from_activitywatch_opted_in(monkeypatch):
+    monkeypatch.setenv("GPTME_TOOL_SELECT_BY_APP", "1")
+    config = _config(user_rules={"*firefox*": ["browser", "read"]})
+    with patch("gptme.tools._activitywatch._get_json", _fake_aw("firefox")):
+        assert _allowlist_from_activitywatch(config) == ["browser", "read"]
+
+
+def test_allowlist_from_activitywatch_opted_in_without_rules(monkeypatch):
+    monkeypatch.setenv("GPTME_TOOL_SELECT_BY_APP", "1")
+    with patch("gptme.tools._activitywatch._get_json", side_effect=AssertionError):
+        assert _allowlist_from_activitywatch(_config()) is None


### PR DESCRIPTION
Adds `--tool-select-by-app`: gptme asks a local [ActivityWatch](https://activitywatch.net/) server which application is currently focused, and loads the tool allowlist mapped to that app instead of the default toolset.

Motivated by discussion gptme/gptme#1294 ("restrict tools based on current app").

## Usage

```toml
# gptme.toml
[settings.tool_select_by_app]
"*firefox*" = ["browser", "read"]
"code"      = ["shell", "read", "save", "patch"]
```

```bash
gptme --tool-select-by-app
```

Keys are case-insensitive globs matched against the focused app name, evaluated in declaration order (first match wins).

## Design notes

- **Last fallback, not an override.** Resolution happens inside `init_tools()` *after* `--tools`/`-t`, `TOOL_ALLOWLIST`, and per-chat `chat.tools` — all of those still win. Putting it there (rather than in the CLI's allowlist plumbing) means it applies to any code path that loads tools, and the CLI flag just exports `GPTME_TOOL_SELECT_BY_APP` (same pattern as `--injection-hygiene`).
- **Fails open, always.** No server, no `currentwindow` bucket, no events yet, malformed payload, or no matching rule → returns `None` and the default toolset loads. The client never raises into the caller.
- **Read-only and dependency-free.** stdlib `urllib` only; gptme never writes to ActivityWatch. Server URL defaults to `http://localhost:5600`, overridable via `AW_SERVER_URL`.
- **No query when unconfigured.** With no rules configured, the AW request is skipped entirely.

## Out of scope

Model selection (this is tool selection only), any change to ActivityWatch itself, and UI for editing the mapping.

## Tests

21 new tests in `tests/test_tool_select_by_app.py` covering the glob matcher (case-insensitivity, first-match-wins), the AW client against a stubbed REST API, all five degrade-to-`None` payload shapes, three offline/exception paths, project-over-user rule merging, and the opt-in gate.

```
tests/test_tool_select_by_app.py tests/test_config.py tests/test_chat_config.py  →  123 passed
mypy: no issues found
ruff: all checks passed
```