### PR TITLE
fix(grok-subscription): enable native tools API and add grok-4.6

### DIFF
--- a/gptme/cli/auth.py
+++ b/gptme/cli/auth.py
@@ -345,7 +345,7 @@ def auth_grok_subscription():
                 f"[green]✓ Found valid grok CLI tokens at {_get_grok_cli_auth_path()}[/green]"
             )
             console.print(
-                "\nYou can now use models like: [cyan]grok-subscription/grok-4.5[/cyan]"
+                "\nYou can now use models like: [cyan]grok-subscription/grok-4.6[/cyan]"
             )
             return
 
@@ -490,7 +490,7 @@ def auth_grok_subscription():
 
     console.print("\n[green bold]✓ Authentication successful![/green bold]")
     console.print(
-        "\nYou can now use models like: [cyan]grok-subscription/grok-4.5[/cyan]"
+        "\nYou can now use models like: [cyan]grok-subscription/grok-4.6[/cyan]"
     )
 
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -96,7 +96,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini/gemini-2.0-flash",
     "groq": "groq/llama-3.3-70b-versatile",
     "xai": "xai/grok-3-mini",
-    "grok-subscription": "grok-subscription/grok-4.5",
+    "grok-subscription": "grok-subscription/grok-4.6",
     "deepseek": "deepseek/deepseek-chat",
     "moonshot": "moonshot/kimi-k2.6",
 }

--- a/gptme/llm/llm_grok_subscription.py
+++ b/gptme/llm/llm_grok_subscription.py
@@ -12,7 +12,7 @@ scope ``api:access`` explicitly authorizes this endpoint.
 Prerequisite: Install and authenticate the grok CLI first:
     1. Install: download from https://grok.com/download or ``pip install grok-cli``
     2. Login: ``grok login``
-    3. Use:   ``gptme --model grok-subscription/grok-4.5``
+    3. Use:   ``gptme --model grok-subscription/grok-4.6``
 
 Or authenticate directly via gptme (opens grok.com in browser):
     ``gptme auth grok-subscription``

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1925,7 +1925,10 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> ChatCompletionToolParam:
         )
         description = description[:1024]
 
-    # Custom providers are OpenAI-compatible and support tools API
+    # Custom providers are OpenAI-compatible and support tools API.
+    # grok-subscription routes to xAI's OpenAI-compatible subscription proxy
+    # (cli-chat-proxy.grok.com), which supports function calling — without it
+    # here, `--tool-format tool` raised "Provider doesn't support tools API".
     if model.provider in [
         "openai",
         "azure",
@@ -1933,6 +1936,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> ChatCompletionToolParam:
         "deepseek",
         "moonshot",
         "local",
+        "grok-subscription",
     ] or is_custom_provider(model.model.split("/")[0]):
         all_required = all(p.required for p in spec.parameters)
         supports_strict = model.supports_strict_tools and all_required

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -308,7 +308,19 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Auth: run `grok login` or `gptme auth grok-subscription`.
     "grok-subscription": _mark_subscription(
         {
-            # grok-4.5 — frontier model available on SuperGrok subscription
+            # grok-4.6 — current frontier model on SuperGrok subscription and
+            # the grok CLI default (grok CLI 0.2.117, 2026-08). Context/output
+            # assumed equal to grok-4.5 until xAI publishes the model card.
+            "grok-4.6": {
+                "context": 500_000,
+                "max_output": 128_000,
+                "price_input": 2,
+                "price_output": 6,
+                "supports_vision": True,
+                "supports_reasoning": True,
+                "preferred_edit_format": "diff",
+            },
+            # grok-4.5 — previous frontier model available on SuperGrok subscription
             # https://x.ai/blog/grok-4-5 (500K context, reasoning support)
             "grok-4.5": {
                 "context": 500_000,

--- a/tests/test_llm_grok_subscription.py
+++ b/tests/test_llm_grok_subscription.py
@@ -399,7 +399,7 @@ def test_grok_subscription_default_model():
     from gptme.llm import PROVIDER_DEFAULT_MODELS
 
     assert (
-        PROVIDER_DEFAULT_MODELS.get("grok-subscription") == "grok-subscription/grok-4.5"
+        PROVIDER_DEFAULT_MODELS.get("grok-subscription") == "grok-subscription/grok-4.6"
     )
 
 
@@ -420,3 +420,29 @@ def test_grok_subscription_appears_in_available_providers(tmp_path):
 
     provider_names = [p for p, _ in providers]
     assert "grok-subscription" in provider_names
+
+
+def test_grok_subscription_supports_tools_api():
+    """grok-subscription routes to an OpenAI-compatible proxy that supports
+    function calling; `--tool-format tool` must not raise."""
+    from gptme.llm.llm_openai import _spec2tool
+    from gptme.llm.models import get_model
+    from gptme.tools.base import Parameter, ToolSpec
+
+    spec = ToolSpec(
+        name="echo",
+        desc="echo a value",
+        parameters=[Parameter(name="value", type="string", description="v")],
+    )
+    tool = _spec2tool(spec, get_model("grok-subscription/grok-4.6"))
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "echo"
+
+
+def test_grok_46_is_registered():
+    from gptme.llm.models import get_model
+
+    meta = get_model("grok-subscription/grok-4.6")
+    assert meta.provider == "grok-subscription"
+    assert meta.model == "grok-4.6"
+    assert meta.context == 500_000


### PR DESCRIPTION
## Summary

Two gaps in the `grok-subscription` provider (#3289):

1. **Native tools API failed.** `_spec2tool` didn't list `grok-subscription` among tools-capable providers, so `gptme --model grok-subscription/... --tool-format tool` raised `ValueError: Provider doesn't support tools API` (every autonomous Bob session on this provider failed at first turn). The SuperGrok proxy is OpenAI-compatible and supports function calling — verified live: grok-4.6 executes a `shell` tool call natively through the proxy.
2. **`grok-4.6` unregistered.** It is the current SuperGrok frontier model and the grok CLI's default since 0.2.117. Added to `models/data.py` (metadata mirrors grok-4.5 until xAI publishes the card) and made the provider default; auth hints + docstring updated.

## Tests

- `test_grok_subscription_supports_tools_api` — `_spec2tool` returns a function tool for the provider
- `test_grok_46_is_registered`
- existing grok-subscription / pricing / setup tests updated for the new default — 46 passed

## Live verification

```
gptme --model grok-subscription/grok-4.6 --tool-format tool -n \
  "Use the shell tool to run exactly: echo GROK46-TOOLS-OK"
→ @shell(...): {"command":"echo GROK46-TOOLS-OK"}  → GROK46-TOOLS-OK
```