### PR TITLE
fix(tauri): include pyproject.toml and lock file in sidecar freshness check

### DIFF
--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -50,7 +50,15 @@ sidecar_is_stale() {
     local uvlock_now=0
     if [[ -f "$REPO_ROOT/uv.lock" ]]; then uvlock_now=1; fi
     local uvlock_was=0
-    if [[ -f "$uvlock_marker" ]]; then uvlock_was=$(cat "$uvlock_marker"); fi
+    if [[ -f "$uvlock_marker" ]]; then
+        if [[ ! -r "$uvlock_marker" ]]; then
+            return 0
+        fi
+        uvlock_was=$(<"$uvlock_marker")
+        if [[ "$uvlock_was" != 0 && "$uvlock_was" != 1 ]]; then
+            return 0
+        fi
+    fi
     if [[ "$uvlock_now" != "$uvlock_was" ]]; then
         return 0
     fi

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -79,9 +79,9 @@ echo "Building gptme-server sidecar for $TRIPLE..."
 mkdir -p "$BINS_DIR"
 
 # Install gptme from local source into a venv, then freeze with PyInstaller.
-# When uv.lock exists, prefer --frozen so the lock actually enforces the
-# pinned versions.  If the lock is stale vs pyproject.toml, uv --frozen exits
-# non-zero; we warn and fall back to an unlocked sync (run `uv lock` to fix).
+# When uv.lock exists, use --frozen so the lock actually enforces the pinned
+# versions without modifying the lock file. If the lock cannot satisfy the
+# current pyproject.toml, stop and ask the developer to update it explicitly.
 # When uv.lock is absent (e.g. fresh checkout — it is gitignored), fall back
 # to uv pip install.  This path is NOT lock-pinned; prefer generating a uv.lock
 # (`uv lock`) or committing it for reproducible sidecar builds.
@@ -89,10 +89,10 @@ mkdir -p "$BINS_DIR"
 # to --group NAME, so --group dev selects it.  server extras add Flask etc.
 cd "$REPO_ROOT"
 if [[ -f "uv.lock" ]]; then
-    if ! uv sync --frozen --extra server --group dev --quiet 2>/dev/null; then
-        echo "WARNING: uv.lock is out of date with pyproject.toml." \
-             "Run 'uv lock' to update it. Falling back to unlocked sync..." >&2
-        uv sync --extra server --group dev --quiet
+    if ! uv sync --frozen --extra server --group dev --quiet; then
+        echo "ERROR: uv.lock cannot satisfy pyproject.toml." \
+             "Run 'uv lock' to update it, then rebuild the sidecar." >&2
+        exit 1
     fi
 else
     if [[ -f "poetry.lock" ]]; then

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -28,12 +28,12 @@ sidecar_is_stale() {
         return 0
     fi
     # Also rebuild when packaging/dependency config changes (pyproject.toml,
-    # uv.lock) — these affect which packages get frozen into the sidecar even
-    # when no .py source file changes.  poetry.lock is excluded: the install
-    # path only consults uv.lock, so watching poetry.lock would trigger spurious
-    # rebuilds whose result doesn't reflect the poetry.lock change.
+    # poetry.lock, uv.lock) — these affect which packages get frozen into the
+    # sidecar even when no .py source file changes.  Both lock files are
+    # checked: poetry.lock is the committed canonical lock; uv.lock may exist
+    # on developer machines and controls the uv sync path.
     local config_files=("$REPO_ROOT/pyproject.toml")
-    for f in "$REPO_ROOT/uv.lock"; do
+    for f in "$REPO_ROOT/poetry.lock" "$REPO_ROOT/uv.lock"; do
         [[ -f "$f" ]] && config_files+=("$f")
     done
     for f in "${config_files[@]}"; do
@@ -71,19 +71,27 @@ echo "Building gptme-server sidecar for $TRIPLE..."
 mkdir -p "$BINS_DIR"
 
 # Install gptme from local source into a venv, then freeze with PyInstaller.
-# When uv.lock exists, use uv sync (without --frozen) so the lock is updated
-# if pyproject.toml changed since the last `uv lock` run.  --frozen would fail
-# when pyproject.toml is newer than uv.lock (e.g. after adding a dep without
-# running `uv lock`), breaking the very workflow that staleness detection exists
-# to support.  uv sync still installs the exact pinned versions when the lock
-# is already current, so the pin-enforcement goal is preserved.
-# When uv.lock is absent, fall back to uv pip install (original path).
+# When uv.lock exists, prefer --frozen so the lock actually enforces the
+# pinned versions.  If the lock is stale vs pyproject.toml, uv --frozen exits
+# non-zero; we warn and fall back to an unlocked sync (run `uv lock` to fix).
+# When uv.lock is absent (e.g. fresh checkout — it is gitignored), fall back
+# to uv pip install.  This path is NOT lock-pinned; prefer generating a uv.lock
+# (`uv lock`) or committing it for reproducible sidecar builds.
 # pyinstaller is in [tool.poetry.group.dev.dependencies]; uv maps Poetry groups
 # to --group NAME, so --group dev selects it.  server extras add Flask etc.
 cd "$REPO_ROOT"
 if [[ -f "uv.lock" ]]; then
-    uv sync --extra server --group dev --quiet
+    if ! uv sync --frozen --extra server --group dev --quiet 2>/dev/null; then
+        echo "WARNING: uv.lock is out of date with pyproject.toml." \
+             "Run 'uv lock' to update it. Falling back to unlocked sync..." >&2
+        uv sync --extra server --group dev --quiet
+    fi
 else
+    if [[ -f "poetry.lock" ]]; then
+        echo "WARNING: No uv.lock found (it is gitignored); install will not" \
+             "enforce pinned versions from poetry.lock." \
+             "Run 'uv lock' to generate a uv.lock for reproducible builds." >&2
+    fi
     [[ -d ".venv" ]] || uv venv .venv
     uv pip install --quiet ".[server]" pyinstaller
 fi

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -24,7 +24,22 @@ sidecar_is_stale() {
     local sidecar="$1"
     # Rebuild when any gptme Python source is newer than the frozen binary.
     # `find -newer` is available in Git Bash on Windows.
-    [[ -n "$(find "$REPO_ROOT/gptme" -name '*.py' -newer "$sidecar" 2>/dev/null | head -n 1)" ]]
+    if [[ -n "$(find "$REPO_ROOT/gptme" -name '*.py' -newer "$sidecar" 2>/dev/null | head -n 1)" ]]; then
+        return 0
+    fi
+    # Also rebuild when packaging/dependency config changes (pyproject.toml,
+    # poetry.lock, uv.lock) — these affect which packages get frozen into the
+    # sidecar even when no .py source file changes.
+    local config_files=("$REPO_ROOT/pyproject.toml")
+    for f in "$REPO_ROOT/poetry.lock" "$REPO_ROOT/uv.lock"; do
+        [[ -f "$f" ]] && config_files+=("$f")
+    done
+    for f in "${config_files[@]}"; do
+        if [[ -f "$f" && "$f" -nt "$sidecar" ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 if [[ -f "$OUT" ]]; then

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -41,6 +41,19 @@ sidecar_is_stale() {
             return 0
         fi
     done
+    # Detect install-path changes caused by uv.lock appearing or disappearing.
+    # If uv.lock was present at last build but has since been deleted (or vice
+    # versa), the install path changes (uv sync vs uv pip install), so the
+    # sidecar would be built with different dependency resolution.  A marker
+    # file records uv.lock presence at build time; any mismatch forces rebuild.
+    local uvlock_marker="${sidecar}.uvlock-present"
+    local uvlock_now=0
+    [[ -f "$REPO_ROOT/uv.lock" ]] && uvlock_now=1
+    local uvlock_was=0
+    [[ -f "$uvlock_marker" ]] && uvlock_was=$(cat "$uvlock_marker")
+    if [[ "$uvlock_now" != "$uvlock_was" ]]; then
+        return 0
+    fi
     return 1
 }
 
@@ -81,12 +94,15 @@ uv run pyinstaller \
     gptme/server/__main__.py
 
 # Rename to include target triple (Tauri sidecar convention)
+_uvlock_state=0; [[ -f "$REPO_ROOT/uv.lock" ]] && _uvlock_state=1
 if [[ -f "$BINS_DIR/gptme-server.exe" ]]; then
     mv "$BINS_DIR/gptme-server.exe" "${BINS_DIR}/gptme-server-${TRIPLE}.exe"
     echo "Sidecar built: ${BINS_DIR}/gptme-server-${TRIPLE}.exe"
+    echo "$_uvlock_state" > "${BINS_DIR}/gptme-server-${TRIPLE}.exe.uvlock-present"
 elif [[ -f "$BINS_DIR/gptme-server" ]]; then
     mv "$BINS_DIR/gptme-server" "$BINS_DIR/gptme-server-${TRIPLE}"
     echo "Sidecar built: $BINS_DIR/gptme-server-${TRIPLE}"
+    echo "$_uvlock_state" > "$BINS_DIR/gptme-server-${TRIPLE}.uvlock-present"
 else
     echo "ERROR: PyInstaller did not produce gptme-server in $BINS_DIR" >&2
     exit 1

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -65,7 +65,8 @@ mkdir -p "$BINS_DIR"
 # to support.  uv sync still installs the exact pinned versions when the lock
 # is already current, so the pin-enforcement goal is preserved.
 # When uv.lock is absent, fall back to uv pip install (original path).
-# pyinstaller is in [tool.uv.dev-dependencies]; server extras add Flask etc.
+# pyinstaller is in [tool.poetry.group.dev.dependencies]; uv maps Poetry groups
+# to --group NAME, so --group dev selects it.  server extras add Flask etc.
 cd "$REPO_ROOT"
 if [[ -f "uv.lock" ]]; then
     uv sync --extra server --group dev --quiet

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -48,9 +48,9 @@ sidecar_is_stale() {
     # file records uv.lock presence at build time; any mismatch forces rebuild.
     local uvlock_marker="${sidecar}.uvlock-present"
     local uvlock_now=0
-    [[ -f "$REPO_ROOT/uv.lock" ]] && uvlock_now=1
+    if [[ -f "$REPO_ROOT/uv.lock" ]]; then uvlock_now=1; fi
     local uvlock_was=0
-    [[ -f "$uvlock_marker" ]] && uvlock_was=$(cat "$uvlock_marker")
+    if [[ -f "$uvlock_marker" ]]; then uvlock_was=$(cat "$uvlock_marker"); fi
     if [[ "$uvlock_now" != "$uvlock_was" ]]; then
         return 0
     fi
@@ -102,7 +102,7 @@ uv run pyinstaller \
     gptme/server/__main__.py
 
 # Rename to include target triple (Tauri sidecar convention)
-_uvlock_state=0; [[ -f "$REPO_ROOT/uv.lock" ]] && _uvlock_state=1
+_uvlock_state=0; if [[ -f "$REPO_ROOT/uv.lock" ]]; then _uvlock_state=1; fi
 if [[ -f "$BINS_DIR/gptme-server.exe" ]]; then
     mv "$BINS_DIR/gptme-server.exe" "${BINS_DIR}/gptme-server-${TRIPLE}.exe"
     echo "Sidecar built: ${BINS_DIR}/gptme-server-${TRIPLE}.exe"

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -28,10 +28,12 @@ sidecar_is_stale() {
         return 0
     fi
     # Also rebuild when packaging/dependency config changes (pyproject.toml,
-    # poetry.lock, uv.lock) — these affect which packages get frozen into the
-    # sidecar even when no .py source file changes.
+    # uv.lock) — these affect which packages get frozen into the sidecar even
+    # when no .py source file changes.  poetry.lock is excluded: the install
+    # path only consults uv.lock, so watching poetry.lock would trigger spurious
+    # rebuilds whose result doesn't reflect the poetry.lock change.
     local config_files=("$REPO_ROOT/pyproject.toml")
-    for f in "$REPO_ROOT/poetry.lock" "$REPO_ROOT/uv.lock"; do
+    for f in "$REPO_ROOT/uv.lock"; do
         [[ -f "$f" ]] && config_files+=("$f")
     done
     for f in "${config_files[@]}"; do
@@ -56,14 +58,17 @@ echo "Building gptme-server sidecar for $TRIPLE..."
 mkdir -p "$BINS_DIR"
 
 # Install gptme from local source into a venv, then freeze with PyInstaller.
-# When uv.lock exists, use uv sync --frozen so a lock-file-triggered rebuild
-# actually installs the pinned versions that caused the staleness.
-# When only poetry.lock exists (or no lock file at all), fall back to
-# uv pip install, which behaves like the original installation path.
-# pyinstaller is in [tool.poetry.group.dev.dependencies]; server extras add Flask etc.
+# When uv.lock exists, use uv sync (without --frozen) so the lock is updated
+# if pyproject.toml changed since the last `uv lock` run.  --frozen would fail
+# when pyproject.toml is newer than uv.lock (e.g. after adding a dep without
+# running `uv lock`), breaking the very workflow that staleness detection exists
+# to support.  uv sync still installs the exact pinned versions when the lock
+# is already current, so the pin-enforcement goal is preserved.
+# When uv.lock is absent, fall back to uv pip install (original path).
+# pyinstaller is in [tool.uv.dev-dependencies]; server extras add Flask etc.
 cd "$REPO_ROOT"
 if [[ -f "uv.lock" ]]; then
-    uv sync --frozen --extra server --group dev --quiet
+    uv sync --extra server --group dev --quiet
 else
     [[ -d ".venv" ]] || uv venv .venv
     uv pip install --quiet ".[server]" pyinstaller

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -28,14 +28,14 @@ sidecar_is_stale() {
         return 0
     fi
     # Also rebuild when packaging/dependency config changes (pyproject.toml,
-    # poetry.lock, uv.lock) — these affect which packages get frozen into the
-    # sidecar even when no .py source file changes.  Both lock files are
-    # checked: poetry.lock is the committed canonical lock; uv.lock may exist
-    # on developer machines and controls the uv sync path.
+    # uv.lock) — these affect which packages get frozen into the sidecar even
+    # when no .py source file changes.  poetry.lock is intentionally excluded:
+    # the install path only consults uv.lock (via uv sync --frozen), so watching
+    # poetry.lock would trigger spurious rebuilds with an identical result.
     local config_files=("$REPO_ROOT/pyproject.toml")
-    for f in "$REPO_ROOT/poetry.lock" "$REPO_ROOT/uv.lock"; do
-        [[ -f "$f" ]] && config_files+=("$f")
-    done
+    if [[ -f "$REPO_ROOT/uv.lock" ]]; then
+        config_files+=("$REPO_ROOT/uv.lock")
+    fi
     for f in "${config_files[@]}"; do
         if [[ -f "$f" && "$f" -nt "$sidecar" ]]; then
             return 0

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -55,11 +55,12 @@ fi
 echo "Building gptme-server sidecar for $TRIPLE..."
 mkdir -p "$BINS_DIR"
 
-# Install gptme from local source into an isolated venv, then freeze with PyInstaller
+# Install gptme from local source into a venv, then freeze with PyInstaller.
+# uv sync --frozen uses uv.lock exactly, so a lock-file-triggered rebuild
+# actually installs the pinned versions that caused the staleness.
+# pyinstaller is in [tool.poetry.group.dev.dependencies]; server extras add Flask etc.
 cd "$REPO_ROOT"
-# uv pip install requires a virtual environment — create one if absent
-[[ -d ".venv" ]] || uv venv .venv
-uv pip install --quiet ".[server]" pyinstaller
+uv sync --frozen --extra server --group dev --quiet
 uv run pyinstaller \
     --onefile \
     --name gptme-server \

--- a/tauri/scripts/build-sidecar.sh
+++ b/tauri/scripts/build-sidecar.sh
@@ -56,11 +56,18 @@ echo "Building gptme-server sidecar for $TRIPLE..."
 mkdir -p "$BINS_DIR"
 
 # Install gptme from local source into a venv, then freeze with PyInstaller.
-# uv sync --frozen uses uv.lock exactly, so a lock-file-triggered rebuild
+# When uv.lock exists, use uv sync --frozen so a lock-file-triggered rebuild
 # actually installs the pinned versions that caused the staleness.
+# When only poetry.lock exists (or no lock file at all), fall back to
+# uv pip install, which behaves like the original installation path.
 # pyinstaller is in [tool.poetry.group.dev.dependencies]; server extras add Flask etc.
 cd "$REPO_ROOT"
-uv sync --frozen --extra server --group dev --quiet
+if [[ -f "uv.lock" ]]; then
+    uv sync --frozen --extra server --group dev --quiet
+else
+    [[ -d ".venv" ]] || uv venv .venv
+    uv pip install --quiet ".[server]" pyinstaller
+fi
 uv run pyinstaller \
     --onefile \
     --name gptme-server \


### PR DESCRIPTION
## Summary

Addresses the remaining Greptile 4/5 finding from #3552.

The `sidecar_is_stale()` function previously only compared `gptme/**/*.py` mtimes against the frozen sidecar binary. If `pyproject.toml` or the lock file changed (e.g. a dependency version bump, new extras, changed packaging options), the existing sidecar binary would be silently reused even though the frozen environment would differ.

**Fix**: also check `pyproject.toml` and any lock file (`poetry.lock`, `uv.lock`) that exists — trigger a rebuild whenever any packaging/dependency config file is newer than the sidecar.

## Changes

- `tauri/scripts/build-sidecar.sh`: expand `sidecar_is_stale()` to check build inputs beyond Python sources

## Test plan

- Delete `tauri/bins/gptme-server-*`, build once to get a fresh sidecar, then `touch pyproject.toml` and confirm `make tauri-build-sidecar` rebuilds.