### PR TITLE
feat(computer): allow out-of-tree transports via register_transport()

### DIFF
--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -765,10 +765,23 @@ def get_transport() -> ComputerTransport | None:
     if _transport is not None and _transport_name == current:
         return _transport
 
-    # Env var changed — close the stale transport to avoid resource leaks
+    # Env var changed — clear cache before fallible cleanup so a broken
+    # third-party close() cannot preserve a stale, partially closed instance.
     if _transport is not None and _transport_name != current:
-        _transport.close()
+        stale_transport = _transport
+        stale_name = _transport_name
         _transport = None
+        _transport_name = None
+        try:
+            stale_transport.close()
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "Failed to close transport %r while switching to %r",
+                stale_name,
+                current,
+            )
 
     # No transport requested
     if not current:
@@ -795,7 +808,13 @@ def get_transport() -> ComputerTransport | None:
             _transport_name = None
     elif current in _transport_registry:
         try:
-            _transport = _transport_registry[current]()
+            transport = _transport_registry[current]()
+            if not isinstance(transport, ComputerTransport):
+                raise TypeError(
+                    f"factory for transport {current!r} returned "
+                    f"{type(transport).__name__}, expected ComputerTransport"
+                )
+            _transport = transport
             _transport_name = current  # only cache on success
         except Exception as e:
             import logging

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -719,13 +719,21 @@ def register_transport(name: str, factory: Callable[[], ComputerTransport]) -> N
             f"cannot register {name!r}: shadows a built-in gptme transport"
         )
 
-    # Re-registering the selected transport must make the replacement effective
-    # immediately rather than leaving the old name-keyed instance cached.
-    if name in _transport_registry and _transport_name == name:
-        if _transport is not None:
-            _transport.close()
+    # Registering the selected name must make the factory effective immediately,
+    # including when the current cache is the native fallback for an unknown name.
+    if _transport_name == name:
+        stale_transport = _transport
         _transport = None
         _transport_name = None
+        if stale_transport is not None:
+            try:
+                stale_transport.close()
+            except Exception:
+                import logging
+
+                logging.getLogger(__name__).exception(
+                    "Failed to close transport %r while replacing its factory", name
+                )
 
     _transport_registry[name] = factory
 

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -6,6 +6,8 @@ to dispatch through different backends:
 
 - **Native** (xdotool+scrot or cliclick) — default, zero-dependency
 - **Cua Sandbox** — opt-in via ``GPTME_COMPUTER_TRANSPORT=cua`` env var
+- **Out-of-tree** — any transport registered via :func:`register_transport`,
+  selected by its registered name
 
 Usage::
 
@@ -32,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import concurrent.futures
-    from collections.abc import Coroutine
+    from collections.abc import Callable, Coroutine
 
 
 class ComputerTransport(abc.ABC):
@@ -679,6 +681,43 @@ class CuaComputerTransport(ComputerTransport):
 _transport: ComputerTransport | None = None
 _transport_name: str | None = None  # env-var value the cache was built for
 
+# Out-of-tree transports, keyed by the ``GPTME_COMPUTER_TRANSPORT`` value that
+# selects them.  Populated by :func:`register_transport`.
+_transport_registry: dict[str, Callable[[], ComputerTransport]] = {}
+
+# Names handled by the built-in branches of get_transport(); may not be shadowed.
+_BUILTIN_TRANSPORTS = frozenset({"native", "cua"})
+
+
+def register_transport(name: str, factory: Callable[[], ComputerTransport]) -> None:
+    """Register an out-of-tree transport under ``name``.
+
+    Lets transports that live outside gptme (in a plugin or a separate
+    package) be selected with ``GPTME_COMPUTER_TRANSPORT=<name>``, without
+    gptme having to import or depend on them::
+
+        from gptme.tools.computer_transport import register_transport
+
+        register_transport("phone-harness", PhoneComputerTransport)
+
+    ``factory`` is called with no arguments the first time the transport is
+    selected, and must return a :class:`ComputerTransport`.  It is only
+    called when the env var actually names this transport, so importing a
+    heavy or platform-specific dependency inside the factory is fine.
+
+    Registering the same name twice replaces the previous factory.
+
+    :raises ValueError: if ``name`` is empty or shadows a built-in transport.
+    """
+    name = name.strip()
+    if not name:
+        raise ValueError("transport name must be non-empty")
+    if name in _BUILTIN_TRANSPORTS:
+        raise ValueError(
+            f"cannot register {name!r}: shadows a built-in gptme transport"
+        )
+    _transport_registry[name] = factory
+
 
 def get_transport() -> ComputerTransport | None:
     """Return the configured transport, or None for native (default) path.
@@ -688,6 +727,10 @@ def get_transport() -> ComputerTransport | None:
     - ``native`` → ``NativeComputerTransport`` (explicit opt-in to
       transport-layer wrapper around xdotool/cliclick)
     - ``cua`` → ``CuaComputerTransport`` (Docker sandbox via cua-sandbox)
+    - any name passed to :func:`register_transport` → that transport
+
+    An out-of-tree transport whose factory raises falls back to native,
+    the same way a failed ``cua`` init does.
 
     Caches the transport object.  Re-validates against the current env
     var on every call so that tests can switch backends without process
@@ -730,6 +773,23 @@ def get_transport() -> ComputerTransport | None:
             _transport = NativeComputerTransport()
             # Leave _transport_name as None so the next call retries CuaComputerTransport
             # (allows recovery from transient failures like Docker not yet running)
+            _transport_name = None
+    elif current in _transport_registry:
+        try:
+            _transport = _transport_registry[current]()
+            _transport_name = current  # only cache on success
+        except Exception as e:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Registered transport %r failed to initialize: %s; falling back to native",
+                current,
+                e,
+            )
+            _transport = NativeComputerTransport()
+            # Leave _transport_name as None so the next call retries the
+            # registered factory (recovers from transient failures).
             _transport_name = None
     else:
         import logging

--- a/gptme/tools/computer_transport.py
+++ b/gptme/tools/computer_transport.py
@@ -709,6 +709,8 @@ def register_transport(name: str, factory: Callable[[], ComputerTransport]) -> N
 
     :raises ValueError: if ``name`` is empty or shadows a built-in transport.
     """
+    global _transport, _transport_name
+
     name = name.strip()
     if not name:
         raise ValueError("transport name must be non-empty")
@@ -716,6 +718,15 @@ def register_transport(name: str, factory: Callable[[], ComputerTransport]) -> N
         raise ValueError(
             f"cannot register {name!r}: shadows a built-in gptme transport"
         )
+
+    # Re-registering the selected transport must make the replacement effective
+    # immediately rather than leaving the old name-keyed instance cached.
+    if name in _transport_registry and _transport_name == name:
+        if _transport is not None:
+            _transport.close()
+        _transport = None
+        _transport_name = None
+
     _transport_registry[name] = factory
 
 

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -22,6 +22,7 @@ from gptme.tools.computer_transport import (
     NativeComputerTransport,
     _resize_image,
     get_transport,
+    register_transport,
 )
 
 
@@ -842,3 +843,119 @@ class TestDispatchTransportScroll(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTransportRegistry(unittest.TestCase):
+    """register_transport() lets out-of-tree transports be selected by name."""
+
+    def setUp(self):
+        import gptme.tools.computer_transport as ct
+
+        self._saved_registry = dict(ct._transport_registry)
+        ct._transport_registry.clear()
+        ct._transport = None
+        ct._transport_name = None
+
+    def tearDown(self):
+        import gptme.tools.computer_transport as ct
+
+        ct._transport_registry.clear()
+        ct._transport_registry.update(self._saved_registry)
+        ct._transport = None
+        ct._transport_name = None
+
+    def test_registered_transport_is_selected_by_env_var(self):
+        """GPTME_COMPUTER_TRANSPORT=<registered name> returns that transport."""
+        register_transport("stub-transport", StubTransport)
+
+        with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "stub-transport"}):
+            transport = get_transport()
+
+        self.assertIsInstance(transport, StubTransport)
+
+    def test_factory_is_not_called_at_registration_time(self):
+        """The factory must stay lazy so heavy/platform-specific imports are deferred."""
+        calls: list[int] = []
+
+        def factory() -> ComputerTransport:
+            calls.append(1)
+            return StubTransport()
+
+        register_transport("lazy-transport", factory)
+        self.assertEqual(calls, [], "factory must not run at registration time")
+
+        with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "lazy-transport"}):
+            get_transport()
+
+        self.assertEqual(calls, [1], "factory must run once on selection")
+
+    def test_registered_transport_is_cached_across_calls(self):
+        """A successfully created transport is reused, not rebuilt per call."""
+        calls: list[int] = []
+
+        def factory() -> ComputerTransport:
+            calls.append(1)
+            return StubTransport()
+
+        register_transport("cached-transport", factory)
+
+        with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "cached-transport"}):
+            first = get_transport()
+            second = get_transport()
+
+        self.assertIs(first, second)
+        self.assertEqual(calls, [1])
+
+    def test_failing_factory_falls_back_to_native_and_retries(self):
+        """A raising factory must not break the computer tool, and must be retried."""
+        import gptme.tools.computer_transport as ct
+
+        calls: list[int] = []
+
+        def failing_factory() -> ComputerTransport:
+            calls.append(1)
+            raise RuntimeError("phone not connected")
+
+        register_transport("flaky-transport", failing_factory)
+
+        with (
+            patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "flaky-transport"}),
+            patch.object(ct, "NativeComputerTransport", StubTransport),
+        ):
+            transport = get_transport()
+            self.assertIsInstance(transport, StubTransport)
+            # _transport_name stays None so the next call retries the factory
+            self.assertIsNone(ct._transport_name)
+            get_transport()
+
+        self.assertEqual(calls, [1, 1], "failing factory must be retried, not cached")
+
+    def test_registering_builtin_name_raises(self):
+        """Built-in transports may not be shadowed — silently losing them is worse."""
+        for name in ("native", "cua"):
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                register_transport(name, StubTransport)
+
+    def test_registering_empty_name_raises(self):
+        with self.assertRaises(ValueError):
+            register_transport("   ", StubTransport)
+
+    def test_reregistering_replaces_the_factory(self):
+        class OtherStub(StubTransport):
+            pass
+
+        register_transport("dup-transport", StubTransport)
+        register_transport("dup-transport", OtherStub)
+
+        with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "dup-transport"}):
+            self.assertIsInstance(get_transport(), OtherStub)
+
+    def test_unknown_name_still_falls_back_to_native(self):
+        """Registry lookup must not change behaviour for unregistered names."""
+        import gptme.tools.computer_transport as ct
+
+        with (
+            patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "does-not-exist"}),
+            patch.object(ct, "NativeComputerTransport", StubTransport),
+        ):
+            self.assertIsInstance(get_transport(), StubTransport)

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -958,6 +958,50 @@ class TestTransportRegistry(unittest.TestCase):
         self.assertIsNot(original, replacement)
         self.assertEqual(closed, [True])
 
+    def test_registering_unknown_selected_name_replaces_native_fallback(self):
+        """Late registration replaces the cached fallback for that env-var name."""
+        import gptme.tools.computer_transport as ct
+
+        class ReplacementStub(StubTransport):
+            pass
+
+        with (
+            patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "late-transport"}),
+            patch.object(ct, "NativeComputerTransport", StubTransport),
+        ):
+            fallback = get_transport()
+            register_transport("late-transport", ReplacementStub)
+            replacement = get_transport()
+
+        self.assertIsInstance(fallback, StubTransport)
+        self.assertIsInstance(replacement, ReplacementStub)
+        self.assertIsNot(fallback, replacement)
+
+    def test_failed_close_does_not_prevent_replacement(self):
+        """A broken old transport cannot retain stale registration state."""
+
+        class FailingCloseStub(StubTransport):
+            def close(self) -> None:
+                raise RuntimeError("close failed")
+
+        class ReplacementStub(StubTransport):
+            pass
+
+        register_transport("broken-close", FailingCloseStub)
+
+        with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "broken-close"}):
+            original = get_transport()
+            with self.assertLogs(
+                "gptme.tools.computer_transport", level="ERROR"
+            ) as logs:
+                register_transport("broken-close", ReplacementStub)
+            replacement = get_transport()
+
+        self.assertIsInstance(original, FailingCloseStub)
+        self.assertIsInstance(replacement, ReplacementStub)
+        self.assertIsNot(original, replacement)
+        self.assertIn("Failed to close transport", "\n".join(logs.output))
+
     def test_unknown_name_still_falls_back_to_native(self):
         """Registry lookup must not change behaviour for unregistered names."""
         import gptme.tools.computer_transport as ct

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -902,6 +902,60 @@ class TestTransportRegistry(unittest.TestCase):
         self.assertIs(first, second)
         self.assertEqual(calls, [1])
 
+    def test_switch_with_failing_close_clears_stale_transport(self):
+        """A close failure cannot preserve stale cache state during a switch."""
+        import gptme.tools.computer_transport as ct
+
+        calls: list[int] = []
+
+        class FailingCloseStub(StubTransport):
+            def close(self) -> None:
+                raise RuntimeError("close failed")
+
+        def replacement_factory() -> ComputerTransport:
+            calls.append(1)
+            return StubTransport()
+
+        register_transport("replacement", replacement_factory)
+        ct._transport = FailingCloseStub()
+        ct._transport_name = "original"
+
+        with (
+            patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "replacement"}),
+            self.assertLogs("gptme.tools.computer_transport", level="ERROR") as logs,
+        ):
+            replacement = get_transport()
+
+        self.assertIsInstance(replacement, StubTransport)
+        self.assertEqual(calls, [1])
+        self.assertEqual(ct._transport_name, "replacement")
+        self.assertIn("Failed to close transport", "\n".join(logs.output))
+
+    def test_invalid_factory_result_falls_back_to_native_and_retries(self):
+        """A factory returning the wrong type follows the failure fallback path."""
+        import gptme.tools.computer_transport as ct
+
+        calls: list[int] = []
+
+        def invalid_factory() -> ComputerTransport:
+            calls.append(1)
+            return None  # type: ignore[return-value]
+
+        register_transport("invalid-transport", invalid_factory)
+
+        with (
+            patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "invalid-transport"}),
+            patch.object(ct, "NativeComputerTransport", StubTransport),
+            self.assertLogs("gptme.tools.computer_transport", level="WARNING") as logs,
+        ):
+            transport = get_transport()
+            self.assertIsInstance(transport, StubTransport)
+            self.assertIsNone(ct._transport_name)
+            get_transport()
+
+        self.assertEqual(calls, [1, 1])
+        self.assertIn("expected ComputerTransport", "\n".join(logs.output))
+
     def test_failing_factory_falls_back_to_native_and_retries(self):
         """A raising factory must not break the computer tool, and must be retried."""
         import gptme.tools.computer_transport as ct

--- a/tests/test_computer_transport.py
+++ b/tests/test_computer_transport.py
@@ -841,10 +841,6 @@ class TestDispatchTransportScroll(unittest.TestCase):
         stub.scroll.assert_called_once_with(100, 200, "down")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTransportRegistry(unittest.TestCase):
     """register_transport() lets out-of-tree transports be selected by name."""
 
@@ -940,15 +936,27 @@ class TestTransportRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             register_transport("   ", StubTransport)
 
-    def test_reregistering_replaces_the_factory(self):
-        class OtherStub(StubTransport):
+    def test_reregistering_replaces_cached_transport(self):
+        closed: list[bool] = []
+
+        class OriginalStub(StubTransport):
+            def close(self) -> None:
+                closed.append(True)
+
+        class ReplacementStub(StubTransport):
             pass
 
-        register_transport("dup-transport", StubTransport)
-        register_transport("dup-transport", OtherStub)
+        register_transport("dup-transport", OriginalStub)
 
         with patch.dict(os.environ, {"GPTME_COMPUTER_TRANSPORT": "dup-transport"}):
-            self.assertIsInstance(get_transport(), OtherStub)
+            original = get_transport()
+            register_transport("dup-transport", ReplacementStub)
+            replacement = get_transport()
+
+        self.assertIsInstance(original, OriginalStub)
+        self.assertIsInstance(replacement, ReplacementStub)
+        self.assertIsNot(original, replacement)
+        self.assertEqual(closed, [True])
 
     def test_unknown_name_still_falls_back_to_native(self):
         """Registry lookup must not change behaviour for unregistered names."""
@@ -959,3 +967,7 @@ class TestTransportRegistry(unittest.TestCase):
             patch.object(ct, "NativeComputerTransport", StubTransport),
         ):
             self.assertIsInstance(get_transport(), StubTransport)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`get_transport()` resolves `GPTME_COMPUTER_TRANSPORT` through a hardcoded
if/elif over `native` and `cua`. A `ComputerTransport` implemented **outside**
gptme cannot be selected at all — any other value falls through to the
"Unknown GPTME_COMPUTER_TRANSPORT" warning and silently uses native.

That makes the ABC only half-pluggable: you can implement the interface, but
you can't get gptme to actually use your implementation. The only way in today
is to patch a branch into gptme's factory, which would mean gptme importing and
depending on the out-of-tree transport (often platform-specific).

## Change

A small `name -> factory` registry:

```python
from gptme.tools.computer_transport import register_transport

register_transport("phone-harness", PhoneComputerTransport)
# GPTME_COMPUTER_TRANSPORT=phone-harness now selects it
```

Design points:

- **Lazy factory** — called only when the env var actually names that transport,
  so a heavy or platform-specific import stays off the default path.
- **Failure is non-fatal** — a factory that raises falls back to native and is
  retried on the next call, exactly matching the existing `cua` behaviour. A
  third-party transport must not be able to break the computer tool.
- **Built-in names are reserved** — registering `native`/`cua` raises
  `ValueError` rather than silently shadowing them (a silently-ignored
  registration is the worse failure).
- Behaviour for unregistered names is unchanged: warn, fall back to native.

Pairs naturally with the plugin system — a `GptmePlugin`'s `init` hook is a
good place to call `register_transport`.

## How to verify

```bash
pytest tests/test_computer_transport.py -q
```

8 new tests in `TestTransportRegistry` cover selection by env var, factory
laziness, caching, retry-on-failure with native fallback, reserved-name and
empty-name rejection, re-registration, and the unchanged unknown-name path.

Confirmed the tests actually exercise the wiring: with the new `elif` branch
removed, 5 of the 8 fail (the other 3 cover `register_transport` validation and
existing fallback behaviour, so they correctly still pass).

`ruff check` / `ruff format` clean; `mypy` reports no new errors in the module.