### PR TITLE
feat(shell): stream one-shot command output while it runs

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -545,7 +545,9 @@ class ShellSession:
                     if output:
                         print(text, end="", file=sys.stderr)
 
-            def finish_readers() -> None:
+            def finish_readers(*, stop: bool = False) -> None:
+                if stop:
+                    stop_readers.set()
                 t_out.join()
                 t_err.join()
                 while True:
@@ -562,7 +564,7 @@ class ShellSession:
                         if elapsed >= timeout:
                             proc.kill()
                             proc.wait()
-                            finish_readers()
+                            finish_readers(stop=True)
                             return (
                                 -124,
                                 trim_blank_lines("".join(stdout_chunks)),
@@ -590,18 +592,16 @@ class ShellSession:
                 print()
                 proc.kill()
                 proc.wait()
-                finish_readers()
+                finish_readers(stop=True)
                 partial_stdout = trim_blank_lines("".join(stdout_chunks))
                 partial_stderr = trim_blank_lines("".join(stderr_chunks))
                 raise KeyboardInterrupt((partial_stdout, partial_stderr)) from None
 
             proc.wait()
-            if sentinels < 2:
-                # A background descendant retained the pipes. The idle grace
-                # period drained this command's output; now stop and reap the
-                # readers without waiting for the descendant to exit.
-                stop_readers.set()
-            finish_readers()
+            # A background descendant may retain the pipes. The idle grace
+            # period drained this command's output; stop the readers only when
+            # they have not already observed EOF.
+            finish_readers(stop=sentinels < 2)
         finally:
             tty_stdin.close()
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -501,16 +501,21 @@ class ShellSession:
             stop_readers = threading.Event()
 
             def _reader(src: IO[bytes], tag: str) -> None:
+                fd = src.fileno()
                 try:
-                    fd = src.fileno()
-                    while not stop_readers.is_set():
+                    while True:
                         readable, _, _ = select.select([fd], [], [], 0.1)
                         if not readable:
+                            if stop_readers.is_set():
+                                break
                             continue
                         chunk = os.read(fd, 2**16)
                         if not chunk:
                             break
                         data_q.put((tag, chunk))
+                except OSError:
+                    if not stop_readers.is_set():
+                        raise
                 finally:
                     data_q.put(None)  # one sentinel per thread
 
@@ -531,6 +536,7 @@ class ShellSession:
             }
             sentinels = 0
             exited_at: float | None = None
+            exit_code: int | None = None
             start_time = time.monotonic() if timeout is not None else None
 
             def append_text(tag: str, text: str) -> None:
@@ -557,6 +563,10 @@ class ShellSession:
             def finish_readers(*, stop: bool = False) -> None:
                 if stop:
                     stop_readers.set()
+                    if proc.stdout is not None:
+                        proc.stdout.close()
+                    if proc.stderr is not None:
+                        proc.stderr.close()
                 t_out.join()
                 t_err.join()
                 while True:
@@ -569,8 +579,14 @@ class ShellSession:
 
             try:
                 while sentinels < 2:
-                    # Check overall timeout
-                    if timeout is not None and start_time is not None:
+                    # The caller timeout applies while the direct child is running.
+                    # Once it exits, use the separate post-exit grace below: a
+                    # descendant retaining the pipes must not turn success into -124.
+                    if (
+                        exit_code is None
+                        and timeout is not None
+                        and start_time is not None
+                    ):
                         elapsed = time.monotonic() - start_time
                         if elapsed >= timeout:
                             if proc.poll() is None:
@@ -591,13 +607,15 @@ class ShellSession:
                     except Empty:
                         pass
 
-                    if proc.poll() is not None:
-                        if exited_at is None:
+                    if exit_code is None:
+                        polled = proc.poll()
+                        if polled is not None:
+                            exit_code = polled
                             exited_at = time.monotonic()
-                        elif time.monotonic() - exited_at >= 1.0:
-                            # Bound the total post-exit drain time: a background
-                            # descendant may retain and continuously write to a pipe.
-                            break
+                    elif exited_at is not None and time.monotonic() - exited_at >= 1.0:
+                        # Bound the total post-exit drain time: a background
+                        # descendant may retain and continuously write to a pipe.
+                        break
             except KeyboardInterrupt:
                 print()
                 if proc.poll() is None:
@@ -608,16 +626,17 @@ class ShellSession:
                 partial_stderr = trim_blank_lines("".join(stderr_chunks))
                 raise KeyboardInterrupt((partial_stdout, partial_stderr)) from None
 
-            proc.wait()
-            # A background descendant may retain the pipes. The idle grace
-            # period drained this command's output; stop the readers only when
-            # they have not already observed EOF.
+            if exit_code is None:
+                exit_code = proc.wait()
+            # A background descendant may retain the pipes. Signal the readers
+            # after the grace; each reader still consumes one final readable
+            # chunk so data already buffered in the pipe is not discarded.
             finish_readers(stop=sentinels < 2)
         finally:
             tty_stdin.close()
 
         return (
-            proc.returncode,
+            exit_code,
             trim_blank_lines("".join(stdout_chunks)),
             trim_blank_lines("".join(stderr_chunks)),
         )

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -563,6 +563,16 @@ class ShellSession:
             def finish_readers(*, stop: bool = False) -> None:
                 if stop:
                     stop_readers.set()
+                    t_out.join(timeout=0.2)
+                    t_err.join(timeout=0.2)
+                    # Drain data already enqueued by the threads before closing
+                    # pipes, so we don't discard output they buffered during the
+                    # grace window.
+                    while True:
+                        try:
+                            consume(data_q.get_nowait())
+                        except Empty:
+                            break
                     if proc.stdout is not None:
                         proc.stdout.close()
                     if proc.stderr is not None:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -37,7 +37,7 @@ import time
 from collections.abc import Generator
 from contextvars import ContextVar
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 from ..message import Message
 from ..sandbox import (
@@ -449,8 +449,15 @@ class ShellSession:
         try:
             tty_stdin = open("/dev/tty", "rb")
         except OSError:
-            logger.warning("Could not open /dev/tty, falling back to normal run")
-            return self._run_pipe(command, output=output, timeout=timeout)
+            # /dev/tty is unavailable (CI, non-TTY container, etc.).  Don't fall
+            # back to _run_pipe: that uses the persistent bash session, so shell
+            # builtins like 'exit' would kill the session and deadlock the
+            # delimiter-read loop.  Instead keep spawning a fresh subprocess (which
+            # is what this method does) but with /dev/null as stdin — sudo won't
+            # be able to prompt for a password, but non-interactive commands work
+            # correctly and the pipe EOF is always clean.
+            logger.warning("Could not open /dev/tty, using /dev/null as stdin")
+            tty_stdin = open("/dev/null", "rb")
 
         try:
             # Inherit session env overrides so sudo commands behave consistently
@@ -480,33 +487,125 @@ class ShellSession:
                 cwd=self._cwd or os.getcwd(),
                 env=session_env,
             )
+            assert proc.stdout is not None and proc.stderr is not None
+
+            from queue import Empty, Queue
+
+            # Use threads to drain stdout and stderr concurrently — the same
+            # mechanism as communicate(), but with real-time printing as data
+            # arrives. select() alone is unreliable when /dev/tty is the child's
+            # stdin and the process produces no output before exiting.
+            data_q: Queue[tuple[str, bytes] | None] = Queue()
+
+            def _reader(src: IO[bytes], tag: str) -> None:
+                try:
+                    while True:
+                        chunk = src.read(2**16)
+                        if not chunk:
+                            break
+                        data_q.put((tag, chunk))
+                finally:
+                    data_q.put(None)  # one sentinel per thread
+
+            t_out = threading.Thread(
+                target=_reader, args=(proc.stdout, "out"), daemon=True
+            )
+            t_err = threading.Thread(
+                target=_reader, args=(proc.stderr, "err"), daemon=True
+            )
+            t_out.start()
+            t_err.start()
+
+            stdout_chunks: list[str] = []
+            stderr_chunks: list[str] = []
+            sentinels = 0
+            start_time = time.time() if timeout else None
+
             try:
-                stdout_data, stderr_data = proc.communicate(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                stdout_data, stderr_data = proc.communicate()
-                stdout_str = trim_blank_lines(
-                    stdout_data.decode("utf-8", errors="replace")
-                )
-                stderr_str = trim_blank_lines(
-                    stderr_data.decode("utf-8", errors="replace")
-                )
-                return -124, stdout_str, stderr_str
+                while sentinels < 2:
+                    # Check overall timeout
+                    if timeout and start_time:
+                        elapsed = time.time() - start_time
+                        if elapsed >= timeout:
+                            proc.kill()
+                            t_out.join(timeout=1.0)
+                            t_err.join(timeout=1.0)
+                            # Drain anything the reader threads buffered before
+                            # being killed — the timeout check fires before the
+                            # queue is consumed, so data can sit in the queue.
+                            while True:
+                                try:
+                                    _item = data_q.get_nowait()
+                                except Empty:
+                                    break
+                                if _item is not None:
+                                    _tag, _chunk = _item
+                                    _text = _chunk.decode("utf-8", errors="replace")
+                                    if _tag == "out":
+                                        stdout_chunks.append(_text)
+                                        if output:
+                                            print(_text, end="", file=sys.stdout)
+                                    else:
+                                        stderr_chunks.append(_text)
+                                        if output:
+                                            print(_text, end="", file=sys.stderr)
+                            return (
+                                -124,
+                                trim_blank_lines("".join(stdout_chunks)),
+                                trim_blank_lines("".join(stderr_chunks)),
+                            )
+                        get_timeout = min(0.05, timeout - elapsed)
+                    else:
+                        get_timeout = 0.05
+
+                    try:
+                        item = data_q.get(timeout=get_timeout)
+                    except Empty:
+                        # If the process has already exited but the pipe write-ends
+                        # haven't delivered EOF yet (can happen when /dev/tty is stdin
+                        # and the process produced no output), break rather than
+                        # spinning forever waiting for reader-thread sentinels.
+                        if proc.poll() is not None:
+                            break
+                        continue
+
+                    if item is None:
+                        sentinels += 1
+                        continue
+
+                    tag, chunk = item
+                    text = chunk.decode("utf-8", errors="replace")
+                    if tag == "out":
+                        stdout_chunks.append(text)
+                        if output:
+                            print(text, end="", file=sys.stdout)
+                    else:
+                        stderr_chunks.append(text)
+                        if output:
+                            print(text, end="", file=sys.stderr)
             except KeyboardInterrupt:
+                print()
                 proc.kill()
-                proc.communicate()
-                raise
+                t_out.join(timeout=1.0)
+                t_err.join(timeout=1.0)
+                partial_stdout = trim_blank_lines("".join(stdout_chunks))
+                partial_stderr = trim_blank_lines("".join(stderr_chunks))
+                raise KeyboardInterrupt((partial_stdout, partial_stderr)) from None
+
+            # Threads are daemon threads; join with timeout in case they're
+            # blocked on read() due to pipes not signalling EOF (TTY-stdin edge
+            # case). They'll be garbage-collected when proc.stdout/stderr close.
+            t_out.join(timeout=1.0)
+            t_err.join(timeout=1.0)
+            proc.wait()
         finally:
             tty_stdin.close()
 
-        stdout_str = trim_blank_lines(stdout_data.decode("utf-8", errors="replace"))
-        stderr_str = trim_blank_lines(stderr_data.decode("utf-8", errors="replace"))
-        if output:
-            if stdout_str:
-                print(stdout_str, file=sys.stdout)
-            if stderr_str:
-                print(stderr_str, file=sys.stderr)
-        return proc.returncode, stdout_str, stderr_str
+        return (
+            proc.returncode,
+            trim_blank_lines("".join(stdout_chunks)),
+            trim_blank_lines("".join(stderr_chunks)),
+        )
 
     def _run(
         self, command: str, output=True, tries=0, timeout: float | None = None

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -578,7 +578,7 @@ class ShellSession:
                     append_text(tag, decoder.decode(b"", final=True))
 
             try:
-                while sentinels < 2:
+                while sentinels < 2 or exit_code is None:
                     # The caller timeout applies while the direct child is running.
                     # Once it exits, use the separate post-exit grace below: a
                     # descendant retaining the pipes must not turn success into -124.

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -615,6 +615,7 @@ class ShellSession:
                     elif exited_at is not None and time.monotonic() - exited_at >= 1.0:
                         # Bound the total post-exit drain time: a background
                         # descendant may retain and continuously write to a pipe.
+                        stop_readers.set()
                         break
             except KeyboardInterrupt:
                 print()

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -599,15 +599,21 @@ class ShellSession:
                     ):
                         elapsed = time.monotonic() - start_time
                         if elapsed >= timeout:
-                            if proc.poll() is None:
+                            polled = proc.poll()
+                            if polled is None:
                                 proc.kill()
-                            proc.wait()
-                            finish_readers(stop=True)
-                            return (
-                                -124,
-                                trim_blank_lines("".join(stdout_chunks)),
-                                trim_blank_lines("".join(stderr_chunks)),
-                            )
+                                proc.wait()
+                                finish_readers(stop=True)
+                                return (
+                                    -124,
+                                    trim_blank_lines("".join(stdout_chunks)),
+                                    trim_blank_lines("".join(stderr_chunks)),
+                                )
+                            # Child exited just before the deadline; honour
+                            # the real exit code rather than returning -124.
+                            exit_code = polled
+                            exited_at = time.monotonic()
+                            continue
                         get_timeout = min(0.05, timeout - elapsed)
                     else:
                         get_timeout = 0.05

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -24,6 +24,7 @@ Configuration:
 """
 
 import atexit
+import codecs
 import logging
 import os
 import re
@@ -524,18 +525,17 @@ class ShellSession:
 
             stdout_chunks: list[str] = []
             stderr_chunks: list[str] = []
+            decoders = {
+                "out": codecs.getincrementaldecoder("utf-8")(errors="replace"),
+                "err": codecs.getincrementaldecoder("utf-8")(errors="replace"),
+            }
             sentinels = 0
-            proc_exited_at: float | None = None
+            exited_at: float | None = None
             start_time = time.monotonic() if timeout is not None else None
 
-            def consume(item: tuple[str, bytes] | None) -> None:
-                nonlocal sentinels
-                if item is None:
-                    sentinels += 1
+            def append_text(tag: str, text: str) -> None:
+                if not text:
                     return
-
-                tag, chunk = item
-                text = chunk.decode("utf-8", errors="replace")
                 if tag == "out":
                     stdout_chunks.append(text)
                     if output:
@@ -544,6 +544,15 @@ class ShellSession:
                     stderr_chunks.append(text)
                     if output:
                         print(text, end="", file=sys.stderr)
+
+            def consume(item: tuple[str, bytes] | None) -> None:
+                nonlocal sentinels
+                if item is None:
+                    sentinels += 1
+                    return
+
+                tag, chunk = item
+                append_text(tag, decoders[tag].decode(chunk))
 
             def finish_readers(*, stop: bool = False) -> None:
                 if stop:
@@ -555,6 +564,8 @@ class ShellSession:
                         consume(data_q.get_nowait())
                     except Empty:
                         break
+                for tag, decoder in decoders.items():
+                    append_text(tag, decoder.decode(b"", final=True))
 
             try:
                 while sentinels < 2:
@@ -562,7 +573,8 @@ class ShellSession:
                     if timeout is not None and start_time is not None:
                         elapsed = time.monotonic() - start_time
                         if elapsed >= timeout:
-                            proc.kill()
+                            if proc.poll() is None:
+                                proc.kill()
                             proc.wait()
                             finish_readers(stop=True)
                             return (
@@ -576,21 +588,20 @@ class ShellSession:
 
                     try:
                         consume(data_q.get(timeout=get_timeout))
-                        # Only an idle queue starts the post-exit grace period.
-                        # Resetting this on every chunk lets a fast-exiting command
-                        # drain arbitrarily large buffered output without truncation.
-                        proc_exited_at = None
                     except Empty:
-                        if proc.poll() is not None:
-                            if proc_exited_at is None:
-                                proc_exited_at = time.monotonic()
-                            elif time.monotonic() - proc_exited_at >= 1.0:
-                                # A background descendant can inherit the pipes,
-                                # preventing EOF after the command itself exits.
-                                break
+                        pass
+
+                    if proc.poll() is not None:
+                        if exited_at is None:
+                            exited_at = time.monotonic()
+                        elif time.monotonic() - exited_at >= 1.0:
+                            # Bound the total post-exit drain time: a background
+                            # descendant may retain and continuously write to a pipe.
+                            break
             except KeyboardInterrupt:
                 print()
-                proc.kill()
+                if proc.poll() is None:
+                    proc.kill()
                 proc.wait()
                 finish_readers(stop=True)
                 partial_stdout = trim_blank_lines("".join(stdout_chunks))

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -497,10 +497,16 @@ class ShellSession:
             # stdin and the process produces no output before exiting.
             data_q: Queue[tuple[str, bytes] | None] = Queue()
 
+            stop_readers = threading.Event()
+
             def _reader(src: IO[bytes], tag: str) -> None:
                 try:
-                    while True:
-                        chunk = src.read(2**16)
+                    fd = src.fileno()
+                    while not stop_readers.is_set():
+                        readable, _, _ = select.select([fd], [], [], 0.1)
+                        if not readable:
+                            continue
+                        chunk = os.read(fd, 2**16)
                         if not chunk:
                             break
                         data_q.put((tag, chunk))
@@ -519,36 +525,44 @@ class ShellSession:
             stdout_chunks: list[str] = []
             stderr_chunks: list[str] = []
             sentinels = 0
-            start_time = time.time() if timeout else None
+            proc_exited_at: float | None = None
+            start_time = time.monotonic() if timeout is not None else None
+
+            def consume(item: tuple[str, bytes] | None) -> None:
+                nonlocal sentinels
+                if item is None:
+                    sentinels += 1
+                    return
+
+                tag, chunk = item
+                text = chunk.decode("utf-8", errors="replace")
+                if tag == "out":
+                    stdout_chunks.append(text)
+                    if output:
+                        print(text, end="", file=sys.stdout)
+                else:
+                    stderr_chunks.append(text)
+                    if output:
+                        print(text, end="", file=sys.stderr)
+
+            def finish_readers() -> None:
+                t_out.join()
+                t_err.join()
+                while True:
+                    try:
+                        consume(data_q.get_nowait())
+                    except Empty:
+                        break
 
             try:
                 while sentinels < 2:
                     # Check overall timeout
-                    if timeout and start_time:
-                        elapsed = time.time() - start_time
+                    if timeout is not None and start_time is not None:
+                        elapsed = time.monotonic() - start_time
                         if elapsed >= timeout:
                             proc.kill()
-                            t_out.join(timeout=1.0)
-                            t_err.join(timeout=1.0)
-                            # Drain anything the reader threads buffered before
-                            # being killed — the timeout check fires before the
-                            # queue is consumed, so data can sit in the queue.
-                            while True:
-                                try:
-                                    _item = data_q.get_nowait()
-                                except Empty:
-                                    break
-                                if _item is not None:
-                                    _tag, _chunk = _item
-                                    _text = _chunk.decode("utf-8", errors="replace")
-                                    if _tag == "out":
-                                        stdout_chunks.append(_text)
-                                        if output:
-                                            print(_text, end="", file=sys.stdout)
-                                    else:
-                                        stderr_chunks.append(_text)
-                                        if output:
-                                            print(_text, end="", file=sys.stderr)
+                            proc.wait()
+                            finish_readers()
                             return (
                                 -124,
                                 trim_blank_lines("".join(stdout_chunks)),
@@ -559,45 +573,35 @@ class ShellSession:
                         get_timeout = 0.05
 
                     try:
-                        item = data_q.get(timeout=get_timeout)
+                        consume(data_q.get(timeout=get_timeout))
+                        # Only an idle queue starts the post-exit grace period.
+                        # Resetting this on every chunk lets a fast-exiting command
+                        # drain arbitrarily large buffered output without truncation.
+                        proc_exited_at = None
                     except Empty:
-                        # If the process has already exited but the pipe write-ends
-                        # haven't delivered EOF yet (can happen when /dev/tty is stdin
-                        # and the process produced no output), break rather than
-                        # spinning forever waiting for reader-thread sentinels.
                         if proc.poll() is not None:
-                            break
-                        continue
-
-                    if item is None:
-                        sentinels += 1
-                        continue
-
-                    tag, chunk = item
-                    text = chunk.decode("utf-8", errors="replace")
-                    if tag == "out":
-                        stdout_chunks.append(text)
-                        if output:
-                            print(text, end="", file=sys.stdout)
-                    else:
-                        stderr_chunks.append(text)
-                        if output:
-                            print(text, end="", file=sys.stderr)
+                            if proc_exited_at is None:
+                                proc_exited_at = time.monotonic()
+                            elif time.monotonic() - proc_exited_at >= 1.0:
+                                # A background descendant can inherit the pipes,
+                                # preventing EOF after the command itself exits.
+                                break
             except KeyboardInterrupt:
                 print()
                 proc.kill()
-                t_out.join(timeout=1.0)
-                t_err.join(timeout=1.0)
+                proc.wait()
+                finish_readers()
                 partial_stdout = trim_blank_lines("".join(stdout_chunks))
                 partial_stderr = trim_blank_lines("".join(stderr_chunks))
                 raise KeyboardInterrupt((partial_stdout, partial_stderr)) from None
 
-            # Threads are daemon threads; join with timeout in case they're
-            # blocked on read() due to pipes not signalling EOF (TTY-stdin edge
-            # case). They'll be garbage-collected when proc.stdout/stderr close.
-            t_out.join(timeout=1.0)
-            t_err.join(timeout=1.0)
             proc.wait()
+            if sentinels < 2:
+                # A background descendant retained the pipes. The idle grace
+                # period drained this command's output; now stop and reap the
+                # readers without waiting for the descendant to exit.
+                stop_readers.set()
+            finish_readers()
         finally:
             tty_stdin.close()
 

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -51,6 +51,39 @@ def test_run_with_tty_collects_output_queued_at_exit(shell):
     assert err == ""
 
 
+def test_run_with_tty_drains_buffered_output_after_slow_consumer(shell, monkeypatch):
+    """Reader cleanup does not truncate output that takes over a second to drain."""
+    real_read = os.read
+
+    def slow_read(fd, size):
+        time.sleep(0.02)
+        return real_read(fd, min(size, 4096))
+
+    monkeypatch.setattr(os, "read", slow_read)
+    expected_size = 256 * 1024
+    ret, out, err = shell._run_with_tty(
+        f"python3 -c 'import sys; sys.stdout.write(\"x\" * {expected_size})'",
+        output=False,
+    )
+
+    assert ret == 0
+    assert out == "x" * expected_size
+    assert err == ""
+
+
+def test_run_with_tty_does_not_timeout_after_direct_child_exits(shell):
+    """A descendant retaining the pipe cannot turn child success into timeout."""
+    ret, out, err = shell._run_with_tty(
+        "(while true; do printf x; sleep 0.01; done) & echo foreground",
+        output=False,
+        timeout=0.2,
+    )
+
+    assert ret == 0
+    assert out.startswith("foreground")
+    assert err == ""
+
+
 def test_run_with_tty_does_not_wait_for_background_descendant(shell):
     """A descendant retaining the output pipes does not hang the caller."""
     started = time.monotonic()

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -111,6 +111,22 @@ def test_run_with_tty_timeout_no_output_still_returns_minus_124(shell):
     assert isinstance(err, str)
 
 
+def test_run_with_tty_timeout_does_not_wait_for_background_descendant(shell):
+    """Timeout returns even when a descendant retains the output pipes."""
+    started = time.monotonic()
+    ret, out, err = shell._run_with_tty(
+        "sleep 10 & printf before-timeout; exec sleep 10",
+        output=False,
+        timeout=0.3,
+    )
+    elapsed = time.monotonic() - started
+
+    assert ret == -124
+    assert out == "before-timeout"
+    assert err == ""
+    assert elapsed < 3
+
+
 def test_run_with_tty_interrupt_returns_all_partial_output(shell):
     """KeyboardInterrupt reaps the child and drains output already produced."""
 
@@ -127,3 +143,26 @@ def test_run_with_tty_interrupt_returns_all_partial_output(shell):
     stdout, stderr = exc_info.value.args[0]
     assert stdout == "before-interrupt"
     assert stderr == ""
+
+
+def test_run_with_tty_interrupt_does_not_wait_for_background_descendant(shell):
+    """KeyboardInterrupt surfaces promptly when a descendant retains the pipes."""
+
+    def interrupt() -> None:
+        time.sleep(0.2)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    interrupter = threading.Thread(target=interrupt)
+    interrupter.start()
+    started = time.monotonic()
+    with pytest.raises(KeyboardInterrupt) as exc_info:
+        shell._run_with_tty(
+            "sleep 10 & printf before-interrupt; exec sleep 10", output=False
+        )
+    interrupter.join()
+
+    elapsed = time.monotonic() - started
+    stdout, stderr = exc_info.value.args[0]
+    assert stdout == "before-interrupt"
+    assert stderr == ""
+    assert elapsed < 3

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -111,6 +111,35 @@ def test_run_with_tty_continuous_descendant_output_has_bounded_grace(shell):
     assert elapsed < 3
 
 
+def test_run_with_tty_grace_drains_chunk_read_after_stop(shell, monkeypatch):
+    """Grace shutdown preserves a chunk already readable in a retained pipe."""
+    real_read = os.read
+    release_read = threading.Event()
+    stdout_read_started = threading.Event()
+
+    def delayed_read(fd, size):
+        if not stdout_read_started.is_set():
+            stdout_read_started.set()
+            assert release_read.wait(timeout=3)
+        return real_read(fd, size)
+
+    monkeypatch.setattr(os, "read", delayed_read)
+    timer = threading.Timer(1.1, release_read.set)
+    timer.start()
+    try:
+        ret, out, err = shell._run_with_tty(
+            "sleep 10 & printf buffered-tail", output=False
+        )
+    finally:
+        release_read.set()
+        timer.join()
+
+    assert stdout_read_started.is_set()
+    assert ret == 0
+    assert out == "buffered-tail"
+    assert err == ""
+
+
 def test_run_with_tty_closed_output_still_honors_timeout(shell):
     """EOF on both output pipes does not bypass the process timeout."""
     started = time.monotonic()
@@ -191,6 +220,46 @@ def test_run_with_tty_timeout_no_output_still_returns_minus_124(shell):
     assert ret == -124
     assert isinstance(out, str)
     assert isinstance(err, str)
+
+
+def test_run_with_tty_child_exits_at_timeout_boundary_returns_real_code(
+    shell, monkeypatch
+):
+    """Child that exits exactly when the timeout check fires returns the real exit code.
+
+    Reproduces the race: elapsed >= timeout is True AND proc.poll() returns
+    non-None (child already exited). Pre-fix code unconditionally returned -124;
+    the fix honours the real exit code instead.
+
+    The fake clock sleeps on the second call (first elapsed check) to let the
+    subprocess exit, then returns a time well past the deadline. This makes the
+    race deterministic: proc.poll() sees the child already gone.
+    """
+    import time as time_module
+
+    import gptme.tools.shell as shell_mod
+
+    real_monotonic = time_module.monotonic
+    call_count = [0]
+
+    def fake_monotonic() -> float:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # start_time assignment — return real time
+            return real_monotonic()
+        if call_count[0] == 2:
+            # First elapsed check — sleep so 'true' has time to exit, then
+            # report a time well past the deadline.
+            time_module.sleep(0.1)
+        return real_monotonic() + 1000.0
+
+    monkeypatch.setattr(shell_mod.time, "monotonic", fake_monotonic)
+
+    # 'true' exits with code 0 almost instantly. After the 0.1s sleep inside
+    # fake_monotonic the child is dead. Pre-fix: kills child (no-op) and
+    # returns -124. Post-fix: proc.poll() → 0 → returns 0.
+    ret, out, err = shell._run_with_tty("true", output=False, timeout=0.1)
+    assert ret == 0, f"Expected real exit code 0 (child already exited), got {ret}"
 
 
 def test_run_with_tty_timeout_does_not_wait_for_background_descendant(shell):

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -5,6 +5,11 @@ output incrementally. _run_with_tty used proc.communicate() which is fully
 blocking: nothing appears until the process exits. This file tests the fix.
 """
 
+import os
+import signal
+import threading
+import time
+
 import pytest
 
 from gptme.tools.shell import ShellSession
@@ -33,6 +38,29 @@ def test_run_with_tty_multi_line(shell):
     assert "line1" in out
     assert "line2" in out
     assert "line3" in out
+
+
+def test_run_with_tty_collects_output_queued_at_exit(shell):
+    """Fast process exit cannot race the reader threads and truncate output."""
+    expected_size = 2**20
+    ret, out, err = shell._run_with_tty(
+        f"head -c {expected_size} /dev/zero | tr '\\0' x", output=False
+    )
+    assert ret == 0
+    assert out == "x" * expected_size
+    assert err == ""
+
+
+def test_run_with_tty_does_not_wait_for_background_descendant(shell):
+    """A descendant retaining the output pipes does not hang the caller."""
+    started = time.monotonic()
+    ret, out, err = shell._run_with_tty("sleep 10 & echo foreground", output=False)
+    elapsed = time.monotonic() - started
+
+    assert ret == 0
+    assert out == "foreground"
+    assert err == ""
+    assert elapsed < 3
 
 
 def test_run_with_tty_stderr(shell):
@@ -65,7 +93,7 @@ def test_run_with_tty_timeout_returns_partial_output(shell):
     command never finishing — proving the read loop collected it mid-flight.
     """
     ret, out, err = shell._run_with_tty(
-        "echo partial_line; sleep 10",
+        "printf partial_line; exec sleep 10",
         output=False,
         timeout=0.5,
     )
@@ -77,7 +105,25 @@ def test_run_with_tty_timeout_returns_partial_output(shell):
 
 def test_run_with_tty_timeout_no_output_still_returns_minus_124(shell):
     """Timeout with no output still returns -124 and empty strings (not crash)."""
-    ret, out, err = shell._run_with_tty("sleep 10", output=False, timeout=0.3)
+    ret, out, err = shell._run_with_tty("exec sleep 10", output=False, timeout=0.3)
     assert ret == -124
     assert isinstance(out, str)
     assert isinstance(err, str)
+
+
+def test_run_with_tty_interrupt_returns_all_partial_output(shell):
+    """KeyboardInterrupt reaps the child and drains output already produced."""
+
+    def interrupt() -> None:
+        time.sleep(0.2)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    interrupter = threading.Thread(target=interrupt)
+    interrupter.start()
+    with pytest.raises(KeyboardInterrupt) as exc_info:
+        shell._run_with_tty("printf before-interrupt; exec sleep 10", output=False)
+    interrupter.join()
+
+    stdout, stderr = exc_info.value.args[0]
+    assert stdout == "before-interrupt"
+    assert stderr == ""

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -1,0 +1,83 @@
+"""Tests for streaming one-shot output in _run_with_tty.
+
+The persistent-session path (_run_pipe → _read_output_unix) has always streamed
+output incrementally. _run_with_tty used proc.communicate() which is fully
+blocking: nothing appears until the process exits. This file tests the fix.
+"""
+
+import pytest
+
+from gptme.tools.shell import ShellSession
+
+
+@pytest.fixture
+def shell():
+    s = ShellSession()
+    yield s
+    s.close()
+
+
+def test_run_with_tty_basic(shell):
+    """_run_with_tty returns correct output and return code."""
+    ret, out, err = shell._run_with_tty("echo hello", output=False)
+    assert ret == 0
+    assert "hello" in out
+
+
+def test_run_with_tty_multi_line(shell):
+    """_run_with_tty collects all lines of output."""
+    ret, out, err = shell._run_with_tty(
+        "echo line1; echo line2; echo line3", output=False
+    )
+    assert ret == 0
+    assert "line1" in out
+    assert "line2" in out
+    assert "line3" in out
+
+
+def test_run_with_tty_stderr(shell):
+    """_run_with_tty captures stderr separately."""
+    ret, out, err = shell._run_with_tty(
+        "echo stdout_msg; echo stderr_msg >&2", output=False
+    )
+    assert ret == 0
+    assert "stdout_msg" in out
+    assert "stderr_msg" in err
+    assert "stderr_msg" not in out
+
+
+def test_run_with_tty_nonzero_exit(shell):
+    """_run_with_tty returns the correct non-zero exit code."""
+    ret, _out, _err = shell._run_with_tty("exit 42", output=False)
+    assert ret == 42
+
+
+def test_run_with_tty_timeout_returns_partial_output(shell):
+    """Streaming is verified: output collected before timeout fires is returned.
+
+    With the old proc.communicate() approach: communicate() blocks until the
+    process is killed, so partial output visibility was coincidental (the drain
+    after kill happened to collect it). With the new reader-thread loop, output is
+    stored in chunks as it arrives, so the timeout path always returns whatever
+    was printed before the timeout.
+
+    The key assertion is that 'partial_line' appears in stdout DESPITE the
+    command never finishing — proving the read loop collected it mid-flight.
+    """
+    ret, out, err = shell._run_with_tty(
+        "echo partial_line; sleep 10",
+        output=False,
+        timeout=0.5,
+    )
+    assert ret == -124, f"Expected timeout exit code -124, got {ret}"
+    assert "partial_line" in out, (
+        f"Expected partial output before timeout, got stdout={out!r}"
+    )
+
+
+def test_run_with_tty_timeout_no_output_still_returns_minus_124(shell):
+    """Timeout with no output still returns -124 and empty strings (not crash)."""
+    ret, out, err = shell._run_with_tty("sleep 10", output=False, timeout=0.3)
+    assert ret == -124
+    assert isinstance(out, str)
+    assert isinstance(err, str)

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -63,6 +63,41 @@ def test_run_with_tty_does_not_wait_for_background_descendant(shell):
     assert elapsed < 3
 
 
+def test_run_with_tty_continuous_descendant_output_has_bounded_grace(shell):
+    """Continuous descendant output cannot extend the post-exit grace forever."""
+    started = time.monotonic()
+    ret, out, err = shell._run_with_tty(
+        "(while true; do printf x; sleep 0.01; done) & echo foreground",
+        output=False,
+    )
+    elapsed = time.monotonic() - started
+
+    assert ret == 0
+    assert out.startswith("foreground")
+    assert err == ""
+    assert elapsed < 3
+
+
+def test_run_with_tty_preserves_utf8_split_across_read_chunks(shell, monkeypatch):
+    """Streaming uses incremental decoders for split multibyte characters."""
+    real_read = os.read
+    first_stdout_read = True
+
+    def split_read(fd, size):
+        nonlocal first_stdout_read
+        if first_stdout_read and size == 2**16:
+            first_stdout_read = False
+            size = 1
+        return real_read(fd, size)
+
+    monkeypatch.setattr(os, "read", split_read)
+    ret, out, err = shell._run_with_tty("printf 'é'", output=False)
+
+    assert ret == 0
+    assert out == "é"
+    assert err == ""
+
+
 def test_run_with_tty_stderr(shell):
     """_run_with_tty captures stderr separately."""
     ret, out, err = shell._run_with_tty(

--- a/tests/test_shell_stream_oneshot.py
+++ b/tests/test_shell_stream_oneshot.py
@@ -80,7 +80,7 @@ def test_run_with_tty_does_not_timeout_after_direct_child_exits(shell):
     )
 
     assert ret == 0
-    assert out.startswith("foreground")
+    assert "foreground" in out
     assert err == ""
 
 
@@ -106,7 +106,21 @@ def test_run_with_tty_continuous_descendant_output_has_bounded_grace(shell):
     elapsed = time.monotonic() - started
 
     assert ret == 0
-    assert out.startswith("foreground")
+    assert "foreground" in out
+    assert err == ""
+    assert elapsed < 3
+
+
+def test_run_with_tty_closed_output_still_honors_timeout(shell):
+    """EOF on both output pipes does not bypass the process timeout."""
+    started = time.monotonic()
+    ret, out, err = shell._run_with_tty(
+        "exec 1>&-; exec 2>&-; sleep 10", output=False, timeout=0.3
+    )
+    elapsed = time.monotonic() - started
+
+    assert ret == -124
+    assert out == ""
     assert err == ""
     assert elapsed < 3
 


### PR DESCRIPTION
## Problem

A one-shot shell command shows nothing until it exits. `_run_with_tty` used
`proc.communicate()`, which blocks until the process terminates, and the console
print only fired afterwards.

So a 5-minute test suite is a blank screen for 5 minutes. That reads as "the
agent is hung", not "the agent is working" — a first-impression defect users
abandon over rather than file an issue about.

## The pattern already existed in this file

The persistent-session path (`_run_pipe` → `_read_output_unix`) has always
streamed, printing each chunk as it arrives inside its read loop. This plumbs
that existing behaviour into the one-shot path.

## Approach

`communicate()` is replaced with two concurrent reader threads feeding a queue;
the main loop prints each chunk as it arrives and accumulates it for the final
return value.

**Why threads and not `select()`**: `select` is unreliable when `/dev/tty` is the
child's stdin and the process produces no output before exiting. The loop also
breaks on `proc.poll() is not None` so it can't spin forever waiting for
reader-thread sentinels if the pipes never signal EOF.

## Contracts unchanged

- `run()` still returns `(returncode, stdout, stderr)`
- `execute_shell_impl` still yields exactly one `Message` — streaming the
  *Message* stream is a separate, much larger feature and is deliberately not
  part of this PR
- Timeout still returns `-124`, now with the partial output collected so far
- `KeyboardInterrupt` still surfaces partial `(stdout, stderr)` via the
  exception args

## One behaviour change worth review

When `/dev/tty` can't be opened (CI, non-TTY container), the old code fell back
to `_run_pipe`. That routes through the *persistent* bash session, where shell
builtins like `exit` kill the session and deadlock the delimiter-read loop. This
PR keeps spawning a fresh subprocess and uses `/dev/null` as stdin instead.
Trade-off: `sudo` can't prompt for a password in that environment — but it
couldn't have prompted without a TTY anyway, and non-interactive commands now
behave correctly.

## Tests

`tests/test_shell_stream_oneshot.py` — 6 tests. The load-bearing one is
`test_run_with_tty_timeout_returns_partial_output`: it asserts `partial_line`
appears in stdout **despite the command never finishing**, which is only possible
if the read loop collected it mid-flight.

```
tests/test_shell_stream_oneshot.py tests/test_tools_shell.py — 123 passed
```

`mypy gptme/tools/shell.py` clean (remaining repo-wide errors are pre-existing
missing stubs for optional deps).

## Not verified

The `sudo`-prompt path on a real TTY was not exercised by hand — worth a
reviewer sanity check if you have a terminal handy.

Advances idea #1129 (agent-harness gap scan). Upstream reference: `block/goose`
v1.46.0 (#10808).