### PR TITLE
feat(precommit): add check-root-structure hook from gptme-contrib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,40 @@ repos:
   - id: mypy
     additional_dependencies: [types-tabulate, types-docutils, tomli, tomli_w, opentelemetry-api, opentelemetry-sdk, prometheus-client, prompt_toolkit, click, pytest, openai==1.101.0, rich, tomlkit, dspy, textual]
     args: [--ignore-missing-imports, --check-untyped-defs]
+- repo: https://github.com/gptme/gptme-contrib
+  # Pin to the commit that introduced .pre-commit-hooks.yaml + --allow support.
+  # Update to a released tag/SHA once gptme-contrib#1479 is merged.
+  rev: 7875514efd358d4ff5cb4781ad961f754bfbde8d
+  hooks:
+  - id: check-root-structure
+    args:
+      # Files
+      - --allow=.dockerignore
+      - --allow=.env.example
+      - --allow=.github
+      - --allow=.gitignore
+      - --allow=.pre-commit-config.yaml
+      - --allow=AGENTS.md
+      - --allow=LICENSE
+      - --allow=Makefile
+      - --allow=README.md
+      - --allow=SECURITY.md
+      - --allow=docker-compose.yml
+      - --allow=gptme.toml
+      - --allow=mypy.ini
+      - --allow=poetry.lock
+      - --allow=pyproject.toml
+      # Directories
+      - --allow=docs
+      - --allow=gptme
+      - --allow=gptme-extension
+      - --allow=media
+      - --allow=packages
+      - --allow=scripts
+      - --allow=site
+      - --allow=tauri
+      - --allow=tests
+      - --allow=webui
 - repo: local
   hooks:
   - id: check-rst-formatting


### PR DESCRIPTION
## What

Adds a `check-root-structure` pre-commit hook that blocks new top-level entries without an explicit allowlist update. Root-dir sprawl is a real cost: agents that list the repo root for navigation get noisier results with each uncategorized file or directory.

## How

References the hook from `gptme/gptme-contrib` via `.pre-commit-hooks.yaml` — the hook is now a shared, DRY asset (gptme/gptme-contrib#1479). Each consuming repo configures its own allowlist through `--allow ENTRY` args in `.pre-commit-config.yaml`.

```yaml
- repo: https://github.com/gptme/gptme-contrib
  rev: 7875514efd358d4ff5cb4781ad961f754bfbde8d
  hooks:
  - id: check-root-structure
    args:
      - --allow=.github
      - --allow=README.md
      # ... one per permitted root entry
```

## Follow-up

Once gptme-contrib#1479 is merged and tagged, update `rev:` to the stable release SHA/tag.

Part of gptme/gptme-contrib#1445.

<!-- gptme-id:v1:gai_s6BkzKucDgM2V5avP5HxJIGlAnFmtq42DKfgqfen9Qv -->