### PR TITLE
docs: document subscription auth (ChatGPT Plus/Pro, SuperGrok) in README and providers docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ You can find more [Demos][docs-demos] and [Examples][docs-examples] in the [docu
 - 🤖 **Support for many LLM [providers][docs-providers]**
   - Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), DeepSeek, and more.
   - Use OpenRouter for access to 100+ models, or serve locally with `llama.cpp`.
+  - Bring your own subscription: use your existing ChatGPT Plus/Pro or SuperGrok plan instead of API keys (see [providers][docs-providers]).
   - [Pick the right model per task][docs-model-routing] — fast/cheap for triage, powerful for coding.
 - 🌐 **Web UI and REST API**
   - Modern [gptme-webui] bundled with `gptme-server` and hosted at [chat.gptme.org](https://chat.gptme.org).
@@ -412,6 +413,9 @@ This stack is simple and composable: selectors improve work choice, lessons stee
 - Credentials for at least one LLM provider:
   - OpenRouter can be configured interactively with `/account setup openrouter`
     inside gptme, using browser OAuth onboarding.
+  - Subscriptions work too: sign in with your ChatGPT Plus/Pro or SuperGrok plan
+    via `gptme-auth openai-subscription` or `gptme-auth grok-subscription`,
+    no API key needed (see [providers docs][docs-providers]).
   - You can also set API keys manually for [Anthropic](https://console.anthropic.com/)
     (`ANTHROPIC_API_KEY`), [OpenAI](https://platform.openai.com/)
     (`OPENAI_API_KEY`), [OpenRouter](https://openrouter.ai/)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -3,6 +3,8 @@ Providers
 
 We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter, Requesty, Deepseek, Azure, and any OpenAI-compatible server (e.g. ``ollama``, ``llama-cpp-python``).
 
+You can also bring your own subscription instead of an API key: a ChatGPT Plus/Pro plan via `OpenAI Subscription`_ or a SuperGrok plan via `Grok Subscription`_.
+
 .. note::
 
     We are in the process of adding support for configurable :doc:`custom providers <providers-custom>`.
@@ -24,6 +26,8 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m gemini/gemini-2.5-flash
     gptme "hello" -m groq/llama-3.3-70b-versatile
     gptme "hello" -m xai/grok-4
+    gptme "hello" -m openai-subscription/gpt-5.5-pro
+    gptme "hello" -m grok-subscription/grok-4.6
     gptme "hello" -m local/llama3.2:1b
     gptme "hello" -m gptme/claude-sonnet-4-6
 
@@ -46,6 +50,8 @@ To configure provider credentials interactively, run ``/account`` inside gptme:
 ``/account setup openrouter`` starts browser-based OpenRouter sign-in using OAuth / PKCE, stores the resulting key in ``~/.config/gptme/credentials.toml``, and switches the default model to OpenRouter's recommended default.
 
 For providers without OAuth onboarding yet, ``/account setup <provider>`` prompts for the key without putting it in shell history and stores it in ``~/.config/gptme/credentials.toml`` (or ``$XDG_CONFIG_HOME/gptme/credentials.toml`` if set). Supported manual providers currently include ``anthropic``, ``openai``, ``deepseek``, ``gemini``, ``groq``, and ``xai``.
+
+Subscription sign-in (ChatGPT Plus/Pro and SuperGrok) is also offered in the first-run setup when gptme starts without any configured credentials.
 
 You can still use the ``[env]`` section in the :ref:`global-config` file to store API keys using the same format as the environment variables:
 
@@ -221,6 +227,43 @@ You can also append reasoning levels: ``:low``, ``:medium``, ``:high``, or ``:xh
     This is for **personal development use** with your own ChatGPT Plus/Pro subscription.
     For production or multi-user applications, use the OpenAI Platform API.
     OAuth credentials are stored locally and access tokens are refreshed automatically.
+
+Grok Subscription
+-----------------
+
+You can use your existing SuperGrok subscription (`grok.com <https://grok.com>`_) with gptme, instead of an xAI API key. This uses the same subscription endpoint as the grok CLI.
+
+**Setup:**
+
+If you have the grok CLI installed and have run ``grok login``, gptme automatically reuses those tokens (from ``~/.grok/auth.json``) with no extra steps.
+
+Otherwise, authenticate directly using the OAuth command (opens browser for login):
+
+.. code-block:: sh
+
+    gptme-auth grok-subscription
+
+This stores credentials locally at ``~/.config/gptme/oauth/grok_subscription.json``.
+Access tokens are automatically refreshed before expiry, and refreshed tokens are synced back to the grok CLI's auth file when present.
+
+**Usage:**
+
+.. code-block:: sh
+
+    gptme "hello" -m grok-subscription/grok-4.6
+    gptme "hello" -m grok-subscription/grok-4.5
+
+**Available Models:**
+
+- ``grok-4.6`` - Current frontier model (500K context, vision, reasoning)
+- ``grok-4.5`` - Previous frontier model (500K context, vision, reasoning)
+
+The subscription endpoint is OpenAI-compatible and supports native function calling (``--tool-format tool``).
+
+.. note::
+
+    This is for **personal development use** with your own SuperGrok subscription.
+    For production or multi-user applications, use the xAI Platform API (``xai`` provider) with an API key from `console.x.ai <https://console.x.ai>`_.
 
 gptme Managed Service
 ---------------------


### PR DESCRIPTION
## Why

Subscription-based auth shipped in v0.33.0 (#3289: `grok-subscription` provider, plus first-run setup integration in #3295/#3304, and `openai-subscription` before that), but the docs never exposed it:

- README.md did not mention subscription auth at all (neither in the features/providers bullet nor in the prerequisites section, which implied API keys were the only option besides OpenRouter OAuth).
- `docs/providers.rst` documented `openai-subscription` but had no section for `grok-subscription`.

Users had no way to discover that they can bring an existing ChatGPT Plus/Pro or SuperGrok plan instead of API keys.

## Changes

**docs/providers.rst**
- New "Grok Subscription" section mirroring the OpenAI Subscription one: grok CLI token reuse (`~/.grok/auth.json`), `gptme-auth grok-subscription` OAuth flow, token storage at `~/.config/gptme/oauth/grok_subscription.json`, auto-refresh with sync-back to the grok CLI auth file, available models (`grok-4.6`, `grok-4.5`), native tools support, and the personal-use notice (xAI Platform API for production).
- Intro now mentions both subscription providers, with links to the sections.
- Added `openai-subscription`/`grok-subscription` examples to the model selection list.
- Noted that subscription sign-in is offered in the first-run setup.

**README.md**
- Providers feature bullet: new sub-bullet for bring-your-own-subscription.
- Prerequisites: subscription sign-in listed as an alternative to API keys, with the `gptme-auth` commands.

Details verified against `gptme/llm/llm_grok_subscription.py`, `gptme/cli/auth.py`, and `gptme/llm/models/data.py`. Docs build checked with sphinx (section renders, internal links resolve) and `scripts/check_rst_formatting.py` passes.