### PR TITLE
fix(precommit): update gptme-contrib rev to post-#1479 merge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,7 @@ repos:
     additional_dependencies: [types-tabulate, types-docutils, tomli, tomli_w, opentelemetry-api, opentelemetry-sdk, prometheus-client, prompt_toolkit, click, pytest, openai==1.101.0, rich, tomlkit, dspy, textual]
     args: [--ignore-missing-imports, --check-untyped-defs]
 - repo: https://github.com/gptme/gptme-contrib
-  # Pin to the commit that introduced .pre-commit-hooks.yaml + --allow support.
-  # Update to a released tag/SHA once gptme-contrib#1479 is merged.
-  rev: 7875514efd358d4ff5cb4781ad961f754bfbde8d
+  rev: 74c946c792c87eccd8632dbf26cbc390dd5c26bd  # post-#1479: shareable hook + git-ls-files impl
   hooks:
   - id: check-root-structure
     args:


### PR DESCRIPTION
gptme-contrib#1479 (make check-root-structure a shareable remote hook, simplify to git ls-files) merged 2026-08-20.

This updates the pinned SHA from the pre-merge staging SHA to the current contrib master. The TODO comment is removed now that the PR has landed.

Part of the cross-repo propagation tracked in gptme-contrib#1445 (clean up root dir + CI checks).