### PR TITLE
ci: add dependency advisory gate (Phase 1, non-blocking)

### DIFF
--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -1,0 +1,58 @@
+name: Security Advisories
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly, Monday 8am UTC
+  workflow_dispatch:
+
+jobs:
+  dependency-audit:
+    name: Dependency Advisory Scan
+    runs-on: ubuntu-latest
+    # Phase 1: continue-on-error so this never blocks CI
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v5
+
+      # gptme has no committed uv.lock (gitignored; project uses poetry), so
+      # --frozen would fail. `uv sync` generates the gitignored lockfile that
+      # `uv audit` reads.
+      - name: Install dependencies and resolve lockfile
+        run: uv sync --all-extras
+
+      - name: Run dependency audit
+        id: audit
+        run: |
+          # Phase 1: report-only. Remove `|| true` in Phase 2 to block on findings.
+          uv audit --preview-features audit-command \
+            --ignore PYSEC-2026-2151 \
+            --ignore CVE-2025-69872 \
+            --ignore PYSEC-2026-2447 \
+            --ignore PYSEC-2026-3447 \
+            || true
+
+      - name: Upload SARIF (optional — enables GitHub Security tab)
+        if: always()
+        continue-on-error: true
+        run: |
+          uv audit --preview-features audit-command \
+            --output-format sarif \
+            --ignore PYSEC-2026-2151 \
+            --ignore CVE-2025-69872 \
+            --ignore PYSEC-2026-2447 \
+            --ignore PYSEC-2026-3447 \
+            > audit.sarif 2>/dev/null || true
+          echo "Generated audit.sarif"
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: security-audit-sarif
+          path: audit.sarif
+          if-no-files-found: ignore

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -30,7 +30,7 @@ jobs:
       # the Poetry-committed snapshot; Phase 2 can add `poetry export | pip-audit`
       # for exact parity with what Poetry installs.
       - name: Install dependencies and resolve lockfile
-        run: uv sync --all-extras
+        run: uv sync --all-extras || echo "::warning::Failed to resolve dependencies; audit will run against any existing lockfile or report a tooling error."
 
       - name: Run dependency audit
         id: audit

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -47,13 +47,17 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          if uv audit --preview-features audit-command \
+          uv audit --preview-features audit-command \
               --output-format sarif \
               --ignore PYSEC-2026-2151 \
               --ignore CVE-2025-69872 \
               --ignore PYSEC-2026-2447 \
               --ignore PYSEC-2026-3447 \
-              > /tmp/audit_tmp.sarif; then
+              > /tmp/audit_tmp.sarif
+          audit_exit=$?
+          # exit 0 = no advisories; exit 1 = advisories found — both produce valid SARIF.
+          # Any other exit code is a tooling failure (bad pyproject, network error, etc.).
+          if [ "$audit_exit" -eq 0 ] || [ "$audit_exit" -eq 1 ]; then
             if [ -s /tmp/audit_tmp.sarif ]; then
               mv /tmp/audit_tmp.sarif audit.sarif
               echo "SARIF report generated ($(wc -c < audit.sarif) bytes)."
@@ -61,7 +65,7 @@ jobs:
               echo "::warning::SARIF generation produced empty output (non-blocking)."
             fi
           else
-            echo "::warning::SARIF generation failed (non-blocking). See log above."
+            echo "::warning::SARIF generation failed with exit $audit_exit (non-blocking). See log above."
           fi
 
       - name: Upload SARIF to GitHub Security tab

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -47,18 +47,24 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          uv audit --preview-features audit-command \
-            --output-format sarif \
-            --ignore PYSEC-2026-2151 \
-            --ignore CVE-2025-69872 \
-            --ignore PYSEC-2026-2447 \
-            --ignore PYSEC-2026-3447 \
-            > audit.sarif 2>/dev/null || true
-          echo "Generated audit.sarif"
+          if uv audit --preview-features audit-command \
+              --output-format sarif \
+              --ignore PYSEC-2026-2151 \
+              --ignore CVE-2025-69872 \
+              --ignore PYSEC-2026-2447 \
+              --ignore PYSEC-2026-3447 \
+              > audit.sarif; then
+            echo "SARIF report generated ($(wc -c < audit.sarif) bytes)."
+          else
+            echo "::warning::SARIF generation failed (non-blocking). See log above."
+          fi
+          if [ ! -s audit.sarif ]; then
+            echo "::warning::audit.sarif is empty — skipping Security tab upload."
+          fi
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('audit.sarif') != ''
         continue-on-error: true
         with:
           sarif_file: audit.sarif

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -53,13 +53,15 @@ jobs:
               --ignore CVE-2025-69872 \
               --ignore PYSEC-2026-2447 \
               --ignore PYSEC-2026-3447 \
-              > audit.sarif; then
-            echo "SARIF report generated ($(wc -c < audit.sarif) bytes)."
+              > /tmp/audit_tmp.sarif; then
+            if [ -s /tmp/audit_tmp.sarif ]; then
+              mv /tmp/audit_tmp.sarif audit.sarif
+              echo "SARIF report generated ($(wc -c < audit.sarif) bytes)."
+            else
+              echo "::warning::SARIF generation produced empty output (non-blocking)."
+            fi
           else
             echo "::warning::SARIF generation failed (non-blocking). See log above."
-          fi
-          if [ ! -s audit.sarif ]; then
-            echo "::warning::audit.sarif is empty — skipping Security tab upload."
           fi
 
       - name: Upload SARIF to GitHub Security tab

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -44,11 +44,14 @@ jobs:
           audit_exit=0
           uv audit --preview-features audit-command \
               --output-format sarif \
-              --ignore PYSEC-2026-2151 \
               --ignore CVE-2025-69872 \
               --ignore PYSEC-2026-2447 \
-              --ignore PYSEC-2026-3447 \
               > /tmp/audit_tmp.sarif || audit_exit=$?
+          # Accepted ignores (diskcache advisories, no fix available):
+          #   CVE-2025-69872, PYSEC-2026-2447 — diskcache; no upstream fix yet.
+          # NOT ignored (flask/setuptools advisories currently inactive in dep tree):
+          #   PYSEC-2026-2151, PYSEC-2026-3447 — unconditionally ignoring them
+          #   would mask real advisories if these packages re-enter the dep tree.
           if [ "$audit_exit" -eq 0 ]; then
             echo "No known advisories found."
           elif [ "$audit_exit" -eq 1 ]; then

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -47,14 +47,14 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          audit_exit=0
           uv audit --preview-features audit-command \
               --output-format sarif \
               --ignore PYSEC-2026-2151 \
               --ignore CVE-2025-69872 \
               --ignore PYSEC-2026-2447 \
               --ignore PYSEC-2026-3447 \
-              > /tmp/audit_tmp.sarif
-          audit_exit=$?
+              > /tmp/audit_tmp.sarif || audit_exit=$?
           # exit 0 = no advisories; exit 1 = advisories found — both produce valid SARIF.
           # Any other exit code is a tooling failure (bad pyproject, network error, etc.).
           if [ "$audit_exit" -eq 0 ] || [ "$audit_exit" -eq 1 ]; then

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -20,7 +20,7 @@ jobs:
     # Phase 1: continue-on-error so this never blocks CI
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
 

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -32,21 +32,15 @@ jobs:
       - name: Install dependencies and resolve lockfile
         run: uv sync --all-extras || echo "::warning::Failed to resolve dependencies; audit will run against any existing lockfile or report a tooling error."
 
-      - name: Run dependency audit
+      - name: Run audit and generate SARIF
         id: audit
-        run: |
-          # Phase 1: report-only. Remove `|| echo` in Phase 2 to block on findings.
-          uv audit --preview-features audit-command \
-            --ignore PYSEC-2026-2151 \
-            --ignore CVE-2025-69872 \
-            --ignore PYSEC-2026-2447 \
-            --ignore PYSEC-2026-3447 \
-          || echo "::warning::Dependency advisories detected — see job log for details. Phase 1: non-blocking."
-
-      - name: Generate SARIF report
         if: always()
         continue-on-error: true
         run: |
+          # Single uv audit run: SARIF output + exit-code-aware warnings.
+          # exit 0 = no advisories; exit 1 = advisories found — both produce valid SARIF.
+          # exit ≥2 = tooling failure (bad pyproject, network, missing lockfile) — not a finding.
+          # Phase 1: report-only. In Phase 2 remove continue-on-error to block on advisories.
           audit_exit=0
           uv audit --preview-features audit-command \
               --output-format sarif \
@@ -55,8 +49,13 @@ jobs:
               --ignore PYSEC-2026-2447 \
               --ignore PYSEC-2026-3447 \
               > /tmp/audit_tmp.sarif || audit_exit=$?
-          # exit 0 = no advisories; exit 1 = advisories found — both produce valid SARIF.
-          # Any other exit code is a tooling failure (bad pyproject, network error, etc.).
+          if [ "$audit_exit" -eq 0 ]; then
+            echo "No known advisories found."
+          elif [ "$audit_exit" -eq 1 ]; then
+            echo "::warning::Dependency advisories detected — see job log for details. Phase 1: non-blocking."
+          else
+            echo "::warning::Dependency audit tooling error (exit $audit_exit) — not an advisory finding. Phase 1: non-blocking."
+          fi
           if [ "$audit_exit" -eq 0 ] || [ "$audit_exit" -eq 1 ]; then
             if [ -s /tmp/audit_tmp.sarif ]; then
               mv /tmp/audit_tmp.sarif audit.sarif
@@ -64,8 +63,6 @@ jobs:
             else
               echo "::warning::SARIF generation produced empty output (non-blocking)."
             fi
-          else
-            echo "::warning::SARIF generation failed with exit $audit_exit (non-blocking). See log above."
           fi
 
       - name: Upload SARIF to GitHub Security tab

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -17,6 +17,7 @@ jobs:
   dependency-audit:
     name: Dependency Advisory Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Phase 1: continue-on-error so this never blocks CI
     continue-on-error: true
     steps:

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always() && hashFiles('audit.sarif') != ''
+        # Fork PRs have a read-only GITHUB_TOKEN (no security-events: write),
+        # so skip SARIF upload for fork PRs to avoid a silent failure.
+        if: always() && hashFiles('audit.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         continue-on-error: true
         with:
           sarif_file: audit.sarif

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 8 * * 1'  # Weekly, Monday 8am UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write  # Required for SARIF upload to GitHub Security tab
+
 jobs:
   dependency-audit:
     name: Dependency Advisory Scan
@@ -21,23 +25,25 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       # gptme has no committed uv.lock (gitignored; project uses poetry), so
-      # --frozen would fail. `uv sync` generates the gitignored lockfile that
-      # `uv audit` reads.
+      # --frozen would fail. `uv sync` resolves and generates the lockfile that
+      # `uv audit` reads. Note: this audits the uv-resolved graph rather than
+      # the Poetry-committed snapshot; Phase 2 can add `poetry export | pip-audit`
+      # for exact parity with what Poetry installs.
       - name: Install dependencies and resolve lockfile
         run: uv sync --all-extras
 
       - name: Run dependency audit
         id: audit
         run: |
-          # Phase 1: report-only. Remove `|| true` in Phase 2 to block on findings.
+          # Phase 1: report-only. Remove `|| echo` in Phase 2 to block on findings.
           uv audit --preview-features audit-command \
             --ignore PYSEC-2026-2151 \
             --ignore CVE-2025-69872 \
             --ignore PYSEC-2026-2447 \
             --ignore PYSEC-2026-3447 \
-            || true
+          || echo "::warning::Dependency advisories detected — see job log for details. Phase 1: non-blocking."
 
-      - name: Upload SARIF (optional — enables GitHub Security tab)
+      - name: Generate SARIF report
         if: always()
         continue-on-error: true
         run: |
@@ -50,9 +56,10 @@ jobs:
             > audit.sarif 2>/dev/null || true
           echo "Generated audit.sarif"
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
+        continue-on-error: true
         with:
-          name: security-audit-sarif
-          path: audit.sarif
-          if-no-files-found: ignore
+          sarif_file: audit.sarif
+          category: dependency-audit


### PR DESCRIPTION
## Problem

gptme has no automated dependency-advisory gate in CI (gptme#2944). Dependabot bumps versions but does not enforce "known reachable advisory present" as a CI signal. GitHub currently reports **134 known vulnerabilities** on default branch.

## Scope

Phase 1 — **non-blocking** informational gate. Establishes the audit baseline and surfaces findings without failing CI.

- Run `uv audit` against locked deps on push/PR/weekly-schedule
- `continue-on-error: true` + `|| true` → never blocks CI
- Emit `::warning::` on findings so they surface in the PR checks UI
- Upload SARIF artifact for the GitHub Security tab

Phase 2 (follow-up, queue-pressure permitting): remove `continue-on-error` / `|| true` to block on new fixable advisories.

## Design

Full design: dependency-advisory-ci-gate-design (uv audit over pip-audit — zero extra install step, OSV source, native `--ignore` + SARIF).

**Accepted exceptions** (4, from the pip-audit baseline):
- `CVE-2025-69872`, `PYSEC-2026-2447` — diskcache, no fix available
- `PYSEC-2026-2151`, `PYSEC-2026-3447` — pre-approved flask/setuptools entries (currently inactive in gptme's dep tree)

**Adaptation vs the design doc**: dropped `--frozen` from the sync step — gptme has no committed `uv.lock` (gitignored, poetry-based), so `uv sync --all-extras` generates the lockfile `uv audit` reads.

## Verification

- `uv audit` with ignores → exit 0, "Found no known vulnerabilities"
- `uv audit` without the diskcache ignores → exit 1 (gate genuinely catches the advisory)
- SARIF output step produces valid SARIF

## How to reproduce

```bash
uv sync --all-extras
uv audit --preview-features audit-command --ignore PYSEC-2026-2151 --ignore CVE-2025-69872 --ignore PYSEC-2026-2447 --ignore PYSEC-2026-3447
```
