### PR TITLE
feat(service-init): add launchd support for macOS agents

### DIFF
--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -476,6 +476,11 @@ def init(
                 "Use a path without control characters.",
                 param_hint="'--work-dir'",
             )
+    else:
+        # Validate the work-dir for systemd BEFORE creating dirs — _escape_systemd_value
+        # raises BadParameter for quotes/backslashes/newlines, and we must not leave
+        # a stray empty directory behind when that validation fires.
+        _escape_systemd_value(str(work))
 
     # All validation passed — now create directories and generate files.
     work.mkdir(parents=True, exist_ok=True)
@@ -609,7 +614,7 @@ def init(
 
     if platform_choice == "macos":
         plist_file = out_dir / f"com.gptme.{name}.plist"
-        click.echo(f"  launchctl load {plist_file}")
+        click.echo(f'  launchctl load "{plist_file}"')
         click.echo(f"  launchctl start com.gptme.{name}")
         click.echo(
             f"  log stream --predicate 'eventMessage contains[cd] \"{name}\"'  # follow logs"

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -34,6 +34,7 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
+from xml.sax.saxutils import escape as _xml_escape
 
 import click
 
@@ -276,12 +277,13 @@ def _generate_launchd_plist(
         interval = LAUNCHD_SCHEDULE_INTERVALS.get(timer_schedule, 86400)
         schedule_section = LAUNCHD_SCHEDULE_SECTION.format(interval_seconds=interval)
 
-    run_at_load = "true" if timer_schedule == "on-demand" else "false"
+    # on-demand = manual start only (RunAtLoad=false); scheduled = start on load too
+    run_at_load = "false" if timer_schedule == "on-demand" else "true"
 
     return LAUNCHD_PLIST_TEMPLATE.format(
-        name=name,
-        model=model,
-        work_dir=work_dir,
+        name=_xml_escape(name),
+        model=_xml_escape(model),
+        work_dir=_xml_escape(work_dir),
         schedule_section=schedule_section,
         run_at_load=run_at_load,
     )

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -249,10 +249,8 @@ Never modify historical entries.
 
 
 def _resolve_work_dir(work_dir: str) -> Path:
-    """Resolve the agent work directory, creating it if needed."""
-    path = Path(work_dir).expanduser().resolve()
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    """Resolve the agent work directory path (does not create it)."""
+    return Path(work_dir).expanduser().resolve()
 
 
 def _write_file(path: Path, content: str, force: bool = False) -> bool:
@@ -445,15 +443,9 @@ def init(
         else:
             output_dir = "~/.config/systemd/user"
 
-    work = _resolve_work_dir(work_dir)
-    out_dir = Path(output_dir).expanduser().resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    click.echo(f"Scaffolding headless agent '{name}' ({platform_choice})...")
-
-    # Validate model consistently across platforms — systemd rejects
-    # newlines/quotes/backslashes; launchd must too (else the same input is
-    # silently truncated on macOS but rejected on Linux, which is confusing
+    # Validate model consistently across platforms BEFORE creating any directories.
+    # systemd rejects newlines/quotes/backslashes; launchd must too (else the same
+    # input is silently truncated on macOS but rejected on Linux, which is confusing
     # and allows injection attempts to go unnoticed on macOS).
     if "\n" in model or "\r" in model:
         raise click.BadParameter(
@@ -466,11 +458,15 @@ def init(
             param_hint="'--model'",
         )
 
+    # Resolve work dir path for validation (no mkdir yet — avoid leaving behind
+    # side-effect directories when subsequent validation raises BadParameter).
+    work = _resolve_work_dir(work_dir)
+
     # Platform-specific service generation
     if platform_choice == "macos":
-        # Reject paths that contain XML 1.0-forbidden characters. Unlike model
-        # (an env-var string where silent stripping is harmless), the work-dir
-        # path must match the one written to disk — silently sanitizing it in
+        # Reject paths that contain XML 1.0-forbidden characters BEFORE creating dirs.
+        # Unlike model (an env-var string where silent stripping is harmless), the
+        # work-dir path must match the one written to disk — silently sanitizing it in
         # the plist would cause launchd to reference a nonexistent directory.
         resolved_work = str(work)
         if _XML10_FORBIDDEN.search(resolved_work):
@@ -481,6 +477,14 @@ def init(
                 param_hint="'--work-dir'",
             )
 
+    # All validation passed — now create directories and generate files.
+    work.mkdir(parents=True, exist_ok=True)
+    out_dir = Path(output_dir).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"Scaffolding headless agent '{name}' ({platform_choice})...")
+
+    if platform_choice == "macos":
         # launchd: create logs directory and plist
         logs_dir = work / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -301,8 +301,8 @@ def _generate_launchd_plist(
 
     return LAUNCHD_PLIST_TEMPLATE.format(
         name=_xml_safe(name),
-        model=_xml_safe(model),
-        work_dir=_xml_safe(work_dir),
+        model=_xml_escape(model),
+        work_dir=_xml_escape(work_dir),
         schedule_section=schedule_section,
         run_at_load=run_at_load,
     )
@@ -464,10 +464,19 @@ def init(
 
     # Platform-specific service generation
     if platform_choice == "macos":
+        # Reject model identifiers that contain XML 1.0-forbidden characters.
+        # Silently stripping them would cause the agent to run with a different
+        # (or nonexistent) model than the user requested.
+        if _XML10_FORBIDDEN.search(model):
+            raise click.BadParameter(
+                f"Model {model!r} contains XML 1.0-forbidden characters "
+                "(control characters or lone surrogates) that cannot be "
+                "represented in a launchd plist. Use a valid model identifier.",
+                param_hint="'--model'",
+            )
         # Reject paths that contain XML 1.0-forbidden characters BEFORE creating dirs.
-        # Unlike model (an env-var string where silent stripping is harmless), the
-        # work-dir path must match the one written to disk — silently sanitizing it in
-        # the plist would cause launchd to reference a nonexistent directory.
+        # The work-dir path must match the one written to disk — silently sanitizing
+        # it in the plist would cause launchd to reference a nonexistent directory.
         resolved_work = str(work)
         if _XML10_FORBIDDEN.search(resolved_work):
             raise click.BadParameter(

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -37,8 +37,9 @@ from pathlib import Path
 from xml.sax.saxutils import escape as _xml_escape
 
 # XML 1.0 permits only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
-# Strip everything else (control characters that survive saxutils.escape and corrupt plists).
-_XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F￾￿]")
+# Strip control characters and lone UTF-16 surrogates — both survive saxutils.escape unchanged
+# and cause launchctl to reject the generated plist.
+_XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF￾￿]")
 
 
 def _xml_safe(value: str) -> str:

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -269,11 +269,21 @@ def _write_file(path: Path, content: str, force: bool = False) -> bool:
 
 
 def _detect_platform() -> str:
-    """Detect the current platform: 'macos' or 'linux'."""
-    system = platform.system().lower()
-    if system == "darwin":
+    """Detect the current platform: 'macos' or 'linux'.
+
+    Raises UsageError for platforms where neither systemd nor launchd applies
+    (e.g. Windows, FreeBSD). Use --platform explicitly on those systems.
+    """
+    system = platform.system()
+    if system == "Darwin":
         return "macos"
-    return "linux"
+    if system == "Linux":
+        return "linux"
+    raise click.UsageError(
+        f"Platform {system!r} is not supported by 'gptme service init'. "
+        "Use --platform linux or --platform macos to generate service files "
+        "for a supported platform."
+    )
 
 
 def _generate_launchd_plist(
@@ -416,6 +426,17 @@ def init(
     # Resolve platform (auto-detect if needed)
     if platform_choice == "auto":
         platform_choice = _detect_platform()
+        if platform_choice == "macos" and output_dir is None:
+            # Inform users explicitly: on macOS we now default to launchd
+            # instead of the old systemd default, so anyone with scripts
+            # expecting ~/.config/systemd/user gets a clear heads-up.
+            click.echo(
+                "Note: macOS detected — generating a launchd plist in "
+                "~/Library/LaunchAgents instead of a systemd unit. "
+                "Pass --platform linux to generate systemd units for a "
+                "Linux target.",
+                err=True,
+            )
 
     # Set default output directory based on platform
     if output_dir is None:
@@ -429,6 +450,21 @@ def init(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     click.echo(f"Scaffolding headless agent '{name}' ({platform_choice})...")
+
+    # Validate model consistently across platforms — systemd rejects
+    # newlines/quotes/backslashes; launchd must too (else the same input is
+    # silently truncated on macOS but rejected on Linux, which is confusing
+    # and allows injection attempts to go unnoticed on macOS).
+    if "\n" in model or "\r" in model:
+        raise click.BadParameter(
+            f"{model!r} must not contain newlines",
+            param_hint="'--model'",
+        )
+    if any(ch in model for ch in ("\\", '"', "'")):
+        raise click.BadParameter(
+            f"{model!r} must not contain quotes or backslashes",
+            param_hint="'--model'",
+        )
 
     # Platform-specific service generation
     if platform_choice == "macos":

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -36,6 +36,16 @@ import subprocess
 from pathlib import Path
 from xml.sax.saxutils import escape as _xml_escape
 
+# XML 1.0 permits only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
+# Strip everything else (control characters that survive saxutils.escape and corrupt plists).
+_XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F￾￿]")
+
+
+def _xml_safe(value: str) -> str:
+    """Strip XML 1.0-forbidden control characters, then XML-escape special chars."""
+    return _xml_escape(_XML10_FORBIDDEN.sub("", value))
+
+
 import click
 
 # Allowed characters for the agent name: matches systemd/launchd unit-name conventions.
@@ -281,9 +291,9 @@ def _generate_launchd_plist(
     run_at_load = "false" if timer_schedule == "on-demand" else "true"
 
     return LAUNCHD_PLIST_TEMPLATE.format(
-        name=_xml_escape(name),
-        model=_xml_escape(model),
-        work_dir=_xml_escape(work_dir),
+        name=_xml_safe(name),
+        model=_xml_safe(model),
+        work_dir=_xml_safe(work_dir),
         schedule_section=schedule_section,
         run_at_load=run_at_load,
     )

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -416,9 +416,6 @@ def init(
     work = _resolve_work_dir(work_dir)
     out_dir = Path(output_dir).expanduser().resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
-    escaped_work_dir = _escape_systemd_value(str(work))
-    escaped_exec_work_dir = _escape_systemd_exec_value(str(work))
-    escaped_model = _escape_systemd_value(model)
 
     click.echo(f"Scaffolding headless agent '{name}' ({platform_choice})...")
 
@@ -441,6 +438,11 @@ def init(
         )
     else:
         # systemd: service unit + optional timer
+        # Apply systemd-specific escaping only in this branch — these chars
+        # are forbidden in systemd unit values but are valid in launchd plists.
+        escaped_work_dir = _escape_systemd_value(str(work))
+        escaped_exec_work_dir = _escape_systemd_exec_value(str(work))
+        escaped_model = _escape_systemd_value(model)
         _write_file(
             out_dir / f"{name}.service",
             SYSTEMD_SERVICE_TEMPLATE.format(

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -39,7 +39,7 @@ from xml.sax.saxutils import escape as _xml_escape
 # XML 1.0 permits only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
 # Strip control characters and lone UTF-16 surrogates — both survive saxutils.escape unchanged
 # and cause launchctl to reject the generated plist.
-_XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF￾￿]")
+_XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]")
 
 
 def _xml_safe(value: str) -> str:

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -432,6 +432,19 @@ def init(
 
     # Platform-specific service generation
     if platform_choice == "macos":
+        # Reject paths that contain XML 1.0-forbidden characters. Unlike model
+        # (an env-var string where silent stripping is harmless), the work-dir
+        # path must match the one written to disk — silently sanitizing it in
+        # the plist would cause launchd to reference a nonexistent directory.
+        resolved_work = str(work)
+        if _XML10_FORBIDDEN.search(resolved_work):
+            raise click.BadParameter(
+                f"Work directory {resolved_work!r} contains XML 1.0-forbidden "
+                "characters that cannot be represented in a launchd plist. "
+                "Use a path without control characters.",
+                param_hint="'--work-dir'",
+            )
+
         # launchd: create logs directory and plist
         logs_dir = work / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -1,25 +1,35 @@
 """
-Scaffold a persistent headless gptme agent as a systemd user service.
+Scaffold a persistent headless gptme agent as a systemd user service (Linux) or
+launchd agent (macOS).
 
-Generates the systemd unit(s), startup script, and skeleton config needed to
+Generates the unit file(s), startup script, and skeleton config needed to
 run a gptme agent on a timer — the pattern Bob uses for autonomous sessions —
 without reverse-engineering an existing agent workspace.
 
+For the full agent workspace template with examples and best practices, see:
+https://github.com/gptme/gptme-agent-template
+
 Usage:
     gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
-    gptme service init --name myagent --timer-schedule hourly
-    gptme service init --name myagent --output-dir ~/.config/systemd/user
+    gptme service init --name myagent --timer-schedule hourly --platform linux
+    gptme service init --name myagent --output-dir ~/.config/systemd/user --platform linux
+    gptme service init --name myagent --output-dir ~/Library/LaunchAgents --platform macos
 
 The command writes files only; it does not install or start the service.
-After generation, run:
+After generation (Linux), run:
 
     systemctl --user daemon-reload
     systemctl --user enable --now myagent.service   # or myagent.timer
+
+After generation (macOS), run:
+
+    launchctl load ~/Library/LaunchAgents/com.gptme.myagent.plist
 """
 
 from __future__ import annotations
 
 import logging
+import platform
 import re
 import shlex
 import subprocess
@@ -27,7 +37,7 @@ from pathlib import Path
 
 import click
 
-# Allowed characters for the agent name: matches systemd unit-name conventions.
+# Allowed characters for the agent name: matches systemd/launchd unit-name conventions.
 _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 logger = logging.getLogger(__name__)
@@ -101,6 +111,52 @@ SCHEDULES: dict[str, str] = {
     "hourly": "*-*-* *:00:00",
     "daily": "*-*-* 00:00:00",
     "weekly": "Mon *-*-* 00:00:00",
+}
+
+LAUNCHD_PLIST_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.gptme.{name}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>{work_dir}/gptme-agent-run.sh</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>{work_dir}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>GPTME_AGENT_NAME</key>
+		<string>{name}</string>
+		<key>GPTME_AGENT_MODEL</key>
+		<string>{model}</string>
+		<key>GPTME_NON_INTERACTIVE</key>
+		<string>1</string>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>{work_dir}/logs/stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>{work_dir}/logs/stderr.log</string>
+	<key>RunAtLoad</key>
+	<{run_at_load}/>
+	{schedule_section}
+</dict>
+</plist>
+"""
+
+# launchd schedule templates
+LAUNCHD_SCHEDULE_SECTION = """\
+	<key>StartInterval</key>
+	<integer>{interval_seconds}</integer>
+"""
+
+LAUNCHD_SCHEDULE_INTERVALS: dict[str, int] = {
+    "hourly": 3600,
+    "daily": 86400,
+    "weekly": 604800,
 }
 
 STARTUP_SCRIPT_TEMPLATE = """\
@@ -200,6 +256,37 @@ def _write_file(path: Path, content: str, force: bool = False) -> bool:
     return True
 
 
+def _detect_platform() -> str:
+    """Detect the current platform: 'macos' or 'linux'."""
+    system = platform.system().lower()
+    if system == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _generate_launchd_plist(
+    name: str,
+    model: str,
+    work_dir: str,
+    timer_schedule: str,
+) -> str:
+    """Generate a launchd .plist file for macOS agents."""
+    schedule_section = ""
+    if timer_schedule != "on-demand":
+        interval = LAUNCHD_SCHEDULE_INTERVALS.get(timer_schedule, 86400)
+        schedule_section = LAUNCHD_SCHEDULE_SECTION.format(interval_seconds=interval)
+
+    run_at_load = "true" if timer_schedule == "on-demand" else "false"
+
+    return LAUNCHD_PLIST_TEMPLATE.format(
+        name=name,
+        model=model,
+        work_dir=work_dir,
+        schedule_section=schedule_section,
+        run_at_load=run_at_load,
+    )
+
+
 @click.group(
     name="service",
     help="Manage persistent headless gptme agent services.",
@@ -215,7 +302,7 @@ def cli() -> None:
 
 @cli.command(
     name="init",
-    help="Scaffold a systemd user service for a headless gptme agent.",
+    help="Scaffold a persistent service for a headless gptme agent.",
 )
 @click.option(
     "--name",
@@ -244,9 +331,8 @@ def cli() -> None:
     "--output-dir",
     "-o",
     type=str,
-    default="~/.config/systemd/user",
-    show_default=True,
-    help="Directory to write systemd units (usually ~/.config/systemd/user).",
+    default=None,
+    help="Directory to write service files. Defaults to ~/.config/systemd/user (Linux) or ~/Library/LaunchAgents (macOS).",
 )
 @click.option(
     "--timer-schedule",
@@ -254,6 +340,14 @@ def cli() -> None:
     default="daily",
     show_default=True,
     help="Timer schedule. 'on-demand' writes no timer (manual start only).",
+)
+@click.option(
+    "--platform",
+    "platform_choice",
+    type=click.Choice(["linux", "macos", "auto"]),
+    default="auto",
+    show_default=True,
+    help="Target platform. 'auto' detects the current system.",
 )
 @click.option(
     "--force",
@@ -264,27 +358,40 @@ def init(
     name: str,
     model: str,
     work_dir: str,
-    output_dir: str,
+    output_dir: str | None,
     timer_schedule: str,
+    platform_choice: str,
     force: bool,
 ) -> None:
-    """Scaffold a systemd user service for a headless gptme agent.
+    """Scaffold a persistent service for a headless gptme agent.
 
     Generates, in the agent work directory:
 
         gptme.toml, AGENTS.md, gptme-agent-run.sh
 
-    and, in the systemd output directory:
+    and, in the service output directory:
 
-        {name}.service             # main service unit
-        {name}.timer               # optional periodic timer
+        Linux (systemd):
+            {name}.service             # main service unit
+            {name}.timer               # optional periodic timer
 
-    Example:
+        macOS (launchd):
+            com.gptme.{name}.plist     # launchd property list
+
+    Examples:
 
         \b
+        # Linux (systemd)
         gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
         systemctl --user daemon-reload
         systemctl --user enable --now myagent.timer
+
+        # macOS (launchd)
+        gptme service init --name myagent --platform macos --work-dir ~/gptme-agent
+        launchctl load ~/Library/LaunchAgents/com.gptme.myagent.plist
+
+    For the full agent workspace template, see:
+    https://github.com/gptme/gptme-agent-template
     """
     if not _NAME_RE.match(name):
         raise click.BadParameter(
@@ -293,6 +400,17 @@ def init(
             param_hint="'--name'",
         )
 
+    # Resolve platform (auto-detect if needed)
+    if platform_choice == "auto":
+        platform_choice = _detect_platform()
+
+    # Set default output directory based on platform
+    if output_dir is None:
+        if platform_choice == "macos":
+            output_dir = "~/Library/LaunchAgents"
+        else:
+            output_dir = "~/.config/systemd/user"
+
     work = _resolve_work_dir(work_dir)
     out_dir = Path(output_dir).expanduser().resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -300,76 +418,100 @@ def init(
     escaped_exec_work_dir = _escape_systemd_exec_value(str(work))
     escaped_model = _escape_systemd_value(model)
 
-    click.echo(f"Scaffolding headless agent '{name}'...")
+    click.echo(f"Scaffolding headless agent '{name}' ({platform_choice})...")
 
-    # Service unit
-    _write_file(
-        out_dir / f"{name}.service",
-        SYSTEMD_SERVICE_TEMPLATE.format(
-            name=name,
-            model=escaped_model,
-            work_dir=escaped_work_dir,
-            exec_work_dir=escaped_exec_work_dir,
-        ),
-        force=force,
-    )
+    # Platform-specific service generation
+    if platform_choice == "macos":
+        # launchd: create logs directory and plist
+        logs_dir = work / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
 
-    # Timer (skip for on-demand; remove stale timer only with --force)
-    if timer_schedule == "on-demand":
-        stale_timer = out_dir / f"{name}.timer"
-        if stale_timer.exists():
-            if force:
-                # Disable the unit BEFORE removing the file so systemd can
-                # resolve and stop the unit while the file is still present.
-                click.echo(
-                    f"  Disabling loaded timer unit {name}.timer (on-demand mode, --force)"
-                )
-                try:
-                    result = subprocess.run(
-                        ["systemctl", "--user", "disable", "--now", f"{name}.timer"],
-                        check=False,  # best-effort; unit may not be enabled
-                        timeout=_SYSTEMCTL_TIMEOUT_SEC,
-                    )
-                except OSError as exc:
+        plist_name = f"com.gptme.{name}.plist"
+        _write_file(
+            out_dir / plist_name,
+            _generate_launchd_plist(
+                name=name,
+                model=model,
+                work_dir=str(work),
+                timer_schedule=timer_schedule,
+            ),
+            force=force,
+        )
+    else:
+        # systemd: service unit + optional timer
+        _write_file(
+            out_dir / f"{name}.service",
+            SYSTEMD_SERVICE_TEMPLATE.format(
+                name=name,
+                model=escaped_model,
+                work_dir=escaped_work_dir,
+                exec_work_dir=escaped_exec_work_dir,
+            ),
+            force=force,
+        )
+
+        # Timer (skip for on-demand; remove stale timer only with --force)
+        if timer_schedule == "on-demand":
+            stale_timer = out_dir / f"{name}.timer"
+            if stale_timer.exists():
+                if force:
+                    # Disable the unit BEFORE removing the file so systemd can
+                    # resolve and stop the unit while the file is still present.
                     click.echo(
-                        f"  Warning: cannot run systemctl to disable {name}.timer: "
-                        f"{exc}. Remove the timer file manually and run "
-                        "'systemctl --user daemon-reload' to clear the unit.",
-                        err=True,
+                        f"  Disabling loaded timer unit {name}.timer (on-demand mode, --force)"
                     )
-                except subprocess.TimeoutExpired:
-                    click.echo(
-                        f"  Warning: systemctl --user disable --now {name}.timer "
-                        f"timed out after {_SYSTEMCTL_TIMEOUT_SEC}s; leaving the "
-                        "timer file in place. Disable it manually.",
-                        err=True,
-                    )
-                else:
-                    if result.returncode != 0:
+                    try:
+                        result = subprocess.run(
+                            [
+                                "systemctl",
+                                "--user",
+                                "disable",
+                                "--now",
+                                f"{name}.timer",
+                            ],
+                            check=False,  # best-effort; unit may not be enabled
+                            timeout=_SYSTEMCTL_TIMEOUT_SEC,
+                        )
+                    except OSError as exc:
                         click.echo(
-                            f"  Warning: could not disable {name}.timer "
-                            "(unit may not be enabled/loaded). "
-                            "Periodic runs may continue until the next daemon-reload.",
+                            f"  Warning: cannot run systemctl to disable {name}.timer: "
+                            f"{exc}. Remove the timer file manually and run "
+                            "'systemctl --user daemon-reload' to clear the unit.",
+                            err=True,
+                        )
+                    except subprocess.TimeoutExpired:
+                        click.echo(
+                            f"  Warning: systemctl --user disable --now {name}.timer "
+                            f"timed out after {_SYSTEMCTL_TIMEOUT_SEC}s; leaving the "
+                            "timer file in place. Disable it manually.",
                             err=True,
                         )
                     else:
-                        stale_timer.unlink()
-                        click.echo(f"  Removed stale timer file {stale_timer}")
-            else:
-                click.echo(
-                    f"  Warning: existing timer {stale_timer} preserved (use --force to remove)."
-                )
-                click.echo(
-                    "  The scheduled runs remain active until you disable the timer:"
-                )
-                click.echo(f"    systemctl --user disable --now {name}.timer")
-    else:
-        schedule = SCHEDULES.get(timer_schedule, SCHEDULES["daily"])
-        _write_file(
-            out_dir / f"{name}.timer",
-            SYSTEMD_TIMER_TEMPLATE.format(name=name, schedule=schedule),
-            force=force,
-        )
+                        if result.returncode != 0:
+                            click.echo(
+                                f"  Warning: could not disable {name}.timer "
+                                "(unit may not be enabled/loaded). "
+                                "Periodic runs may continue until the next daemon-reload.",
+                                err=True,
+                            )
+                        else:
+                            stale_timer.unlink()
+                            click.echo(f"  Removed stale timer file {stale_timer}")
+                else:
+                    click.echo(
+                        f"  Warning: existing timer {stale_timer} preserved (use --force to remove)."
+                    )
+                    click.echo(
+                        "  The scheduled runs remain active until you disable the timer:"
+                    )
+                    click.echo(f"    systemctl --user disable --now {name}.timer")
+        else:
+            schedule = SCHEDULES.get(timer_schedule, SCHEDULES["daily"])
+            _write_file(
+                out_dir / f"{name}.timer",
+                SYSTEMD_TIMER_TEMPLATE.format(name=name, schedule=schedule),
+                force=force,
+            )
 
     # Work directory contents
     _write_file(
@@ -396,11 +538,24 @@ def init(
     click.echo(f"✅ Initialized headless agent '{name}'")
     click.echo()
     click.echo("Next steps:")
-    click.echo("  systemctl --user daemon-reload")
-    if timer_schedule != "on-demand":
-        click.echo(f"  systemctl --user enable --now {name}.timer")
-    click.echo(f"  systemctl --user start {name}.service   # first run")
-    click.echo(f"  journalctl --user -u {name}.service -f  # follow logs")
+
+    if platform_choice == "macos":
+        plist_file = out_dir / f"com.gptme.{name}.plist"
+        click.echo(f"  launchctl load {plist_file}")
+        click.echo(f"  launchctl start com.gptme.{name}")
+        click.echo(
+            f"  log stream --predicate 'eventMessage contains[cd] \"{name}\"'  # follow logs"
+        )
+    else:
+        click.echo("  systemctl --user daemon-reload")
+        if timer_schedule != "on-demand":
+            click.echo(f"  systemctl --user enable --now {name}.timer")
+        click.echo(f"  systemctl --user start {name}.service   # first run")
+        click.echo(f"  journalctl --user -u {name}.service -f  # follow logs")
+
+    click.echo()
+    click.echo("For the full agent workspace template with examples, see:")
+    click.echo("  https://github.com/gptme/gptme-agent-template")
 
 
 main = cli

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -683,6 +683,41 @@ def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
     assert "\ud800" not in plist_text
 
 
+def test_launchd_work_dir_with_forbidden_chars_rejected(tmp_path: Path) -> None:
+    """Work-dir containing XML 1.0-forbidden chars must be rejected on macOS.
+
+    Silently sanitizing the path in the plist would cause launchd to look for a
+    nonexistent directory/script. Validation is the correct response.
+    """
+    from unittest.mock import patch
+
+    special_work = tmp_path / "work\x01dir"
+    special_work.mkdir()
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    with patch(
+        "gptme.cli.cmd_service._resolve_work_dir",
+        return_value=special_work,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--name",
+                "testagent",
+                "--work-dir",
+                str(special_work),
+                "--output-dir",
+                str(out_dir),
+                "--platform",
+                "macos",
+            ],
+        )
+    assert result.exit_code != 0, (
+        "macOS scaffolding must reject work-dir containing XML-forbidden control chars"
+    )
+
+
 def test_macos_path_with_systemd_invalid_chars_accepted(tmp_path: Path) -> None:
     """Paths with apostrophes/backslashes are valid on macOS and must not be
     rejected by systemd-specific escaping when --platform macos is used."""

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -455,6 +455,82 @@ def test_model_newline_rejected(tmp_path: Path) -> None:
     assert not (tmp_path / "systemd4" / "modelagent.service").exists()
 
 
+def test_model_newline_rejected_on_macos(tmp_path: Path) -> None:
+    """A model with a newline must be rejected on macOS just as on Linux."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "modelagent",
+            "--model",
+            "gpt-4o-mini\nEnvironment=GPTME_MALICIOUS=1",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code != 0, "newline in model must be rejected on macOS too"
+    assert not (out_dir / "com.gptme.modelagent.plist").exists()
+
+
+def test_detect_platform_unsupported_raises(tmp_path: Path) -> None:
+    """Running with --platform auto on an unsupported OS must raise a usage error."""
+    from unittest.mock import patch
+
+    runner = CliRunner()
+    with patch("gptme.cli.cmd_service.platform.system", return_value="Windows"):
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--name",
+                "agent",
+                "--work-dir",
+                str(tmp_path),
+                "--output-dir",
+                str(tmp_path / "out"),
+                "--platform",
+                "auto",
+            ],
+        )
+    assert result.exit_code != 0, "unsupported platform must produce a non-zero exit"
+    assert "not supported" in (result.output + str(result.exception)).lower()
+
+
+def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
+    """Auto-detecting macOS should print a note about launchd vs systemd."""
+    from unittest.mock import patch
+
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    with patch("gptme.cli.cmd_service.platform.system", return_value="Darwin"):
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--name",
+                "agent",
+                "--work-dir",
+                str(tmp_path),
+                "--output-dir",
+                str(out_dir),
+                "--platform",
+                "auto",
+            ],
+        )
+    assert result.exit_code == 0, f"should succeed; got: {result.output}"
+    # CliRunner mixes stderr into .output by default
+    assert "macos" in result.output.lower() or "launchd" in result.output.lower(), (
+        "expected a macOS/launchd note in output"
+    )
+
+
 def test_launchd_plist_generated_on_macos_platform(tmp_path: Path) -> None:
     """When --platform=macos, a launchd plist should be generated instead of systemd files."""
     out_dir = tmp_path / "launchd"

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -504,10 +504,13 @@ def test_detect_platform_unsupported_raises(tmp_path: Path) -> None:
 
 
 def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
-    """Auto-detecting macOS should print a note about launchd vs systemd."""
+    """Auto-detecting macOS should print a note about launchd vs systemd.
+
+    The note is only emitted when --output-dir is NOT passed (output_dir is None),
+    so we must NOT pass --output-dir here or the note path is never reached.
+    """
     from unittest.mock import patch
 
-    out_dir = tmp_path / "launchd"
     runner = CliRunner()
     with patch("gptme.cli.cmd_service.platform.system", return_value="Darwin"):
         result = runner.invoke(
@@ -518,16 +521,17 @@ def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
                 "agent",
                 "--work-dir",
                 str(tmp_path),
-                "--output-dir",
-                str(out_dir),
+                # no --output-dir: note fires only when output_dir is None
                 "--platform",
                 "auto",
             ],
         )
     assert result.exit_code == 0, f"should succeed; got: {result.output}"
-    # CliRunner mixes stderr into .output by default
-    assert "macos" in result.output.lower() or "launchd" in result.output.lower(), (
-        "expected a macOS/launchd note in output"
+    # CliRunner mixes stderr into .output by default.
+    # The note specifically mentions "launchd plist" — check for that phrase
+    # to ensure the actual warning path was exercised (not just the scaffold line).
+    assert "launchd plist" in result.output.lower(), (
+        "expected the launchd-plist note in output (fires only when output_dir is None)"
     )
 
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -525,6 +525,7 @@ def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
                 "--platform",
                 "auto",
             ],
+            env={"HOME": str(tmp_path)},  # redirect ~/Library/LaunchAgents to tmp
         )
     assert result.exit_code == 0, f"should succeed; got: {result.output}"
     # CliRunner mixes stderr into .output by default.

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -589,7 +589,7 @@ def test_launchd_plist_daily_schedule(tmp_path: Path) -> None:
 
 
 def test_launchd_plist_on_demand_no_schedule(tmp_path: Path) -> None:
-    """launchd plist with on-demand should have RunAtLoad=true and no StartInterval."""
+    """launchd plist with on-demand should have RunAtLoad=false and no StartInterval."""
     out_dir = tmp_path / "launchd"
     runner = CliRunner()
     result = runner.invoke(
@@ -613,7 +613,7 @@ def test_launchd_plist_on_demand_no_schedule(tmp_path: Path) -> None:
     plist_file = out_dir / "com.gptme.testagent.plist"
     plist_text = plist_file.read_text()
 
-    assert "<true/>" in plist_text  # RunAtLoad=true for on-demand
+    assert "<false/>" in plist_text  # RunAtLoad=false for on-demand (manual start only)
     assert "StartInterval" not in plist_text  # no periodic schedule
 
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -453,3 +453,189 @@ def test_model_newline_rejected(tmp_path: Path) -> None:
     )
     assert result.exit_code != 0, "newline in model must be rejected"
     assert not (tmp_path / "systemd4" / "modelagent.service").exists()
+
+
+def test_launchd_plist_generated_on_macos_platform(tmp_path: Path) -> None:
+    """When --platform=macos, a launchd plist should be generated instead of systemd files."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    work = tmp_path
+
+    # launchd plist should be generated
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    assert plist_file.exists(), "should generate com.gptme.{name}.plist"
+    assert "com.gptme.testagent" in result.output
+
+    # NO systemd files
+    assert not (out_dir / "testagent.service").exists()
+    assert not (out_dir / "testagent.timer").exists()
+
+    # Workspace files still generated
+    assert (work / "gptme.toml").exists()
+    assert (work / "AGENTS.md").exists()
+    assert (work / "gptme-agent-run.sh").exists()
+
+
+def test_launchd_plist_is_valid_xml(tmp_path: Path) -> None:
+    """The generated launchd plist should be valid XML that can be parsed."""
+    import xml.etree.ElementTree as ET
+
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    plist_text = plist_file.read_text()
+
+    # Should parse as valid XML
+    tree = ET.fromstring(plist_text)
+    assert tree.tag == "plist"
+
+    # Should have proper structure
+    root_dict = tree.find("dict")
+    assert root_dict is not None
+
+
+def test_launchd_plist_contains_agent_variables(tmp_path: Path) -> None:
+    """The generated launchd plist should contain proper agent env variables."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--model",
+            "gpt-4o-mini",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    plist_text = plist_file.read_text()
+
+    # Check key environment variables are present
+    assert "GPTME_AGENT_NAME" in plist_text
+    assert "testagent" in plist_text
+    assert "GPTME_AGENT_MODEL" in plist_text
+    assert "gpt-4o-mini" in plist_text
+    assert "GPTME_NON_INTERACTIVE" in plist_text
+
+
+def test_launchd_plist_daily_schedule(tmp_path: Path) -> None:
+    """launchd plist with daily schedule should include StartInterval."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+            "--timer-schedule",
+            "daily",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    plist_text = plist_file.read_text()
+
+    # Daily schedule = 86400 seconds (1 day)
+    assert "StartInterval" in plist_text
+    assert "86400" in plist_text  # daily interval in seconds
+
+
+def test_launchd_plist_on_demand_no_schedule(tmp_path: Path) -> None:
+    """launchd plist with on-demand should have RunAtLoad=true and no StartInterval."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+            "--timer-schedule",
+            "on-demand",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    plist_text = plist_file.read_text()
+
+    assert "<true/>" in plist_text  # RunAtLoad=true for on-demand
+    assert "StartInterval" not in plist_text  # no periodic schedule
+
+
+def test_launchd_logs_directory_created(tmp_path: Path) -> None:
+    """launchd scaffolding should create a logs directory for plist output redirection."""
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    logs_dir = tmp_path / "logs"
+    assert logs_dir.exists() and logs_dir.is_dir(), "logs/ directory should be created"

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -641,6 +641,47 @@ def test_launchd_logs_directory_created(tmp_path: Path) -> None:
     assert logs_dir.exists() and logs_dir.is_dir(), "logs/ directory should be created"
 
 
+def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
+    """XML 1.0-forbidden control characters in model/work-dir must be stripped, not escaped."""
+    import xml.etree.ElementTree as ET
+    from unittest.mock import patch
+
+    special_work = tmp_path / "work"
+    special_work.mkdir()
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    # Inject control chars (\x01, \x0B) into the model string via _generate_launchd_plist directly
+    with patch(
+        "gptme.cli.cmd_service._resolve_work_dir",
+        return_value=special_work,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--name",
+                "testagent",
+                "--model",
+                "gpt-4o\x01mini\x0b",
+                "--work-dir",
+                str(special_work),
+                "--output-dir",
+                str(out_dir),
+                "--platform",
+                "macos",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    plist_file = out_dir / "com.gptme.testagent.plist"
+    plist_text = plist_file.read_text()
+    # Must parse as valid XML (control chars would cause a ParseError)
+    tree = ET.fromstring(plist_text)
+    assert tree.tag == "plist"
+    # Control chars must be gone from the output
+    assert "\x01" not in plist_text
+    assert "\x0b" not in plist_text
+
+
 def test_macos_path_with_systemd_invalid_chars_accepted(tmp_path: Path) -> None:
     """Paths with apostrophes/backslashes are valid on macOS and must not be
     rejected by systemd-specific escaping when --platform macos is used."""

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -722,9 +722,12 @@ def test_launchd_logs_directory_created(tmp_path: Path) -> None:
     assert logs_dir.exists() and logs_dir.is_dir(), "logs/ directory should be created"
 
 
-def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
-    """XML 1.0-forbidden control characters in model/work-dir must be stripped, not escaped."""
-    import xml.etree.ElementTree as ET
+def test_launchd_model_with_forbidden_chars_rejected(tmp_path: Path) -> None:
+    """Model identifiers containing XML 1.0-forbidden chars must be rejected on macOS.
+
+    Silently stripping them would cause the agent to run with a different model
+    than the user requested. Validation is the correct response.
+    """
     from unittest.mock import patch
 
     special_work = tmp_path / "work"
@@ -752,16 +755,9 @@ def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
                 "macos",
             ],
         )
-    assert result.exit_code == 0, result.output
-    plist_file = out_dir / "com.gptme.testagent.plist"
-    plist_text = plist_file.read_text()
-    # Must parse as valid XML (control chars would cause a ParseError)
-    tree = ET.fromstring(plist_text)
-    assert tree.tag == "plist"
-    # Control chars and lone surrogates must be gone from the output
-    assert "\x01" not in plist_text
-    assert "\x0b" not in plist_text
-    assert "\ud800" not in plist_text
+    assert result.exit_code != 0, (
+        "macOS scaffolding must reject model containing XML-forbidden control chars"
+    )
 
 
 def test_launchd_work_dir_with_forbidden_chars_rejected(tmp_path: Path) -> None:

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -639,3 +639,31 @@ def test_launchd_logs_directory_created(tmp_path: Path) -> None:
 
     logs_dir = tmp_path / "logs"
     assert logs_dir.exists() and logs_dir.is_dir(), "logs/ directory should be created"
+
+
+def test_macos_path_with_systemd_invalid_chars_accepted(tmp_path: Path) -> None:
+    """Paths with apostrophes/backslashes are valid on macOS and must not be
+    rejected by systemd-specific escaping when --platform macos is used."""
+    # Create a subdir whose name contains a character systemd forbids but
+    # launchd allows (apostrophe), then scaffold into it.
+    special_work = tmp_path / "user's workspace"
+    special_work.mkdir()
+    out_dir = tmp_path / "launchd"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(special_work),
+            "--output-dir",
+            str(out_dir),
+            "--platform",
+            "macos",
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"macOS scaffolding should accept apostrophes in work-dir; got: {result.output}"
+    )

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -650,7 +650,7 @@ def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
     special_work.mkdir()
     out_dir = tmp_path / "launchd"
     runner = CliRunner()
-    # Inject control chars (\x01, \x0B) into the model string via _generate_launchd_plist directly
+    # Inject control chars (\x01, \x0B) and a lone surrogate (\uD800) into the model
     with patch(
         "gptme.cli.cmd_service._resolve_work_dir",
         return_value=special_work,
@@ -662,7 +662,7 @@ def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
                 "--name",
                 "testagent",
                 "--model",
-                "gpt-4o\x01mini\x0b",
+                "gpt-4o\x01mini\x0b\ud800",
                 "--work-dir",
                 str(special_work),
                 "--output-dir",
@@ -677,9 +677,10 @@ def test_launchd_plist_strips_control_characters(tmp_path: Path) -> None:
     # Must parse as valid XML (control chars would cause a ParseError)
     tree = ET.fromstring(plist_text)
     assert tree.tag == "plist"
-    # Control chars must be gone from the output
+    # Control chars and lone surrogates must be gone from the output
     assert "\x01" not in plist_text
     assert "\x0b" not in plist_text
+    assert "\ud800" not in plist_text
 
 
 def test_macos_path_with_systemd_invalid_chars_accepted(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #3574, addressing Erik's feedback to add macOS support.

## Summary

- Added `--platform` flag (linux/macos/auto) for cross-platform scaffolding
- Auto-detect platform (macOS/Linux) — defaults to current system or explicit choice
- **launchd plist generation** for macOS agents with configurable scheduling (hourly/daily/weekly/on-demand)
- Logs directory creation for plist output redirection
- Updated docstrings to reference gptme-agent-template as the full version
- Comprehensive tests for launchd XML validity, env variables, and scheduling

## Implementation Details

### launchd Support
- New LAUNCHD_PLIST_TEMPLATE with proper XML structure and env variable configuration
- StartInterval scheduling (3600s hourly, 86400s daily, 604800s weekly)
- RunAtLoad flag for on-demand/immediate startup
- Plist filename follows macOS convention: com.gptme.{name}.plist

### Platform Handling
- Helper functions: _detect_platform() and _generate_launchd_plist()
- Default output directory logic: ~/.config/systemd/user (Linux) or ~/Library/LaunchAgents (macOS)
- Platform-specific final instructions in CLI output

### Tests Added
- 6 new tests for plist generation, XML validity, env variables, and scheduling