### PR TITLE
feat(skills): invoke skills as slash commands (/skill:<name>)

### DIFF
--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -186,9 +186,9 @@ Invoking Skills as Commands
 ---------------------------
 
 Every discovered skill is also registered as a slash command, matching how
-Claude Code and Codex expose skills. Inside a chat, ``/skill:<name> [args]``
-queues the skill body as your next user prompt (with a ``Skill invoked:``
-header) so the assistant acts on it immediately:
+Claude Code and Codex expose skills. Inside a chat (CLI, TUI, or server/WebUI),
+``/skill:<name> [args]`` queues the skill body as your next user prompt (with a
+``Skill invoked:`` header) so the assistant acts on it immediately:
 
 .. code-block:: text
 

--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -182,6 +182,24 @@ Use the utility CLI to see what the current workspace already knows about:
 lessons in the same discovery pass, and ``skills dirs`` shows exactly which
 directories are being scanned.
 
+Invoking Skills as Commands
+---------------------------
+
+Every discovered skill is also registered as a slash command, matching how
+Claude Code and Codex expose skills. Inside a chat, ``/skill:<name> [args]``
+queues the skill body as your next user prompt (with a ``Skill invoked:``
+header) so the assistant acts on it immediately:
+
+.. code-block:: text
+
+    /skill:end                # canonical form, never collides
+    /end                      # bare alias, only if no command/tool is named "end"
+    /skill:review src/app.py  # arguments are passed through
+
+In the skill body, ``$ARGUMENTS`` expands to the full argument string and
+``$ARGUMENTS[N]`` / ``$N`` to the N-th (0-based) whitespace-separated
+argument. Use ``/skills read <name>`` to view a skill without invoking it.
+
 Creating Skills
 ---------------
 

--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -197,8 +197,10 @@ header) so the assistant acts on it immediately:
     /skill:review src/app.py  # arguments are passed through
 
 In the skill body, ``$ARGUMENTS`` expands to the full argument string and
-``$ARGUMENTS[N]`` / ``$N`` to the N-th (0-based) whitespace-separated
-argument. Use ``/skills read <name>`` to view a skill without invoking it.
+``$ARGUMENTS[N]`` / ``${N}`` to the N-th (0-based) whitespace-separated
+argument (curly braces are required for positional references to avoid
+ambiguity with literal dollar amounts like ``$100`` in skill prose).
+Use ``/skills read <name>`` to view a skill without invoking it.
 
 Creating Skills
 ---------------

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -83,9 +83,6 @@ def init(
             first_line,
         )
     init_tools(tool_allowlist)
-    # Expose skills as /skill:<name> commands (after tools so bare aliases can
-    # avoid shadowing loaded tool names). Never raises.
-    register_skill_commands()
     init_hooks(interactive=interactive, no_confirm=no_confirm, server=server)
 
     config = get_config()
@@ -98,6 +95,9 @@ def init(
         register_script_hooks(script_hooks, workspace or Path.cwd())
 
     init_commands()
+    # Expose skills as /skill:<name> commands (after both tools and built-in
+    # commands so bare aliases see the full registry). Never raises.
+    register_skill_commands()
 
     set_tool_format(tool_format)
     # Mark initialization done at the end so callers can retry init()

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -16,6 +16,7 @@ from .cli.setup import ask_for_api_key
 from .commands import init_commands
 from .config import Config, get_config
 from .hooks import init_hooks
+from .lessons.skill_commands import register_skill_commands
 from .llm import guess_provider_from_config, init_llm, is_custom_provider
 from .llm.llm_gptme import GptmeAuthError
 from .llm.models import (
@@ -82,6 +83,9 @@ def init(
             first_line,
         )
     init_tools(tool_allowlist)
+    # Expose skills as /skill:<name> commands (after tools so bare aliases can
+    # avoid shadowing loaded tool names). Never raises.
+    register_skill_commands()
     init_hooks(interactive=interactive, no_confirm=no_confirm, server=server)
 
     config = get_config()

--- a/gptme/lessons/__init__.py
+++ b/gptme/lessons/__init__.py
@@ -19,7 +19,7 @@ from .commands import register_lesson_commands
 from .index import LessonIndex, clear_cache, get_cache_stats
 from .matcher import LessonMatcher, MatchContext, MatchResult
 from .parser import Lesson, LessonMetadata, parse_lesson
-from .skill_commands import register_skill_commands
+from .skill_commands import is_skill_command, register_skill_commands
 
 # Register commands
 register_lesson_commands()
@@ -33,6 +33,7 @@ __all__ = [
     # Functions
     "parse_lesson",
     "auto_include_lessons",
+    "is_skill_command",
     "register_skill_commands",
     "clear_cache",
     "get_cache_stats",

--- a/gptme/lessons/__init__.py
+++ b/gptme/lessons/__init__.py
@@ -19,6 +19,7 @@ from .commands import register_lesson_commands
 from .index import LessonIndex, clear_cache, get_cache_stats
 from .matcher import LessonMatcher, MatchContext, MatchResult
 from .parser import Lesson, LessonMetadata, parse_lesson
+from .skill_commands import register_skill_commands
 
 # Register commands
 register_lesson_commands()
@@ -32,6 +33,7 @@ __all__ = [
     # Functions
     "parse_lesson",
     "auto_include_lessons",
+    "register_skill_commands",
     "clear_cache",
     "get_cache_stats",
     # Classes

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -86,11 +86,8 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
     def handler(ctx: CommandContext) -> Generator[Message, None, None]:
         from ..prompt_queue import queue_prompt  # fmt: skip
 
-        # Remove the "/skill:<name>" command message from the log, like built-in
-        # commands do; the queued prompt carries its own "Skill invoked" header.
-        ctx.manager.undo(1, quiet=True)
-        ctx.manager.write()
-
+        # Build the prompt first; only undo the command message on success so a
+        # broken skill leaves the log intact instead of silently disappearing.
         try:
             content = build_skill_prompt(skill, index, ctx.full_args.strip(), ctx.args)
         except Exception as e:
@@ -98,6 +95,10 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
             yield from ()
             return
         queue_prompt(ctx.manager.logdir, content)
+        # Remove the "/skill:<name>" command message from the log after queuing,
+        # like built-in commands do; the queued prompt carries its own header.
+        ctx.manager.undo(1, quiet=True)
+        ctx.manager.write()
         logger.debug("Queued skill prompt for /%s%s", SKILL_COMMAND_PREFIX, name)
         # Yield nothing: the chat loop drains the queue on its next iteration
         # and the assistant responds to the skill body as a normal user turn.
@@ -164,6 +165,9 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
         # alias can accidentally shadow a real tool command.
         tools_available = tool_names is not _TOOL_NAMES_UNAVAILABLE
 
+        # Two-pass registration so canonicals never collide with our own aliases.
+        # Pass 1: collect valid skills and register all canonicals.
+        skill_entries: list[tuple[str, str, CommandHandler]] = []
         for skill in index.lessons:
             name = skill.metadata.name
             if not name:
@@ -189,8 +193,13 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
             register_command(canonical, handler)
             _registered_skill_commands[canonical] = handler
             registered.append(canonical)
+            skill_entries.append((name, canonical, handler))
 
-            if name in _command_registry:
+        # Pass 2: register bare aliases, checking against all canonicals we just
+        # registered so a skill named "skill:X" doesn't block bare alias for "X".
+        our_canonicals = {canonical for _, canonical, _ in skill_entries}
+        for name, canonical, handler in skill_entries:
+            if name in _command_registry and name not in our_canonicals:
                 logger.debug(
                     "Skill %r collides with existing command; only /%s registered",
                     name,

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -233,3 +233,8 @@ def unregister_skill_commands() -> None:
         if _command_registry.get(name) is handler:
             unregister_command(name)
     _registered_skill_commands.clear()
+
+
+def is_skill_command(name: str) -> bool:
+    """Return True if *name* (without leading ``/``) is a registered skill command."""
+    return name in _registered_skill_commands

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -40,7 +40,7 @@ SKILL_COMMAND_PREFIX = "skill:"
 # aliases not count as collisions.
 _registered_skill_commands: dict[str, CommandHandler] = {}
 
-_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS\b|\$\{(\d+)\}")
+_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS(?!\[)\b|\$\{(\d+)\}")
 
 
 def substitute_arguments(body: str, full_args: str, args: list[str]) -> str:

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -206,7 +206,7 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
                     name,
                     canonical,
                 )
-            elif not tools_available or name in tool_names:  # type: ignore[operator]
+            elif not tools_available or name.lower() in {t.lower() for t in tool_names}:  # type: ignore[attr-defined]
                 logger.debug(
                     "Skill %r collides with loaded tool (or tool list unavailable); only /%s registered",
                     name,

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -1,0 +1,193 @@
+"""Expose skills as user-invocable slash commands.
+
+Claude Code and Codex expose every ``SKILL.md`` skill as a ``/<name>`` command
+that injects the skill body as the user's prompt. This module gives gptme the
+same behavior so skills can be shared across runtimes:
+
+- ``/skill:<name> [args]`` is the canonical, collision-free form.
+- ``/<name>`` is registered as an alias only when ``<name>`` does not collide
+  with an existing command or a loaded tool (``handle_cmd`` falls back to tool
+  execution for unknown names, so a skill named ``shell`` must never shadow
+  the shell tool).
+
+The handler substitutes ``$ARGUMENTS`` (and ``$ARGUMENTS[N]`` / ``$N``
+positional forms) in the skill body and queues the result via
+:func:`gptme.prompt_queue.queue_prompt`, so the main chat loop drains it as a
+normal user message on its next iteration and the assistant acts on it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from .index import LessonIndex
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ..commands.base import CommandContext, CommandHandler
+    from ..message import Message
+    from .parser import Lesson
+
+logger = logging.getLogger(__name__)
+
+SKILL_COMMAND_PREFIX = "skill:"
+
+# Names registered by the most recent register_skill_commands() call.
+# Used to make re-registration idempotent and to let our own previous bare
+# aliases not count as collisions.
+_registered_skill_commands: dict[str, CommandHandler] = {}
+
+_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS|\$(\d+)")
+
+
+def substitute_arguments(body: str, full_args: str, args: list[str]) -> str:
+    """Substitute ``$ARGUMENTS``, ``$ARGUMENTS[N]`` and ``$N`` placeholders.
+
+    ``$ARGUMENTS`` expands to the full argument string; ``$ARGUMENTS[N]`` and
+    ``$N`` expand to the N-th (0-based) whitespace-split argument, or the empty
+    string when out of range.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        idx_str = match.group(1) or match.group(2)
+        if idx_str is None:
+            return full_args
+        idx = int(idx_str)
+        return args[idx] if idx < len(args) else ""
+
+    return _ARG_PATTERN.sub(_replace, body)
+
+
+def build_skill_prompt(
+    skill: Lesson, index: LessonIndex, full_args: str, args: list[str]
+) -> str:
+    """Materialize a skill and render it as a user prompt."""
+    if skill.is_stub:
+        skill = index.materialize_lesson(skill)
+    name = skill.metadata.name or skill.path.stem
+    header = f"Skill invoked: /{SKILL_COMMAND_PREFIX}{name}"
+    if full_args:
+        header += f" {full_args}"
+    body = substitute_arguments(skill.body, full_args, args)
+    return f"{header}\n\n{body}".rstrip()
+
+
+def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
+    name = skill.metadata.name or skill.path.stem
+
+    def handler(ctx: CommandContext) -> Generator[Message, None, None]:
+        from ..prompt_queue import queue_prompt  # fmt: skip
+
+        # Remove the "/skill:<name>" command message from the log, like built-in
+        # commands do; the queued prompt carries its own "Skill invoked" header.
+        ctx.manager.undo(1, quiet=True)
+        ctx.manager.write()
+
+        content = build_skill_prompt(skill, index, ctx.full_args.strip(), ctx.args)
+        queue_prompt(ctx.manager.logdir, content)
+        logger.debug("Queued skill prompt for /%s%s", SKILL_COMMAND_PREFIX, name)
+        # Yield nothing: the chat loop drains the queue on its next iteration
+        # and the assistant responds to the skill body as a normal user turn.
+        yield from ()
+
+    desc = skill.metadata.description or skill.description or f"Invoke skill {name}"
+    handler.__doc__ = desc.strip().split("\n")[0]
+    handler.__name__ = f"skill_{name}"
+    return handler
+
+
+def _loaded_tool_names() -> set[str]:
+    try:
+        from ..tools import get_tools  # fmt: skip
+
+        return {tool.name for tool in get_tools()}
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Could not list loaded tools for skill alias check: %s", e)
+        return set()
+
+
+def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
+    """Register every skill in the lesson index as a ``/skill:<name>`` command.
+
+    Also registers a bare ``/<name>`` alias when it collides with neither an
+    existing command nor a loaded tool. Safe to call repeatedly (stale skill
+    commands from a previous call are removed first) and never raises.
+
+    Returns:
+        The list of command names registered.
+    """
+    from ..commands.base import (  # fmt: skip
+        _command_registry,
+        register_command,
+        unregister_command,
+    )
+
+    registered: list[str] = []
+    try:
+        # Drop commands from a previous registration so renamed/removed skills
+        # do not linger and re-registration stays idempotent.
+        for old_name, old_handler in list(_registered_skill_commands.items()):
+            if _command_registry.get(old_name) is old_handler:
+                unregister_command(old_name)
+        _registered_skill_commands.clear()
+
+        if index is None:
+            index = LessonIndex()
+        tool_names = _loaded_tool_names()
+
+        for skill in index.lessons:
+            name = skill.metadata.name
+            if not name:
+                continue
+            name = name.strip()
+            if not name or any(ch.isspace() for ch in name):
+                logger.warning("Skipping skill with invalid name: %r", name)
+                continue
+
+            try:
+                handler = _make_skill_handler(skill, index)
+            except Exception as e:
+                logger.warning("Failed to build command for skill %r: %s", name, e)
+                continue
+
+            canonical = f"{SKILL_COMMAND_PREFIX}{name}"
+            register_command(canonical, handler)
+            _registered_skill_commands[canonical] = handler
+            registered.append(canonical)
+
+            if name in _command_registry:
+                logger.debug(
+                    "Skill %r collides with existing command; only /%s registered",
+                    name,
+                    canonical,
+                )
+            elif name in tool_names:
+                logger.debug(
+                    "Skill %r collides with loaded tool; only /%s registered",
+                    name,
+                    canonical,
+                )
+            else:
+                register_command(name, handler)
+                _registered_skill_commands[name] = handler
+                registered.append(name)
+
+        if registered:
+            logger.debug("Registered %d skill command(s)", len(registered))
+    except Exception as e:
+        logger.warning("Failed to register skill commands: %s", e)
+
+    return registered
+
+
+def unregister_skill_commands() -> None:
+    """Remove all commands registered by :func:`register_skill_commands`."""
+    from ..commands.base import _command_registry, unregister_command  # fmt: skip
+
+    for name, handler in list(_registered_skill_commands.items()):
+        if _command_registry.get(name) is handler:
+            unregister_command(name)
+    _registered_skill_commands.clear()

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -12,8 +12,8 @@ same behavior so skills can be shared across runtimes:
 
 The handler substitutes ``$ARGUMENTS`` (and ``$ARGUMENTS[N]`` / ``${N}``
 positional forms) in the skill body and queues the result via
-:func:`gptme.prompt_queue.queue_prompt`, so the main chat loop drains it as a
-normal user message on its next iteration and the assistant acts on it.
+:func:`gptme.prompt_queue.queue_prompt`. The CLI chat loop, TUI, and server
+API drain that queue as a normal user message so the assistant acts on it.
 """
 
 from __future__ import annotations

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -40,7 +40,7 @@ SKILL_COMMAND_PREFIX = "skill:"
 # aliases not count as collisions.
 _registered_skill_commands: dict[str, CommandHandler] = {}
 
-_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS|\$(\d+)")
+_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS\b|\$(\d+)")
 
 
 def substitute_arguments(body: str, full_args: str, args: list[str]) -> str:
@@ -156,6 +156,12 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
                 continue
 
             canonical = f"{SKILL_COMMAND_PREFIX}{name}"
+            if canonical in _command_registry:
+                logger.debug(
+                    "Skill canonical %r already registered by another component; skipping",
+                    canonical,
+                )
+                continue
             register_command(canonical, handler)
             _registered_skill_commands[canonical] = handler
             registered.append(canonical)

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -69,7 +69,7 @@ def build_skill_prompt(
     """Materialize a skill and render it as a user prompt."""
     if skill.is_stub:
         skill = index.materialize_lesson(skill)
-    name = skill.metadata.name or skill.path.stem
+    name = (skill.metadata.name or skill.path.stem).strip()
     header = f"Skill invoked: /{SKILL_COMMAND_PREFIX}{name}"
     if full_args:
         header += f" {full_args}"
@@ -78,7 +78,7 @@ def build_skill_prompt(
 
 
 def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
-    name = skill.metadata.name or skill.path.stem
+    name = (skill.metadata.name or skill.path.stem).strip()
 
     def handler(ctx: CommandContext) -> Generator[Message, None, None]:
         from ..prompt_queue import queue_prompt  # fmt: skip
@@ -88,7 +88,12 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
         ctx.manager.undo(1, quiet=True)
         ctx.manager.write()
 
-        content = build_skill_prompt(skill, index, ctx.full_args.strip(), ctx.args)
+        try:
+            content = build_skill_prompt(skill, index, ctx.full_args.strip(), ctx.args)
+        except Exception as e:
+            logger.warning("Failed to build prompt for skill %r: %s", name, e)
+            yield from ()
+            return
         queue_prompt(ctx.manager.logdir, content)
         logger.debug("Queued skill prompt for /%s%s", SKILL_COMMAND_PREFIX, name)
         # Yield nothing: the chat loop drains the queue on its next iteration
@@ -101,14 +106,27 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
     return handler
 
 
-def _loaded_tool_names() -> set[str]:
+_TOOL_NAMES_UNAVAILABLE = object()  # sentinel: get_tools() failed
+
+
+def _loaded_tool_names() -> set[str] | object:
+    """Return the set of loaded tool names, or ``_TOOL_NAMES_UNAVAILABLE`` on error.
+
+    Callers must treat the sentinel as "all names are occupied" so a failing
+    get_tools() never accidentally grants a bare ``/<name>`` alias to a skill
+    that shares its name with a real tool.
+    """
     try:
         from ..tools import get_tools  # fmt: skip
 
         return {tool.name for tool in get_tools()}
     except Exception as e:  # pragma: no cover - defensive
-        logger.debug("Could not list loaded tools for skill alias check: %s", e)
-        return set()
+        logger.warning(
+            "Could not list loaded tools for skill alias check — "
+            "bare skill aliases suppressed: %s",
+            e,
+        )
+        return _TOOL_NAMES_UNAVAILABLE
 
 
 def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
@@ -139,6 +157,9 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
         if index is None:
             index = LessonIndex()
         tool_names = _loaded_tool_names()
+        # When tool enumeration failed, treat every name as occupied so no bare
+        # alias can accidentally shadow a real tool command.
+        tools_available = tool_names is not _TOOL_NAMES_UNAVAILABLE
 
         for skill in index.lessons:
             name = skill.metadata.name
@@ -172,9 +193,9 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
                     name,
                     canonical,
                 )
-            elif name in tool_names:
+            elif not tools_available or name in tool_names:  # type: ignore[operator]
                 logger.debug(
-                    "Skill %r collides with loaded tool; only /%s registered",
+                    "Skill %r collides with loaded tool (or tool list unavailable); only /%s registered",
                     name,
                     canonical,
                 )

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -56,7 +56,9 @@ def substitute_arguments(body: str, full_args: str, args: list[str]) -> str:
         if idx_str is None:
             return full_args
         idx = int(idx_str)
-        return args[idx] if idx < len(args) else ""
+        # Return the original text unchanged when the index is out of range,
+        # so "$100" in skill prose (prices, currency) is never silently deleted.
+        return args[idx] if idx < len(args) else match.group(0)
 
     return _ARG_PATTERN.sub(_replace, body)
 

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -195,11 +195,12 @@ def register_skill_commands(index: LessonIndex | None = None) -> list[str]:
             registered.append(canonical)
             skill_entries.append((name, canonical, handler))
 
-        # Pass 2: register bare aliases, checking against all canonicals we just
-        # registered so a skill named "skill:X" doesn't block bare alias for "X".
-        our_canonicals = {canonical for _, canonical, _ in skill_entries}
+        # Pass 2: register bare aliases. Any name already in the registry —
+        # including a canonical from pass 1 — is a collision and must not be
+        # overwritten. Without that, a skill named "skill:X" would register
+        # its bare alias as "skill:X" and clobber skill "X"'s canonical.
         for name, canonical, handler in skill_entries:
-            if name in _command_registry and name not in our_canonicals:
+            if name in _command_registry:
                 logger.debug(
                     "Skill %r collides with existing command; only /%s registered",
                     name,

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -10,7 +10,7 @@ same behavior so skills can be shared across runtimes:
   execution for unknown names, so a skill named ``shell`` must never shadow
   the shell tool).
 
-The handler substitutes ``$ARGUMENTS`` (and ``$ARGUMENTS[N]`` / ``$N``
+The handler substitutes ``$ARGUMENTS`` (and ``$ARGUMENTS[N]`` / ``${N}``
 positional forms) in the skill body and queues the result via
 :func:`gptme.prompt_queue.queue_prompt`, so the main chat loop drains it as a
 normal user message on its next iteration and the assistant acts on it.
@@ -40,15 +40,18 @@ SKILL_COMMAND_PREFIX = "skill:"
 # aliases not count as collisions.
 _registered_skill_commands: dict[str, CommandHandler] = {}
 
-_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS\b|\$(\d+)")
+_ARG_PATTERN = re.compile(r"\$ARGUMENTS\[(\d+)\]|\$ARGUMENTS\b|\$\{(\d+)\}")
 
 
 def substitute_arguments(body: str, full_args: str, args: list[str]) -> str:
-    """Substitute ``$ARGUMENTS``, ``$ARGUMENTS[N]`` and ``$N`` placeholders.
+    """Substitute ``$ARGUMENTS``, ``$ARGUMENTS[N]`` and ``${N}`` placeholders.
 
     ``$ARGUMENTS`` expands to the full argument string; ``$ARGUMENTS[N]`` and
-    ``$N`` expand to the N-th (0-based) whitespace-split argument, or the empty
-    string when out of range.
+    ``${N}`` expand to the N-th (0-based) whitespace-split argument.
+    Out-of-range references (e.g. ``${5}`` with fewer than 6 args) are left
+    unchanged so skill prose with ``${...}`` expressions is not corrupted.
+    The ``${N}`` curly-brace form is required for positional arguments to avoid
+    ambiguity with literal dollar amounts like ``$100`` in skill bodies.
     """
 
     def _replace(match: re.Match[str]) -> str:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1913,15 +1913,11 @@ def api_conversation_post(conversation_id: str):
 
     # Append and execute a command under its reservation, not the conversation lock.
     # The reservation is always cleared, including when handle_cmd raises.
+    from ..lessons.skill_commands import is_skill_command  # fmt: skip
+
     responses: list[Message] = []
     try:
         log.append(msg)
-        # Track log length before running the command. Skill command handlers
-        # call ctx.manager.undo(1) to remove the command message from the log
-        # (the skill prompt is the real user turn, not the /skill:<name> command).
-        # We defer emitting message_added for the command message and only emit
-        # it after handle_cmd finishes — skipping it when it was undone avoids
-        # sending a phantom message_added event that clients can't reconcile.
         _len_after_cmd_append = len(log.log.messages)
 
         def _emit(m: Message) -> None:
@@ -1935,14 +1931,29 @@ def api_conversation_post(conversation_id: str):
                 },
             )
 
+        # Determine whether the command is a skill command. Skill handlers call
+        # undo(1) to remove the /skill:<name> message from the log and replace
+        # it with the skill prompt, so we defer their message_added event until
+        # after handle_cmd to avoid emitting a phantom message the client can
+        # never reconcile. Regular commands yield responses, so the event must
+        # arrive FIRST (user message → response is the expected SSE order).
+        _cmd_name = msg.content.strip().split()[0].lstrip("/")
+        _is_skill = is_skill_command(_cmd_name)
+        if not _is_skill:
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "message_added",
+                    "message": msg2dict(msg, log.workspace, log.logdir),
+                },
+            )
+
         try:
             for resp in handle_cmd(msg.content, log):
                 _emit(resp)
-            # Emit the command-message event only when the command did not undo
-            # it. Skill handlers undo the command message after queuing the
-            # skill prompt (handle_cmd yields nothing for them), which reduces
-            # log length below _len_after_cmd_append.
-            if len(log.log.messages) >= _len_after_cmd_append:
+            # For skill commands: emit only when the handler did not undo the
+            # message (log length stayed at or above the pre-responses baseline).
+            if _is_skill and len(log.log.messages) >= _len_after_cmd_append:
                 SessionManager.add_event(
                     conversation_id,
                     {
@@ -1958,6 +1969,12 @@ def api_conversation_post(conversation_id: str):
                 _emit(queued)
         except Exception as e:
             logger.exception("Error executing command: %s", msg.content)
+            # Discard any prompt queued by a handler that raised, so stale
+            # prompts don't leak into the next command's conversation turn.
+            try:
+                list(drain_prompt_queue(log.logdir))
+            except Exception:
+                pass
             error_msg = Message("system", f"Command error: {e}")
             log.append(error_msg)
             responses.append(error_msg)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -77,6 +77,7 @@ from ..logmanager import (
 )
 from ..logmanager import conversations as conversations_module
 from ..message import Message
+from ..prompt_queue import drain_prompt_queue
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
 from ..util.uri import URI, FilePath, is_uri, parse_file_reference
@@ -1922,17 +1923,27 @@ def api_conversation_post(conversation_id: str):
                 "message": msg2dict(msg, log.workspace, log.logdir),
             },
         )
+
+        def _emit(m: Message) -> None:
+            log.append(m)
+            responses.append(m)
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "message_added",
+                    "message": msg2dict(m, log.workspace, log.logdir),
+                },
+            )
+
         try:
             for resp in handle_cmd(msg.content, log):
-                log.append(resp)
-                responses.append(resp)
-                SessionManager.add_event(
-                    conversation_id,
-                    {
-                        "type": "message_added",
-                        "message": msg2dict(resp, log.workspace, log.logdir),
-                    },
-                )
+                _emit(resp)
+            # Skill commands (and any other handler using queue_prompt) write
+            # a follow-up user prompt to the durable queue instead of yielding.
+            # The CLI drains that queue at the top of its chat loop; drain
+            # here so the next /step sees the prompt as a normal user message.
+            for queued in drain_prompt_queue(log.logdir):
+                _emit(queued)
         except Exception as e:
             logger.exception("Error executing command: %s", msg.content)
             error_msg = Message("system", f"Command error: {e}")

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1916,13 +1916,13 @@ def api_conversation_post(conversation_id: str):
     responses: list[Message] = []
     try:
         log.append(msg)
-        SessionManager.add_event(
-            conversation_id,
-            {
-                "type": "message_added",
-                "message": msg2dict(msg, log.workspace, log.logdir),
-            },
-        )
+        # Track log length before running the command. Skill command handlers
+        # call ctx.manager.undo(1) to remove the command message from the log
+        # (the skill prompt is the real user turn, not the /skill:<name> command).
+        # We defer emitting message_added for the command message and only emit
+        # it after handle_cmd finishes — skipping it when it was undone avoids
+        # sending a phantom message_added event that clients can't reconcile.
+        _len_after_cmd_append = len(log.log.messages)
 
         def _emit(m: Message) -> None:
             log.append(m)
@@ -1938,6 +1938,18 @@ def api_conversation_post(conversation_id: str):
         try:
             for resp in handle_cmd(msg.content, log):
                 _emit(resp)
+            # Emit the command-message event only when the command did not undo
+            # it. Skill handlers undo the command message after queuing the
+            # skill prompt (handle_cmd yields nothing for them), which reduces
+            # log length below _len_after_cmd_append.
+            if len(log.log.messages) >= _len_after_cmd_append:
+                SessionManager.add_event(
+                    conversation_id,
+                    {
+                        "type": "message_added",
+                        "message": msg2dict(msg, log.workspace, log.logdir),
+                    },
+                )
             # Skill commands (and any other handler using queue_prompt) write
             # a follow-up user prompt to the durable queue instead of yielding.
             # The CLI drains that queue at the top of its chat loop; drain

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -56,6 +56,7 @@ from ..hooks.confirm import ConfirmationResult
 from ..llm.models import ModelMeta, get_default_model
 from ..logmanager import LogManager
 from ..message import Message
+from ..prompt_queue import drain_prompt_queue
 from ..tools import ToolFormat, ToolUse
 from ..tools.base import ToolUse as ToolUseType
 from ..tools.base import get_tool_format
@@ -1397,7 +1398,27 @@ class GptmeApp(App):
         if not handled:
             logger.warning("Command %r not handled by registry", text)
             self._show_info(f"Unknown command: /{cmd}")
+        else:
+            # Commands like /skill:<name> queue a follow-up user prompt.
+            # Drain it and start a turn, matching the CLI chat loop.
+            self._drain_command_queued_prompts()
         self._update_status()
+
+    def _drain_command_queued_prompts(self) -> None:
+        """Turn durable prompts queued by a command into a TUI user turn.
+
+        Skill commands write to the durable prompt queue instead of yielding a
+        message. The CLI drains that queue at the top of its chat loop; without
+        this, the prompt sits until a CLI session opens the same log.
+        """
+        drained = drain_prompt_queue(self.manager.logdir)
+        if not drained:
+            return
+        first, *rest = drained
+        self.manager.append(first)
+        self._show_message(first)
+        self.prompt_queue.extend(msg.content for msg in rest)
+        self._start_generation()
 
     def _rebuild_chat(self) -> None:
         if self.inline:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1071,6 +1071,54 @@ def test_api_v2_conversation_command(conv, client: FlaskClient):
     assert data.get("command") is True
 
 
+def test_api_v2_skill_command_drains_prompt_queue(
+    conv, client: FlaskClient, tmp_path, monkeypatch
+):
+    """/skill:<name> should land as a user prompt, not sit in the durable queue."""
+    from gptme.dirs import get_logs_dir
+    from gptme.lessons.index import LessonIndex, clear_cache
+    from gptme.lessons.skill_commands import (
+        register_skill_commands,
+        unregister_skill_commands,
+    )
+    from gptme.prompt_queue import get_prompt_queue_path
+
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    skill_dir = skills_root / "parity-demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: parity-demo\ndescription: A parity skill\n---\n\n"
+        "Do the parity thing.\n"
+    )
+    monkeypatch.setattr(
+        LessonIndex, "_default_dirs", staticmethod(lambda: [skills_root])
+    )
+    clear_cache()
+    register_skill_commands()
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{conv}",
+            json={"role": "user", "content": "/skill:parity-demo"},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data.get("command") is True
+        assert data.get("responses", 0) >= 1
+
+        log = client.get(f"/api/v2/conversations/{conv}").get_json()["log"]
+        user_contents = [m["content"] for m in log if m["role"] == "user"]
+        assert any(
+            "Skill invoked: /skill:parity-demo" in c and "Do the parity thing." in c
+            for c in user_contents
+        )
+        assert "/skill:parity-demo" not in user_contents
+        assert not get_prompt_queue_path(get_logs_dir() / conv).exists()
+    finally:
+        unregister_skill_commands()
+        clear_cache()
+
+
 def test_api_v2_conversation_command_undo(conv, client: FlaskClient):
     """Test /undo command removes the last message."""
     # First, add a message

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -1,0 +1,230 @@
+"""Tests for invoking skills as slash commands (/skill:<name>)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gptme.commands.base import (
+    CommandContext,
+    _command_registry,
+    get_commands_with_descriptions,
+    get_user_commands,
+    handle_cmd,
+    register_command,
+    unregister_command,
+)
+from gptme.lessons.index import LessonIndex, clear_cache
+from gptme.lessons.skill_commands import (
+    register_skill_commands,
+    substitute_arguments,
+    unregister_skill_commands,
+)
+from gptme.prompt_queue import drain_prompt_queue
+
+DEMO_BODY = """# Demo Skill
+
+Do the thing with: $ARGUMENTS
+
+First arg: $ARGUMENTS[0]
+Second arg: $1
+Missing arg: $ARGUMENTS[9]
+"""
+
+
+def _write_skill(root: Path, name: str, description: str, body: str) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}"
+    )
+    return skill_file
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path, monkeypatch) -> Iterator[Path]:
+    """Temp skills directory that LessonIndex() discovers by default."""
+    root = tmp_path / "skills"
+    root.mkdir()
+    monkeypatch.setattr(LessonIndex, "_default_dirs", staticmethod(lambda: [root]))
+    clear_cache()
+    yield root
+    unregister_skill_commands()
+    clear_cache()
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> MagicMock:
+    mgr = MagicMock()
+    mgr.logdir = tmp_path / "logs" / "conv"
+    mgr.logdir.mkdir(parents=True)
+    return mgr
+
+
+def _ctx(manager: MagicMock, full_args: str = "") -> CommandContext:
+    return CommandContext(args=full_args.split(), full_args=full_args, manager=manager)
+
+
+def test_substitute_arguments():
+    body = "all=$ARGUMENTS a0=$ARGUMENTS[0] a1=$1 missing=$5"
+    out = substitute_arguments(body, "foo bar", ["foo", "bar"])
+    assert out == "all=foo bar a0=foo a1=bar missing="
+
+
+def test_register_skill_commands_registers_canonical_and_alias(skills_root: Path):
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+
+    registered = register_skill_commands()
+
+    assert "skill:demo" in registered
+    assert "demo" in registered
+    assert "skill:demo" in _command_registry
+    assert "demo" in _command_registry
+    assert _command_registry["demo"] is _command_registry["skill:demo"]
+
+    # Description surfaces in /help via the handler docstring (alias deduped)
+    descs = dict(get_commands_with_descriptions())
+    assert descs["skill:demo"] == "A demo skill"
+    assert "demo" not in descs
+
+    # Tab-completion source includes the prefixed form
+    assert "/skill:demo" in get_user_commands()
+
+
+def test_skill_handler_queues_substituted_prompt(skills_root: Path, manager):
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+
+    handler = _command_registry["skill:demo"]
+    yielded = list(handler(_ctx(manager, "foo bar")))
+    assert yielded == []
+
+    # Command message is undone (like built-in commands)
+    manager.undo.assert_called_once_with(1, quiet=True)
+
+    drained = drain_prompt_queue(manager.logdir)
+    assert len(drained) == 1
+    msg = drained[0]
+    assert msg.role == "user"
+    assert msg.content.startswith("Skill invoked: /skill:demo foo bar")
+    assert "Do the thing with: foo bar" in msg.content
+    assert "First arg: foo" in msg.content
+    assert "Second arg: bar" in msg.content
+    assert "Missing arg: \n" in msg.content or msg.content.endswith("Missing arg:")
+    assert "$ARGUMENTS" not in msg.content
+
+    # Queue is drained: nothing left
+    assert drain_prompt_queue(manager.logdir) == []
+
+
+def test_skill_invocation_via_handle_cmd(skills_root: Path, manager):
+    """End-to-end: /skill:demo dispatches through handle_cmd to the queue."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+
+    assert list(handle_cmd("/skill:demo hello", manager)) == []
+    drained = drain_prompt_queue(manager.logdir)
+    assert len(drained) == 1
+    assert "Do the thing with: hello" in drained[0].content
+
+    # Bare alias works too
+    assert list(handle_cmd("/demo world", manager)) == []
+    drained = drain_prompt_queue(manager.logdir)
+    assert len(drained) == 1
+    assert "Do the thing with: world" in drained[0].content
+
+
+def test_skill_without_args(skills_root: Path, manager):
+    _write_skill(skills_root, "demo", "A demo skill", "Body $ARGUMENTS end")
+    register_skill_commands()
+
+    list(_command_registry["skill:demo"](_ctx(manager)))
+    drained = drain_prompt_queue(manager.logdir)
+    assert drained[0].content == "Skill invoked: /skill:demo\n\nBody  end"
+
+
+def test_collision_with_existing_command_skips_bare_alias(skills_root: Path):
+    _write_skill(skills_root, "help", "Shadows /help", "Never shown")
+
+    # Make sure /help exists as a built-in command before registering
+    from gptme import commands as _commands  # noqa: F401
+
+    assert "help" in _command_registry
+    original_help = _command_registry["help"]
+
+    registered = register_skill_commands()
+
+    assert "skill:help" in registered
+    assert "help" not in registered
+    assert _command_registry["help"] is original_help
+
+
+def test_collision_with_loaded_tool_skips_bare_alias(skills_root: Path, monkeypatch):
+    _write_skill(skills_root, "shell", "Shadows the shell tool", "Never shown")
+
+    fake_tool = MagicMock()
+    fake_tool.name = "shell"
+    monkeypatch.setattr("gptme.tools.get_tools", lambda: [fake_tool])
+
+    registered = register_skill_commands()
+
+    assert "skill:shell" in registered
+    assert "shell" not in registered
+    assert "shell" not in _command_registry
+
+
+def test_reregistration_is_idempotent_and_drops_stale(skills_root: Path):
+    skill_file = _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    first = register_skill_commands()
+    assert set(first) == {"skill:demo", "demo"}
+
+    # Re-register: our own previous bare alias must not count as a collision
+    second = register_skill_commands()
+    assert set(second) == {"skill:demo", "demo"}
+
+    # Remove the skill and re-register: stale commands are dropped
+    skill_file.unlink()
+    skill_file.parent.rmdir()
+    clear_cache()
+    third = register_skill_commands()
+    assert third == []
+    assert "skill:demo" not in _command_registry
+    assert "demo" not in _command_registry
+
+
+def test_reregistration_does_not_clobber_foreign_command(skills_root: Path):
+    """A command registered by someone else under a skill's name is left alone."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+    assert "demo" in _command_registry
+
+    # Someone else (e.g. a tool) takes over the bare name after us
+    def other(ctx):
+        yield from ()
+
+    register_command("demo", other)
+    try:
+        register_skill_commands()
+        assert _command_registry["demo"] is other
+        assert "skill:demo" in _command_registry
+    finally:
+        unregister_command("demo")
+
+
+def test_register_never_raises_on_broken_index(monkeypatch):
+    def boom():
+        raise RuntimeError("broken skill dir")
+
+    monkeypatch.setattr(LessonIndex, "_default_dirs", staticmethod(boom))
+    assert register_skill_commands() == []
+
+
+def test_lessons_without_name_are_not_registered(skills_root: Path):
+    lesson_dir = skills_root / "plain"
+    lesson_dir.mkdir()
+    (lesson_dir / "plain.md").write_text(
+        "---\nmatch:\n  keywords: [foo]\n---\n\n# Plain Lesson\n\nBody\n"
+    )
+    assert register_skill_commands() == []

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -95,6 +95,14 @@ def test_substitute_arguments_word_boundary():
     assert out == "Use $ARGUMENTSvar and x normally"
 
 
+def test_substitute_arguments_non_numeric_bracket_not_matched():
+    # $ARGUMENTS[name] (non-numeric bracket) must NOT be matched by the bare
+    # $ARGUMENTS alternative — the '[' lookahead prevents this.
+    body = "Use $ARGUMENTS[name] as a label"
+    out = substitute_arguments(body, "hello", ["hello"])
+    assert out == "Use $ARGUMENTS[name] as a label"
+
+
 def test_register_skill_commands_registers_canonical_and_alias(skills_root: Path):
     _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
 

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -269,6 +269,47 @@ def test_lessons_without_name_are_not_registered(skills_root: Path):
     assert register_skill_commands() == []
 
 
+def test_handler_undo_happens_after_build_on_success(skills_root: Path, manager):
+    """The command message is only removed from the log when build succeeds, not before."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+    list(_command_registry["skill:demo"](_ctx(manager, "hello world")))
+    # manager.undo must have been called (success path removes the command message)
+    manager.undo.assert_called_once_with(1, quiet=True)
+
+
+def test_handler_undo_not_called_when_build_fails(
+    skills_root: Path, manager, monkeypatch
+):
+    """When build_skill_prompt raises, the log is left intact (undo not called)."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+
+    import gptme.lessons.skill_commands as sc
+
+    monkeypatch.setattr(
+        sc,
+        "build_skill_prompt",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    list(_command_registry["skill:demo"](_ctx(manager, "")))
+    # manager.undo must NOT have been called — the log stays intact so the user
+    # can see the failed invocation instead of a silent disappear.
+    manager.undo.assert_not_called()
+
+
+def test_two_pass_registration_skill_named_with_prefix(skills_root: Path):
+    """Skill 'X' gets a canonical even when another skill is named 'skill:X'."""
+    # Skill with a name that happens to start with the "skill:" prefix.
+    _write_skill(skills_root, "skill:demo", "Weird name", "Body")
+    # Skill whose canonical would be "skill:demo" — must not be blocked by the alias
+    # that the first skill registers for its bare name.
+    _write_skill(skills_root, "demo", "Normal skill", DEMO_BODY)
+    registered = register_skill_commands()
+    # "skill:demo" canonical must exist for the second skill.
+    assert "skill:demo" in registered
+
+
 def test_tool_list_unavailable_suppresses_all_bare_aliases(
     skills_root: Path, monkeypatch
 ):

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -70,7 +70,15 @@ def _ctx(manager: MagicMock, full_args: str = "") -> CommandContext:
 def test_substitute_arguments():
     body = "all=$ARGUMENTS a0=$ARGUMENTS[0] a1=$1 missing=$5"
     out = substitute_arguments(body, "foo bar", ["foo", "bar"])
-    assert out == "all=foo bar a0=foo a1=bar missing="
+    # Out-of-range $N stays unchanged rather than becoming empty string
+    assert out == "all=foo bar a0=foo a1=bar missing=$5"
+
+
+def test_substitute_arguments_preserves_dollar_amounts():
+    # $N with a large index should not silently delete currency amounts in prose
+    body = "Set budget to $100 and limit to $ARGUMENTS[99]."
+    out = substitute_arguments(body, "", [])
+    assert out == "Set budget to $100 and limit to $ARGUMENTS[99]."
 
 
 def test_register_skill_commands_registers_canonical_and_alias(skills_root: Path):
@@ -112,8 +120,9 @@ def test_skill_handler_queues_substituted_prompt(skills_root: Path, manager):
     assert "Do the thing with: foo bar" in msg.content
     assert "First arg: foo" in msg.content
     assert "Second arg: bar" in msg.content
-    assert "Missing arg: \n" in msg.content or msg.content.endswith("Missing arg:")
-    assert "$ARGUMENTS" not in msg.content
+    # Out-of-range $ARGUMENTS[N] is preserved, not replaced with empty string
+    assert "Missing arg: $ARGUMENTS[9]" in msg.content
+    # (bare $ARGUMENTS was substituted — verified implicitly by line 120)
 
     # Queue is drained: nothing left
     assert drain_prompt_queue(manager.logdir) == []

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -28,7 +28,7 @@ DEMO_BODY = """# Demo Skill
 Do the thing with: $ARGUMENTS
 
 First arg: $ARGUMENTS[0]
-Second arg: $1
+Second arg: ${1}
 Missing arg: $ARGUMENTS[9]
 """
 
@@ -68,17 +68,24 @@ def _ctx(manager: MagicMock, full_args: str = "") -> CommandContext:
 
 
 def test_substitute_arguments():
-    body = "all=$ARGUMENTS a0=$ARGUMENTS[0] a1=$1 missing=$5"
+    body = "all=$ARGUMENTS a0=$ARGUMENTS[0] a1=${1} missing=${5}"
     out = substitute_arguments(body, "foo bar", ["foo", "bar"])
-    # Out-of-range $N stays unchanged rather than becoming empty string
-    assert out == "all=foo bar a0=foo a1=bar missing=$5"
+    # Out-of-range ${N} stays unchanged rather than becoming empty string
+    assert out == "all=foo bar a0=foo a1=bar missing=${5}"
 
 
 def test_substitute_arguments_preserves_dollar_amounts():
-    # $N with a large index should not silently delete currency amounts in prose
+    # Plain $N without curly braces is never matched — dollar amounts are safe.
+    # ${N} is the placeholder syntax; $100 (no braces) is prose and untouched.
     body = "Set budget to $100 and limit to $ARGUMENTS[99]."
     out = substitute_arguments(body, "", [])
     assert out == "Set budget to $100 and limit to $ARGUMENTS[99]."
+
+    # Even with 101 args, $100 in prose is NOT substituted (no braces → no match).
+    # $ARGUMENTS[99] IS substituted correctly (index 99 is in range with 101 args).
+    many_args = [str(i) for i in range(101)]
+    out2 = substitute_arguments(body, " ".join(many_args), many_args)
+    assert out2 == "Set budget to $100 and limit to 99."
 
 
 def test_substitute_arguments_word_boundary():

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -81,6 +81,13 @@ def test_substitute_arguments_preserves_dollar_amounts():
     assert out == "Set budget to $100 and limit to $ARGUMENTS[99]."
 
 
+def test_substitute_arguments_word_boundary():
+    # $ARGUMENTS adjacent to another word char must not partially match
+    body = "Use $ARGUMENTSvar and $ARGUMENTS normally"
+    out = substitute_arguments(body, "x", ["x"])
+    assert out == "Use $ARGUMENTSvar and x normally"
+
+
 def test_register_skill_commands_registers_canonical_and_alias(skills_root: Path):
     _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
 
@@ -201,6 +208,22 @@ def test_reregistration_is_idempotent_and_drops_stale(skills_root: Path):
     assert third == []
     assert "skill:demo" not in _command_registry
     assert "demo" not in _command_registry
+
+
+def test_canonical_does_not_clobber_foreign_skill_prefix_command(skills_root: Path):
+    """A foreign command with 'skill:' prefix is not overwritten by our registration."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+
+    def other(ctx):
+        yield from ()
+
+    register_command("skill:demo", other)
+    try:
+        registered = register_skill_commands()
+        assert "skill:demo" not in registered
+        assert _command_registry["skill:demo"] is other
+    finally:
+        unregister_command("skill:demo")
 
 
 def test_reregistration_does_not_clobber_foreign_command(skills_root: Path):

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -17,6 +17,7 @@ from gptme.commands.base import (
 )
 from gptme.lessons.index import LessonIndex, clear_cache
 from gptme.lessons.skill_commands import (
+    is_skill_command,
     register_skill_commands,
     substitute_arguments,
     unregister_skill_commands,
@@ -372,3 +373,21 @@ def test_tool_list_unavailable_suppresses_all_bare_aliases(
     # Bare alias must be suppressed: fail-safe means no alias when tool list is unavailable.
     assert "demo" not in registered
     assert "demo" not in _command_registry
+
+
+def test_is_skill_command_returns_true_for_registered(skills_root: Path):
+    """is_skill_command returns True for both canonical and bare alias forms."""
+    _write_skill(skills_root, "sentinel", "A sentinel skill", DEMO_BODY)
+    register_skill_commands()
+    try:
+        # Canonical form
+        assert is_skill_command("skill:sentinel")
+        # Bare alias form (no collision with built-in commands or tools)
+        assert is_skill_command("sentinel")
+        # Non-registered names return False
+        assert not is_skill_command("help")
+        assert not is_skill_command("nonexistent")
+        assert not is_skill_command("")
+    finally:
+        unregister_skill_commands()
+        clear_cache()

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -298,16 +298,38 @@ def test_handler_undo_not_called_when_build_fails(
     manager.undo.assert_not_called()
 
 
-def test_two_pass_registration_skill_named_with_prefix(skills_root: Path):
-    """Skill 'X' gets a canonical even when another skill is named 'skill:X'."""
-    # Skill with a name that happens to start with the "skill:" prefix.
-    _write_skill(skills_root, "skill:demo", "Weird name", "Body")
-    # Skill whose canonical would be "skill:demo" — must not be blocked by the alias
-    # that the first skill registers for its bare name.
-    _write_skill(skills_root, "demo", "Normal skill", DEMO_BODY)
+def test_two_pass_registration_skill_named_with_prefix(skills_root: Path, manager):
+    """Skill 'X' keeps its canonical when another skill is named 'skill:X'.
+
+    Pass 2 must not register the prefix-named skill's bare alias over
+    /skill:X — that name is already the canonical of skill X.
+    """
+    _write_skill(skills_root, "skill:demo", "Weird name", "Body of prefix skill")
+    _write_skill(skills_root, "demo", "Normal skill", "Body of demo skill")
     registered = register_skill_commands()
-    # "skill:demo" canonical must exist for the second skill.
+
     assert "skill:demo" in registered
+    assert "skill:skill:demo" in registered
+    assert "demo" in registered
+
+    # Handler identity: /skill:demo belongs to the 'demo' skill, not the
+    # prefix-named one. Membership alone would pass even if pass 2 clobbered
+    # the canonical with the wrong handler.
+    assert _command_registry["skill:demo"].__name__ == "skill_demo"
+    assert _command_registry["skill:skill:demo"].__name__ == "skill_skill:demo"
+    assert _command_registry["demo"] is _command_registry["skill:demo"]
+
+    list(_command_registry["skill:demo"](_ctx(manager, "")))
+    drained = drain_prompt_queue(manager.logdir)
+    assert len(drained) == 1
+    assert "Body of demo skill" in drained[0].content
+    assert drained[0].content.startswith("Skill invoked: /skill:demo")
+
+    list(_command_registry["skill:skill:demo"](_ctx(manager, "")))
+    drained = drain_prompt_queue(manager.logdir)
+    assert len(drained) == 1
+    assert "Body of prefix skill" in drained[0].content
+    assert drained[0].content.startswith("Skill invoked: /skill:skill:demo")
 
 
 def test_tool_list_unavailable_suppresses_all_bare_aliases(

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -267,3 +267,22 @@ def test_lessons_without_name_are_not_registered(skills_root: Path):
         "---\nmatch:\n  keywords: [foo]\n---\n\n# Plain Lesson\n\nBody\n"
     )
     assert register_skill_commands() == []
+
+
+def test_tool_list_unavailable_suppresses_all_bare_aliases(
+    skills_root: Path, monkeypatch
+):
+    """When _loaded_tool_names() returns the sentinel (get_tools raised), no bare aliases are registered."""
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+
+    def raise_err():
+        raise RuntimeError("tools not initialised")
+
+    monkeypatch.setattr("gptme.tools.get_tools", lambda: raise_err())
+    registered = register_skill_commands()
+
+    # Canonical must still be registered (tool-list failure doesn't block it).
+    assert "skill:demo" in registered
+    # Bare alias must be suppressed: fail-safe means no alias when tool list is unavailable.
+    assert "demo" not in registered
+    assert "demo" not in _command_registry

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -206,6 +206,21 @@ def test_collision_with_loaded_tool_skips_bare_alias(skills_root: Path, monkeypa
     assert "shell" not in _command_registry
 
 
+def test_collision_with_loaded_tool_is_case_insensitive(skills_root: Path, monkeypatch):
+    """A skill named 'Shell' (capital S) must not shadow the 'shell' tool."""
+    _write_skill(skills_root, "Shell", "Case-variant of shell tool", "Never shown")
+
+    fake_tool = MagicMock()
+    fake_tool.name = "shell"
+    monkeypatch.setattr("gptme.tools.get_tools", lambda: [fake_tool])
+
+    registered = register_skill_commands()
+
+    assert "skill:Shell" in registered
+    assert "Shell" not in registered
+    assert "Shell" not in _command_registry
+
+
 def test_reregistration_is_idempotent_and_drops_stale(skills_root: Path):
     skill_file = _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
     first = register_skill_commands()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -196,6 +196,69 @@ async def test_slash_command_help(tmp_path):
         assert infos, "expected /help output to be shown"
 
 
+def _write_skill(root, name: str, description: str, body: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_command_drains_prompt_queue_and_starts_generation(
+    tmp_path, monkeypatch
+):
+    """/skill:<name> should become a user prompt and start a TUI turn."""
+    from gptme.lessons.index import LessonIndex, clear_cache
+    from gptme.lessons.skill_commands import (
+        register_skill_commands,
+        unregister_skill_commands,
+    )
+    from gptme.prompt_queue import get_prompt_queue_path
+
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    _write_skill(skills_root, "parity-demo", "A parity skill", "Do the parity thing.")
+    monkeypatch.setattr(
+        LessonIndex, "_default_dirs", staticmethod(lambda: [skills_root])
+    )
+    clear_cache()
+    register_skill_commands()
+    try:
+        manager = make_manager(tmp_path)
+        app = GptmeApp(manager, workspace=tmp_path)
+        started: list[bool] = []
+
+        def _fake_start() -> None:
+            started.append(True)
+
+        monkeypatch.setattr(app, "_start_generation", _fake_start)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            inp = app.query_one("#input", ChatInput)
+            inp.text = "/skill:parity-demo"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            user_contents = [m.content for m in manager.log if m.role == "user"]
+            assert any(
+                "Skill invoked: /skill:parity-demo" in c and "Do the parity thing." in c
+                for c in user_contents
+            )
+            assert "/skill:parity-demo" not in user_contents
+            assert not get_prompt_queue_path(manager.logdir).exists()
+            assert started, (
+                "TUI should start generation after draining the skill prompt"
+            )
+            assert any(
+                "Do the parity thing." in w.content for w in app.query(UserMessage)
+            )
+    finally:
+        unregister_skill_commands()
+        clear_cache()
+
+
 @pytest.mark.asyncio
 async def test_experimental_jelly_errors_show_recovery_hints(tmp_path):
     app = GptmeApp(make_manager(tmp_path), experimental_jelly_errors=True)


### PR DESCRIPTION
## Summary

Claude Code and Codex expose every `SKILL.md` skill as a `/<name>` slash command that injects the skill body as the user's prompt and lets the assistant act on it. gptme only had `/skills read <name>`, which prints the skill as a system message and never triggers an assistant turn (`chat.py`: `if msg.role == "user" and execute_cmd(msg, manager): continue`).

This adds parity so cross-runtime shared skills (e.g. an `end` skill invoked as `/skill:end` or `/end`) work the same way in gptme.

## Changes

- **`gptme/lessons/skill_commands.py`** (new): `register_skill_commands()` registers `skill:<name>` for every indexed skill with `metadata.name`. A bare `/<name>` alias is added only when it collides with neither an already-registered command nor a loaded tool (`handle_cmd` falls back to tool execution for unknown names, so a skill named `shell` must never shadow the shell tool).
  - Handler materializes stub skills, substitutes `$ARGUMENTS`, `$ARGUMENTS[N]` and `${N}` (0-based), prepends `Skill invoked: /skill:<name> <args>`, and queues the result via `prompt_queue.queue_prompt()`. The command message itself is undone (like built-in commands) so the body isn't logged twice.
  - Handler `__doc__` is the skill description, so `/help` / `get_commands_with_descriptions()` show it (alias deduped by handler identity).
  - Idempotent and never raises: stale commands from a previous registration are removed first; a foreign command that later took over a bare name is left alone; any index failure is logged as a warning.
- **`gptme/init.py`**: call `register_skill_commands()` right after `init_commands()` so the tool-collision check sees loaded tools and built-in commands.
- **`gptme/lessons/__init__.py`**: export `register_skill_commands`.
- **`gptme/server/api_v2.py`**: drain the durable prompt queue after executing a slash command and append drained prompts as user messages so `/step` (WebUI auto-steps after send) generates a response.
- **`gptme/tui/app.py`**: drain the durable prompt queue after a handled command, show the skill prompt, and start a generation turn.
- **`docs/skills.rst`**: "Invoking Skills as Commands" section (CLI, TUI, and server/WebUI).
- **`tests/test_skill_commands.py`**: substitution, registration + `/help` + completion source, handler → prompt queue, collisions, idempotent re-registration, foreign-command preservation, broken index never raises, prefix-named skills do not clobber canonicals.
- **`tests/test_server.py` / `tests/test_tui.py`**: smoke tests that `/skill:<name>` drains the queue and becomes a user prompt (TUI also starts generation).

Tab completion needs no changes: `GptmeCompleter` matches `option.startswith(text)` over `get_user_commands()`, so `/skill:` completes to the registered names.

## Test plan

- [x] `poetry run pytest tests/test_skill_commands.py tests/test_tui.py::test_skill_command_drains_prompt_queue_and_starts_generation tests/test_tui.py::test_slash_command_help tests/test_server.py::test_api_v2_skill_command_drains_prompt_queue tests/test_server.py::test_api_v2_conversation_command -q` → 22 passed
- [x] `poetry run mypy gptme/lessons/skill_commands.py gptme/server/api_v2.py gptme/tui/app.py tests/test_tui.py tests/test_server.py` → clean
- [x] `ruff check` / `ruff format` on touched files
- [x] Manual smoke with real tools loaded (`init_tools(['shell'])` + temp skills `shell`, `end`): registered `['skill:end', 'end', 'skill:shell']` — `shell` alias correctly suppressed; `/help` shows skill descriptions; `get_user_commands()` includes `/skill:end`, `/end`.