### PR TITLE
fix(server): don't let step() finally clear a continuation reservation

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -727,6 +727,11 @@ def api_conversation_tool_confirm(conversation_id: str):
 
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            # Advance step_seq before capturing the epoch so that any
+            # concurrent tool worker whose my_seq equals the pre-skip value
+            # sees a mismatch and stands down (same protocol as /step and
+            # /interrupt + rerun).
+            session.step_seq += 1
             skip_step_seq = session.step_seq
             try:
                 current_tool.status = ToolStatus.SKIPPED

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -506,6 +506,7 @@ def api_conversation_step(conversation_id: str):
                 auto_confirm=auto_confirm_enabled,
                 stream=stream,
                 reserved=True,
+                step_seq=step_seq,
             )
         _step_dispatched = True
     finally:
@@ -726,6 +727,7 @@ def api_conversation_tool_confirm(conversation_id: str):
 
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            skip_step_seq = session.step_seq
             try:
                 current_tool.status = ToolStatus.SKIPPED
                 session.pending_tools.pop(tool_id)
@@ -751,6 +753,7 @@ def api_conversation_tool_confirm(conversation_id: str):
                     chat_config.workspace,
                     branch=current_tool.branch,
                     reserved=True,
+                    step_seq=skip_step_seq,
                 )
             finally:
                 if not continuation_dispatched:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -783,6 +783,16 @@ def step(
     if tool_format == "tool":
         tools = [t for t in get_tools() if t.is_runnable]
 
+    # Snapshot the step sequence at entry. The finally block uses this to detect
+    # whether the tool-continuation path has taken ownership of `generating`:
+    # if a fast tool completes and the tool worker increments step_seq (inside
+    # step_lock) before our finally runs, we skip the clear and leave the
+    # continuation's reservation intact. Without this guard the originating
+    # step's unconditional `generating = False` would race and clear the
+    # reservation the continuation just set (Race 5 — "originating step clears
+    # continuation reservation").
+    my_step_seq = session.step_seq
+
     try:
         # Stream tokens from the model
         output = ""
@@ -970,8 +980,24 @@ def step(
             conversation_id, {"type": "error", "error": error_message}
         )
     finally:
-        session.generating = False
-        session.generating_since = None
+        # Only release generating if this step still owns the reservation.
+        # A fast tool may finish, increment step_seq, set generating=True for
+        # the continuation, and return BEFORE we reach here. If we clear
+        # unconditionally we erase the continuation's reservation (Race 5).
+        # The tool worker increments step_seq inside step_lock before handing
+        # off, so the compare-and-clear below is atomic with respect to that
+        # handoff.
+        with session.step_lock:
+            if session.step_seq == my_step_seq:
+                session.generating = False
+                session.generating_since = None
+            else:
+                logger.debug(
+                    "step() finally: skipping generating=False — "
+                    "reservation transferred to continuation (seq %d→%d)",
+                    my_step_seq,
+                    session.step_seq,
+                )
 
 
 def start_tool_execution(
@@ -1235,6 +1261,12 @@ def start_tool_execution(
                         not SessionManager.conversation_generating(conversation_id)
                         and not SessionManager.command_is_active(conversation_id)
                     ):
+                        # Advance step_seq BEFORE setting generating=True (Race 5).
+                        # The originating step() finally block snapshots
+                        # my_step_seq at entry; incrementing here signals
+                        # ownership transferred to the continuation so that
+                        # finally skips the clear instead of erasing this
+                        # reservation.
                         session.step_seq += 1
                         continuation_seq = session.step_seq
                         session.generating = True

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -638,6 +638,7 @@ def step(
     branch: str = "main",
     auto_confirm: bool = False,
     stream: bool = True,
+    step_seq: int | None = None,
 ) -> None:
     """
     Generate a response and detect tools.
@@ -657,6 +658,9 @@ def step(
         branch: Branch to use (default: "main")
         auto_confirm: Whether to auto-confirm tools (default: False)
         stream: Whether to stream the response (default: True)
+        step_seq: The epoch this step owns, captured under step_lock by the caller.
+            Used in finally to detect whether the continuation has taken ownership.
+            If None, falls back to sampling session.step_seq at entry (racy on delay).
     """
 
     # Load chat config and prepare execution environment
@@ -791,7 +795,13 @@ def step(
     # step's unconditional `generating = False` would race and clear the
     # reservation the continuation just set (Race 5 — "originating step clears
     # continuation reservation").
-    my_step_seq = session.step_seq
+    #
+    # Use the epoch passed by the caller (captured under step_lock before thread
+    # spawn) rather than sampling session.step_seq here. A thread delayed before
+    # this line could see the epoch of a replacement step if interrupt + /step
+    # ran while the thread was descheduled, causing the finally block to
+    # incorrectly clear the replacement's reservation.
+    my_step_seq = step_seq if step_seq is not None else session.step_seq
 
     try:
         # Stream tokens from the model
@@ -1285,6 +1295,7 @@ def start_tool_execution(
                         chat_config.workspace,
                         branch=branch,
                         reserved=True,
+                        step_seq=continuation_seq,
                     )
                 except Exception:
                     # Dispatch failed after ownership transfer. Release that new
@@ -1331,8 +1342,16 @@ def _start_step_thread(
     stream: bool = True,
     *,
     reserved: bool = False,
+    step_seq: int | None = None,
 ) -> bool:
-    """Start a step unless another operation has already reserved it."""
+    """Start a step unless another operation has already reserved it.
+
+    ``step_seq`` should be the epoch captured under ``step_lock`` by the caller
+    (e.g. the value stored after incrementing ``session.step_seq`` in the /step
+    route). It is passed into ``step()`` so the finally block's compare-and-clear
+    uses the epoch sampled under the lock rather than inside the spawned thread
+    (where a delay could cause it to see a later epoch).
+    """
 
     # Direct callers (tool continuations and A2A) share /step's atomic
     # check-and-reserve protocol. The /step route reserves before setup and
@@ -1345,6 +1364,11 @@ def _start_step_thread(
                 return False
             session.generating = True
             session.generating_since = datetime.now(tz=timezone.utc)
+            # Capture the epoch under the lock so step() doesn't need to sample
+            # session.step_seq inside the thread (where a delay could give it
+            # a stale or replacement epoch).
+            if step_seq is None:
+                step_seq = session.step_seq
     session.last_error = None
 
     def step_thread() -> None:
@@ -1363,6 +1387,7 @@ def _start_step_thread(
             branch=branch,
             auto_confirm=auto_confirm,
             stream=stream,
+            step_seq=step_seq,
         )
 
     # Propagate ContextVars (model, config) from the caller into the step thread.

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1310,7 +1310,17 @@ def start_tool_execution(
             )
             if reserved:
                 with session.step_lock:
-                    if session.step_seq == my_seq:
+                    # If the election block advanced step_seq (setting
+                    # continuation_seq) but an exception prevented
+                    # start_continuation from being set to True, the
+                    # reservation is at continuation_seq, not my_seq.
+                    # Release whichever epoch we actually own.
+                    release_seq = (
+                        continuation_seq
+                        if continuation_seq is not None and not start_continuation
+                        else my_seq
+                    )
+                    if session.step_seq == release_seq:
                         session.generating = False
                         session.generating_since = None
             raise

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -679,6 +679,17 @@ def step(
         lock=False,
     )
 
+    # Snapshot the step sequence at the earliest possible point — before any
+    # early-exit path that might clear `generating`. All generating=False clears
+    # below (workspace missing, no messages, and the main finally block) use
+    # compare-and-clear against this value so that a descheduled thread waking
+    # up in the setup phase cannot erase a newer step's reservation.
+    # Use the epoch passed by the caller (captured under step_lock before thread
+    # spawn) rather than sampling session.step_seq here. A thread delayed before
+    # this line could see the epoch of a replacement step if interrupt + /step
+    # ran while the thread was descheduled.
+    my_step_seq = step_seq if step_seq is not None else session.step_seq
+
     # Fail cleanly if the configured workspace is missing (e.g. an external
     # symlinked workspace that was moved/deleted). step() runs in a daemon
     # thread, so an uncaught error here would silently leave the session stuck
@@ -691,8 +702,9 @@ def step(
         _persist_generation_error(manager, session, str(e))
         SessionManager.add_event(conversation_id, ws_error_event)
         session.last_error = str(e)
-        session.generating = False
-        session.generating_since = None
+        if session.step_seq == my_step_seq:
+            session.generating = False
+            session.generating_since = None
         return
 
     # Set the model as default before triggering hooks
@@ -775,8 +787,9 @@ def step(
             "error": "No messages to process",
         }
         SessionManager.add_event(conversation_id, error_event)
-        session.generating = False
-        session.generating_since = None
+        if session.step_seq == my_step_seq:
+            session.generating = False
+            session.generating_since = None
         return
 
     # Notify clients about generation status
@@ -786,22 +799,6 @@ def step(
     tools = None
     if tool_format == "tool":
         tools = [t for t in get_tools() if t.is_runnable]
-
-    # Snapshot the step sequence at entry. The finally block uses this to detect
-    # whether the tool-continuation path has taken ownership of `generating`:
-    # if a fast tool completes and the tool worker increments step_seq (inside
-    # step_lock) before our finally runs, we skip the clear and leave the
-    # continuation's reservation intact. Without this guard the originating
-    # step's unconditional `generating = False` would race and clear the
-    # reservation the continuation just set (Race 5 — "originating step clears
-    # continuation reservation").
-    #
-    # Use the epoch passed by the caller (captured under step_lock before thread
-    # spawn) rather than sampling session.step_seq here. A thread delayed before
-    # this line could see the epoch of a replacement step if interrupt + /step
-    # ran while the thread was descheduled, causing the finally block to
-    # incorrectly clear the replacement's reservation.
-    my_step_seq = step_seq if step_seq is not None else session.step_seq
 
     try:
         # Stream tokens from the model

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -702,9 +702,10 @@ def step(
         _persist_generation_error(manager, session, str(e))
         SessionManager.add_event(conversation_id, ws_error_event)
         session.last_error = str(e)
-        if session.step_seq == my_step_seq:
-            session.generating = False
-            session.generating_since = None
+        with session.step_lock:
+            if session.step_seq == my_step_seq:
+                session.generating = False
+                session.generating_since = None
         return
 
     # Set the model as default before triggering hooks
@@ -787,9 +788,10 @@ def step(
             "error": "No messages to process",
         }
         SessionManager.add_event(conversation_id, error_event)
-        if session.step_seq == my_step_seq:
-            session.generating = False
-            session.generating_since = None
+        with session.step_lock:
+            if session.step_seq == my_step_seq:
+                session.generating = False
+                session.generating_since = None
         return
 
     # Notify clients about generation status

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -1409,9 +1409,14 @@ def _start_step_thread(
     except Exception:
         # A reserved caller owns this slot; release it if dispatch itself fails.
         # Non-reserved callers reserved above and need the same rollback.
+        # Compare-and-clear: only release if no newer step has taken ownership.
+        # An interrupt + replacement /step increments step_seq under step_lock
+        # before setting generating=True; if our epoch is stale we must not
+        # clear the replacement's reservation.
         with session.step_lock:
-            session.generating = False
-            session.generating_since = None
+            if step_seq is None or session.step_seq == step_seq:
+                session.generating = False
+                session.generating_since = None
         raise
     return True
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -635,7 +635,7 @@ class TestInterruptEndpoint:
         assert session.step_seq == initial_seq
 
     def test_continuation_reservation_not_cleared_by_originating_step(
-        self, conv, tmp_path
+        self, conv, tmp_path, monkeypatch
     ):
         """Race 5: step() finally must not clear generating when a continuation reserved it.
 
@@ -644,6 +644,9 @@ class TestInterruptEndpoint:
         captures step_seq at entry; a mismatch means the continuation took over
         and we must not clear its reservation.
         """
+        # step() calls os.chdir(workspace) when user_messages <= 1; use monkeypatch so
+        # the cwd change is scoped to this test and doesn't bleed into siblings.
+        monkeypatch.chdir(tmp_path)
 
         from gptme.message import Message
         from gptme.server.session_step import step

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1038,7 +1038,11 @@ class TestToolConfirmEndpoint:
         resolve.assert_called_once_with(tool_id, "skip", None)
         assert start_step.call_count == 1
         assert start_step.call_args.args[:2] == (conv["conversation_id"], session)
-        assert start_step.call_args.kwargs == {"branch": "main", "reserved": True}
+        assert start_step.call_args.kwargs == {
+            "branch": "main",
+            "reserved": True,
+            "step_seq": session.step_seq,
+        }
 
     def test_skip_preserves_tool_when_step_reserved_generation(
         self, conv, client: FlaskClient

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -707,6 +707,81 @@ class TestInterruptEndpoint:
         )
         assert session.step_seq == 2
 
+    def test_step_seq_passed_by_caller_not_sampled_in_thread(
+        self, conv, tmp_path, monkeypatch
+    ):
+        """step() must use the caller-supplied step_seq, not sample session.step_seq.
+
+        Race: a thread delayed between spawn and step_seq snapshot can see the epoch
+        of a replacement step (if interrupt + /step ran while it was descheduled).
+        The fix passes the epoch from the caller (captured under step_lock before
+        dispatch) so the finally compare-and-clear uses the original epoch, not
+        the replacement's.
+
+        Scenario:
+        - Route handler increments step_seq to 1 and spawns step() with step_seq=1.
+        - Thread is delayed; interrupt fires (step_seq → 2), new /step starts (→ 3).
+        - Thread finally runs step() with the passed step_seq=1.
+        - session.step_seq is now 3; step() must NOT clear generating (3 != 1).
+        """
+        monkeypatch.chdir(tmp_path)
+
+        from gptme.message import Message
+        from gptme.server.session_step import step
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        # Simulate the state AFTER interrupt+replacement: step_seq advanced to 3,
+        # generating=True is held by the replacement step.
+        session.step_seq = 3
+        session.generating = True
+
+        with (
+            patch("gptme.server.session_step._stream", return_value=iter([])),
+            patch("gptme.server.session_step.require_workspace_exists"),
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch("gptme.server.session_step.trigger_hook", return_value=[]),
+            patch(
+                "gptme.server.session_step.prepare_messages",
+                return_value=[Message("user", "test")],
+            ),
+            patch("gptme.server.session_step._try_auto_name_and_notify"),
+            patch("gptme.server.session_step.set_workspace_cwd"),
+            patch(
+                "gptme.server.session_step.ChatConfig.load_or_create",
+                return_value=MagicMock(
+                    tool_format="markdown",
+                    tools=None,
+                    workspace=tmp_path,
+                    max_tokens=None,
+                    temperature=None,
+                    top_p=None,
+                ),
+            ),
+            patch("gptme.llm.models.set_default_model"),
+            patch("gptme.model_attestation.record_runtime_selection"),
+        ):
+            # Pass step_seq=1: the original epoch captured under step_lock by the
+            # route handler. The thread sees session.step_seq=3 (replacement), but
+            # must use 1 as my_step_seq for the finally compare-and-clear.
+            step(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                model="mock/model",
+                workspace=tmp_path,
+                step_seq=1,
+            )
+
+        # finally: session.step_seq (3) != my_step_seq (1) → must NOT clear generating.
+        # Without the fix (step() sampled session.step_seq=3 inside the thread),
+        # my_step_seq would have been 3 and generating would be False here.
+        assert session.generating is True, (
+            "Delayed-thread race: step() finally must not clear the replacement "
+            "step's generating reservation when step_seq passed from caller != current"
+        )
+        assert session.step_seq == 3
+
 
 # --- Tool confirm endpoint tests ---
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -634,6 +634,76 @@ class TestInterruptEndpoint:
         assert session.interrupted is False
         assert session.step_seq == initial_seq
 
+    def test_continuation_reservation_not_cleared_by_originating_step(
+        self, conv, tmp_path
+    ):
+        """Race 5: step() finally must not clear generating when a continuation reserved it.
+
+        The tool worker increments step_seq (inside step_lock) before setting
+        generating=True for the continuation. The originating step()'s finally
+        captures step_seq at entry; a mismatch means the continuation took over
+        and we must not clear its reservation.
+        """
+
+        from gptme.message import Message
+        from gptme.server.session_step import step
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        # step_seq=1 is the value set by the /step API handler before step() runs.
+        # step() will snapshot my_step_seq=1 at entry.
+        session.step_seq = 1
+        session.generating = True
+
+        def advance_seq_then_return(*args, **kwargs):
+            """Simulate: tool continuation advanced step_seq to 2 inside step_lock."""
+            with session.step_lock:
+                session.step_seq += 1  # 1 → 2
+            return iter([])  # no tokens; step() finds no tools, exits normally
+
+        with (
+            patch(
+                "gptme.server.session_step._stream", side_effect=advance_seq_then_return
+            ),
+            patch("gptme.server.session_step.require_workspace_exists"),
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch("gptme.server.session_step.trigger_hook", return_value=[]),
+            patch(
+                "gptme.server.session_step.prepare_messages",
+                return_value=[Message("user", "test")],
+            ),
+            patch("gptme.server.session_step._try_auto_name_and_notify"),
+            patch("gptme.server.session_step.set_workspace_cwd"),
+            patch(
+                "gptme.server.session_step.ChatConfig.load_or_create",
+                return_value=MagicMock(
+                    tool_format="markdown",
+                    tools=None,
+                    workspace=tmp_path,
+                    max_tokens=None,
+                    temperature=None,
+                    top_p=None,
+                ),
+            ),
+            patch("gptme.llm.models.set_default_model"),
+            patch("gptme.model_attestation.record_runtime_selection"),
+        ):
+            step(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                model="mock/model",
+                workspace=tmp_path,
+            )
+
+        # step() captured my_step_seq=1 at entry; advance_seq_then_return bumped to 2.
+        # The finally block must have seen 2 != 1 and skipped clearing generating.
+        assert session.generating is True, (
+            "Race 5: originating step() finally must not clear the "
+            "continuation's generating reservation when step_seq advanced"
+        )
+        assert session.step_seq == 2
+
 
 # --- Tool confirm endpoint tests ---
 

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -1091,6 +1091,49 @@ class TestToolConfirmEndpoint:
             "step_seq": session.step_seq,
         }
 
+    def test_skip_increments_step_seq_to_invalidate_stale_workers(
+        self, conv, client: FlaskClient
+    ):
+        """Skip must advance step_seq so concurrent tool workers stand down.
+
+        A concurrent auto-confirm tool worker captures my_seq at start_tool_execution
+        time. If skip does NOT increment step_seq, the worker's owns_reservation check
+        (session.step_seq == my_seq) still holds after skip fires, and the worker elects
+        its own continuation — producing duplicate LLM turns alongside the skip
+        continuation.
+        """
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+        initial_step_seq = session.step_seq
+        tool_id = str(uuid.uuid4())
+        tool_exec = ToolExecution(
+            tool_id=tool_id,
+            tooluse=ToolUse("bash", [], "echo hi"),
+        )
+        session.pending_tools[tool_id] = tool_exec
+
+        with (
+            patch("gptme.server.api_v2_sessions._append_and_notify"),
+            patch("gptme.server.api_v2_sessions._start_step_thread", return_value=True),
+            patch("gptme.server.api_v2_sessions.resolve_hook_confirmation"),
+        ):
+            response = client.post(
+                f"/api/v2/conversations/{conv['conversation_id']}/tool/confirm",
+                json={
+                    "session_id": conv["session_id"],
+                    "tool_id": tool_id,
+                    "action": "skip",
+                },
+            )
+
+        assert response.status_code == 200
+        # step_seq must have advanced so any stale tool worker with the old
+        # my_seq sees a mismatch and releases its reservation instead of
+        # electing a duplicate continuation.
+        assert session.step_seq == initial_step_seq + 1, (
+            "skip must increment step_seq to invalidate stale concurrent workers"
+        )
+
     def test_skip_preserves_tool_when_step_reserved_generation(
         self, conv, client: FlaskClient
     ):

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -782,6 +782,53 @@ class TestInterruptEndpoint:
         )
         assert session.step_seq == 3
 
+    def test_setup_exit_does_not_clear_newer_reservation(
+        self, conv, tmp_path, monkeypatch
+    ):
+        """Early-exit paths (workspace missing, no messages) must not clear a newer step's reservation.
+
+        Race: step A is spawned (step_seq=1), descheduled during setup,
+        step B interrupts + starts (step_seq=3, generating=True). When step A's
+        thread wakes up and hits an early exit (e.g. workspace missing), it must
+        compare step_seq before clearing generating, so it does not erase B's
+        reservation.
+        """
+        monkeypatch.chdir(tmp_path)
+
+        from gptme.server.session_step import step
+
+        session = SessionManager.get_session(conv["session_id"])
+        assert session is not None
+
+        # Simulate: replacement step B has taken over (step_seq=3, generating=True).
+        session.step_seq = 3
+        session.generating = True
+
+        with (
+            patch(
+                "gptme.server.session_step.require_workspace_exists",
+                side_effect=FileNotFoundError("workspace missing"),
+            ),
+            patch("gptme.server.session_step.prepare_execution_environment"),
+            patch("gptme.server.session_step._persist_generation_error"),
+            patch("gptme.server.session_step.SessionManager.add_event"),
+        ):
+            # Old step A calls step() with its original epoch (1).
+            step(
+                conversation_id=conv["conversation_id"],
+                session=session,
+                model="mock/model",
+                workspace=tmp_path,
+                step_seq=1,
+            )
+
+        # step_seq (3) != my_step_seq (1) → early exit must NOT have cleared generating.
+        assert session.generating is True, (
+            "Setup exit: step() workspace-missing early exit must not clear "
+            "a newer step's generating reservation when step_seq advanced"
+        )
+        assert session.step_seq == 3
+
 
 # --- Tool confirm endpoint tests ---
 


### PR DESCRIPTION
## Why

`step()`'s `finally` block still did `session.generating = False` unconditionally. The tool-continuation path already increments `session.step_seq` before re-reserving generation. If an auto-confirm tool finishes *before* the originating `step()` reaches `finally`, that increment happens first and then `finally` erases the continuation's reservation. A later `/step` can start concurrently with the continuation (duplicate LLM turns).

This is Race 5 from the interrupt/continuation work. gptme/gptme#3457 landed the other races; this slice existed as `8cb2e89c` / `recovered/server-continuation-reservation-test` and never made it onto master. Cherry-picked onto current master: kept today's continuation-election path (it already bumps `step_seq`) and added the missing `finally` compare-and-clear.

Recovered from `tasks/triage-recovered-branches-2026-08-10.md`.

## Change

- Snapshot `step_seq` before streaming.
- In `step()` `finally`, clear `generating` only if `step_seq` is still ours.
- Regression: `test_continuation_reservation_not_cleared_by_originating_step`.

## Test plan

- [x] `pytest tests/test_server_v2_sessions.py::TestInterruptEndpoint` — 16 passed (includes the new Race 5 test)