### PR TITLE
feat(cli): auto-discover local Ollama and LM Studio providers

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -95,6 +95,9 @@ To run gptme without an API key, use a local model via `Ollama <https://ollama.c
     ollama pull llama3.2:1b
     ollama serve  # run in background or separate terminal
 
+    # Check that gptme can see the local server (probes /v1/models)
+    gptme providers list
+
     # Use with gptme (OPENAI_BASE_URL is required by the local provider)
     export OPENAI_BASE_URL="http://127.0.0.1:11434/v1"
     gptme "hello" -m local/llama3.2:1b

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -133,6 +133,29 @@ Tool use fails or loops
   **Cause:** Model too small for tool format
   **Fix:** Use a 7B+ instruction-tuned model; or try a different tool format (``gptme --tool-format xml``)
 
+Auto-discovery
+---------------
+
+``gptme providers list`` probes well-known local OpenAI-compatible endpoints and
+reports what it finds — including candidates that are not running:
+
+- Ollama: ``GET http://127.0.0.1:11434/v1/models``
+- LM Studio: ``GET http://127.0.0.1:1234/v1/models``
+
+Detection is an HTTP GET of the real ``/v1/models`` path (the OpenAI models
+list), not a port-open check and not Ollama's native ``/api/tags``. A process
+listening on the port that is not OpenAI-compatible is listed with a reason
+rather than silently skipped.
+
+Auto-discovery never writes config. Use ``gptme providers add`` (or a
+``[[providers]]`` block) to persist a provider. Disable probes with
+``GPTME_NO_LOCAL_DISCOVERY=1`` or ``gptme providers list --no-discover``.
+
+.. code-block:: sh
+
+    gptme providers list
+    gptme providers list --json
+
 vLLM and OpenAI-compatible servers
 -----------------------------------
 

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -275,7 +275,9 @@ def _print_discovery_result(result) -> None:
         if result.configured_as:
             click.echo(f"      already configured as '{result.configured_as}'")
         else:
-            example = _strip_controls(result.models[0]) if result.models else "<model>"
+            example = next(
+                (s for m in result.models if (s := _strip_controls(m))), "<model>"
+            )
             click.echo("      not in config — persist with `gptme providers add`, or:")
             click.echo(
                 f"      OPENAI_BASE_URL={cand.base_url} gptme -m local/{example}"

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -145,9 +145,35 @@ def providers():
 
 
 @providers.command("list")
-def providers_list():
-    """List configured custom OpenAI-compatible providers."""
+@click.option(
+    "--discover/--no-discover",
+    default=True,
+    help="Probe well-known local OpenAI-compatible endpoints (Ollama :11434, LM Studio :1234).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def providers_list(discover: bool = True, as_json: bool = False):
+    """List configured and auto-discovered local OpenAI-compatible providers.
+
+    Configured ``[[providers]]`` entries are listed first. Then gptme probes
+    Ollama (``http://127.0.0.1:11434/v1/models``) and LM Studio
+    (``http://127.0.0.1:1234/v1/models``) and reports each candidate — live
+    servers and the reason a probe did not count as available. Discovery never
+    writes config; use ``gptme providers add`` to persist a provider.
+    """
     config = get_config()
+    discovered = []
+    if discover:
+        from ..llm.local_discovery import discover_local_providers  # fmt: skip
+
+        discovered = discover_local_providers(configured=config.user.providers)
+
+    if as_json:
+        payload = {
+            "configured": [_configured_provider_dict(p) for p in config.user.providers],
+            "discovered": [r.to_dict() for r in discovered],
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
 
     if not config.user.providers:
         click.echo("📭 No custom providers configured")
@@ -160,29 +186,92 @@ def providers_list():
         click.echo('base_url = "http://localhost:8000/v1"')
         click.echo('api_key_env = "MY_PROVIDER_API_KEY"')
         click.echo('default_model = "my-model"')
+        click.echo()
+    else:
+        click.echo(f"🔌 Found {len(config.user.providers)} custom provider(s):")
+        click.echo()
+
+        for provider in config.user.providers:
+            click.echo(f"📡 {provider.name}")
+            click.echo(f"   Base URL: {provider.base_url}")
+
+            # Show API key source (but not the actual key)
+            if provider.api_key:
+                click.echo("   API Key: (configured directly)")
+            elif provider.api_key_env:
+                click.echo(f"   API Key: ${provider.api_key_env}")
+            else:
+                click.echo(
+                    f"   API Key: ${provider.name.upper().replace('-', '_')}_API_KEY (default)"
+                )
+
+            if provider.default_model:
+                click.echo(f"   Default Model: {provider.default_model}")
+
+            click.echo()
+
+    if not discover:
         return
 
-    click.echo(f"🔌 Found {len(config.user.providers)} custom provider(s):")
-    click.echo()
+    click.echo("🔍 Local auto-discovery")
+    if not discovered:
+        click.echo("   (disabled via GPTME_NO_LOCAL_DISCOVERY)")
+        return
 
-    for provider in config.user.providers:
-        click.echo(f"📡 {provider.name}")
-        click.echo(f"   Base URL: {provider.base_url}")
+    for result in discovered:
+        _print_discovery_result(result)
 
-        # Show API key source (but not the actual key)
-        if provider.api_key:
-            click.echo("   API Key: (configured directly)")
-        elif provider.api_key_env:
-            click.echo(f"   API Key: ${provider.api_key_env}")
-        else:
-            click.echo(
-                f"   API Key: ${provider.name.upper().replace('-', '_')}_API_KEY (default)"
+
+def _configured_provider_dict(provider) -> dict:
+    return {
+        "name": provider.name,
+        "base_url": provider.base_url,
+        "api_key_env": provider.api_key_env,
+        "default_model": provider.default_model,
+        "api_key_configured": bool(provider.api_key),
+    }
+
+
+def _print_discovery_result(result) -> None:
+    from ..llm.local_discovery import DiscoveryResult  # fmt: skip
+
+    if not isinstance(result, DiscoveryResult):
+        raise TypeError(f"expected DiscoveryResult, got {type(result).__name__}")
+    cand = result.candidate
+    status_icon = {
+        "up": "✅",
+        "down": "⚪",
+        "incompatible": "❌",
+        "auth_required": "🔒",
+        "error": "❌",
+    }.get(result.status, "⚪")
+    click.echo(f"   {status_icon} {cand.display_name}  {cand.base_url}")
+    click.echo(f"      probe: {cand.models_url}")
+    if result.status == "up":
+        if result.models:
+            shown = ", ".join(result.models[:8])
+            extra = (
+                f" (+{len(result.models) - 8} more)" if len(result.models) > 8 else ""
             )
-
-        if provider.default_model:
-            click.echo(f"   Default Model: {provider.default_model}")
-
-        click.echo()
+            click.echo(f"      models ({len(result.models)}): {shown}{extra}")
+        else:
+            click.echo("      models: (none listed — server is up)")
+        if result.configured_as:
+            click.echo(f"      already configured as '{result.configured_as}'")
+        else:
+            example = result.models[0] if result.models else "<model>"
+            click.echo("      not in config — persist with `gptme providers add`, or:")
+            click.echo(
+                f"      OPENAI_BASE_URL={cand.base_url} gptme -m local/{example}"
+            )
+    else:
+        click.echo(f"      {result.reason}")
+        if result.status == "down":
+            click.echo(f"      hint: {cand.hint}")
+        if result.configured_as:
+            click.echo(
+                f"      configured as '{result.configured_as}' but the endpoint is not reachable"
+            )
 
 
 @providers.command("test")

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -220,7 +220,10 @@ def providers_list(discover: bool = True, as_json: bool = False):
 
     click.echo("🔍 Local auto-discovery")
     if not discovered:
-        click.echo("   (disabled via GPTME_NO_LOCAL_DISCOVERY)")
+        if local_discovery_disabled():
+            click.echo("   (disabled via GPTME_NO_LOCAL_DISCOVERY)")
+        else:
+            click.echo("   (no local providers found)")
         return
 
     for result in discovered:
@@ -274,9 +277,14 @@ def _print_discovery_result(result) -> None:
         if result.status == "down":
             click.echo(f"      hint: {cand.hint}")
         if result.configured_as:
-            click.echo(
-                f"      configured as '{result.configured_as}' but the endpoint is not reachable"
-            )
+            if result.status == "down":
+                click.echo(
+                    f"      configured as '{result.configured_as}' but the endpoint is not reachable"
+                )
+            else:
+                click.echo(
+                    f"      configured as '{result.configured_as}' but did not respond as expected"
+                )
 
 
 @providers.command("test")

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -240,6 +240,13 @@ def _configured_provider_dict(provider) -> dict:
     }
 
 
+def _strip_controls(s: str) -> str:
+    """Strip C0/C1 terminal control characters from untrusted probe output."""
+    import re
+
+    return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", s)
+
+
 def _print_discovery_result(result) -> None:
     from ..llm.local_discovery import DiscoveryResult  # fmt: skip
 
@@ -257,7 +264,8 @@ def _print_discovery_result(result) -> None:
     click.echo(f"      probe: {cand.models_url}")
     if result.status == "up":
         if result.models:
-            shown = ", ".join(result.models[:8])
+            safe_models = [_strip_controls(m) for m in result.models]
+            shown = ", ".join(safe_models[:8])
             extra = (
                 f" (+{len(result.models) - 8} more)" if len(result.models) > 8 else ""
             )
@@ -267,13 +275,13 @@ def _print_discovery_result(result) -> None:
         if result.configured_as:
             click.echo(f"      already configured as '{result.configured_as}'")
         else:
-            example = result.models[0] if result.models else "<model>"
+            example = _strip_controls(result.models[0]) if result.models else "<model>"
             click.echo("      not in config — persist with `gptme providers add`, or:")
             click.echo(
                 f"      OPENAI_BASE_URL={cand.base_url} gptme -m local/{example}"
             )
     else:
-        click.echo(f"      {result.reason}")
+        click.echo(f"      {_strip_controls(result.reason)}")
         if result.status == "down":
             click.echo(f"      hint: {cand.hint}")
         if result.configured_as:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -163,15 +163,19 @@ def providers_list(discover: bool = True, as_json: bool = False):
     config = get_config()
     discovered = []
     if discover:
-        from ..llm.local_discovery import discover_local_providers  # fmt: skip
+        from ..llm.local_discovery import (  # fmt: skip
+            discover_local_providers,
+            local_discovery_disabled,
+        )
 
         discovered = discover_local_providers(configured=config.user.providers)
 
     if as_json:
+        _env_disabled = discover and local_discovery_disabled()
         payload = {
             "configured": [_configured_provider_dict(p) for p in config.user.providers],
             "discovered": [r.to_dict() for r in discovered],
-            "discovery_disabled": not discover,
+            "discovery_disabled": not discover or _env_disabled,
         }
         click.echo(json.dumps(payload, indent=2))
         return

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -171,6 +171,7 @@ def providers_list(discover: bool = True, as_json: bool = False):
         payload = {
             "configured": [_configured_provider_dict(p) for p in config.user.providers],
             "discovered": [r.to_dict() for r in discovered],
+            "discovery_disabled": not discover,
         }
         click.echo(json.dumps(payload, indent=2))
         return

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -368,7 +368,10 @@ def _endpoint_key(url: str) -> tuple[str, str, int, str] | None:
     if not host:
         return None
     scheme = parsed.scheme.lower()
-    port = parsed.port
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
     if port is None:
         port = 443 if scheme == "https" else 80
     canonical = "loopback" if _is_loopback_host(host) else host

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -136,6 +136,9 @@ def discover_local_providers(
     to_probe = (
         tuple(candidates) if candidates is not None else LOCAL_PROVIDER_CANDIDATES
     )
+    if not to_probe:
+        return []
+
     fetch_fn = fetch or _http_get
     configured_index = _index_configured(configured or ())
 
@@ -157,7 +160,7 @@ def _probe_one(
     candidate: LocalProviderCandidate,
     timeout: float,
     fetch: FetchFn,
-    configured_index: dict[tuple[str, int], str],
+    configured_index: dict[tuple[str, str, int, str], str],
 ) -> DiscoveryResult:
     url = candidate.models_url
     parsed = urlparse(url)
@@ -291,7 +294,9 @@ def _http_get(url: str, timeout: float) -> tuple[int, bytes]:
             },
         )
         resp = conn.getresponse()
-        body = resp.read(MAX_BODY_BYTES)
+        body = resp.read(MAX_BODY_BYTES + 1)
+        if len(body) > MAX_BODY_BYTES:
+            raise OSError(f"response body exceeds {MAX_BODY_BYTES} bytes")
         return resp.status, body
     finally:
         conn.close()
@@ -328,8 +333,10 @@ def _parse_openai_models(body: bytes) -> tuple[tuple[str, ...], str | None]:
     return tuple(ids), None
 
 
-def _index_configured(configured: Sequence[object]) -> dict[tuple[str, int], str]:
-    index: dict[tuple[str, int], str] = {}
+def _index_configured(
+    configured: Sequence[object],
+) -> dict[tuple[str, str, int, str], str]:
+    index: dict[tuple[str, str, int, str], str] = {}
     for item in configured:
         name = getattr(item, "name", None)
         base_url = getattr(item, "base_url", None)
@@ -342,7 +349,7 @@ def _index_configured(configured: Sequence[object]) -> dict[tuple[str, int], str
 
 
 def _match_configured(
-    candidate: LocalProviderCandidate, index: dict[tuple[str, int], str]
+    candidate: LocalProviderCandidate, index: dict[tuple[str, str, int, str], str]
 ) -> str | None:
     key = _endpoint_key(candidate.base_url)
     if key is None:
@@ -350,16 +357,19 @@ def _match_configured(
     return index.get(key)
 
 
-def _endpoint_key(url: str) -> tuple[str, int] | None:
+def _endpoint_key(url: str) -> tuple[str, str, int, str] | None:
+    """Return a canonical (scheme, host, port, path) key for endpoint identity matching."""
     parsed = urlparse(url)
     host = (parsed.hostname or "").lower()
     if not host:
         return None
+    scheme = parsed.scheme.lower()
     port = parsed.port
     if port is None:
-        port = 443 if parsed.scheme == "https" else 80
+        port = 443 if scheme == "https" else 80
     canonical = "loopback" if _is_loopback_host(host) else host
-    return canonical, port
+    path = parsed.path.rstrip("/").lower() or "/"
+    return scheme, canonical, port, path
 
 
 def _is_loopback_host(host: str) -> bool:

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -1,0 +1,419 @@
+"""Probe well-known local OpenAI-compatible providers.
+
+gptme should "just work" with a local Ollama or LM Studio instance. This module
+detects those servers by hitting their real OpenAI-compatible ``/v1/models``
+endpoint — not by checking whether a port is open, and not by guessing native
+APIs such as Ollama's ``/api/tags``.
+
+Candidates (loopback only):
+
+- Ollama:    ``http://127.0.0.1:11434/v1/models``
+- LM Studio: ``http://127.0.0.1:1234/v1/models``
+
+A probe is a GET of that URL with a short timeout. Success requires HTTP 200
+and an OpenAI models-list JSON body (``{"data": [{"id": ...}, ...]}``). Every
+other outcome is returned with a reason so callers never silently drop a
+candidate.
+
+This module never writes config. Listing is opt-in display; persisting a
+provider is ``gptme providers add``.
+
+Disable probes with ``GPTME_NO_LOCAL_DISCOVERY=1`` (CI / hermetic tests).
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import time
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from http.client import HTTPConnection, HTTPException
+from typing import Literal
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_S = 0.5
+MAX_BODY_BYTES = 65_536
+USER_AGENT = "gptme-local-discovery/1.0"
+
+ProbeStatus = Literal["up", "down", "incompatible", "auth_required", "error"]
+
+
+@dataclass(frozen=True)
+class LocalProviderCandidate:
+    """A well-known local OpenAI-compatible server to probe."""
+
+    name: str
+    display_name: str
+    base_url: str
+    hint: str
+
+    @property
+    def models_url(self) -> str:
+        """The real OpenAI-compat models list URL (``{base_url}/models``)."""
+        return self.base_url.rstrip("/") + "/models"
+
+
+LOCAL_PROVIDER_CANDIDATES: tuple[LocalProviderCandidate, ...] = (
+    LocalProviderCandidate(
+        name="ollama",
+        display_name="Ollama",
+        base_url="http://127.0.0.1:11434/v1",
+        hint="Install from https://ollama.com and run `ollama serve`",
+    ),
+    LocalProviderCandidate(
+        name="lmstudio",
+        display_name="LM Studio",
+        base_url="http://127.0.0.1:1234/v1",
+        hint="Open LM Studio → Local Server → Start",
+    ),
+)
+
+# Hostnames treated as the same loopback endpoint when matching config.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    """Outcome of probing one local provider candidate."""
+
+    candidate: LocalProviderCandidate
+    status: ProbeStatus
+    reason: str
+    models: tuple[str, ...] = ()
+    configured_as: str | None = None
+    elapsed_s: float = 0.0
+
+    @property
+    def is_up(self) -> bool:
+        return self.status == "up"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.candidate.name,
+            "display_name": self.candidate.display_name,
+            "base_url": self.candidate.base_url,
+            "models_url": self.candidate.models_url,
+            "status": self.status,
+            "reason": self.reason,
+            "models": list(self.models),
+            "configured_as": self.configured_as,
+            "hint": self.candidate.hint,
+        }
+
+
+FetchFn = Callable[[str, float], tuple[int, bytes]]
+
+
+def local_discovery_disabled() -> bool:
+    """Return True when GPTME_NO_LOCAL_DISCOVERY disables probing."""
+    raw = os.environ.get("GPTME_NO_LOCAL_DISCOVERY", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def discover_local_providers(
+    *,
+    candidates: Sequence[LocalProviderCandidate] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    configured: Sequence[object] | None = None,
+    fetch: FetchFn | None = None,
+) -> list[DiscoveryResult]:
+    """Probe well-known local providers and return a result for each candidate.
+
+    Every candidate is represented in the result list. Failures are never
+    dropped — ``status`` and ``reason`` explain why a probe did not count as
+    a live OpenAI-compatible provider.
+    """
+    if local_discovery_disabled():
+        logger.debug("local provider discovery disabled via GPTME_NO_LOCAL_DISCOVERY")
+        return []
+
+    to_probe = (
+        tuple(candidates) if candidates is not None else LOCAL_PROVIDER_CANDIDATES
+    )
+    fetch_fn = fetch or _http_get
+    configured_index = _index_configured(configured or ())
+
+    if len(to_probe) == 1:
+        return [_probe_one(to_probe[0], timeout, fetch_fn, configured_index)]
+
+    results: list[DiscoveryResult | None] = [None] * len(to_probe)
+    with ThreadPoolExecutor(max_workers=len(to_probe)) as pool:
+        futs = {
+            pool.submit(_probe_one, cand, timeout, fetch_fn, configured_index): i
+            for i, cand in enumerate(to_probe)
+        }
+        for fut, idx in futs.items():
+            results[idx] = fut.result()
+    return [r for r in results if r is not None]
+
+
+def _probe_one(
+    candidate: LocalProviderCandidate,
+    timeout: float,
+    fetch: FetchFn,
+    configured_index: dict[tuple[str, int], str],
+) -> DiscoveryResult:
+    url = candidate.models_url
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if not _is_loopback_host(host):
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="error",
+            reason=f"refusing to probe non-loopback host {host!r}",
+        )
+        _log_result(result)
+        return result
+
+    t0 = time.monotonic()
+    try:
+        status_code, body = fetch(url, timeout)
+    except TimeoutError:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="down",
+            reason=f"timeout after {timeout:.1f}s probing {url}",
+            elapsed_s=time.monotonic() - t0,
+            configured_as=_match_configured(candidate, configured_index),
+        )
+        _log_result(result)
+        return result
+    except (ConnectionRefusedError, ConnectionResetError, BrokenPipeError) as e:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="down",
+            reason=f"not running ({_short_oserror(e)})",
+            elapsed_s=time.monotonic() - t0,
+            configured_as=_match_configured(candidate, configured_index),
+        )
+        _log_result(result)
+        return result
+    except OSError as e:
+        # Connection refused often arrives as OSError on some platforms.
+        reason = _short_oserror(e)
+        status: ProbeStatus = "down" if _looks_like_unreachable(e) else "error"
+        result = DiscoveryResult(
+            candidate=candidate,
+            status=status,
+            reason=reason,
+            elapsed_s=time.monotonic() - t0,
+            configured_as=_match_configured(candidate, configured_index),
+        )
+        _log_result(result)
+        return result
+    except HTTPException as e:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="error",
+            reason=f"HTTP error probing {url}: {e}",
+            elapsed_s=time.monotonic() - t0,
+            configured_as=_match_configured(candidate, configured_index),
+        )
+        _log_result(result)
+        return result
+
+    elapsed = time.monotonic() - t0
+    configured_as = _match_configured(candidate, configured_index)
+
+    if status_code in {401, 403}:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="auth_required",
+            reason=f"HTTP {status_code} from {url} (reachable, auth required)",
+            elapsed_s=elapsed,
+            configured_as=configured_as,
+        )
+        _log_result(result)
+        return result
+
+    if status_code != 200:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="error",
+            reason=f"HTTP {status_code} from {url}",
+            elapsed_s=elapsed,
+            configured_as=configured_as,
+        )
+        _log_result(result)
+        return result
+
+    models, parse_error = _parse_openai_models(body)
+    if parse_error:
+        result = DiscoveryResult(
+            candidate=candidate,
+            status="incompatible",
+            reason=f"{url} is not an OpenAI-compatible /v1/models endpoint: {parse_error}",
+            elapsed_s=elapsed,
+            configured_as=configured_as,
+        )
+        _log_result(result)
+        return result
+
+    result = DiscoveryResult(
+        candidate=candidate,
+        status="up",
+        reason="ok",
+        models=models,
+        elapsed_s=elapsed,
+        configured_as=configured_as,
+    )
+    _log_result(result)
+    return result
+
+
+def _http_get(url: str, timeout: float) -> tuple[int, bytes]:
+    """GET ``url`` without following redirects. Loopback-only by construction."""
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        raise OSError("missing host")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if parsed.scheme != "http":
+        raise OSError(f"unsupported scheme {parsed.scheme!r} (http only)")
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    conn = HTTPConnection(host, port, timeout=timeout)
+    try:
+        conn.request(
+            "GET",
+            path,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        resp = conn.getresponse()
+        body = resp.read(MAX_BODY_BYTES)
+        return resp.status, body
+    finally:
+        conn.close()
+
+
+def _parse_openai_models(body: bytes) -> tuple[tuple[str, ...], str | None]:
+    """Return (model ids, error). Error is set when the body is not OpenAI-shaped."""
+    if not body.strip():
+        return (), "empty body"
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as e:
+        return (), f"not UTF-8 ({e})"
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as e:
+        return (), f"not JSON ({e.msg})"
+    if not isinstance(payload, dict):
+        return (), f"JSON {type(payload).__name__} is not an object"
+    data = payload.get("data")
+    if not isinstance(data, list):
+        # Deliberately reject Ollama's native {"models": [...]} /api/tags shape.
+        if isinstance(payload.get("models"), list):
+            return (), "native Ollama /api/tags shape, not OpenAI /v1/models"
+        return (), "missing OpenAI 'data' list"
+    ids: list[str] = []
+    for item in data:
+        if isinstance(item, str) and item:
+            ids.append(item)
+        elif isinstance(item, dict):
+            model_id = item.get("id")
+            if isinstance(model_id, str) and model_id:
+                ids.append(model_id)
+    return tuple(ids), None
+
+
+def _index_configured(configured: Sequence[object]) -> dict[tuple[str, int], str]:
+    index: dict[tuple[str, int], str] = {}
+    for item in configured:
+        name = getattr(item, "name", None)
+        base_url = getattr(item, "base_url", None)
+        if not isinstance(name, str) or not isinstance(base_url, str):
+            continue
+        key = _endpoint_key(base_url)
+        if key is not None:
+            index[key] = name
+    return index
+
+
+def _match_configured(
+    candidate: LocalProviderCandidate, index: dict[tuple[str, int], str]
+) -> str | None:
+    key = _endpoint_key(candidate.base_url)
+    if key is None:
+        return None
+    return index.get(key)
+
+
+def _endpoint_key(url: str) -> tuple[str, int] | None:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    canonical = "loopback" if _is_loopback_host(host) else host
+    return canonical, port
+
+
+def _is_loopback_host(host: str) -> bool:
+    return host.lower() in _LOOPBACK_HOSTS
+
+
+def _looks_like_unreachable(exc: OSError) -> bool:
+    if isinstance(exc, ConnectionRefusedError | ConnectionResetError | BrokenPipeError):
+        return True
+    err = getattr(exc, "errno", None)
+    if err in {
+        errno.ECONNREFUSED,
+        errno.ECONNRESET,
+        errno.ECONNABORTED,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+    }:
+        return True
+    msg = str(exc).lower()
+    return any(
+        token in msg
+        for token in (
+            "connection refused",
+            "connect call failed",
+            "name or service not known",
+            "nodename nor servname",
+            "network is unreachable",
+        )
+    )
+
+
+def _short_oserror(exc: BaseException) -> str:
+    msg = str(exc).strip() or type(exc).__name__
+    # urllib/http.client wrap "Connection refused" in longer strings.
+    if "connection refused" in msg.lower():
+        return "connection refused"
+    if "timed out" in msg.lower():
+        return "timeout"
+    return msg
+
+
+def _log_result(result: DiscoveryResult) -> None:
+    name = result.candidate.name
+    url = result.candidate.models_url
+    if result.status == "up":
+        logger.info(
+            "local provider %s up at %s (%d models)",
+            name,
+            url,
+            len(result.models),
+        )
+    elif result.status == "incompatible":
+        logger.warning("local provider %s ignored: %s", name, result.reason)
+    else:
+        logger.info(
+            "local provider %s not listed as available: %s", name, result.reason
+        )

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -370,7 +370,7 @@ def _endpoint_key(url: str) -> tuple[str, str, int, str] | None:
     if port is None:
         port = 443 if scheme == "https" else 80
     canonical = "loopback" if _is_loopback_host(host) else host
-    path = parsed.path.rstrip("/").lower() or "/"
+    path = parsed.path.rstrip("/") or "/"
     return scheme, canonical, port, path
 
 

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -330,6 +330,8 @@ def _parse_openai_models(body: bytes) -> tuple[tuple[str, ...], str | None]:
             model_id = item.get("id")
             if isinstance(model_id, str) and model_id:
                 ids.append(model_id)
+            else:
+                return (), f"data item missing valid 'id' field: {item!r}"
         else:
             return (), f"data item is not a model object: {type(item).__name__}"
     return tuple(ids), None

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -74,8 +74,13 @@ LOCAL_PROVIDER_CANDIDATES: tuple[LocalProviderCandidate, ...] = (
     ),
 )
 
-# Hostnames treated as the same loopback endpoint when matching config.
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
+# Hosts we will actually probe. 0.0.0.0 is the unspecified/any address,
+# not loopback, so `_probe_one` refuses it.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# Extra names treated as the same endpoint when matching config. Users
+# often copy a bind address (`0.0.0.0`) into `base_url`.
+_LOOPBACK_CONFIG_ALIASES = _LOOPBACK_HOSTS | {"0.0.0.0"}
 
 
 @dataclass(frozen=True)
@@ -276,7 +281,12 @@ def _http_get(url: str, timeout: float) -> tuple[int, bytes]:
     host = parsed.hostname
     if not host:
         raise OSError("missing host")
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        port = parsed.port
+    except ValueError as e:
+        raise OSError(f"invalid port in {url}") from e
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
     if parsed.scheme != "http":
         raise OSError(f"unsupported scheme {parsed.scheme!r} (http only)")
     path = parsed.path or "/"
@@ -374,13 +384,17 @@ def _endpoint_key(url: str) -> tuple[str, str, int, str] | None:
         return None
     if port is None:
         port = 443 if scheme == "https" else 80
-    canonical = "loopback" if _is_loopback_host(host) else host
+    canonical = "loopback" if _is_loopback_alias(host) else host
     path = parsed.path.rstrip("/") or "/"
     return scheme, canonical, port, path
 
 
 def _is_loopback_host(host: str) -> bool:
     return host.lower() in _LOOPBACK_HOSTS
+
+
+def _is_loopback_alias(host: str) -> bool:
+    return host.lower() in _LOOPBACK_CONFIG_ALIASES
 
 
 def _looks_like_unreachable(exc: OSError) -> bool:

--- a/gptme/llm/local_discovery.py
+++ b/gptme/llm/local_discovery.py
@@ -330,6 +330,8 @@ def _parse_openai_models(body: bytes) -> tuple[tuple[str, ...], str | None]:
             model_id = item.get("id")
             if isinstance(model_id, str) and model_id:
                 ids.append(model_id)
+        else:
+            return (), f"data item is not a model object: {type(item).__name__}"
     return tuple(ids), None
 
 

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -16,6 +16,7 @@ from gptme.config.models import ProviderConfig
 from gptme.llm.local_discovery import (
     LOCAL_PROVIDER_CANDIDATES,
     LocalProviderCandidate,
+    _endpoint_key,
     discover_local_providers,
 )
 
@@ -262,6 +263,15 @@ def test_up_with_empty_model_list_still_counts(handler_cls) -> None:
         server.shutdown()
     assert results[0].status == "up"
     assert results[0].models == ()
+
+
+def test_case_distinct_paths_are_not_equal() -> None:
+    # HTTP paths are case-sensitive; /V1 and /v1 are different resources.
+    key_lower = _endpoint_key("http://localhost:11434/v1")
+    key_upper = _endpoint_key("http://localhost:11434/V1")
+    assert key_lower is not None
+    assert key_upper is not None
+    assert key_lower != key_upper
 
 
 def test_default_candidates_include_ollama_and_lmstudio() -> None:

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -1,0 +1,269 @@
+"""Tests for local OpenAI-compatible provider auto-discovery.
+
+Probes hit a real HTTP server on loopback so we assert the actual
+``/v1/models`` path and payload shape, not a mocked URL guess.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from gptme.config.models import ProviderConfig
+from gptme.llm.local_discovery import (
+    LOCAL_PROVIDER_CANDIDATES,
+    LocalProviderCandidate,
+    discover_local_providers,
+)
+
+
+class _ModelsHandler(BaseHTTPRequestHandler):
+    """Configurable /v1/models fixture. Class attrs set per test."""
+
+    status: int = 200
+    body: bytes = b""
+    seen_paths: list[str] = []
+    delay_s: float = 0.0
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def do_GET(self) -> None:
+        if self.delay_s:
+            import time
+
+            time.sleep(self.delay_s)
+        path = self.path.split("?", 1)[0]
+        type(self).seen_paths.append(path)
+        if path != "/v1/models":
+            self.send_error(404)
+            return
+        self.send_response(self.status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(self.body)))
+        self.end_headers()
+        if self.body:
+            self.wfile.write(self.body)
+
+
+def _serve(handler: type[BaseHTTPRequestHandler]) -> tuple[HTTPServer, str]:
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = int(server.server_address[1])
+    base = f"http://127.0.0.1:{port}/v1"
+    return server, base
+
+
+def _candidate(base_url: str, name: str = "ollama") -> LocalProviderCandidate:
+    return LocalProviderCandidate(
+        name=name,
+        display_name=name,
+        base_url=base_url,
+        hint="test",
+    )
+
+
+def _openai_models_body(*ids: str) -> bytes:
+    return json.dumps(
+        {
+            "object": "list",
+            "data": [{"id": model_id, "object": "model"} for model_id in ids],
+        }
+    ).encode()
+
+
+@pytest.fixture
+def handler_cls():
+    class H(_ModelsHandler):
+        status = 200
+        body = _openai_models_body("llama3.2:3b", "mistral:7b")
+        seen_paths: list[str] = []
+        delay_s = 0.0
+
+    return H
+
+
+def test_candidates_point_at_v1_models() -> None:
+    """Hardcoded probes must hit /v1/models, not native APIs like /api/tags."""
+    by_name = {c.name: c for c in LOCAL_PROVIDER_CANDIDATES}
+    assert by_name["ollama"].models_url == "http://127.0.0.1:11434/v1/models"
+    assert by_name["lmstudio"].models_url == "http://127.0.0.1:1234/v1/models"
+    assert "/api/tags" not in by_name["ollama"].models_url
+
+
+def test_discovers_openai_compat_models(handler_cls) -> None:
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == "up"
+    assert result.models == ("llama3.2:3b", "mistral:7b")
+    assert result.reason == "ok"
+    assert handler_cls.seen_paths == ["/v1/models"]
+    assert result.candidate.models_url.endswith("/v1/models")
+
+
+def test_reports_connection_refused_instead_of_dropping() -> None:
+    # Bind-and-close so the port is unused; probe must still return a result.
+    import socket
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    base = f"http://127.0.0.1:{port}/v1"
+
+    results = discover_local_providers(
+        candidates=[_candidate(base, name="lmstudio")],
+        timeout=0.3,
+    )
+    assert len(results) == 1
+    assert results[0].status == "down"
+    assert (
+        "connection refused" in results[0].reason.lower()
+        or "not running" in results[0].reason.lower()
+    )
+    assert results[0].models == ()
+
+
+def test_rejects_native_ollama_tags_shape(handler_cls) -> None:
+    """A 200 body that looks like /api/tags is incompatible, not a hit."""
+    handler_cls.body = json.dumps(
+        {"models": [{"name": "llama3.2:3b", "size": 1}]}
+    ).encode()
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert results[0].status == "incompatible"
+    assert "api/tags" in results[0].reason or "data" in results[0].reason
+    assert results[0].models == ()
+    assert handler_cls.seen_paths == ["/v1/models"]
+
+
+def test_rejects_html_on_known_port(handler_cls) -> None:
+    handler_cls.body = b"<html>not a model server</html>"
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert results[0].status == "incompatible"
+    assert "JSON" in results[0].reason
+
+
+def test_auth_required_is_not_silent(handler_cls) -> None:
+    handler_cls.status = 401
+    handler_cls.body = b'{"error":"unauthorized"}'
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert results[0].status == "auth_required"
+    assert "401" in results[0].reason
+
+
+def test_http_404_is_reported(handler_cls) -> None:
+    handler_cls.status = 404
+    handler_cls.body = b"not found"
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert results[0].status == "error"
+    assert "404" in results[0].reason
+
+
+def test_marks_already_configured_loopback_alias(handler_cls) -> None:
+    server, base = _serve(handler_cls)
+    try:
+        # Config uses localhost; probe uses 127.0.0.1 — same endpoint.
+        port = int(base.rsplit(":", 1)[1].split("/")[0])
+        configured = [
+            ProviderConfig(
+                name="my-ollama",
+                base_url=f"http://localhost:{port}/v1",
+            )
+        ]
+        results = discover_local_providers(
+            candidates=[_candidate(base, name="ollama")],
+            configured=configured,
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+
+    assert results[0].status == "up"
+    assert results[0].configured_as == "my-ollama"
+
+
+def test_env_disable_returns_empty(monkeypatch, handler_cls) -> None:
+    monkeypatch.setenv("GPTME_NO_LOCAL_DISCOVERY", "1")
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+    assert results == []
+    assert handler_cls.seen_paths == []
+
+
+def test_refuses_non_loopback_host() -> None:
+    results = discover_local_providers(
+        candidates=[_candidate("http://example.com:11434/v1", name="remote-ollama")],
+        timeout=0.2,
+    )
+    assert results[0].status == "error"
+    assert "non-loopback" in results[0].reason
+
+
+def test_up_with_empty_model_list_still_counts(handler_cls) -> None:
+    handler_cls.body = json.dumps({"object": "list", "data": []}).encode()
+    server, base = _serve(handler_cls)
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base)],
+            timeout=1.0,
+        )
+    finally:
+        server.shutdown()
+    assert results[0].status == "up"
+    assert results[0].models == ()
+
+
+def test_default_candidates_include_ollama_and_lmstudio() -> None:
+    names = [c.name for c in LOCAL_PROVIDER_CANDIDATES]
+    assert names == ["ollama", "lmstudio"]

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -289,3 +289,35 @@ def test_endpoint_key_malformed_port_returns_none() -> None:
     # _index_configured (and therefore gptme providers list) with a ValueError.
     assert _endpoint_key("http://localhost:abc/v1") is None
     assert _endpoint_key("http://127.0.0.1:notaport/v1") is None
+
+
+def test_refuses_unspecified_address() -> None:
+    # 0.0.0.0 is a bind address, not loopback. Probe must refuse it; config
+    # matching still treats it as the same endpoint as 127.0.0.1.
+    results = discover_local_providers(
+        candidates=[_candidate("http://0.0.0.0:11434/v1", name="wildcard")],
+        timeout=0.2,
+    )
+    assert results[0].status == "error"
+    assert "non-loopback" in results[0].reason
+    assert "0.0.0.0" in results[0].reason
+
+
+def test_zero_addr_config_matches_loopback() -> None:
+    key_loop = _endpoint_key("http://127.0.0.1:11434/v1")
+    key_zero = _endpoint_key("http://0.0.0.0:11434/v1")
+    key_local = _endpoint_key("http://localhost:11434/v1")
+    assert key_loop is not None
+    assert key_loop == key_zero == key_local
+
+
+def test_malformed_candidate_port_does_not_crash() -> None:
+    # Custom candidates are public API. A typo in the port must return an
+    # error result, not propagate ValueError out of gptme providers list.
+    results = discover_local_providers(
+        candidates=[_candidate("http://127.0.0.1:abc/v1", name="bad-port")],
+        timeout=0.2,
+    )
+    assert len(results) == 1
+    assert results[0].status == "error"
+    assert "invalid port" in results[0].reason.lower()

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -282,3 +282,10 @@ def test_case_distinct_paths_are_not_equal() -> None:
 def test_default_candidates_include_ollama_and_lmstudio() -> None:
     names = [c.name for c in LOCAL_PROVIDER_CANDIDATES]
     assert names == ["ollama", "lmstudio"]
+
+
+def test_endpoint_key_malformed_port_returns_none() -> None:
+    # A TOML config typo like base_url="http://localhost:abc/v1" must not crash
+    # _index_configured (and therefore gptme providers list) with a ValueError.
+    assert _endpoint_key("http://localhost:abc/v1") is None
+    assert _endpoint_key("http://127.0.0.1:notaport/v1") is None

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -116,19 +116,24 @@ def test_discovers_openai_compat_models(handler_cls) -> None:
 
 
 def test_reports_connection_refused_instead_of_dropping() -> None:
-    # Bind-and-close so the port is unused; probe must still return a result.
+    # Keep the socket bound-but-not-listening so the port stays reserved for
+    # the duration of the probe, preventing any other process from binding to
+    # it and causing spurious non-refused results.
     import socket
 
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
-    sock.close()
     base = f"http://127.0.0.1:{port}/v1"
 
-    results = discover_local_providers(
-        candidates=[_candidate(base, name="lmstudio")],
-        timeout=0.3,
-    )
+    try:
+        results = discover_local_providers(
+            candidates=[_candidate(base, name="lmstudio")],
+            timeout=0.3,
+        )
+    finally:
+        sock.close()
+
     assert len(results) == 1
     assert results[0].status == "down"
     assert (

--- a/tests/test_util_cli_providers.py
+++ b/tests/test_util_cli_providers.py
@@ -1,5 +1,6 @@
 """Tests for the providers-related gptme-util CLI commands."""
 
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -7,6 +8,16 @@ from click.testing import CliRunner
 
 from gptme.cli.util import main
 from gptme.config import ProviderConfig
+from gptme.llm.local_discovery import (
+    DiscoveryResult,
+    LocalProviderCandidate,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_real_local_discovery(monkeypatch):
+    """Keep CLI tests hermetic: never probe the developer's real :11434/:1234."""
+    monkeypatch.setenv("GPTME_NO_LOCAL_DISCOVERY", "1")
 
 
 @pytest.fixture
@@ -356,3 +367,88 @@ class TestProvidersAdd:
         result = runner.invoke(main, ["providers", "list"])
         assert result.exit_code == 0
         assert "gptme providers add" in result.output
+
+
+def _ollama_up(*models: str) -> DiscoveryResult:
+    cand = LocalProviderCandidate(
+        name="ollama",
+        display_name="Ollama",
+        base_url="http://127.0.0.1:11434/v1",
+        hint="run ollama serve",
+    )
+    return DiscoveryResult(
+        candidate=cand,
+        status="up",
+        reason="ok",
+        models=models,
+    )
+
+
+def _lmstudio_down() -> DiscoveryResult:
+    cand = LocalProviderCandidate(
+        name="lmstudio",
+        display_name="LM Studio",
+        base_url="http://127.0.0.1:1234/v1",
+        hint="Open LM Studio → Local Server → Start",
+    )
+    return DiscoveryResult(
+        candidate=cand,
+        status="down",
+        reason="not running (connection refused)",
+    )
+
+
+class TestProvidersListDiscovery:
+    """Tests for auto-discovered local providers in 'providers list'."""
+
+    def test_shows_discovered_ollama(self, mock_config, monkeypatch, mocker):
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[_ollama_up("llama3.2:3b"), _lmstudio_down()],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "Local auto-discovery" in result.output
+        assert "Ollama" in result.output
+        assert "http://127.0.0.1:11434/v1" in result.output
+        assert "llama3.2:3b" in result.output
+        assert "/v1/models" in result.output
+        assert "LM Studio" in result.output
+        assert "connection refused" in result.output
+        assert "gptme providers add" in result.output
+
+    def test_json_includes_discovered(self, mock_config, monkeypatch, mocker):
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[_ollama_up("llama3.2:3b"), _lmstudio_down()],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["configured"] == []
+        names = [d["name"] for d in payload["discovered"]]
+        assert names == ["ollama", "lmstudio"]
+        ollama = payload["discovered"][0]
+        assert ollama["status"] == "up"
+        assert ollama["models"] == ["llama3.2:3b"]
+        assert ollama["models_url"] == "http://127.0.0.1:11434/v1/models"
+        assert payload["discovered"][1]["status"] == "down"
+        assert payload["discovered"][1]["reason"]
+
+    def test_no_discover_flag_skips_probe(self, mock_config, mocker):
+        spy = mocker.patch("gptme.llm.local_discovery.discover_local_providers")
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list", "--no-discover"])
+        assert result.exit_code == 0
+        spy.assert_not_called()
+        assert "Local auto-discovery" not in result.output
+
+    def test_env_disable_notes_disabled(self, mock_config):
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "GPTME_NO_LOCAL_DISCOVERY" in result.output

--- a/tests/test_util_cli_providers.py
+++ b/tests/test_util_cli_providers.py
@@ -452,3 +452,39 @@ class TestProvidersListDiscovery:
         result = runner.invoke(main, ["providers", "list"])
         assert result.exit_code == 0
         assert "GPTME_NO_LOCAL_DISCOVERY" in result.output
+
+    def test_json_discovery_disabled_flag(self, mock_config, monkeypatch, mocker):
+        """--no-discover sets discovery_disabled=true in JSON output."""
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        spy = mocker.patch("gptme.llm.local_discovery.discover_local_providers")
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list", "--json", "--no-discover"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["discovery_disabled"] is True
+        assert payload["discovered"] == []
+        spy.assert_not_called()
+
+    def test_json_discovery_disabled_env_var(self, mock_config, monkeypatch):
+        """GPTME_NO_LOCAL_DISCOVERY sets discovery_disabled=true in JSON output."""
+        # env var already set by the autouse fixture; ensure --discover flag is default (True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["discovery_disabled"] is True
+        assert payload["discovered"] == []
+
+    def test_json_discovery_enabled(self, mock_config, monkeypatch, mocker):
+        """When discovery runs and finds nothing, discovery_disabled=false."""
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["discovery_disabled"] is False
+        assert payload["discovered"] == []

--- a/tests/test_util_cli_providers.py
+++ b/tests/test_util_cli_providers.py
@@ -488,3 +488,71 @@ class TestProvidersListDiscovery:
         payload = json.loads(result.output)
         assert payload["discovery_disabled"] is False
         assert payload["discovered"] == []
+
+
+class TestStripControls:
+    """Unit tests for _strip_controls helper."""
+
+    def test_removes_c0_control_chars(self):
+        from gptme.cli.util import _strip_controls
+
+        # ESC byte is stripped; the printable bracket/letter tail is kept (harmless without ESC)
+        assert _strip_controls("\x1b[1mhello\x1b[0m") == "[1mhello[0m"
+        assert _strip_controls("clean") == "clean"
+        assert _strip_controls("\x00null\x01soh\x1f us") == "nullsoh us"
+
+    def test_removes_c1_control_chars(self):
+        from gptme.cli.util import _strip_controls
+
+        assert _strip_controls("\x80\x9f") == ""
+        assert _strip_controls("ok\x9bsequence") == "oksequence"
+
+    def test_preserves_printable_and_unicode(self):
+        from gptme.cli.util import _strip_controls
+
+        assert _strip_controls("llama3.2:3b") == "llama3.2:3b"
+        assert _strip_controls("model/name-v1") == "model/name-v1"
+        assert _strip_controls("Ångström") == "Ångström"
+
+
+class TestEscapeInjectionInDiscovery:
+    """Verify terminal escape sequences from probe responses are stripped at display time."""
+
+    def test_model_id_escape_stripped(self, mock_config, monkeypatch, mocker):
+        """Model IDs containing escape sequences must not reach the terminal raw."""
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        evil_model_id = "\x1b]51;A\x07evil-model"
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[_ollama_up(evil_model_id)],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "\x1b" not in result.output
+        assert "evil-model" in result.output
+
+    def test_reason_escape_stripped(self, mock_config, monkeypatch, mocker):
+        """Probe reason strings containing escape sequences must not reach the terminal raw."""
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        cand = LocalProviderCandidate(
+            name="ollama",
+            display_name="Ollama",
+            base_url="http://127.0.0.1:11434/v1",
+            hint="run ollama serve",
+        )
+        evil_reason = "HTTP error: \x1b[31mfailed\x1b[0m"
+        evil_result = DiscoveryResult(
+            candidate=cand,
+            status="error",
+            reason=evil_reason,
+        )
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[evil_result],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "\x1b" not in result.output
+        assert "failed" in result.output

--- a/tests/test_util_cli_providers.py
+++ b/tests/test_util_cli_providers.py
@@ -556,3 +556,18 @@ class TestEscapeInjectionInDiscovery:
         assert result.exit_code == 0
         assert "\x1b" not in result.output
         assert "failed" in result.output
+
+    def test_all_control_model_ids_fall_back_to_placeholder(
+        self, mock_config, monkeypatch, mocker
+    ):
+        """When every model ID is pure control chars, example falls back to <model>."""
+        monkeypatch.delenv("GPTME_NO_LOCAL_DISCOVERY", raising=False)
+        mocker.patch(
+            "gptme.llm.local_discovery.discover_local_providers",
+            return_value=[_ollama_up("\x1b\x00\x9f")],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "list"])
+        assert result.exit_code == 0
+        assert "\x1b" not in result.output
+        assert "local/<model>" in result.output


### PR DESCRIPTION
## Why

A user running Ollama or LM Studio still has to set `OPENAI_BASE_URL` / `[[providers]]` before gptme will acknowledge the local server. `gptme providers list` only showed configured custom providers, so a running local instance was invisible.

## Change

- Add `gptme.llm.local_discovery`: GET the real `/v1/models` endpoint on loopback (Ollama `:11434`, LM Studio `:1234`). Not a port-open check, not Ollama's native `/api/tags`.
- Every candidate is reported with a reason if it isn't a live OpenAI-compatible server (connection refused, HTML on the port, native Ollama payload, 401, etc.). Nothing is silently dropped.
- `gptme providers list` shows auto-discovery results. `--json`, `--no-discover`, and `GPTME_NO_LOCAL_DISCOVERY=1` are the escape hatches.
- Discovery never writes config. Persist with `gptme providers add`.

## Test plan

- [x] `pytest tests/test_local_discovery.py tests/test_util_cli_providers.py` — 36 passed
- [x] Probe hits a real loopback HTTP server and asserts the path is `/v1/models`
- [x] Connection refused, HTML, native `/api/tags` shape, 401, 404, already-configured loopback alias, env disable