### PR TITLE
feat(cli): add cross-session knowledge base (gptme-util knowledge)

### DIFF
--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -1,0 +1,101 @@
+"""CLI commands for the cross-session knowledge base (``gptme-util knowledge``)."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from ..knowledge import (
+    KnowledgeValidationError,
+    load_entries,
+    save_entry,
+    search_entries,
+)
+
+
+@click.group()
+def knowledge() -> None:
+    """Save and search your personal cross-session knowledge base."""
+
+
+@knowledge.command("save")
+@click.option(
+    "--problem", required=True, help="Concise problem statement (max 200 chars)."
+)
+@click.option("--resolution", required=True, help="Step-by-step fix or workaround.")
+@click.option(
+    "--context", default="", help="Longer context (max 2000 chars, optional)."
+)
+@click.option("--tag", "problem_tags", multiple=True, help="Machine-readable tag.")
+@click.option("--keyword", "keywords", multiple=True, help="Search hint keyword.")
+@click.option("--session-id", default="", help="gptme session that resolved this.")
+@click.option("--model", default="", help="Model that made the fix.")
+def save_cmd(
+    problem: str,
+    resolution: str,
+    context: str,
+    problem_tags: tuple[str, ...],
+    keywords: tuple[str, ...],
+    session_id: str,
+    model: str,
+) -> None:
+    """Save a resolved problem to the knowledge base."""
+    try:
+        entry = save_entry(
+            problem=problem,
+            resolution=resolution,
+            context=context,
+            problem_tags=list(problem_tags),
+            keywords=list(keywords),
+            session_id=session_id,
+            model=model,
+        )
+    except KnowledgeValidationError as e:
+        raise click.UsageError(str(e)) from e
+    click.echo(f"Saved knowledge entry {entry.id}")
+    click.echo(f"  {entry.problem}")
+
+
+@knowledge.command("search")
+@click.argument("query")
+@click.option(
+    "-k",
+    "--top-k",
+    default=5,
+    type=click.IntRange(min=1, max=50),
+    help="Number of results to return.",
+)
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON array.")
+def search_cmd(query: str, top_k: int, output_json: bool) -> None:
+    """Search the knowledge base for relevant entries."""
+    results = search_entries(query, top_k=top_k)
+
+    if output_json:
+        click.echo(json.dumps([e.__dict__ for e in results], indent=2))
+        return
+
+    if not results:
+        click.echo("No knowledge entries match that query.")
+        return
+
+    for i, entry in enumerate(results, 1):
+        click.echo(f"[{i}] {entry.problem}")
+        if entry.problem_tags:
+            click.echo(f"    tags: {', '.join(entry.problem_tags)}")
+        click.echo(f"    {entry.resolution}")
+
+
+@knowledge.command("list")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON array.")
+def list_cmd(output_json: bool) -> None:
+    """List all entries in the knowledge base."""
+    entries = load_entries()
+    if output_json:
+        click.echo(json.dumps([e.__dict__ for e in entries], indent=2))
+        return
+    if not entries:
+        click.echo("Knowledge base is empty.")
+        return
+    for entry in entries:
+        click.echo(f"{entry.id[:8]}  {entry.problem}")

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -55,6 +55,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "computer": (".cmd_computer", "computer"),
     "explain": (".cmd_explain", "explain"),
     "hooks": (".cmd_hooks", "hooks"),
+    "knowledge": (".cmd_knowledge", "knowledge"),
     "mcp": (".cmd_mcp", "mcp"),
     "resume": (".cmd_resume", "resume"),
     # Unified review group (gptme#3442): ``gptme-util review watch``

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -1,0 +1,200 @@
+"""Cross-session knowledge base.
+
+Sessions save resolved errors/workarounds to a local JSONL file so future
+sessions can retrieve and reuse them instead of re-solving the same problem
+from scratch.
+
+Schema follows ``knowledge/technical-designs/2026-08-13-gptme-cross-session-kb-schema.md``
+(idea #1050). This is the personal, semantic-query complement to the global,
+keyword-triggered lesson system.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import uuid
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from .dirs import get_data_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Validation limits (mirror the schema doc).
+MAX_PROBLEM = 200
+MAX_CONTEXT = 2000
+MAX_RESOLUTION = 5000
+
+# Rejects URLs (prevents link/phishing injection).
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+
+
+class KnowledgeValidationError(ValueError):
+    """Raised when an entry field violates the schema contract."""
+
+
+@dataclass
+class KnowledgeEntry:
+    """A single resolved problem in the knowledge base."""
+
+    id: str
+    problem: str
+    resolution: str
+    problem_tags: list[str] = field(default_factory=list)
+    context: str = ""
+    verified_at: str = ""
+    session_id: str = ""
+    model: str = ""
+    keywords: list[str] = field(default_factory=list)
+
+    @property
+    def search_text(self) -> str:
+        """Text used for retrieval scoring."""
+        parts = [self.problem, self.resolution, self.context]
+        parts.extend(self.problem_tags)
+        parts.extend(self.keywords)
+        return " ".join(p for p in parts if p)
+
+
+def get_knowledge_file() -> Path:
+    """Return the path to the knowledge entries file."""
+    return get_data_dir() / "knowledge" / "entries.jsonl"
+
+
+def _validate_text(text: str, field_name: str, max_len: int, *, required: bool) -> None:
+    if required and not text.strip():
+        raise KnowledgeValidationError(f"{field_name} is required and cannot be empty.")
+    if not text.isascii() or not text.isprintable():
+        raise KnowledgeValidationError(f"{field_name} must be UTF-8 plain text.")
+    if len(text) > max_len:
+        raise KnowledgeValidationError(f"{field_name} exceeds {max_len} characters.")
+    if _URL_RE.search(text):
+        raise KnowledgeValidationError(f"{field_name} must not contain URLs.")
+
+
+def validate_entry(
+    problem: str,
+    resolution: str,
+    context: str = "",
+    problem_tags: list[str] | None = None,
+    keywords: list[str] | None = None,
+) -> None:
+    """Validate entry fields against the schema contract."""
+    _validate_text(problem, "problem", MAX_PROBLEM, required=True)
+    _validate_text(resolution, "resolution", MAX_RESOLUTION, required=True)
+    if context:
+        _validate_text(context, "context", MAX_CONTEXT, required=False)
+    for tag_list in (problem_tags or [], keywords or []):
+        for tag in tag_list:
+            if not tag.strip():
+                raise KnowledgeValidationError("Tags and keywords must be non-empty.")
+
+
+def save_entry(
+    problem: str,
+    resolution: str,
+    context: str = "",
+    problem_tags: list[str] | None = None,
+    keywords: list[str] | None = None,
+    session_id: str = "",
+    model: str = "",
+) -> KnowledgeEntry:
+    """Append a new entry to the knowledge base and return it."""
+    validate_entry(problem, resolution, context, problem_tags, keywords)
+    entry = KnowledgeEntry(
+        id=str(uuid.uuid4()),
+        problem=problem.strip(),
+        resolution=resolution.strip(),
+        context=context.strip(),
+        problem_tags=[t.strip() for t in (problem_tags or [])],
+        keywords=[k.strip() for k in (keywords or [])],
+        verified_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        session_id=session_id,
+        model=model,
+    )
+    path = get_knowledge_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")
+    return entry
+
+
+def load_entries() -> list[KnowledgeEntry]:
+    """Load all entries from the knowledge base (empty if missing/corrupt)."""
+    path = get_knowledge_file()
+    if not path.exists():
+        return []
+    entries: list[KnowledgeEntry] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                # Skip corrupt lines; the KB degrades gracefully.
+                continue
+            entries.append(
+                KnowledgeEntry(
+                    id=data.get("id", ""),
+                    problem=data.get("problem", ""),
+                    resolution=data.get("resolution", ""),
+                    problem_tags=data.get("problem_tags", []),
+                    context=data.get("context", ""),
+                    verified_at=data.get("verified_at", ""),
+                    session_id=data.get("session_id", ""),
+                    model=data.get("model", ""),
+                    keywords=data.get("keywords", []),
+                )
+            )
+    return entries
+
+
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9_\-]+", text.lower())
+
+
+def search_entries(query: str, top_k: int = 5) -> list[KnowledgeEntry]:
+    """Return top-k entries by term-overlap relevance to ``query``.
+
+    Simple stdlib BM25-ish scoring (term frequency weighting with an idf-style
+    boost for rare terms). Per the schema's "graceful degradation" constraint
+    this needs no external dependencies.
+    """
+    entries = load_entries()
+    if not entries:
+        return []
+
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return []
+
+    doc_freq: Counter[str] = Counter()
+    for e in entries:
+        for tok in set(_tokenize(e.search_text)):
+            doc_freq[tok] += 1
+
+    n_docs = len(entries)
+    scored: list[tuple[float, KnowledgeEntry]] = []
+    for e in entries:
+        counts = Counter(_tokenize(e.search_text))
+        score = 0.0
+        for tok in query_tokens:
+            tf = counts.get(tok, 0)
+            if not tf:
+                continue
+            df = doc_freq.get(tok, 1)
+            # idf-style boost: rarer terms weight more; floor at 1 to avoid 0.
+            idf = max(1.0, math.log((n_docs + 1) / (df + 0.5)))
+            score += tf * idf
+        if score > 0:
+            scored.append((score, e))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [e for _, e in scored[:top_k]]

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -135,6 +135,11 @@ def load_entries() -> list[KnowledgeEntry]:
             line = line.strip()
             if not line:
                 continue
+            # U+FFFD marks a byte that errors="replace" could not decode — skip.
+            # Mid-line corrupt bytes produce valid-looking JSON with altered data;
+            # rejecting any line that contains the replacement character is safer.
+            if "�" in line:
+                continue
             try:
                 data = json.loads(line)
                 if not isinstance(data, dict):

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -147,15 +147,15 @@ def load_entries() -> list[KnowledgeEntry]:
                     keywords = []
                 entries.append(
                     KnowledgeEntry(
-                        id=data.get("id", ""),
-                        problem=data.get("problem", ""),
-                        resolution=data.get("resolution", ""),
-                        problem_tags=problem_tags,
-                        context=data.get("context", ""),
-                        verified_at=data.get("verified_at", ""),
-                        session_id=data.get("session_id", ""),
-                        model=data.get("model", ""),
-                        keywords=keywords,
+                        id=str(data.get("id") or ""),
+                        problem=str(data.get("problem") or ""),
+                        resolution=str(data.get("resolution") or ""),
+                        problem_tags=[str(t) for t in problem_tags],
+                        context=str(data.get("context") or ""),
+                        verified_at=str(data.get("verified_at") or ""),
+                        session_id=str(data.get("session_id") or ""),
+                        model=str(data.get("model") or ""),
+                        keywords=[str(k) for k in keywords],
                     )
                 )
             except (json.JSONDecodeError, TypeError, AttributeError):
@@ -165,7 +165,8 @@ def load_entries() -> list[KnowledgeEntry]:
 
 
 def _tokenize(text: str) -> list[str]:
-    return re.findall(r"[a-z0-9_\-]+", text.lower())
+    # \w matches Unicode word chars (letters, digits, underscore) in Python 3.
+    return re.findall(r"\w+", text.lower())
 
 
 def search_entries(query: str, top_k: int = 5) -> list[KnowledgeEntry]:

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -69,8 +69,8 @@ def get_knowledge_file() -> Path:
 def _validate_text(text: str, field_name: str, max_len: int, *, required: bool) -> None:
     if required and not text.strip():
         raise KnowledgeValidationError(f"{field_name} is required and cannot be empty.")
-    if not text.isascii() or not text.isprintable():
-        raise KnowledgeValidationError(f"{field_name} must be UTF-8 plain text.")
+    if not text.isprintable():
+        raise KnowledgeValidationError(f"{field_name} must be printable text.")
     if len(text) > max_len:
         raise KnowledgeValidationError(f"{field_name} exceeds {max_len} characters.")
     if _URL_RE.search(text):
@@ -137,22 +137,30 @@ def load_entries() -> list[KnowledgeEntry]:
                 continue
             try:
                 data = json.loads(line)
-            except (json.JSONDecodeError, TypeError):
+                if not isinstance(data, dict):
+                    continue
+                problem_tags = data.get("problem_tags", [])
+                if not isinstance(problem_tags, list):
+                    problem_tags = []
+                keywords = data.get("keywords", [])
+                if not isinstance(keywords, list):
+                    keywords = []
+                entries.append(
+                    KnowledgeEntry(
+                        id=data.get("id", ""),
+                        problem=data.get("problem", ""),
+                        resolution=data.get("resolution", ""),
+                        problem_tags=problem_tags,
+                        context=data.get("context", ""),
+                        verified_at=data.get("verified_at", ""),
+                        session_id=data.get("session_id", ""),
+                        model=data.get("model", ""),
+                        keywords=keywords,
+                    )
+                )
+            except (json.JSONDecodeError, TypeError, AttributeError):
                 # Skip corrupt lines; the KB degrades gracefully.
                 continue
-            entries.append(
-                KnowledgeEntry(
-                    id=data.get("id", ""),
-                    problem=data.get("problem", ""),
-                    resolution=data.get("resolution", ""),
-                    problem_tags=data.get("problem_tags", []),
-                    context=data.get("context", ""),
-                    verified_at=data.get("verified_at", ""),
-                    session_id=data.get("session_id", ""),
-                    model=data.get("model", ""),
-                    keywords=data.get("keywords", []),
-                )
-            )
     return entries
 
 

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -130,7 +130,7 @@ def load_entries() -> list[KnowledgeEntry]:
     if not path.exists():
         return []
     entries: list[KnowledgeEntry] = []
-    with path.open(encoding="utf-8") as f:
+    with path.open(encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
             if not line:

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -69,7 +69,7 @@ def get_knowledge_file() -> Path:
 def _validate_text(text: str, field_name: str, max_len: int, *, required: bool) -> None:
     if required and not text.strip():
         raise KnowledgeValidationError(f"{field_name} is required and cannot be empty.")
-    if not text.isprintable():
+    if any(not (c.isprintable() or c in "\n\r\t") for c in text):
         raise KnowledgeValidationError(f"{field_name} must be printable text.")
     if len(text) > max_len:
         raise KnowledgeValidationError(f"{field_name} exceeds {max_len} characters.")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,123 @@
+"""Tests for the cross-session knowledge base (``gptme-util knowledge``).
+
+Covers the storage layer (save/load/search) and the CLI subcommand dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.cmd_knowledge import knowledge
+from gptme.knowledge import (
+    KnowledgeValidationError,
+    get_knowledge_file,
+    load_entries,
+    save_entry,
+    search_entries,
+)
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_kb(tmp_path, monkeypatch):
+    """Point the knowledge file at a temp dir so tests don't touch live data."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    return get_knowledge_file()
+
+
+# ── storage layer ─────────────────────────────────────────────────────────────
+
+
+def test_save_and_load(isolated_kb):
+    save_entry(
+        problem="pydantic_settings import fails",
+        resolution="pip install pydantic-settings",
+        problem_tags=["pydantic", "import"],
+    )
+    entries = load_entries()
+    assert len(entries) == 1
+    assert entries[0].problem == "pydantic_settings import fails"
+    assert isolated_kb.exists()
+
+
+def test_save_validation_required(isolated_kb):
+    with pytest.raises(KnowledgeValidationError):
+        save_entry(problem="", resolution="fix")
+
+
+def test_save_validation_url_rejected(isolated_kb):
+    with pytest.raises(KnowledgeValidationError):
+        save_entry(problem="bad", resolution="see https://example.com/x")
+
+
+def test_save_validation_max_problem(isolated_kb):
+    with pytest.raises(KnowledgeValidationError):
+        save_entry(problem="x" * 201, resolution="fix")
+
+
+def test_load_missing_file_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert load_entries() == []
+
+
+def test_load_skips_corrupt_lines(isolated_kb):
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    isolated_kb.write_text("{not json}\n")
+    assert load_entries() == []
+
+
+def test_search_relevant_first(isolated_kb):
+    save_entry(problem="pydantic import error", resolution="install pydantic-settings")
+    save_entry(problem="unrelated theme", resolution="nothing to do here")
+    results = search_entries("pydantic import", top_k=5)
+    assert results
+    assert results[0].problem == "pydantic import error"
+
+
+def test_search_no_match(isolated_kb):
+    save_entry(problem="pydantic error", resolution="install pydantic-settings")
+    assert search_entries("zzzz_nomatch", top_k=5) == []
+
+
+def test_search_empty_kb(isolated_kb):
+    assert search_entries("anything") == []
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_save_and_search(isolated_kb):
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge,
+        ["save", "--problem", "import fails", "--resolution", "pip install pkg"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Saved knowledge entry" in result.output
+
+    result = runner.invoke(knowledge, ["search", "import fails"])
+    assert result.exit_code == 0, result.output
+    assert "import fails" in result.output
+
+
+def test_cli_save_validation_error(isolated_kb):
+    runner = CliRunner()
+    result = runner.invoke(knowledge, ["save", "--problem", "", "--resolution", "x"])
+    assert result.exit_code != 0
+    assert "required" in result.output
+
+
+def test_cli_search_json(isolated_kb):
+    runner = CliRunner()
+    runner.invoke(
+        knowledge,
+        ["save", "--problem", "unique prob", "--resolution", "unique res"],
+    )
+    result = runner.invoke(knowledge, ["search", "unique prob", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data[0]["problem"] == "unique prob"

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -186,6 +186,23 @@ def test_save_utf8_accepted(isolated_kb):
     assert entries[0].problem == "Résoudre l'erreur d'importation"
 
 
+def test_save_multiline_resolution_accepted(isolated_kb):
+    """Multi-line resolutions (with \\n) must be accepted — natural for step-by-step fixes."""
+    entry = save_entry(
+        problem="pydantic import fails",
+        resolution="Step 1: install pydantic-settings\nStep 2: restart the server\nStep 3: verify import",
+    )
+    assert "\n" in entry.resolution
+    entries = load_entries()
+    assert entries[0].resolution == entry.resolution
+
+
+def test_save_nul_byte_rejected(isolated_kb):
+    """Actual non-printable control characters (NUL, BEL, ESC) must still be rejected."""
+    with pytest.raises(KnowledgeValidationError):
+        save_entry(problem="test", resolution="bad\x00byte")
+
+
 def test_search_unicode_terms(isolated_kb):
     """Non-ASCII search terms must match saved non-ASCII entries."""
     save_entry(problem="Résoudre erreur importation", resolution="pip install pkg")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -70,6 +70,33 @@ def test_load_skips_corrupt_lines(isolated_kb):
     assert load_entries() == []
 
 
+def test_load_tolerates_corrupt_utf8_bytes(isolated_kb):
+    """Torn multibyte sequences (interrupted append) must not abort loading."""
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    # Write a valid entry then append an incomplete UTF-8 multibyte sequence.
+    valid = json.dumps(
+        {
+            "id": "x",
+            "problem": "p",
+            "resolution": "r",
+            "problem_tags": [],
+            "keywords": [],
+            "context": "",
+            "verified_at": "",
+            "session_id": "",
+            "model": "",
+        }
+    ).encode("utf-8")
+    corrupt = (
+        b'{"problem": "abc\xe9\n'  # \xe9 starts a 2-byte sequence; second byte missing
+    )
+    isolated_kb.write_bytes(valid + b"\n" + corrupt)
+    # Should not raise — valid entry is returned, corrupt line is skipped
+    entries = load_entries()
+    assert len(entries) == 1
+    assert entries[0].id == "x"
+
+
 def test_load_skips_valid_json_wrong_schema(isolated_kb):
     """Valid JSON that is not a dict (or has wrong-type list fields) is skipped."""
     isolated_kb.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -100,6 +100,28 @@ def test_load_skips_wrong_type_list_fields(isolated_kb):
     assert entries[0].keywords == []
 
 
+def test_load_coerces_non_string_scalar_fields(isolated_kb):
+    """Integer/None scalar fields are coerced to str instead of crashing."""
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    bad: dict[str, object] = {
+        "id": 42,  # int, not str
+        "problem": None,  # None, not str
+        "resolution": 3.14,  # float, not str
+        "problem_tags": [],
+        "keywords": [],
+        "context": "",
+        "verified_at": "",
+        "session_id": "",
+        "model": "",
+    }
+    isolated_kb.write_text(json.dumps(bad) + "\n")
+    entries = load_entries()
+    assert len(entries) == 1
+    assert entries[0].id == "42"
+    assert entries[0].problem == ""  # None → ""
+    assert entries[0].resolution == "3.14"
+
+
 def test_save_utf8_accepted(isolated_kb):
     """Printable non-ASCII UTF-8 text must be accepted."""
     entry = save_entry(
@@ -109,6 +131,15 @@ def test_save_utf8_accepted(isolated_kb):
     assert entry.problem == "Résoudre l'erreur d'importation"
     entries = load_entries()
     assert entries[0].problem == "Résoudre l'erreur d'importation"
+
+
+def test_search_unicode_terms(isolated_kb):
+    """Non-ASCII search terms must match saved non-ASCII entries."""
+    save_entry(problem="Résoudre erreur importation", resolution="pip install pkg")
+    save_entry(problem="unrelated english", resolution="do nothing")
+    results = search_entries("Résoudre")
+    assert results
+    assert results[0].problem == "Résoudre erreur importation"
 
 
 def test_search_relevant_first(isolated_kb):

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -70,6 +70,47 @@ def test_load_skips_corrupt_lines(isolated_kb):
     assert load_entries() == []
 
 
+def test_load_skips_valid_json_wrong_schema(isolated_kb):
+    """Valid JSON that is not a dict (or has wrong-type list fields) is skipped."""
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    # JSON array at the top level — not a dict
+    isolated_kb.write_text('["not", "an", "entry"]\n')
+    assert load_entries() == []
+
+
+def test_load_skips_wrong_type_list_fields(isolated_kb):
+    """Records whose list fields are non-lists are skipped without crashing."""
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    bad = {
+        "id": "abc",
+        "problem": "p",
+        "resolution": "r",
+        "problem_tags": "not-a-list",  # should be a list
+        "keywords": 42,  # should be a list
+        "context": "",
+        "verified_at": "",
+        "session_id": "",
+        "model": "",
+    }
+    isolated_kb.write_text(json.dumps(bad) + "\n")
+    # Should degrade gracefully — the record loads with empty lists, not a crash
+    entries = load_entries()
+    assert len(entries) == 1
+    assert entries[0].problem_tags == []
+    assert entries[0].keywords == []
+
+
+def test_save_utf8_accepted(isolated_kb):
+    """Printable non-ASCII UTF-8 text must be accepted."""
+    entry = save_entry(
+        problem="Résoudre l'erreur d'importation",
+        resolution="pip install pydantic-settings",
+    )
+    assert entry.problem == "Résoudre l'erreur d'importation"
+    entries = load_entries()
+    assert entries[0].problem == "Résoudre l'erreur d'importation"
+
+
 def test_search_relevant_first(isolated_kb):
     save_entry(problem="pydantic import error", resolution="install pydantic-settings")
     save_entry(problem="unrelated theme", resolution="nothing to do here")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -97,6 +97,32 @@ def test_load_tolerates_corrupt_utf8_bytes(isolated_kb):
     assert entries[0].id == "x"
 
 
+def test_load_skips_corrupt_utf8_mid_line(isolated_kb):
+    """Corrupt bytes in the middle of a JSON string are skipped, not loaded with altered data."""
+    isolated_kb.parent.mkdir(parents=True, exist_ok=True)
+    valid = json.dumps(
+        {
+            "id": "good",
+            "problem": "p",
+            "resolution": "r",
+            "problem_tags": [],
+            "keywords": [],
+            "context": "",
+            "verified_at": "",
+            "session_id": "",
+            "model": "",
+        }
+    ).encode("utf-8")
+    # \xe9 mid-string: first byte of a 2-byte sequence with no continuation.
+    # errors="replace" turns it into U+FFFD, keeping the JSON structurally valid.
+    # Without the U+FFFD guard this line would load with altered data.
+    corrupt = b'{"id": "bad", "problem": "abc\xe9 rest", "resolution": "r", "problem_tags": [], "keywords": [], "context": "", "verified_at": "", "session_id": "", "model": ""}\n'
+    isolated_kb.write_bytes(valid + b"\n" + corrupt)
+    entries = load_entries()
+    assert len(entries) == 1
+    assert entries[0].id == "good"
+
+
 def test_load_skips_valid_json_wrong_schema(isolated_kb):
     """Valid JSON that is not a dict (or has wrong-type list fields) is skipped."""
     isolated_kb.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Adds a local, offline cross-session knowledge base to gptme — the save/retrieve loop
for idea #1050 (personal KB). Sessions can persist resolved problems/workarounds to
`~/.gptme/knowledge/entries.jsonl` and retrieve top-matching entries on demand.

This is the personal, semantic-query complement to the existing global, keyword-triggered
lesson system: lessons are human-curated and global; this KB is automatic, personal, and
retrieval-query-driven.

## What's included

- `gptme-util knowledge save --problem ... --resolution ... [--tag ...] [--keyword ...]`
  — appends an entry to the JSONL store (UUID, timestamp, session/model auto-fillable)
- `gptme-util knowledge search <query> [-k N] [--json]` — term-overlap relevance ranking
  (stdlib-only BM25-ish scorer; no external deps, graceful degradation on missing/corrupt files)
- `gptme-util knowledge list [--json]` — list all entries
- `gptme knowledge <cmd>` mirroring via the existing `UTIL_SUBCOMMANDS` dispatch
- Schema validation per the design doc: required fields, length caps, URL rejection, UTF-8

## Design

Follows the 2026-08-13 cross-session KB schema design (idea #1050). Storage is
`get_data_dir() / "knowledge" / "entries.jsonl"` — respects `XDG_DATA_HOME`/testing
overrides like the rest of the codebase.

## Tests

`tests/test_knowledge.py` — 12 tests covering storage layer (save/load/search), validation,
corrupt-file degradation, and the CLI surface. Passes locally; ruff + mypy clean.

## Notes

- This is deliberately scoped to the **save/retrieve loop** only — session-start prompt
  injection of top matches is a follow-on slice.
- Kept dependency-free per the design constraint; can swap in `gptme-rag` BM25 later.
