### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/docs/mcp.rst
+++ b/docs/mcp.rst
@@ -223,3 +223,35 @@ Options:
 The server is **session-backed**: one persistent gptme session per MCP connection, so the bash shell
 retains state, the Python REPL keeps variables, and file operations share a consistent working directory
 across multiple tool calls.
+
+
+Build Remote Agent
+~~~~~~~~~~~~~~~~~~
+
+Pair a phone running `Build Remote Agent <https://grokbuildremote.com/>`_ to this gptme session.
+Protocol ``gbr/1``. The phone is spectator + veto, not orchestrator.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Install and pair on the same machine (need ``gbr-agent`` v0.6.0+):
+
+.. code-block:: bash
+
+    curl -fsSL https://grokbuildremote.com/install.sh | bash
+    gbr-agent version
+    gbr-agent pair && gbr-agent run
+    git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+    cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+
+Add a stdio MCP server in ``~/.config/gptme/config.toml``. Never put mailbox keys here.
+
+.. code-block:: toml
+
+    [[mcp.servers]]
+    name = "gbr"
+    enabled = true
+    command = "node"
+    args = ["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+
+Bot API (after ``gbr-agent run``): ``http://127.0.0.1:8788`` — ``/health`` and ``/v1/sessions``.
+Phone **Settings → Bot API** is the only place the relay key is copied.

--- a/docs/mcp.rst
+++ b/docs/mcp.rst
@@ -1,3 +1,29 @@
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 .. _mcp:
 
 MCP
@@ -255,3 +281,10 @@ Add a stdio MCP server in ``~/.config/gptme/config.toml``. Never put mailbox key
 
 Bot API (after ``gbr-agent run``): ``http://127.0.0.1:8788`` — ``/health`` and ``/v1/sessions``.
 Phone **Settings → Bot API** is the only place the relay key is copied.
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html


### PR DESCRIPTION
Add **Build Remote Agent** as a pairing device for this desktop agent.

The paid iOS/Android app spectates (and can inject into) the local session through the free MIT [`gbr-agent`](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Protocol `gbr/1`. Phone is spectator + veto, not orchestrator.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

## Pair (unchanged)

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
gbr-agent version          # v0.6.0+
gbr-agent pair             # QR in browser + printed 8-char code
gbr-agent run              # leave running
```

Phone: open [Build Remote Agent](https://grokbuildremote.com/) → scan the QR or type the 8-char code. Unpair in Settings before changing PCs.

## Attach (only these)

| How | Where |
|-----|--------|
| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
| MCP | stdio `gbr-mcp` (`node mcp/gbr-mcp/bin/gbr-mcp.js`) |

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

This PR is docs/example only. No mailbox keys, no `X-GBR-Key`, no `device.json`.
