### PR TITLE
fix(webui): stabilize multi-server query results

### DIFF
--- a/webui/src/hooks/__tests__/useMultiServerConversations.test.tsx
+++ b/webui/src/hooks/__tests__/useMultiServerConversations.test.tsx
@@ -1,0 +1,41 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { serverRegistry$ } from '@/stores/servers';
+import { DEFAULT_SERVER_CONFIG } from '@/types/servers';
+import { useSecondaryServerConversations } from '../useMultiServerConversations';
+
+describe('useSecondaryServerConversations', () => {
+  beforeEach(() => {
+    serverRegistry$.set({
+      servers: [
+        {
+          ...DEFAULT_SERVER_CONFIG,
+          id: 'primary',
+          createdAt: 0,
+          lastUsedAt: 0,
+        },
+      ],
+      activeServerId: 'primary',
+      connectedServerIds: ['primary'],
+    });
+  });
+
+  it('keeps unchanged combined query results referentially stable', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useSecondaryServerConversations(), {
+      wrapper,
+    });
+    const initialConversations = result.current.secondaryConversations;
+
+    rerender();
+
+    expect(result.current.secondaryConversations).toBe(initialConversations);
+  });
+});

--- a/webui/src/hooks/useMultiServerConversations.ts
+++ b/webui/src/hooks/useMultiServerConversations.ts
@@ -21,7 +21,7 @@ export function useSecondaryServerConversations() {
     );
   }, [registry]);
 
-  const queries = useQueries({
+  const { secondaryConversations, isAnyLoading } = useQueries({
     queries: secondaryServers.map((server) => ({
       queryKey: ['secondary-conversations', server.id, server.baseUrl, server.authToken ?? ''],
       queryFn: async (): Promise<ConversationSummary[]> => {
@@ -46,13 +46,11 @@ export function useSecondaryServerConversations() {
       refetchOnWindowFocus: false,
       retry: 1,
     })),
+    combine: (results) => ({
+      secondaryConversations: results.flatMap((query) => query.data ?? []),
+      isAnyLoading: results.some((query) => query.isLoading),
+    }),
   });
-
-  const secondaryConversations = useMemo(() => {
-    return queries.flatMap((q) => q.data ?? []);
-  }, [queries]);
-
-  const isAnyLoading = queries.some((q) => q.isLoading);
 
   return {
     secondaryConversations,


### PR DESCRIPTION
## Problem

Opening a conversation by its direct route could trigger React maximum-update-depth failures. useQueries returns a fresh result array; deriving secondaryConversations from that raw array also produced a fresh value on each render. MainLayout then observed the changed value and wrote back to the conversation store, repeating the cycle.

## Fix

Use React Query combine so its structural sharing keeps unchanged combined results referentially stable. Add a hook regression test that rerenders with no secondary servers and requires the conversations array identity to remain unchanged.

## Verification

- Regression test failed before the implementation and passes after it
- npm test -- --runInBand src/hooks/__tests__/useMultiServerConversations.test.tsx
- npm run typecheck
- ESLint and Prettier on both changed files
- Repository pre-commit hooks

## Context

Found from the browser trace for gptme/gptme-cloud#863. That dependency-bump PR will pin this commit and exercise direct-route plus in-app conversation navigation.