### PR TITLE
fix(webui): recover local-server bearer handshake after #3430

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -333,7 +333,13 @@ def serve(
     click.echo("Initialization complete, starting server")
 
     # Initialize authentication and display token
-    init_auth(host=host, display=True)
+    token = init_auth(host=host, display=True)
+    if token:
+        # Fragment (not query) so the token is not sent to the server or logged
+        # as a request URL. The bundled UI reads #userToken= and then strips it.
+        # Echo (not logger) so the URL is copyable on one line.
+        display_host = "127.0.0.1" if host in ("0.0.0.0", "::") else host
+        click.echo(f"Open the UI: http://{display_host}:{port}/#userToken={token}")
 
     app = create_app(
         cors_origin=cors_origin,

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -6,6 +6,7 @@ import sys as _sys
 import threading
 import time
 from pathlib import Path
+from urllib.parse import quote as urlquote
 
 
 # Install a minimal SIGTERM handler at module level — before the slow
@@ -342,7 +343,9 @@ def serve(
         # IPv6 literals need square brackets in URLs (e.g. ::1 → [::1])
         if ":" in display_host:
             display_host = f"[{display_host}]"
-        click.echo(f"Open the UI: http://{display_host}:{port}/#userToken={token}")
+        click.echo(
+            f"Open the UI: http://{display_host}:{port}/#userToken={urlquote(token, safe='')}"
+        )
 
     app = create_app(
         cors_origin=cors_origin,

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -339,6 +339,9 @@ def serve(
         # as a request URL. The bundled UI reads #userToken= and then strips it.
         # Echo (not logger) so the URL is copyable on one line.
         display_host = "127.0.0.1" if host in ("0.0.0.0", "::") else host
+        # IPv6 literals need square brackets in URLs (e.g. ::1 → [::1])
+        if ":" in display_host:
+            display_host = f"[{display_host}]"
         click.echo(f"Open the UI: http://{display_host}:{port}/#userToken={token}")
 
     app = create_app(

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -79,7 +79,7 @@ def _write_cancel_op(logdir: Path, agent_id: str) -> None:
 
 
 def _wait_for_cached_subagent_result(
-    agent_id: str, timeout: float = 0.05, poll_interval: float = 0.005
+    agent_id: str, timeout: float = 0.5, poll_interval: float = 0.005
 ) -> ReturnType | None:
     """Briefly wait for a concurrent watchdog/cancel result to hit the cache."""
     deadline = time.monotonic() + timeout

--- a/webui/src/components/SetupWizard.tsx
+++ b/webui/src/components/SetupWizard.tsx
@@ -415,7 +415,11 @@ export function SetupWizard() {
     setIsConnecting(true);
     setConnectError(null);
     try {
-      await connect();
+      const trimmedAuthToken = remoteAuthToken.trim();
+      await connect({
+        authToken: trimmedAuthToken || null,
+        useAuthToken: Boolean(trimmedAuthToken),
+      });
       // The isConnected useEffect will fire and call checkProviderAndAdvance.
     } catch (err) {
       setConnectError(
@@ -749,6 +753,23 @@ export function SetupWizard() {
                   <p className="text-xs text-muted-foreground">
                     The <code className="rounded bg-muted px-1">--cors-origin</code> flag lets this
                     page connect to your local server.
+                  </p>
+                  <Input
+                    autoComplete="off"
+                    placeholder="Server token from gptme-server logs"
+                    type="password"
+                    value={remoteAuthToken}
+                    onChange={(event) => setRemoteAuthToken(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' && !isConnecting) {
+                        event.preventDefault();
+                        void handleLocalSetup();
+                      }
+                    }}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    After gptme#3430 the local server requires the bearer token it prints on
+                    startup. Paste it here if the UI cannot connect.
                   </p>
                 </div>
               )}

--- a/webui/src/components/__tests__/SetupWizard.test.tsx
+++ b/webui/src/components/__tests__/SetupWizard.test.tsx
@@ -772,6 +772,30 @@ describe('SetupWizard', () => {
     warnSpy.mockRestore();
   });
 
+  it('sends the pasted local-server token on Connect', async () => {
+    mockConnect.mockResolvedValue(undefined);
+
+    render(
+      <SettingsProvider>
+        <SetupWizard />
+      </SettingsProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /local run gptme-server/i }));
+    fireEvent.change(screen.getByPlaceholderText('Server token from gptme-server logs'), {
+      target: { value: 'dogfood-65f3-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith({
+        authToken: 'dogfood-65f3-token',
+        useAuthToken: true,
+      });
+    });
+  });
+
   it('connects to a remote server during tauri mobile setup', async () => {
     mockIsTauriEnvironment.mockReturnValue(true);
     mockUseTauriServerStatus.mockReturnValue({

--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -316,6 +316,19 @@ export function ApiProvider({
         }
         return;
       }
+      // A 401 means the server is up and asking for a token. Retrying the same
+      // unauthenticated probe will never recover; the user has to paste it.
+      if (lastResult && !lastResult.ok && lastResult.status === 401) {
+        console.log('[ApiContext] 401 — stopping auto-connect (token required)');
+        stopAutoConnect();
+        if (!isInitialAttempt) {
+          toast.error(
+            lastResult.message ||
+              'Server is running but requires a bearer token. Paste it in settings.'
+          );
+        }
+        return;
+      }
 
       const delay = INITIAL_RETRY_DELAY * Math.pow(2, autoConnectAttempts - 1);
       const maxDelay = 30000;

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -218,6 +218,32 @@ describe('ApiProvider mobile auto-connect', () => {
     // full reactive chain (update → registry change → component re-render) works.
   });
 
+  it('stops retrying after a 401 (token required, not transient)', async () => {
+    setActiveServerBaseUrl('http://127.0.0.1:5799');
+
+    mockCheckConnection.mockImplementation(async () => {
+      lastConnectionResult$.set({
+        ok: false,
+        url: 'http://127.0.0.1:5799/api/v2/conversations?limit=1',
+        reason: 'http_error',
+        status: 401,
+        message:
+          'Server is running but requires a bearer token. Paste the token printed by gptme-server.',
+      });
+      return false;
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mockCheckConnection).toHaveBeenCalledTimes(1);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    expect(mockCheckConnection).toHaveBeenCalledTimes(1);
+  });
+
   it('stops retrying after a CORS failure (permanent, not transient)', async () => {
     setActiveServerBaseUrl('https://bob.example.com');
 

--- a/webui/src/stores/__tests__/servers.test.ts
+++ b/webui/src/stores/__tests__/servers.test.ts
@@ -47,10 +47,13 @@ describe('getBundledLoopbackOrigin', () => {
     expect(getBundledLoopbackOrigin('http://localhost:5700')).toBe('http://localhost:5700');
   });
 
-  it('ignores hosted pages, default ports, and Vite/Playwright ports', () => {
+  it('returns the page origin for default-port loopback (gptme-server on port 80)', () => {
+    expect(getBundledLoopbackOrigin('http://localhost')).toBe('http://localhost');
+    expect(getBundledLoopbackOrigin('http://127.0.0.1')).toBe('http://127.0.0.1');
+  });
+
+  it('ignores hosted pages and Vite/Playwright dev-server ports', () => {
     expect(getBundledLoopbackOrigin('https://chat.gptme.org')).toBeNull();
-    expect(getBundledLoopbackOrigin('http://localhost')).toBeNull();
-    expect(getBundledLoopbackOrigin('http://127.0.0.1')).toBeNull();
     expect(getBundledLoopbackOrigin('http://127.0.0.1:5173')).toBeNull();
     expect(getBundledLoopbackOrigin('http://127.0.0.1:4173')).toBeNull();
     expect(getBundledLoopbackOrigin('http://127.0.0.1:5701')).toBeNull();

--- a/webui/src/stores/__tests__/servers.test.ts
+++ b/webui/src/stores/__tests__/servers.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
 import type { ServerRegistry } from '@/types/servers';
-import { deriveServerName, migrateCloudPreset } from '../servers';
+import {
+  deriveServerName,
+  getBundledLoopbackOrigin,
+  migrateCloudPreset,
+  retargetPresetLocalToBundledOrigin,
+} from '../servers';
 
 describe('deriveServerName', () => {
   it('returns "Local" for default-port localhost URLs', () => {
@@ -33,6 +38,67 @@ describe('deriveServerName', () => {
   it('returns "Server" for malformed URLs', () => {
     expect(deriveServerName('not-a-url')).toBe('Server');
     expect(deriveServerName('')).toBe('Server');
+  });
+});
+
+describe('getBundledLoopbackOrigin', () => {
+  it('returns the page origin for a bundled gptme-server loopback port', () => {
+    expect(getBundledLoopbackOrigin('http://127.0.0.1:5799')).toBe('http://127.0.0.1:5799');
+    expect(getBundledLoopbackOrigin('http://localhost:5700')).toBe('http://localhost:5700');
+  });
+
+  it('ignores hosted pages, default ports, and Vite/Playwright ports', () => {
+    expect(getBundledLoopbackOrigin('https://chat.gptme.org')).toBeNull();
+    expect(getBundledLoopbackOrigin('http://localhost')).toBeNull();
+    expect(getBundledLoopbackOrigin('http://127.0.0.1')).toBeNull();
+    expect(getBundledLoopbackOrigin('http://127.0.0.1:5173')).toBeNull();
+    expect(getBundledLoopbackOrigin('http://127.0.0.1:4173')).toBeNull();
+    expect(getBundledLoopbackOrigin('http://127.0.0.1:5701')).toBeNull();
+  });
+});
+
+describe('retargetPresetLocalToBundledOrigin', () => {
+  it('rewrites the stock 5700 Local preset to the bundled origin', () => {
+    const registry: ServerRegistry = {
+      activeServerId: 'local',
+      connectedServerIds: ['local'],
+      servers: [
+        {
+          id: 'local',
+          name: 'Local',
+          baseUrl: 'http://127.0.0.1:5700',
+          authToken: null,
+          useAuthToken: false,
+          isPreset: true,
+          createdAt: 1,
+          lastUsedAt: 1,
+        },
+      ],
+    };
+
+    retargetPresetLocalToBundledOrigin(registry, 'http://127.0.0.1:5799');
+    expect(registry.servers[0].baseUrl).toBe('http://127.0.0.1:5799');
+  });
+
+  it('leaves a non-preset or already-matching server alone', () => {
+    const registry: ServerRegistry = {
+      activeServerId: 'custom',
+      connectedServerIds: ['custom'],
+      servers: [
+        {
+          id: 'custom',
+          name: 'Local:5700',
+          baseUrl: 'http://127.0.0.1:5700',
+          authToken: null,
+          useAuthToken: false,
+          createdAt: 1,
+          lastUsedAt: 1,
+        },
+      ],
+    };
+
+    retargetPresetLocalToBundledOrigin(registry, 'http://127.0.0.1:5799');
+    expect(registry.servers[0].baseUrl).toBe('http://127.0.0.1:5700');
   });
 });
 

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -12,6 +12,51 @@ const STORAGE_KEY = 'gptme_servers';
 const LEGACY_BASE_URL_KEY = 'gptme_baseUrl';
 const LEGACY_USER_TOKEN_KEY = 'gptme_userToken';
 
+// Vite/Playwright dev servers are not gptme-server; never treat them as the API origin.
+const DEV_SERVER_PORTS = new Set(['5173', '4173', '5701']);
+
+/**
+ * Origin of the bundled web UI when it is served by gptme-server on loopback.
+ *
+ * After gptme#3430, a standalone `gptme-server` requires a bearer token and may
+ * bind a non-5700 port. The bundled UI must talk to `window.location.origin`
+ * in that case — the hardcoded 5700 preset otherwise CORS-retries the wrong
+ * process and never recovers from the same-origin 401.
+ *
+ * Returns null for hosted pages (chat.gptme.org), Vite/Playwright, and
+ * default-port origins so jsdom tests keep the 5700 preset.
+ */
+export function getBundledLoopbackOrigin(
+  pageOrigin: string = typeof window !== 'undefined' ? window.location.origin : ''
+): string | null {
+  if (!pageOrigin) return null;
+  try {
+    const parsed = new URL(pageOrigin);
+    const isLoopback = ['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname);
+    if (!isLoopback) return null;
+    if (!parsed.port || parsed.port === '80' || parsed.port === '443') return null;
+    if (DEV_SERVER_PORTS.has(parsed.port)) return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Point the stock Local 5700 preset at the bundled UI origin when they differ. */
+export function retargetPresetLocalToBundledOrigin(
+  registry: ServerRegistry,
+  pageOrigin?: string
+): void {
+  const origin = getBundledLoopbackOrigin(pageOrigin);
+  if (!origin) return;
+  const preset = registry.servers.find(
+    (s) => s.isPreset && normalizeUrl(s.baseUrl) === normalizeUrl(DEFAULT_SERVER_CONFIG.baseUrl)
+  );
+  if (!preset) return;
+  if (normalizeUrl(preset.baseUrl) === normalizeUrl(origin)) return;
+  preset.baseUrl = origin;
+}
+
 /** Apply post-parse schema normalization to a registry read from storage.
  *  Mutates and returns the object. The caller should fall back to
  *  migrateFromLegacy() if the returned registry has no servers. */
@@ -33,6 +78,7 @@ function normalizeRegistry(parsed: ServerRegistry): ServerRegistry {
   if (parsed.activeServerId && !parsed.connectedServerIds.includes(parsed.activeServerId)) {
     parsed.connectedServerIds.push(parsed.activeServerId);
   }
+  retargetPresetLocalToBundledOrigin(parsed);
   return parsed;
 }
 
@@ -70,7 +116,7 @@ export function migrateCloudPreset(registry: ServerRegistry): void {
 }
 
 function migrateFromLegacy(): ServerRegistry {
-  let baseUrl = DEFAULT_SERVER_CONFIG.baseUrl;
+  let baseUrl = getBundledLoopbackOrigin() || DEFAULT_SERVER_CONFIG.baseUrl;
   let authToken: string | null = null;
   let useAuthToken = false;
 

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -23,8 +23,8 @@ const DEV_SERVER_PORTS = new Set(['5173', '4173', '5701']);
  * in that case — the hardcoded 5700 preset otherwise CORS-retries the wrong
  * process and never recovers from the same-origin 401.
  *
- * Returns null for hosted pages (chat.gptme.org), Vite/Playwright, and
- * default-port origins so jsdom tests keep the 5700 preset.
+ * Returns null for hosted pages (chat.gptme.org), Vite/Playwright dev servers,
+ * and non-loopback origins.
  */
 export function getBundledLoopbackOrigin(
   pageOrigin: string = typeof window !== 'undefined' ? window.location.origin : ''
@@ -34,7 +34,6 @@ export function getBundledLoopbackOrigin(
     const parsed = new URL(pageOrigin);
     const isLoopback = ['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname);
     if (!isLoopback) return null;
-    if (!parsed.port || parsed.port === '80' || parsed.port === '443') return null;
     if (DEV_SERVER_PORTS.has(parsed.port)) return null;
     return parsed.origin;
   } catch {

--- a/webui/src/stores/servers.ts
+++ b/webui/src/stores/servers.ts
@@ -42,16 +42,26 @@ export function getBundledLoopbackOrigin(
   }
 }
 
-/** Point the stock Local 5700 preset at the bundled UI origin when they differ. */
+/** Point the stock Local 5700 preset at the bundled UI origin when they differ.
+ *
+ * We match by isPreset + loopback host rather than exact default URL so that
+ * a preset that was previously retargeted and persisted (e.g. to :5799) can
+ * still be found and updated when the server restarts on a new port. */
 export function retargetPresetLocalToBundledOrigin(
   registry: ServerRegistry,
   pageOrigin?: string
 ): void {
   const origin = getBundledLoopbackOrigin(pageOrigin);
   if (!origin) return;
-  const preset = registry.servers.find(
-    (s) => s.isPreset && normalizeUrl(s.baseUrl) === normalizeUrl(DEFAULT_SERVER_CONFIG.baseUrl)
-  );
+  const preset = registry.servers.find((s) => {
+    if (!s.isPreset) return false;
+    try {
+      const hostname = new URL(s.baseUrl).hostname;
+      return ['localhost', '127.0.0.1', '[::1]'].includes(hostname);
+    } catch {
+      return false;
+    }
+  });
   if (!preset) return;
   if (normalizeUrl(preset.baseUrl) === normalizeUrl(origin)) return;
   preset.baseUrl = origin;

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -144,6 +144,37 @@ describe('ApiClient API compatibility', () => {
     expect(client.compatibilityWarning$.get()).toBeNull();
   });
 
+  it('does not report connected when /api/v2 is open but conversations return 401', async () => {
+    global.fetch = jest.fn().mockImplementation(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.includes('/api/v2/conversations')) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: 'UNAUTHORIZED',
+          json: async () => ({ error: 'Missing authentication credentials' }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          api_version: CLIENT_API_VERSION,
+          contract_revision: CLIENT_MIN_CONTRACT_REVISION,
+        }),
+      } as Response;
+    });
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+
+    await expect(client.checkConnection()).resolves.toBe(false);
+    expect(client.isConnected$.get()).toBe(false);
+    expect(client.lastConnectionResult$.get()).toMatchObject({
+      ok: false,
+      reason: 'http_error',
+      status: 401,
+    });
+  });
+
   it('warns but remains connected when the server contract is older', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -187,6 +218,11 @@ describe('ApiClient API compatibility', () => {
   });
 
   it('clears a stale compatibility warning after reconnecting to a compatible server', async () => {
+    const okConversations = {
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as Response;
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({
@@ -196,13 +232,15 @@ describe('ApiClient API compatibility', () => {
           contract_revision: CLIENT_MIN_CONTRACT_REVISION - 1,
         }),
       } as Response)
+      .mockResolvedValueOnce(okConversations)
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           api_version: CLIENT_API_VERSION,
           contract_revision: CLIENT_MIN_CONTRACT_REVISION,
         }),
-      } as Response);
+      } as Response)
+      .mockResolvedValueOnce(okConversations);
 
     const client = new ApiClient('http://127.0.0.1:5700');
 
@@ -223,6 +261,11 @@ describe('ApiClient API compatibility', () => {
         }),
       } as Response)
       .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as Response)
+      .mockResolvedValueOnce({
         ok: false,
         status: 503,
         statusText: 'Service Unavailable',
@@ -238,6 +281,11 @@ describe('ApiClient API compatibility', () => {
   });
 
   it('keeps legacy servers without version metadata compatible', async () => {
+    const okConversations = {
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as Response;
     global.fetch = jest
       .fn()
       .mockResolvedValueOnce({
@@ -247,10 +295,12 @@ describe('ApiClient API compatibility', () => {
           contract_revision: CLIENT_MIN_CONTRACT_REVISION - 1,
         }),
       } as Response)
+      .mockResolvedValueOnce(okConversations)
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ version: '0.30.0' }),
-      } as Response);
+      } as Response)
+      .mockResolvedValueOnce(okConversations);
 
     const client = new ApiClient('http://127.0.0.1:5700');
 
@@ -278,7 +328,12 @@ describe('ApiClient API compatibility', () => {
     global.fetch = jest
       .fn()
       .mockReturnValueOnce(oldProbePromise)
-      .mockReturnValueOnce(newProbePromise);
+      .mockReturnValueOnce(newProbePromise)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as Response);
 
     const client = new ApiClient('http://127.0.0.1:5700');
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -592,6 +592,27 @@ export class ApiClient {
         return false;
       }
 
+      // /api/v2 is intentionally unauthenticated (version/capability discovery).
+      // After gptme#3430 a live local server still 200s that probe without a
+      // bearer token, then 401-loops on conversations. Confirm auth against a
+      // protected route before reporting connected.
+      const authUrl = `${this.baseUrl}/api/v2/conversations?limit=1`;
+      const authResponse = await this.fetchWithTimeout(authUrl, {}, 3000);
+      if (this._probeNonce !== nonce) return false;
+      if (authResponse.status === 401) {
+        console.error('API accepted the root probe but rejected authenticated routes:', 401);
+        this.isConnected$.set(false);
+        this.lastConnectionResult$.set({
+          ok: false,
+          url: authUrl,
+          reason: 'http_error',
+          status: 401,
+          message:
+            'Server is running but requires a bearer token. Paste the token printed by gptme-server.',
+        });
+        return false;
+      }
+
       this.isConnected$.set(true);
       this.lastConnectionResult$.set({ ok: true, url });
       return true;

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -612,6 +612,18 @@ export class ApiClient {
         });
         return false;
       }
+      if (!authResponse.ok) {
+        console.error('Protected probe failed with status:', authResponse.status);
+        this.isConnected$.set(false);
+        this.lastConnectionResult$.set({
+          ok: false,
+          url: authUrl,
+          reason: 'http_error',
+          status: authResponse.status,
+          message: `Server returned ${authResponse.status} on the authenticated probe.`,
+        });
+        return false;
+      }
 
       this.isConnected$.set(true);
       this.lastConnectionResult$.set({ ok: true, url });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -602,6 +602,7 @@ export class ApiClient {
       if (authResponse.status === 401) {
         console.error('API accepted the root probe but rejected authenticated routes:', 401);
         this.isConnected$.set(false);
+        this.compatibilityWarning$.set(null);
         this.lastConnectionResult$.set({
           ok: false,
           url: authUrl,
@@ -615,6 +616,7 @@ export class ApiClient {
       if (!authResponse.ok) {
         console.error('Protected probe failed with status:', authResponse.status);
         this.isConnected$.set(false);
+        this.compatibilityWarning$.set(null);
         this.lastConnectionResult$.set({
           ok: false,
           url: authUrl,


### PR DESCRIPTION
## Summary

Post-#3430, a standalone `gptme-server` requires a bearer token on every bind address. The bundled UI still hardcoded `http://127.0.0.1:5700` with no token, treated unauthenticated `GET /api/v2` as "connected", then 401-looped on conversations and showed **You're all set**.

Dogfooded from an isolated home/log dir with a known `GPTME_SERVER_TOKEN` against `origin/master`.

**Before** (bare load of `http://127.0.0.1:<port>/`):
- API calls went to `:5700` (CORS retry storm when the server was on another port)
- Same-origin without a token: `/api/v2` 200 → wizard said connected → conversations/models/tasks 401 in a loop
- `#userToken=` alone applied to the 5700 preset, not the serving origin

**After**:
- Loopback bundled UI retargets the Local preset to `window.location.origin`
- Connection probe also hits `/api/v2/conversations?limit=1`; a 401 is "needs token", not "connected"
- Auto-connect stops on 401 (same as CORS — retrying cannot recover)
- Local setup wizard accepts the token from the server logs
- `gptme-server serve` prints a copyable `http://127.0.0.1:<port>/#userToken=<token>` URL
- `#userToken=` on the bundled origin lists/creates conversations and sets the auth cookie; no reload loop

## How to reproduce (before)

```bash
GPTME_SERVER_TOKEN=dogfood gptme-server serve --host 127.0.0.1 --port 5799
# open http://127.0.0.1:5799/ in a fresh profile
# observe: not connected / CORS to :5700, or "You're all set" then 401s
```

With this PR, the same URL talks to `:5799`. Opening the printed `#userToken=` link lists conversations.

## Test plan

- [x] `npx jest` on api/servers/ApiContext/SetupWizard tests
- [x] Live Playwright against bundled UI: bare load 401-stops; `#userToken=` lists + creates
- [ ] CI webui tests