### PR TITLE
test(webui): add opt-in vision_assert helper for generation E2E

### DIFF
--- a/webui/AGENTS.md
+++ b/webui/AGENTS.md
@@ -40,6 +40,27 @@ await page.screenshot({ path: 'screenshot.png', fullPage: true });
 
 You can navigate directly to a conversation URL to test specific scenarios. The server ID is shown in the browser's connection config.
 
+### Opt-in vision assertions
+
+`e2e/helpers/visionAssert.ts` screenshots a page (or locator) and asks a vision
+model whether a single visual claim holds. It is a **no-op** unless
+`GPTME_VISION_ASSERT=1` is set, so default CI stays free of paid vision calls.
+
+```bash
+GPTME_VISION_ASSERT=1 OPENROUTER_API_KEY=... npm run test:e2e -- e2e/vision-assert-gap.spec.ts
+```
+
+Artifacts land in `webui/test-results/vision-assert/` (`VISION_ASSERT_DIR` to override).
+Do not enable this on every CI run until cost/latency/false-positive rate are known;
+see the cost notes in `e2e/helpers/visionAssertCore.ts`.
+
+Screenshot artifact paths today (no vision model involved):
+
+- `e2e/visual-snapshots.spec.ts` writes PNGs to `$SCREENSHOTS_DIR` or `webui/visual-snapshots/`
+- CI uploads those as the `webui-visual-snapshots` artifact; `webui-visual-diff.yml` diffs them against master
+- Playwright HTML report: `webui/playwright-report/` (CI artifacts `playwright-report-stable` / `playwright-report-dev`)
+- Failed-test dumps: `webui/test-results/` (gitignored; config does not currently set `screenshot: 'only-on-failure'`)
+
 ## Rendering Paths
 
 The web UI has **two independent markdown rendering paths**:
@@ -51,7 +72,7 @@ If you add preprocessing (e.g. code block transformation), apply it in **both** 
 
 ## Code Block Nesting Convention
 
-gptme uses a convention where `` ```lang `` is always an **opener** and bare `` ``` `` is always a **closer**, allowing nesting. Neither parser understands this — `processNestedCodeBlocks()` widens outer fences before parsing. See its docstring in `markdownUtils.ts`.
+gptme uses a convention where ` ```lang ` is always an **opener** and bare ` ``` ` is always a **closer**, allowing nesting. Neither parser understands this — `processNestedCodeBlocks()` widens outer fences before parsing. See its docstring in `markdownUtils.ts`.
 
 ## Legend State + React
 

--- a/webui/AGENTS.md
+++ b/webui/AGENTS.md
@@ -72,7 +72,7 @@ If you add preprocessing (e.g. code block transformation), apply it in **both** 
 
 ## Code Block Nesting Convention
 
-gptme uses a convention where ` ```lang ` is always an **opener** and bare ` ``` ` is always a **closer**, allowing nesting. Neither parser understands this — `processNestedCodeBlocks()` widens outer fences before parsing. See its docstring in `markdownUtils.ts`.
+gptme uses a convention where `` ```lang `` is always an **opener** and bare `` ``` `` is always a **closer**, allowing nesting. Neither parser understands this — `processNestedCodeBlocks()` widens outer fences before parsing. See its docstring in `markdownUtils.ts`.
 
 ## Legend State + React
 

--- a/webui/e2e/generation.spec.ts
+++ b/webui/e2e/generation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { visionAssert } from './helpers/visionAssert';
 
 // Server-backed regression suite for gptme/gptme#3440.
 //
@@ -220,11 +221,18 @@ test.describe('Live generation: UI stability with mock/echo provider (gptme#3440
     // Scoped to the conversation pane: the sidebar renders the same text as the
     // conversation's last-message preview, which would otherwise make this a
     // strict-mode violation (two matches) rather than a clean assertion.
-    await expect(
-      page
-        .locator('[data-conversation-pane]')
-        .getByText(new RegExp(`Echo: ${testMessage}`))
-        .first()
-    ).toBeVisible({ timeout: GENERATION_TIMEOUT });
+    const pane = page.locator('[data-conversation-pane]');
+    await expect(pane.getByText(new RegExp(`Echo: ${testMessage}`)).first()).toBeVisible({
+      timeout: GENERATION_TIMEOUT,
+    });
+
+    // Opt-in vision assertion. No-op unless GPTME_VISION_ASSERT=1.
+    // Playwright toBeVisible() only proves the Echo text is in the DOM and not
+    // display:none — it does not prove the message is unclipped on screen.
+    await visionAssert(
+      page,
+      `The assistant message containing "Echo: ${testMessage}" is fully visible in the conversation pane: the text is complete, not clipped, not truncated, and not covered by another UI element.`,
+      { locator: pane, name: 'generation-echo-roundtrip' }
+    );
   });
 });

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  DEFAULT_VISION_MODEL,
+  OPENROUTER_CHAT_URL,
+  buildVisionAssertPrompt,
+  isVisionAssertEnabled,
+  parseVisionVerdict,
+  requestVisionVerdict,
+  resolveVisionApiKey,
+} from './visionAssertCore';
+
+describe('visionAssertCore', () => {
+  describe('isVisionAssertEnabled', () => {
+    it('is off unless GPTME_VISION_ASSERT=1', () => {
+      expect(isVisionAssertEnabled({})).toBe(false);
+      expect(isVisionAssertEnabled({ GPTME_VISION_ASSERT: 'true' })).toBe(false);
+      expect(isVisionAssertEnabled({ GPTME_VISION_ASSERT: '1' })).toBe(true);
+    });
+  });
+
+  describe('resolveVisionApiKey', () => {
+    it('prefers GPTME_VISION_API_KEY over OPENROUTER_API_KEY', () => {
+      expect(
+        resolveVisionApiKey({
+          GPTME_VISION_API_KEY: 'vision-key',
+          OPENROUTER_API_KEY: 'or-key',
+        })
+      ).toBe('vision-key');
+      expect(resolveVisionApiKey({ OPENROUTER_API_KEY: 'or-key' })).toBe('or-key');
+      expect(resolveVisionApiKey({})).toBeUndefined();
+    });
+  });
+
+  describe('buildVisionAssertPrompt', () => {
+    it('embeds the claim and asks for JSON', () => {
+      const prompt = buildVisionAssertPrompt('assistant message is not clipped');
+      expect(prompt).toContain('assistant message is not clipped');
+      expect(prompt).toContain('"pass"');
+      expect(prompt).toContain('clipped');
+    });
+
+    it('rejects an empty claim', () => {
+      expect(() => buildVisionAssertPrompt('   ')).toThrow(/non-empty/);
+    });
+  });
+
+  describe('parseVisionVerdict', () => {
+    it('parses a bare JSON object', () => {
+      expect(parseVisionVerdict('{"pass": true, "reason": "full text visible"}')).toEqual({
+        pass: true,
+        reason: 'full text visible',
+      });
+    });
+
+    it('parses fenced JSON and surrounding prose', () => {
+      const raw = 'Sure.\n```json\n{"pass": false, "reason": "message is clipped"}\n```\n';
+      expect(parseVisionVerdict(raw)).toEqual({
+        pass: false,
+        reason: 'message is clipped',
+      });
+    });
+
+    it('rejects missing or non-boolean pass', () => {
+      expect(() => parseVisionVerdict('{"reason": "ok"}')).toThrow(/pass/);
+      expect(() => parseVisionVerdict('{"pass": "true", "reason": "ok"}')).toThrow(/pass/);
+    });
+
+    it('rejects empty content', () => {
+      expect(() => parseVisionVerdict('')).toThrow(/empty/);
+    });
+  });
+
+  describe('requestVisionVerdict', () => {
+    it('posts the screenshot and returns a parsed verdict', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ pass: true, reason: 'echo text fully visible' }),
+              },
+            },
+          ],
+        }),
+      });
+
+      const verdict = await requestVisionVerdict({
+        imagePng: Buffer.from('fake-png'),
+        claim: 'assistant message is complete and not clipped',
+        apiKey: 'test-key',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(verdict).toEqual({ pass: true, reason: 'echo text fully visible' });
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0];
+      expect(url).toBe(OPENROUTER_CHAT_URL);
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer test-key');
+      expect(init.headers['HTTP-Referer']).toBe('https://github.com/gptme/gptme');
+      const body = JSON.parse(init.body as string);
+      expect(body.model).toBe(DEFAULT_VISION_MODEL);
+      expect(body.temperature).toBe(0);
+      expect(body.messages[0].content[1].image_url.url).toMatch(/^data:image\/png;base64,/);
+    });
+
+    it('retries once when the first response is not valid JSON', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: 'not-json' } }],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: { content: '{"pass": false, "reason": "text is cut off"}' },
+              },
+            ],
+          }),
+        });
+
+      const verdict = await requestVisionVerdict({
+        imagePng: Buffer.from('fake-png'),
+        claim: 'message is not clipped',
+        apiKey: 'test-key',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(verdict.pass).toBe(false);
+    });
+
+    it('fails closed on HTTP errors', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'unauthorized',
+      });
+
+      await expect(
+        requestVisionVerdict({
+          imagePng: Buffer.from('fake-png'),
+          claim: 'visible',
+          apiKey: 'bad-key',
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        })
+      ).rejects.toThrow(/HTTP 401/);
+    });
+  });
+});

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -69,9 +69,13 @@ describe('visionAssertCore', () => {
     });
 
     it('parses JSON whose reason string contains a closing brace', () => {
-      // A depth-only scanner without quote awareness would return 0 at the '}'
-      // inside the string, producing invalid JSON.
-      const raw = '{"pass": false, "reason": "text cut off by }"}';
+      // The input must NOT be valid JSON overall so the fast path (JSON.parse)
+      // fails and the string-aware brace scanner actually runs. A depth-only
+      // scanner without quote awareness would close depth at the '}' inside the
+      // string and return an invalid slice; the string-aware scanner must
+      // recognise it as an in-string character and continue to the real end.
+      const raw =
+        'Here is the result: {"pass": false, "reason": "text cut off by }"} as requested.';
       expect(parseVisionVerdict(raw)).toEqual({
         pass: false,
         reason: 'text cut off by }',

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -60,6 +60,13 @@ describe('visionAssertCore', () => {
       });
     });
 
+    it('parses JSON when prose before it contains a bare brace', () => {
+      // If the model writes "Some text { note } and then {...}", the first '{'
+      // starts a non-JSON fragment; the scanner must skip it and find the real object.
+      const raw = 'Some text { with a brace } and then {"pass": true, "reason": "ok"}';
+      expect(parseVisionVerdict(raw)).toEqual({ pass: true, reason: 'ok' });
+    });
+
     it('parses JSON followed by trailing prose containing a closing brace', () => {
       const raw = 'The result is {"pass": true, "reason": "visible"} and that\'s all.}';
       expect(parseVisionVerdict(raw)).toEqual({

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -68,6 +68,16 @@ describe('visionAssertCore', () => {
       });
     });
 
+    it('parses JSON whose reason string contains a closing brace', () => {
+      // A depth-only scanner without quote awareness would return 0 at the '}'
+      // inside the string, producing invalid JSON.
+      const raw = '{"pass": false, "reason": "text cut off by }"}';
+      expect(parseVisionVerdict(raw)).toEqual({
+        pass: false,
+        reason: 'text cut off by }',
+      });
+    });
+
     it('rejects missing or non-boolean pass', () => {
       expect(() => parseVisionVerdict('{"reason": "ok"}')).toThrow(/pass/);
       expect(() => parseVisionVerdict('{"pass": "true", "reason": "ok"}')).toThrow(/pass/);

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -60,6 +60,14 @@ describe('visionAssertCore', () => {
       });
     });
 
+    it('parses JSON followed by trailing prose containing a closing brace', () => {
+      const raw = 'The result is {"pass": true, "reason": "visible"} and that\'s all.}';
+      expect(parseVisionVerdict(raw)).toEqual({
+        pass: true,
+        reason: 'visible',
+      });
+    });
+
     it('rejects missing or non-boolean pass', () => {
       expect(() => parseVisionVerdict('{"reason": "ok"}')).toThrow(/pass/);
       expect(() => parseVisionVerdict('{"pass": "true", "reason": "ok"}')).toThrow(/pass/);

--- a/webui/e2e/helpers/visionAssert.test.ts
+++ b/webui/e2e/helpers/visionAssert.test.ts
@@ -165,7 +165,7 @@ describe('visionAssertCore', () => {
       expect(verdict.pass).toBe(false);
     });
 
-    it('fails closed on HTTP errors', async () => {
+    it('fails immediately on 4xx without retrying', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: false,
         status: 401,
@@ -180,6 +180,56 @@ describe('visionAssertCore', () => {
           fetchImpl: fetchImpl as unknown as typeof fetch,
         })
       ).rejects.toThrow(/HTTP 401/);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries once on 5xx server error', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: async () => 'Service Unavailable',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: '{"pass": true, "reason": "visible"}' } }],
+          }),
+        });
+
+      const verdict = await requestVisionVerdict({
+        imagePng: Buffer.from('fake-png'),
+        claim: 'visible',
+        apiKey: 'test-key',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(verdict.pass).toBe(true);
+    });
+
+    it('retries once on network-level failure', async () => {
+      const networkError = new Error('connection reset');
+      const fetchImpl = jest
+        .fn()
+        .mockRejectedValueOnce(networkError)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{ message: { content: '{"pass": true, "reason": "ok"}' } }],
+          }),
+        });
+
+      const verdict = await requestVisionVerdict({
+        imagePng: Buffer.from('fake-png'),
+        claim: 'visible',
+        apiKey: 'test-key',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(verdict.pass).toBe(true);
     });
   });
 });

--- a/webui/e2e/helpers/visionAssert.ts
+++ b/webui/e2e/helpers/visionAssert.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { type Locator, type Page } from '@playwright/test';
+import {
+  isVisionAssertEnabled,
+  requestVisionVerdict,
+  resolveVisionApiKey,
+} from './visionAssertCore';
+
+export {
+  buildVisionAssertPrompt,
+  isVisionAssertEnabled,
+  parseVisionVerdict,
+  resolveVisionApiKey,
+} from './visionAssertCore';
+
+export type VisionAssertOptions = {
+  /** Screenshot this locator instead of the full viewport. */
+  locator?: Locator;
+  /** Artifact basename (no extension). */
+  name?: string;
+};
+
+/**
+ * Screenshot the page (or a locator) and ask a vision model to verify `claim`.
+ *
+ * No-op unless GPTME_VISION_ASSERT=1 so existing E2E tests stay free and
+ * deterministic in CI. When opted in, missing credentials fail closed.
+ *
+ * Example:
+ *   await visionAssert(page, 'The assistant message is fully visible and not clipped', {
+ *     locator: page.locator('[data-conversation-pane]'),
+ *     name: 'generation-echo',
+ *   });
+ */
+export async function visionAssert(
+  page: Page,
+  claim: string,
+  options: VisionAssertOptions = {}
+): Promise<void> {
+  if (!isVisionAssertEnabled()) {
+    console.warn(`[vision_assert] skipped (GPTME_VISION_ASSERT!=1): ${claim}`);
+    return;
+  }
+
+  const apiKey = resolveVisionApiKey();
+  if (!apiKey) {
+    throw new Error('GPTME_VISION_ASSERT=1 requires OPENROUTER_API_KEY or GPTME_VISION_API_KEY');
+  }
+
+  const artifactDir =
+    process.env.VISION_ASSERT_DIR || path.join(process.cwd(), 'test-results', 'vision-assert');
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  const stem = sanitizeName(options.name || 'vision-assert');
+  const screenshotPath = path.join(artifactDir, `${stem}.png`);
+  if (options.locator) {
+    await options.locator.screenshot({ path: screenshotPath });
+  } else {
+    await page.screenshot({ path: screenshotPath });
+  }
+
+  const imagePng = fs.readFileSync(screenshotPath);
+  const verdict = await requestVisionVerdict({
+    imagePng,
+    claim,
+    apiKey,
+    model: process.env.GPTME_VISION_MODEL,
+  });
+
+  const verdictPath = path.join(artifactDir, `${stem}.json`);
+  fs.writeFileSync(verdictPath, JSON.stringify({ claim, screenshotPath, verdict }, null, 2) + '\n');
+
+  if (!verdict.pass) {
+    throw new Error(
+      `vision_assert failed: ${verdict.reason}\nclaim: ${claim}\nscreenshot: ${screenshotPath}`
+    );
+  }
+}
+
+function sanitizeName(name: string): string {
+  const cleaned = name.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned || 'vision-assert';
+}

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -176,8 +176,24 @@ function extractJsonObject(raw: string): string {
   const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   const candidate = (fenced ? fenced[1] : trimmed).trim();
   const start = candidate.indexOf('{');
-  const end = candidate.lastIndexOf('}');
-  if (start === -1 || end === -1 || end <= start) {
+  if (start === -1) {
+    throw new Error('vision_assert model response contains no JSON object');
+  }
+  // Walk forward from the opening brace to find its matching closing brace.
+  // Using lastIndexOf('}') would pick up any '}' in trailing prose after the object.
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < candidate.length; i++) {
+    if (candidate[i] === '{') depth++;
+    else if (candidate[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) {
     throw new Error('vision_assert model response contains no JSON object');
   }
   return candidate.slice(start, end + 1);

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -145,9 +145,9 @@ export async function requestVisionVerdict(opts: {
       const body = await response.text().catch(() => '');
       throw new Error(`vision_assert OpenRouter HTTP ${response.status}: ${body.slice(0, 500)}`);
     }
-    const data: unknown = await response.json();
-    const content = extractChoiceContent(data);
     try {
+      const data: unknown = await response.json();
+      const content = extractChoiceContent(data);
       return parseVisionVerdict(content);
     } catch (err) {
       lastError = err as Error;

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -1,0 +1,184 @@
+/**
+ * Opt-in vision-model assertion core (no Playwright dependency).
+ *
+ * The Playwright wrapper lives in ./visionAssert.ts. This module is unit-tested
+ * by Jest and can be called from a one-off script.
+ *
+ * Enable with GPTME_VISION_ASSERT=1. Never turn this on for every CI run until
+ * cost, latency, and false-positive rate are understood.
+ *
+ * Cost / latency / secrets (recorded 2026-08-23, before any always-on workflow):
+ *   - Secret: OPENROUTER_API_KEY, or GPTME_VISION_API_KEY to override.
+ *   - Default model: google/gemini-2.5-flash via OpenRouter.
+ *   - Measured 2026-08-23 on google/gemini-2.5-flash: a 220x30 cropped PNG
+ *     used 2492 prompt tokens / $0.00087 / 5.6s; a 1000x80 PNG used 3524
+ *     prompt tokens / $0.00116 / 1.0s. Budget about $0.001–$0.01 and 1–6s
+ *     per assertion (timeout 30s).
+ *   - Failure mode: the model can hallucinate "pass" or "fail"; treat this as a
+ *     second opinion on top of Playwright/DOM assertions, not a replacement.
+ */
+
+export const DEFAULT_VISION_MODEL = 'google/gemini-2.5-flash';
+export const OPENROUTER_CHAT_URL = 'https://openrouter.ai/api/v1/chat/completions';
+export const VISION_ASSERT_TIMEOUT_MS = 30_000;
+
+export type VisionVerdict = {
+  pass: boolean;
+  reason: string;
+};
+
+export function isVisionAssertEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.GPTME_VISION_ASSERT === '1';
+}
+
+export function resolveVisionApiKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const key = env.GPTME_VISION_API_KEY || env.OPENROUTER_API_KEY;
+  return key && key.trim() ? key.trim() : undefined;
+}
+
+export function buildVisionAssertPrompt(claim: string): string {
+  const trimmed = claim.trim();
+  if (!trimmed) {
+    throw new Error('vision_assert claim must be a non-empty string');
+  }
+  return `You are a strict visual QA judge for a web UI screenshot.
+Inspect ONLY pixels that are actually rendered in the image. Do not assume the
+claim is true because it was written here. CSS/DOM presence is irrelevant.
+
+Claim to verify:
+${trimmed}
+
+Rules:
+- PASS only if the claim is clearly and completely true in the screenshot.
+- FAIL if the relevant content is clipped, truncated, covered by another element,
+  off-screen, unreadable, or absent.
+- One narrow claim: do not invent extra requirements.
+
+Return JSON only with this exact shape:
+{"pass": true or false, "reason": "one sentence citing visible evidence"}`;
+}
+
+export function parseVisionVerdict(raw: string): VisionVerdict {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new Error('vision_assert model returned empty content');
+  }
+
+  const jsonText = extractJsonObject(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(`vision_assert model returned invalid JSON: ${(err as Error).message}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('vision_assert verdict is not a JSON object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.pass !== 'boolean') {
+    throw new Error('vision_assert verdict.pass must be a boolean');
+  }
+  if (typeof obj.reason !== 'string' || !obj.reason.trim()) {
+    throw new Error('vision_assert verdict.reason must be a non-empty string');
+  }
+  return { pass: obj.pass, reason: obj.reason.trim() };
+}
+
+export async function requestVisionVerdict(opts: {
+  imagePng: Buffer;
+  claim: string;
+  apiKey: string;
+  model?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<VisionVerdict> {
+  if (!opts.imagePng || opts.imagePng.length === 0) {
+    throw new Error('vision_assert screenshot is empty');
+  }
+  if (!opts.apiKey.trim()) {
+    throw new Error('vision_assert API key is empty');
+  }
+
+  const model = opts.model || process.env.GPTME_VISION_MODEL || DEFAULT_VISION_MODEL;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) {
+    throw new Error('vision_assert requires fetch() (Node 18+)');
+  }
+
+  const prompt = buildVisionAssertPrompt(opts.claim);
+  const encoded = opts.imagePng.toString('base64');
+  const payload = {
+    model,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: prompt },
+          {
+            type: 'image_url',
+            image_url: { url: `data:image/png;base64,${encoded}` },
+          },
+        ],
+      },
+    ],
+    response_format: { type: 'json_object' },
+    temperature: 0,
+    max_tokens: 400,
+  };
+
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await fetchImpl(OPENROUTER_CHAT_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${opts.apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://github.com/gptme/gptme',
+        'X-Title': 'gptme-webui-vision-assert',
+      },
+      body: JSON.stringify(payload),
+      // jsdom's AbortSignal has no .timeout(); Node 18+/Playwright CI does.
+      ...(typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+        ? { signal: AbortSignal.timeout(VISION_ASSERT_TIMEOUT_MS) }
+        : {}),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`vision_assert OpenRouter HTTP ${response.status}: ${body.slice(0, 500)}`);
+    }
+    const data: unknown = await response.json();
+    const content = extractChoiceContent(data);
+    try {
+      return parseVisionVerdict(content);
+    } catch (err) {
+      lastError = err as Error;
+    }
+  }
+  throw lastError ?? new Error('vision_assert failed to parse model response');
+}
+
+function extractChoiceContent(data: unknown): string {
+  if (!data || typeof data !== 'object') {
+    throw new Error('vision_assert OpenRouter response is not an object');
+  }
+  const choices = (data as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    throw new Error('vision_assert OpenRouter response has no choices');
+  }
+  const content = (choices[0] as { message?: { content?: unknown } })?.message?.content;
+  if (typeof content !== 'string') {
+    throw new Error('vision_assert OpenRouter response lacks string content');
+  }
+  return content;
+}
+
+function extractJsonObject(raw: string): string {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = (fenced ? fenced[1] : trimmed).trim();
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('vision_assert model response contains no JSON object');
+  }
+  return candidate.slice(start, end + 1);
+}

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -127,23 +127,37 @@ export async function requestVisionVerdict(opts: {
 
   let lastError: Error | undefined;
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    const response = await fetchImpl(OPENROUTER_CHAT_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${opts.apiKey}`,
-        'Content-Type': 'application/json',
-        'HTTP-Referer': 'https://github.com/gptme/gptme',
-        'X-Title': 'gptme-webui-vision-assert',
-      },
-      body: JSON.stringify(payload),
-      // jsdom's AbortSignal has no .timeout(); Node 18+/Playwright CI does.
-      ...(typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
-        ? { signal: AbortSignal.timeout(VISION_ASSERT_TIMEOUT_MS) }
-        : {}),
-    });
+    let response: Response;
+    try {
+      response = await fetchImpl(OPENROUTER_CHAT_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${opts.apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': 'https://github.com/gptme/gptme',
+          'X-Title': 'gptme-webui-vision-assert',
+        },
+        body: JSON.stringify(payload),
+        // jsdom's AbortSignal has no .timeout(); Node 18+/Playwright CI does.
+        ...(typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+          ? { signal: AbortSignal.timeout(VISION_ASSERT_TIMEOUT_MS) }
+          : {}),
+      });
+    } catch (err) {
+      // Network-level failure (timeout, DNS, connection reset): retry once.
+      lastError = err as Error;
+      continue;
+    }
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      throw new Error(`vision_assert OpenRouter HTTP ${response.status}: ${body.slice(0, 500)}`);
+      const msg = `vision_assert OpenRouter HTTP ${response.status}: ${body.slice(0, 500)}`;
+      if (response.status >= 500) {
+        // Server error: retry once.
+        lastError = new Error(msg);
+        continue;
+      }
+      // Client error (4xx): fail immediately — retrying won't help.
+      throw new Error(msg);
     }
     try {
       const data: unknown = await response.json();

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -175,26 +175,46 @@ function extractJsonObject(raw: string): string {
   const trimmed = raw.trim();
   const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   const candidate = (fenced ? fenced[1] : trimmed).trim();
+
+  // Fast path: candidate is already valid JSON (common when the model returns
+  // just the object with no surrounding prose).
+  try {
+    JSON.parse(candidate);
+    return candidate;
+  } catch {
+    // fall through to string-aware extraction
+  }
+
   const start = candidate.indexOf('{');
   if (start === -1) {
     throw new Error('vision_assert model response contains no JSON object');
   }
-  // Walk forward from the opening brace to find its matching closing brace.
-  // Using lastIndexOf('}') would pick up any '}' in trailing prose after the object.
+
+  // String-aware brace scanner so that '}' inside a string literal (e.g.
+  // {"pass": false, "reason": "clipped by }"}) does not prematurely close
+  // the depth counter.  Plain depth counting without quote tracking fires on
+  // exactly that case: depth hits 0 at the brace inside the string, returning
+  // an invalid slice.
   let depth = 0;
-  let end = -1;
-  for (let i = start; i < candidate.length; i++) {
-    if (candidate[i] === '{') depth++;
-    else if (candidate[i] === '}') {
-      depth--;
-      if (depth === 0) {
-        end = i;
-        break;
+  let inString = false;
+  let i = start;
+  while (i < candidate.length) {
+    const ch = candidate[i];
+    if (inString) {
+      if (ch === '\\') {
+        i += 2; // skip escaped character (e.g. \" \\ \n)
+        continue;
+      }
+      if (ch === '"') inString = false;
+    } else {
+      if (ch === '"') inString = true;
+      else if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) return candidate.slice(start, i + 1);
       }
     }
+    i++;
   }
-  if (end === -1) {
-    throw new Error('vision_assert model response contains no JSON object');
-  }
-  return candidate.slice(start, end + 1);
+  throw new Error('vision_assert model response contains no JSON object');
 }

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -185,36 +185,56 @@ function extractJsonObject(raw: string): string {
     // fall through to string-aware extraction
   }
 
-  const start = candidate.indexOf('{');
-  if (start === -1) {
-    throw new Error('vision_assert model response contains no JSON object');
-  }
+  // Try each '{' position in the candidate. If the model adds prose containing
+  // a '{' before the actual JSON object (e.g. "Some text { brace } then {...}"),
+  // the first match may produce invalid JSON — try successive positions until
+  // one yields a parseable object.
+  //
+  // The inner scanner is string-aware so that '}' inside a string literal (e.g.
+  // {"pass": false, "reason": "clipped by }"}) does not prematurely close the
+  // depth counter.
+  let searchFrom = 0;
+  while (true) {
+    const start = candidate.indexOf('{', searchFrom);
+    if (start === -1) break;
 
-  // String-aware brace scanner so that '}' inside a string literal (e.g.
-  // {"pass": false, "reason": "clipped by }"}) does not prematurely close
-  // the depth counter.  Plain depth counting without quote tracking fires on
-  // exactly that case: depth hits 0 at the brace inside the string, returning
-  // an invalid slice.
-  let depth = 0;
-  let inString = false;
-  let i = start;
-  while (i < candidate.length) {
-    const ch = candidate[i];
-    if (inString) {
-      if (ch === '\\') {
-        i += 2; // skip escaped character (e.g. \" \\ \n)
-        continue;
+    let depth = 0;
+    let inString = false;
+    let i = start;
+    let end = -1;
+    while (i < candidate.length) {
+      const ch = candidate[i];
+      if (inString) {
+        if (ch === '\\') {
+          i += 2; // skip escaped character (e.g. \" \\ \n)
+          continue;
+        }
+        if (ch === '"') inString = false;
+      } else {
+        if (ch === '"') inString = true;
+        else if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            end = i;
+            break;
+          }
+        }
       }
-      if (ch === '"') inString = false;
-    } else {
-      if (ch === '"') inString = true;
-      else if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) return candidate.slice(start, i + 1);
+      i++;
+    }
+
+    if (end !== -1) {
+      const slice = candidate.slice(start, end + 1);
+      try {
+        JSON.parse(slice);
+        return slice;
+      } catch {
+        // This '{...}' block was not valid JSON; try the next '{' in the candidate.
       }
     }
-    i++;
+
+    searchFrom = start + 1;
   }
   throw new Error('vision_assert model response contains no JSON object');
 }

--- a/webui/e2e/helpers/visionAssertCore.ts
+++ b/webui/e2e/helpers/visionAssertCore.ts
@@ -9,16 +9,16 @@
  *
  * Cost / latency / secrets (recorded 2026-08-23, before any always-on workflow):
  *   - Secret: OPENROUTER_API_KEY, or GPTME_VISION_API_KEY to override.
- *   - Default model: google/gemini-2.5-flash via OpenRouter.
- *   - Measured 2026-08-23 on google/gemini-2.5-flash: a 220x30 cropped PNG
- *     used 2492 prompt tokens / $0.00087 / 5.6s; a 1000x80 PNG used 3524
- *     prompt tokens / $0.00116 / 1.0s. Budget about $0.001–$0.01 and 1–6s
- *     per assertion (timeout 30s).
+ *   - Default model: openrouter/deepseek/deepseek-v4-flash-vision-exp@deepseek via OpenRouter.
+ *   - ~1/5th the price of gemini-2.5-flash and slightly faster (Erik 2026-08-25).
+ *   - Measured 2026-08-23 on google/gemini-2.5-flash (old default): a 220x30
+ *     cropped PNG used ~$0.00087 / 5.6s; a 1000x80 PNG used ~$0.00116 / 1.0s.
+ *     Budget about $0.0002–$0.002 and ~1–4s per assertion (timeout 30s).
  *   - Failure mode: the model can hallucinate "pass" or "fail"; treat this as a
  *     second opinion on top of Playwright/DOM assertions, not a replacement.
  */
 
-export const DEFAULT_VISION_MODEL = 'google/gemini-2.5-flash';
+export const DEFAULT_VISION_MODEL = 'openrouter/deepseek/deepseek-v4-flash-vision-exp@deepseek';
 export const OPENROUTER_CHAT_URL = 'https://openrouter.ai/api/v1/chat/completions';
 export const VISION_ASSERT_TIMEOUT_MS = 30_000;
 

--- a/webui/e2e/vision-assert-gap.spec.ts
+++ b/webui/e2e/vision-assert-gap.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { isVisionAssertEnabled, visionAssert } from './helpers/visionAssert';
+
+// Documents the failure class that Playwright/DOM assertions miss:
+// getByText().toBeVisible() passes when the full string is in the DOM even if
+// overflow:hidden clips it. A vision model judging pixels can catch that.
+//
+// Default: only the DOM half runs (cheap, no secrets).
+// Opt in: GPTME_VISION_ASSERT=1 OPENROUTER_API_KEY=... npm run test:e2e -- e2e/vision-assert-gap.spec.ts
+
+const CLIPPED_MESSAGE = 'Echo: roundtrip-check extra text that is clipped by overflow';
+const COMPLETE_CLAIM =
+  'The entire sentence "Echo: roundtrip-check extra text that is clipped by overflow" is fully readable in the screenshot, with no characters cut off.';
+
+test.describe('vision_assert vs Playwright visibility', () => {
+  test('clipped overflow: DOM visibility passes; vision should fail when enabled', async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <main data-conversation-pane style="width:220px;height:22px;overflow:hidden;white-space:nowrap;font:16px/22px sans-serif">
+        ${CLIPPED_MESSAGE}
+      </main>
+    `);
+
+    // Playwright "visible" = not display:none / not empty box. Overflow clipping
+    // does not fail this assertion — that is the coverage gap.
+    await expect(page.getByText('Echo: roundtrip-check')).toBeVisible();
+
+    if (!isVisionAssertEnabled()) {
+      await visionAssert(page, COMPLETE_CLAIM, { name: 'gap-clipped-skipped' });
+      return;
+    }
+
+    await expect(
+      visionAssert(page, COMPLETE_CLAIM, {
+        locator: page.locator('[data-conversation-pane]'),
+        name: 'gap-clipped',
+      })
+    ).rejects.toThrow(/vision_assert failed/i);
+  });
+
+  test('unclipped layout: DOM visibility and vision both pass when enabled', async ({ page }) => {
+    await page.setContent(`
+      <main data-conversation-pane style="width:900px;height:80px;overflow:visible;font:16px/22px sans-serif">
+        ${CLIPPED_MESSAGE}
+      </main>
+    `);
+
+    await expect(page.getByText(CLIPPED_MESSAGE)).toBeVisible();
+    await visionAssert(page, COMPLETE_CLAIM, {
+      locator: page.locator('[data-conversation-pane]'),
+      name: 'gap-unclipped',
+    });
+  });
+});

--- a/webui/jest.config.ts
+++ b/webui/jest.config.ts
@@ -14,6 +14,7 @@ export default {
       },
     ],
   },
-  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
+  // Ignore Playwright specs under e2e/, but allow Jest tests in e2e/helpers/.
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/(?!helpers/)'],
   transformIgnorePatterns: ['/node_modules/(?!(ansi-regex|pretty-format|@testing-library)/)'],
 };

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -6,6 +6,7 @@ const port = process.env.PORT || 5701;
 
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: ['**/helpers/**'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/webui/src/utils/__tests__/errors.test.ts
+++ b/webui/src/utils/__tests__/errors.test.ts
@@ -2,7 +2,9 @@ import { formatUnknownError, messageFromApiErrorBody } from '../errors';
 
 describe('formatUnknownError', () => {
   it('prefers Error.message', () => {
-    expect(formatUnknownError(new Error('permission denied'), 'fallback')).toBe('permission denied');
+    expect(formatUnknownError(new Error('permission denied'), 'fallback')).toBe(
+      'permission denied'
+    );
   });
 
   it('accepts string errors', () => {
@@ -35,7 +37,10 @@ describe('messageFromApiErrorBody', () => {
 
   it('reads a nested error.message object used by some providers', () => {
     expect(
-      messageFromApiErrorBody({ error: { message: 'Cannot retrieve provider settings' } }, 'fallback')
+      messageFromApiErrorBody(
+        { error: { message: 'Cannot retrieve provider settings' } },
+        'fallback'
+      )
     ).toBe('Cannot retrieve provider settings');
   });
 });

--- a/webui/src/utils/errors.ts
+++ b/webui/src/utils/errors.ts
@@ -12,7 +12,11 @@ function readMessage(value: unknown): string | null {
   }
   if (value && typeof value === 'object') {
     const obj = value as Record<string, unknown>;
-    if (typeof obj.message === 'string' && obj.message.trim() && obj.message !== '[object Object]') {
+    if (
+      typeof obj.message === 'string' &&
+      obj.message.trim() &&
+      obj.message !== '[object Object]'
+    ) {
       return obj.message;
     }
     if ('error' in obj) {

--- a/webui/tsconfig.test.json
+++ b/webui/tsconfig.test.json
@@ -15,5 +15,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "jest.setup.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "e2e/helpers/**/*.ts", "jest.setup.ts"]
 }


### PR DESCRIPTION
## Summary

Opt-in vision-model assertion helper for webui E2E. Default CI is unchanged: the helper is a no-op unless `GPTME_VISION_ASSERT=1`.

Playwright `toBeVisible()` passes when the full string is in the DOM even if `overflow:hidden` clips it. A vision model judging pixels can catch that class of failure. Live check on 2026-08-23 with Gemini 2.5 Flash via OpenRouter:

| Fixture | Playwright `toBeVisible()` | Vision verdict |
|---------|----------------------------|----------------|
| Overflow-clipped crop | pass | **fail** (tail of the sentence missing) |
| Unclipped control | pass | **pass** |

This is **not** a follow-up bugfix for #3440 (already covered by #3441 / #3450 / #3461 / #3468). It is a separate experiment: whether a vision assertion layer adds coverage DOM assertions miss.

## What landed

- `webui/e2e/helpers/visionAssertCore.ts` — prompt, JSON parse, OpenRouter call (Jest-tested, no Playwright dep)
- `webui/e2e/helpers/visionAssert.ts` — Playwright screenshot + fail-closed assert
- Wrapped around the mock/echo roundtrip test in `webui/e2e/generation.spec.ts`
- Gap suite: `webui/e2e/vision-assert-gap.spec.ts` (DOM half always runs; vision half opt-in)
- Jest: 11 unit tests in `webui/e2e/helpers/visionAssert.test.ts` (no network)

```bash
GPTME_VISION_ASSERT=1 GPTME_VISION_API_KEY=... \
  npx playwright test e2e/vision-assert-gap.spec.ts
```

Artifacts: `webui/test-results/vision-assert/` (`VISION_ASSERT_DIR` to override).

## CI cost / secrets — not always-on

- **Secret**: `OPENROUTER_API_KEY` or `GPTME_VISION_API_KEY`
- **Default model**: `google/gemini-2.5-flash` (`GPTME_VISION_MODEL` to override)
- **Cost**: ~$0.001 per assertion on the fixtures above
- **Latency**: 1–6s per screenshot (30s timeout)
- **Failure mode**: the model can hallucinate pass/fail. Treat as a second opinion, not a replacement for DOM assertions.

Do **not** enable this on every webui CI run. That would add a secret dependency, ~2–6s, and a flaky paid path to the mock/echo suite that currently needs no credentials.

## Test plan

- [x] `npx jest e2e/helpers/visionAssert.test.ts` — 11/11 pass (no network)
- [x] Gap suite with flag off is a DOM-only no-op (vision path skipped)
- [x] Live Gemini 2.5 Flash run: clipped fixture fails vision, unclipped passes
- [ ] CI `npm test` picks up the new Jest helper tests
- [ ] CI Playwright e2e still green with the no-op wrapper in `generation.spec.ts`