### PR TITLE
fix(service-init): make the scaffolded agent actually run gptme

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,10 +376,11 @@ gptme service init --name my-agent --work-dir ~/my-agent --timer-schedule hourly
 This command scaffolds:
 - **systemd service unit** — runs your agent in a user session
 - **Optional timer** — schedule autonomous runs (hourly, daily, weekly, or on-demand)
-- **Startup script** — placeholder run script; customize the loop body with your agent's real work
+- **Startup script** — runs one non-interactive gptme session per trigger and writes a durable journal entry
+- **Session prompt** — `prompt.md`, the instruction the agent executes on every run
 - **Skeleton config** — `gptme.toml` and `AGENTS.md` ready to customize
 
-The scaffolded workspace is self-contained; after customizing the startup script with your agent's work loop, all you need is gptme installed. Perfect for automation, monitoring, CI/CD orchestration, or running background agents on headless servers.
+The scaffolded workspace is self-contained and runs as generated — edit `prompt.md` to say what the agent should do each run; all you need is gptme installed. Perfect for automation, monitoring, CI/CD orchestration, or running background agents on headless servers.
 
 See the [Headless Agents guide](https://gptme.org/docs/agents/headless.html) for advanced configurations and troubleshooting.
 

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -257,9 +257,7 @@ cd "$WORK_DIR"
 # Prefix a newline so the raw CLI argument never matches a gptme-util subcommand
 # or plugin name (checked before _group_prompt_args runs). _group_prompt_args
 # strips leading whitespace, so the LLM receives the file content as-is.
-# Note: if prompt.md itself starts with a gptme slash command (/shell, /python,
-# etc.), gptme will execute it as a command — intentional: agents CAN start with
-# a command step. Natural-language task descriptions are never affected.
+# Single-slash commands (e.g. /shell) are rejected above before we reach here.
 prompt_arg=$'\\n'"$(cat "$PROMPT_FILE")"
 exit_code=0
 gptme "${{gptme_args[@]}}" "$prompt_arg" >> "$SESSION_LOG" 2>&1 || exit_code=$?

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -226,6 +226,21 @@ if [ ! -s "$PROMPT_FILE" ]; then
   echo "Prompt file is empty: $PROMPT_FILE (add your agent instructions)." >> "$SESSION_LOG"
   exit 66
 fi
+# Reject prompts whose first content line is a gptme in-chat command.
+# _group_prompt_args strips the leading-newline guard before the chat loop
+# dispatch: /shell, /python, /log, etc. as the first line would be dispatched
+# as a command rather than sent to the model. /path/to/file-style strings are
+# safe because their first word contains more than one slash.
+_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" || true)
+_prompt_fw="${{_prompt_fw%% *}}"
+if [ "${{_prompt_fw#/}}" != "$_prompt_fw" ] \
+   && [ "$(printf '%s' "$_prompt_fw" | awk -F'/' '{{print NF-1}}')" -eq 1 ]; then
+  echo "gptme agent $AGENT_NAME: prompt.md starts with '$_prompt_fw', a gptme in-chat command; it would be dispatched rather than sent to the model." >&2
+  echo "Begin prompt.md with a description or heading (e.g. '# Task')." >&2
+  echo "Prompt starts with in-chat command '$_prompt_fw'." >> "$SESSION_LOG"
+  exit 66
+fi
+unset _prompt_fw
 
 # Run one non-interactive gptme session. --non-interactive is passed as a flag
 # because gptme reads the flag, not GPTME_NON_INTERACTIVE.

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -183,7 +183,7 @@ JOURNAL_DIR="$WORK_DIR/journal/$(date +%Y-%m-%d)"
 PROMPT_FILE="$WORK_DIR/prompt.md"
 
 mkdir -p "$JOURNAL_DIR"
-SESSION_ID=$(date +%Y%m%d-%H%M%S)
+SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$
 SESSION_LOG="$JOURNAL_DIR/session-$SESSION_ID.md"
 
 {{
@@ -219,8 +219,12 @@ echo "## Output" >> "$SESSION_LOG"
 echo >> "$SESSION_LOG"
 
 cd "$WORK_DIR"
+# Prefix a newline so the prompt string never exactly matches a gptme-util
+# subcommand or plugin name (which would trigger CLI dispatch instead of an
+# agent session). gptme strips leading whitespace before sending to the LLM.
+prompt_arg=$'\\n'"$(cat "$PROMPT_FILE")"
 exit_code=0
-gptme "${{gptme_args[@]}}" "$(cat "$PROMPT_FILE")" >> "$SESSION_LOG" 2>&1 || exit_code=$?
+gptme "${{gptme_args[@]}}" "$prompt_arg" >> "$SESSION_LOG" 2>&1 || exit_code=$?
 
 {{
   echo

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -109,6 +109,10 @@ Restart=on-failure
 RestartSec=5
 RestartSteps=5
 RestartMaxDelaySec=60
+# Kill the service if it runs longer than this. Prevents a hung LLM connection
+# from keeping the unit active forever (blocking timer-triggered reruns).
+# Adjust to your expected maximum session length.
+RuntimeMaxSec=3600
 
 [Install]
 WantedBy=default.target
@@ -215,6 +219,11 @@ fi
 if [ ! -r "$PROMPT_FILE" ]; then
   echo "gptme agent $AGENT_NAME: prompt file $PROMPT_FILE is not readable" >&2
   echo "Prompt file not readable: $PROMPT_FILE (check permissions)." >> "$SESSION_LOG"
+  exit 66
+fi
+if [ ! -s "$PROMPT_FILE" ]; then
+  echo "gptme agent $AGENT_NAME: prompt file $PROMPT_FILE is empty" >&2
+  echo "Prompt file is empty: $PROMPT_FILE (add your agent instructions)." >> "$SESSION_LOG"
   exit 66
 fi
 

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -231,8 +231,7 @@ fi
 # dispatch: /shell, /python, /log, etc. as the first line would be dispatched
 # as a command rather than sent to the model. /path/to/file-style strings are
 # safe because their first word contains more than one slash.
-_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" || true)
-_prompt_fw="${{_prompt_fw%% *}}"
+_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" | awk '{{print $1}}' || true)
 if [ "${{_prompt_fw#/}}" != "$_prompt_fw" ] \
    && [ "$(printf '%s' "$_prompt_fw" | awk -F'/' '{{print NF-1}}')" -eq 1 ]; then
   echo "gptme agent $AGENT_NAME: prompt.md starts with '$_prompt_fw', a gptme in-chat command; it would be dispatched rather than sent to the model." >&2

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -180,13 +180,12 @@ set -euo pipefail
 AGENT_NAME="{name}"
 WORK_DIR={work_dir}
 JOURNAL_DIR="$WORK_DIR/journal/$(date +%Y-%m-%d)"
+PROMPT_FILE="$WORK_DIR/prompt.md"
 
 mkdir -p "$JOURNAL_DIR"
 SESSION_ID=$(date +%Y%m%d-%H%M%S)
 SESSION_LOG="$JOURNAL_DIR/session-$SESSION_ID.md"
 
-# Durable session record placeholder. Replace the loop body with your
-# agent's real work loop (CASCADE selector + task executor, etc.).
 {{
   echo "# Session $SESSION_ID"
   echo
@@ -195,7 +194,57 @@ SESSION_LOG="$JOURNAL_DIR/session-$SESSION_ID.md"
   echo
 }} > "$SESSION_LOG"
 
-echo "gptme agent {name}: wrote session log $SESSION_LOG"
+if ! command -v gptme >/dev/null 2>&1; then
+  echo "gptme agent $AGENT_NAME: 'gptme' not found on PATH" >&2
+  echo "gptme not found on PATH; install gptme or set PATH in the service unit." \
+    >> "$SESSION_LOG"
+  exit 127
+fi
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "gptme agent $AGENT_NAME: missing prompt file $PROMPT_FILE" >&2
+  echo "Missing prompt file $PROMPT_FILE." >> "$SESSION_LOG"
+  exit 66
+fi
+
+# Run one non-interactive gptme session. --non-interactive is passed as a flag
+# because gptme reads the flag, not GPTME_NON_INTERACTIVE.
+gptme_args=(--non-interactive --no-confirm --workspace "$WORK_DIR")
+gptme_args+=(--name "$AGENT_NAME-$SESSION_ID")
+if [ -n "${{GPTME_AGENT_MODEL:-}}" ]; then
+  gptme_args+=(--model "$GPTME_AGENT_MODEL")
+fi
+
+echo "## Output" >> "$SESSION_LOG"
+echo >> "$SESSION_LOG"
+
+cd "$WORK_DIR"
+exit_code=0
+gptme "${{gptme_args[@]}}" "$(cat "$PROMPT_FILE")" >> "$SESSION_LOG" 2>&1 || exit_code=$?
+
+{{
+  echo
+  echo "Finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Exit code: $exit_code"
+}} >> "$SESSION_LOG"
+
+echo "gptme agent {name}: session $SESSION_ID exited $exit_code (log: $SESSION_LOG)"
+exit "$exit_code"
+"""
+
+PROMPT_MD_TEMPLATE = """\
+# {name} — session prompt
+
+This is the instruction {name} receives at the start of every headless session.
+Edit it to describe the work the agent should do on each run.
+
+Keep it short and concrete. A headless session has no human to ask, so state the
+goal, where to look, and what "done" means.
+
+## Task
+
+Review the notes in this workspace and summarize anything that needs attention.
+Write findings to `journal/` and stop.
 """
 
 GPTME_TOML_TEMPLATE = """\
@@ -606,6 +655,11 @@ def init(
         AGENTS_MD_TEMPLATE.format(name=name),
         force=force,
     )
+    _write_file(
+        work / "prompt.md",
+        PROMPT_MD_TEMPLATE.format(name=name),
+        force=force,
+    )
 
     # Startup script
     startup = work / "gptme-agent-run.sh"
@@ -620,6 +674,7 @@ def init(
     click.echo(f"✅ Initialized headless agent '{name}'")
     click.echo()
     click.echo("Next steps:")
+    click.echo(f"  $EDITOR {work / 'prompt.md'}   # what the agent does each run")
 
     if platform_choice == "macos":
         plist_file = out_dir / f"com.gptme.{name}.plist"

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -231,7 +231,7 @@ fi
 # dispatch: /shell, /python, /log, etc. as the first line would be dispatched
 # as a command rather than sent to the model. /path/to/file-style strings are
 # safe because their first word contains more than one slash.
-_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" | awk '{{print $1}}' || true)
+_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" | python3 -c "import sys; w=sys.stdin.read().split(); print(w[0] if w else '')" || true)
 if [ "${{_prompt_fw#/}}" != "$_prompt_fw" ] \
    && [ "$(printf '%s' "$_prompt_fw" | awk -F'/' '{{print NF-1}}')" -eq 1 ]; then
   echo "gptme agent $AGENT_NAME: prompt.md starts with '$_prompt_fw', a gptme in-chat command; it would be dispatched rather than sent to the model." >&2

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -88,18 +88,26 @@ SYSTEMD_SERVICE_TEMPLATE = """\
 Description=gptme Autonomous Agent: {name}
 Documentation=https://github.com/gptme/gptme#headless
 After=network-online.target
+# A session is one-shot, so a persistent failure (bad API key, exhausted quota,
+# unusable prompt) would otherwise retry forever against a paid API. Give up
+# after 3 failures in 10 minutes and let the timer try again on schedule.
+StartLimitIntervalSec=600
+StartLimitBurst=3
 
 [Service]
 Type=simple
 WorkingDirectory={work_dir}
 Environment=GPTME_AGENT_NAME={name}
 Environment="GPTME_AGENT_MODEL={model}"
-Environment=GPTME_NON_INTERACTIVE=1
 ExecStart=:"{exec_work_dir}/gptme-agent-run.sh"
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure
+# RestartSteps is required for RestartMaxDelaySec to apply at all; without it
+# systemd logs "has RestartMaxDelaySec= but no RestartSteps=. Ignoring" and
+# retries at a flat RestartSec forever.
 RestartSec=5
+RestartSteps=5
 RestartMaxDelaySec=60
 
 [Install]
@@ -145,8 +153,6 @@ LAUNCHD_PLIST_TEMPLATE = """\
 		<string>{name}</string>
 		<key>GPTME_AGENT_MODEL</key>
 		<string>{model}</string>
-		<key>GPTME_NON_INTERACTIVE</key>
-		<string>1</string>
 	</dict>
 	<key>StandardOutPath</key>
 	<string>{work_dir}/logs/stdout.log</string>

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -182,7 +182,7 @@ WORK_DIR={work_dir}
 JOURNAL_DIR="$WORK_DIR/journal/$(date +%Y-%m-%d)"
 PROMPT_FILE="$WORK_DIR/prompt.md"
 
-mkdir -p "$JOURNAL_DIR"
+mkdir -p "$JOURNAL_DIR" || {{ echo "gptme agent $AGENT_NAME: cannot create journal dir $JOURNAL_DIR" >&2; exit 1; }}
 SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$
 SESSION_LOG="$JOURNAL_DIR/session-$SESSION_ID.md"
 
@@ -204,6 +204,11 @@ fi
 if [ ! -f "$PROMPT_FILE" ]; then
   echo "gptme agent $AGENT_NAME: missing prompt file $PROMPT_FILE" >&2
   echo "Missing prompt file $PROMPT_FILE." >> "$SESSION_LOG"
+  exit 66
+fi
+if [ ! -r "$PROMPT_FILE" ]; then
+  echo "gptme agent $AGENT_NAME: prompt file $PROMPT_FILE is not readable" >&2
+  echo "Prompt file not readable: $PROMPT_FILE (check permissions)." >> "$SESSION_LOG"
   exit 66
 fi
 

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -254,9 +254,12 @@ echo "## Output" >> "$SESSION_LOG"
 echo >> "$SESSION_LOG"
 
 cd "$WORK_DIR"
-# Prefix a newline so the prompt string never exactly matches a gptme-util
-# subcommand or plugin name (which would trigger CLI dispatch instead of an
-# agent session). gptme strips leading whitespace before sending to the LLM.
+# Prefix a newline so the raw CLI argument never matches a gptme-util subcommand
+# or plugin name (checked before _group_prompt_args runs). _group_prompt_args
+# strips leading whitespace, so the LLM receives the file content as-is.
+# Note: if prompt.md itself starts with a gptme slash command (/shell, /python,
+# etc.), gptme will execute it as a command — intentional: agents CAN start with
+# a command step. Natural-language task descriptions are never affected.
 prompt_arg=$'\\n'"$(cat "$PROMPT_FILE")"
 exit_code=0
 gptme "${{gptme_args[@]}}" "$prompt_arg" >> "$SESSION_LOG" 2>&1 || exit_code=$?

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -231,7 +231,7 @@ fi
 # dispatch: /shell, /python, /log, etc. as the first line would be dispatched
 # as a command rather than sent to the model. /path/to/file-style strings are
 # safe because their first word contains more than one slash.
-_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" | python3 -c "import sys; w=sys.stdin.read().split(); print(w[0] if w else '')" || true)
+_prompt_fw=$(grep -m1 '[^[:space:]]' "$PROMPT_FILE" | python3 -c "import sys; w=sys.stdin.read().split(); print(w[0] if w else '')")
 if [ "${{_prompt_fw#/}}" != "$_prompt_fw" ] \
    && [ "$(printf '%s' "$_prompt_fw" | awk -F'/' '{{print NF-1}}')" -eq 1 ]; then
   echo "gptme agent $AGENT_NAME: prompt.md starts with '$_prompt_fw', a gptme in-chat command; it would be dispatched rather than sent to the model." >&2

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -189,7 +189,7 @@ JOURNAL_DIR="$WORK_DIR/journal/$(date +%Y-%m-%d)"
 PROMPT_FILE="$WORK_DIR/prompt.md"
 
 mkdir -p "$JOURNAL_DIR" || {{ echo "gptme agent $AGENT_NAME: cannot create journal dir $JOURNAL_DIR" >&2; exit 1; }}
-SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$
+SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$-$RANDOM
 SESSION_LOG="$JOURNAL_DIR/session-$SESSION_ID.md"
 
 {{

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -821,3 +821,58 @@ def test_macos_path_with_systemd_invalid_chars_accepted(tmp_path: Path) -> None:
     assert result.exit_code == 0, (
         f"macOS scaffolding should accept apostrophes in work-dir; got: {result.output}"
     )
+
+
+def test_startup_script_actually_invokes_gptme(tmp_path: Path) -> None:
+    """The scaffolded service must run a gptme session, not just write a log stub.
+
+    Regression: the original template wrote a session-log header and exited, so
+    `systemctl start <name>.service` produced an empty journal file and never
+    started an agent.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    assert 'gptme "${gptme_args[@]}"' in startup
+    assert "--non-interactive" in startup
+    assert '--workspace "$WORK_DIR"' in startup
+    assert 'exit "$exit_code"' in startup
+
+
+def test_startup_script_passes_non_interactive_as_a_flag(tmp_path: Path) -> None:
+    """GPTME_NON_INTERACTIVE is not read by gptme; the flag must be explicit."""
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    # The env var alone must never be the only thing standing between a headless
+    # unit and an interactive prompt.
+    assert "gptme_args=(--non-interactive" in startup
+
+
+def test_startup_script_forwards_configured_model(tmp_path: Path) -> None:
+    """The model chosen at init time reaches gptme via GPTME_AGENT_MODEL."""
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    assert 'if [ -n "${GPTME_AGENT_MODEL:-}" ]; then' in startup
+    assert 'gptme_args+=(--model "$GPTME_AGENT_MODEL")' in startup
+
+
+def test_prompt_file_is_generated(tmp_path: Path) -> None:
+    """A prompt.md scaffold ships so the first run has something to execute."""
+    _run_init(tmp_path)
+    prompt = tmp_path / "prompt.md"
+
+    assert prompt.exists()
+    assert prompt.read_text().strip()
+
+
+def test_startup_script_fails_loudly_without_prompt(tmp_path: Path) -> None:
+    """A missing prompt file must fail the unit, not silently produce nothing."""
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    assert 'if [ ! -f "$PROMPT_FILE" ]; then' in startup
+    assert "exit 66" in startup
+    assert "command -v gptme" in startup
+    assert "exit 127" in startup

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -930,6 +930,20 @@ def test_startup_script_checks_prompt_readability(tmp_path: Path) -> None:
     assert '[ ! -r "$PROMPT_FILE" ]' in startup
 
 
+def test_startup_script_checks_prompt_nonempty(tmp_path: Path) -> None:
+    """An empty prompt file must fail loudly (exit 66), not run gptme silently.
+
+    Regression: the original template only checked existence and readability.
+    An empty prompt.md passes both checks, but `cat prompt.md` yields nothing,
+    so gptme runs with an effective empty prompt, wastes an API call, and exits 0
+    — appearing successful while doing nothing useful.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    assert '[ ! -s "$PROMPT_FILE" ]' in startup
+
+
 def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
     """A journal directory that cannot be created must fail with an explicit error.
 
@@ -993,3 +1007,20 @@ def test_generated_units_do_not_set_dead_non_interactive_env(tmp_path: Path) -> 
     _run_init(tmp_path, "--platform", "macos")
     plist = (tmp_path / "systemd" / "com.gptme.testagent.plist").read_text()
     assert "GPTME_NON_INTERACTIVE" not in plist
+
+
+def test_service_unit_has_runtime_max_sec(tmp_path: Path) -> None:
+    """A hung LLM connection must not keep the unit active forever.
+
+    Without RuntimeMaxSec the unit stays in active (running) state indefinitely
+    when the gptme process hangs (endpoint unresponsive, infinite stream, etc.).
+    Restart=on-failure never fires because the process has not exited, and timer
+    triggers queue behind the still-active unit. RuntimeMaxSec kills the process
+    after a deadline, moving the unit to failed and allowing restart + timer to
+    proceed normally.
+    """
+    _run_init(tmp_path)
+    unit = (tmp_path / "systemd" / "testagent.service").read_text()
+    assert "RuntimeMaxSec=" in unit, (
+        "Without RuntimeMaxSec a hung gptme process keeps the unit active forever"
+    )

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -963,6 +963,35 @@ def test_startup_script_rejects_slash_command_prompt(tmp_path: Path) -> None:
     assert "in-chat command" in startup
 
 
+@pytest.mark.skipif(not shutil.which("bash"), reason="bash not available")
+def test_startup_script_rejects_slash_command_with_leading_whitespace(
+    tmp_path: Path,
+) -> None:
+    """A prompt.md whose first content line is TAB+/shell must be rejected (exit 66).
+
+    Regression: the original guard used `${_prompt_fw%% *}` to extract the first
+    word, which retains a leading tab — so `\\t/shell` passed the startswith-/
+    check unchanged and was not caught. _group_prompt_args would then strip the
+    tab and expose /shell to the in-chat dispatcher.
+    Using `awk '{print $1}'` strips leading whitespace before extracting the word.
+    """
+    _run_init(tmp_path)
+    startup = tmp_path / "gptme-agent-run.sh"
+    (tmp_path / "prompt.md").write_text("\t/shell echo pwned\n")
+
+    proc = subprocess.run(
+        ["bash", str(startup)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 66, (
+        f"Expected exit 66 for tab-prefixed slash command; got {proc.returncode}\n"
+        f"stderr: {proc.stderr}"
+    )
+    assert "in-chat command" in proc.stderr
+
+
 def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
     """A journal directory that cannot be created must fail with an explicit error.
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -911,3 +911,33 @@ def test_startup_script_prompt_bypasses_command_routing(tmp_path: Path) -> None:
     # backslash is a literal \ in the file content, so Python sees it as \n.
     assert r"prompt_arg=$'\n'" in startup
     assert '"$prompt_arg"' in startup
+
+
+def test_startup_script_checks_prompt_readability(tmp_path: Path) -> None:
+    """A prompt file that exists but is unreadable must fail loudly (exit 66).
+
+    Regression: the original template only checked [ ! -f "$PROMPT_FILE" ] for
+    existence. An unreadable file passes that check, then `cat "$PROMPT_FILE"`
+    fails silently (or with a confusing cat error), causing gptme to run with an
+    empty prompt and exit 0 — appearing successful while doing nothing useful.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    assert '[ ! -r "$PROMPT_FILE" ]' in startup
+
+
+def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
+    """A journal directory that cannot be created must fail with an explicit error.
+
+    Regression: the original template called `mkdir -p "$JOURNAL_DIR"` without
+    checking its exit status. If the workspace lacks write permission, mkdir
+    fails, the subsequent `> "$SESSION_LOG"` redirection also fails, and the
+    script continues as if the journal exists, silently losing all session output.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    # The mkdir line must exit on failure with a diagnostic message.
+    assert 'mkdir -p "$JOURNAL_DIR"' in startup
+    assert "cannot create journal dir" in startup

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -944,6 +944,25 @@ def test_startup_script_checks_prompt_nonempty(tmp_path: Path) -> None:
     assert '[ ! -s "$PROMPT_FILE" ]' in startup
 
 
+def test_startup_script_rejects_slash_command_prompt(tmp_path: Path) -> None:
+    """A prompt.md starting with a gptme in-chat command must be rejected (exit 66).
+
+    Regression: the leading-newline guard ($'\\n') prevents CLI-level subcommand
+    dispatch, but gptme's _group_prompt_args strips the newline before the chat
+    loop dispatch. A first line like /shell or /python would be executed as an
+    in-chat command rather than sent to the model. /path/to/file-style strings
+    are safe because their first word has more than one slash.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    # The check must extract the first word and count its slashes.
+    assert "_prompt_fw" in startup
+    # Single-slash first words that match gptme's in-chat command pattern must
+    # be rejected before gptme is invoked.
+    assert "in-chat command" in startup
+
+
 def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
     """A journal directory that cannot be created must fail with an explicit error.
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -876,3 +876,38 @@ def test_startup_script_fails_loudly_without_prompt(tmp_path: Path) -> None:
     assert "exit 66" in startup
     assert "command -v gptme" in startup
     assert "exit 127" in startup
+
+
+def test_startup_script_session_id_is_collision_resistant(tmp_path: Path) -> None:
+    """Session IDs must be unique even when two runs start within the same second.
+
+    Regression: the original template used date +%%Y%%m%%d-%%H%%M%%S alone, so
+    two service restarts within a second would produce identical SESSION_ID
+    values, causing the later run to truncate the earlier journal entry and
+    reuse the same gptme conversation.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    # PID suffix ($$ in bash) is the only stdlib-portable disambiguation that
+    # is also second-collision-proof without external tools.
+    assert "SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$" in startup
+
+
+def test_startup_script_prompt_bypasses_command_routing(tmp_path: Path) -> None:
+    """The prompt must not trigger gptme's subcommand dispatch.
+
+    Regression: passing "$(cat prompt.md)" as the first positional argument lets
+    gptme's dispatch logic (which checks prompts[0] for exact matches against
+    gptme-util subcommands and gptme-* plugins) route a single-word prompt like
+    'context', 'status', or 'tools' to a utility subcommand instead of starting
+    an agent session. A leading newline prevents the exact-match while
+    _group_prompt_args strips it before the LLM receives the message.
+    """
+    _run_init(tmp_path)
+    startup = (tmp_path / "gptme-agent-run.sh").read_text()
+
+    # In the generated bash file, $'\n' is ANSI-C quoting for a newline; the
+    # backslash is a literal \ in the file content, so Python sees it as \n.
+    assert r"prompt_arg=$'\n'" in startup
+    assert '"$prompt_arg"' in startup

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -6,6 +6,7 @@ parse), and the on-demand (no-timer) path.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from typing import TYPE_CHECKING
@@ -1018,6 +1019,42 @@ def test_startup_script_rejects_slash_command_with_unicode_whitespace(
         f"stderr: {proc.stderr}"
     )
     assert "in-chat command" in proc.stderr
+
+
+def test_startup_script_prompt_guard_fails_loud_without_python3(
+    tmp_path: Path,
+) -> None:
+    """Prompt guard must fail loudly if python3 is absent from PATH.
+
+    Regression: the guard used `| python3 -c ... || true`, so a missing python3
+    set _prompt_fw to '' and silently let the slash-command check pass even for
+    a prompt starting with /shell.
+    """
+    _run_init(tmp_path)
+    startup = tmp_path / "gptme-agent-run.sh"
+    (tmp_path / "prompt.md").write_text("/shell echo pwned\n")
+
+    # Run with a PATH that has the system tools (bash, grep, awk, …) but no python3.
+    # We create a fake python3 shim that exits 127 to simulate a missing interpreter.
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    fake_python3 = fake_bin / "python3"
+    fake_python3.write_text("#!/bin/sh\nexit 127\n")
+    fake_python3.chmod(0o755)
+    # Prepend our fake_bin so it shadows any real python3, but keep system PATH
+    # for bash, grep, mkdir, etc.
+    new_path = f"{fake_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}"
+    proc = subprocess.run(
+        ["bash", str(startup)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PATH": new_path},
+    )
+    # Must not exit 0 — failing open would allow /shell to reach the model dispatcher.
+    assert proc.returncode != 0, (
+        "Expected non-zero exit when python3 is absent; guard silently failed open"
+    )
 
 
 def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -892,9 +892,9 @@ def test_startup_script_session_id_is_collision_resistant(tmp_path: Path) -> Non
     _run_init(tmp_path)
     startup = (tmp_path / "gptme-agent-run.sh").read_text()
 
-    # PID suffix ($$ in bash) is the only stdlib-portable disambiguation that
-    # is also second-collision-proof without external tools.
-    assert "SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$" in startup
+    # PID suffix ($$ in bash) + $RANDOM guards against PID reuse within the
+    # same second on rapid restarts.
+    assert "SESSION_ID=$(date +%Y%m%d-%H%M%S)-$$-$RANDOM" in startup
 
 
 def test_startup_script_prompt_bypasses_command_routing(tmp_path: Path) -> None:

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -992,6 +992,34 @@ def test_startup_script_rejects_slash_command_with_leading_whitespace(
     assert "in-chat command" in proc.stderr
 
 
+def test_startup_script_rejects_slash_command_with_unicode_whitespace(
+    tmp_path: Path,
+) -> None:
+    """A prompt.md whose first content line starts with unicode whitespace then /shell
+    must be rejected (exit 66).
+
+    Regression: awk '{print $1}' only splits on ASCII whitespace. A non-breaking
+    space (U+00A0) before /shell keeps it as the first awk token, bypassing the guard.
+    Python's str.split() strips all Unicode whitespace, so \\u00a0/shell → /shell.
+    """
+    _run_init(tmp_path)
+    startup = tmp_path / "gptme-agent-run.sh"
+    # Write non-breaking space (U+00A0) followed by /shell
+    (tmp_path / "prompt.md").write_bytes("\u00a0/shell echo pwned\n".encode())
+
+    proc = subprocess.run(
+        ["bash", str(startup)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 66, (
+        f"Expected exit 66 for unicode-whitespace-prefixed slash command; got {proc.returncode}\n"
+        f"stderr: {proc.stderr}"
+    )
+    assert "in-chat command" in proc.stderr
+
+
 def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
     """A journal directory that cannot be created must fail with an explicit error.
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -636,7 +636,10 @@ def test_launchd_plist_contains_agent_variables(tmp_path: Path) -> None:
     assert "testagent" in plist_text
     assert "GPTME_AGENT_MODEL" in plist_text
     assert "gpt-4o-mini" in plist_text
-    assert "GPTME_NON_INTERACTIVE" in plist_text
+    # GPTME_NON_INTERACTIVE is deliberately absent: gptme never reads it (the
+    # startup script passes --non-interactive as a flag), so shipping it in the
+    # plist advertised a control that does nothing.
+    assert "GPTME_NON_INTERACTIVE" not in plist_text
 
 
 def test_launchd_plist_daily_schedule(tmp_path: Path) -> None:
@@ -941,3 +944,52 @@ def test_startup_script_mkdir_journal_dir_fails_loudly(tmp_path: Path) -> None:
     # The mkdir line must exit on failure with a diagnostic message.
     assert 'mkdir -p "$JOURNAL_DIR"' in startup
     assert "cannot create journal dir" in startup
+
+
+def test_service_unit_restart_backoff_is_actually_applied(tmp_path: Path) -> None:
+    """RestartMaxDelaySec is inert without RestartSteps.
+
+    Regression: the unit set `RestartSec=5` + `RestartMaxDelaySec=60` intending
+    exponential backoff, but systemd ignores RestartMaxDelaySec unless
+    RestartSteps is also set, logging "Service has RestartMaxDelaySec= but no
+    RestartSteps= setting. Ignoring." and retrying at a flat 5s forever.
+    Observed on a real `systemctl --user start` of a generated unit.
+    """
+    _run_init(tmp_path)
+    unit = (tmp_path / "systemd" / "testagent.service").read_text()
+
+    assert "RestartMaxDelaySec=" in unit
+    assert "RestartSteps=" in unit, (
+        "RestartMaxDelaySec is silently ignored by systemd without RestartSteps"
+    )
+
+
+def test_service_unit_gives_up_on_persistent_failure(tmp_path: Path) -> None:
+    """A one-shot session that keeps failing must not retry forever.
+
+    Regression: with `Restart=on-failure` and no start limit, a persistent
+    failure (invalid API key, exhausted quota, unusable prompt) restarted the
+    agent every 5 seconds indefinitely, hammering a paid API. Verified against a
+    real run: an invalid key produced exit 76 and an immediate auto-restart.
+    """
+    _run_init(tmp_path)
+    unit = (tmp_path / "systemd" / "testagent.service").read_text()
+
+    assert "StartLimitIntervalSec=" in unit
+    assert "StartLimitBurst=" in unit
+
+    # The start limit must be declared in [Unit]; systemd ignores it in [Service].
+    unit_section = unit.split("[Service]", 1)[0]
+    assert "StartLimitIntervalSec=" in unit_section
+    assert "StartLimitBurst=" in unit_section
+
+
+def test_generated_units_do_not_set_dead_non_interactive_env(tmp_path: Path) -> None:
+    """GPTME_NON_INTERACTIVE is never read by gptme; shipping it is misleading."""
+    _run_init(tmp_path)
+    unit = (tmp_path / "systemd" / "testagent.service").read_text()
+    assert "GPTME_NON_INTERACTIVE" not in unit
+
+    _run_init(tmp_path, "--platform", "macos")
+    plist = (tmp_path / "systemd" / "com.gptme.testagent.plist").read_text()
+    assert "GPTME_NON_INTERACTIVE" not in plist


### PR DESCRIPTION
## Problem

`gptme service init` (#3574) generates a startup script that **never invokes gptme**. It writes a session-log header and exits:

```bash
{
  echo "# Session $SESSION_ID"
  ...
} > "$SESSION_LOG"

echo "gptme agent myagent: wrote session log $SESSION_LOG"
```

So `systemctl --user start <name>.service` produces a four-line markdown file and no agent run. The feature's own acceptance criterion — "systemctl start foo.service runs the first session" — does not hold out of the box, which is the thing Discussion #1294 was asking for.

Two related defects found while verifying:

1. The generated unit sets `GPTME_NON_INTERACTIVE=1`, but **gptme never reads that variable** (it appears only in this file's own templates). The real control is the `-n/--non-interactive` flag. A user adding a `gptme` call naively would get an interactive prompt under systemd.
2. The script always exited 0, so systemd's `Restart=on-failure` could never see a broken agent.

## Changes

- Startup script runs one real session:
  `gptme --non-interactive --no-confirm --workspace <dir> --name <agent>-<session> [--model $GPTME_AGENT_MODEL]`, output appended to the durable session log.
- `--non-interactive` passed as an explicit flag, not left to the env var.
- Generate `prompt.md` so the first run has something to execute; `$EDITOR prompt.md` is now the first "next step" printed.
- Fail loudly with distinct exit codes — gptme missing (127), prompt file absent (66) — and propagate gptme's exit code.
- README: the scaffold is described as running a real session, not a placeholder.

## Verification

- 39 tests pass in `tests/test_cmd_service.py` (34 existing + 5 new).
- The 5 new tests **fail against the previous template** (confirmed by reverting `cmd_service.py` and re-running) — they catch the defect rather than describing the fix.
- End-to-end: generated into a temp dir and executed with a `gptme` shim. Args arrive as `--non-interactive --no-confirm --workspace /tmp/svc-out2 --name myagent-<id> --model gpt-4o-mini` plus the prompt.
- Failure paths exercised: no gptme on PATH → 127; missing prompt → 66; gptme exit 3 → script exits 3.
- `bash -n` and `shellcheck` clean on the generated script; `ruff check`/`ruff format` clean.

## Note

`ExecStart=:"..."` in the systemd template looked suspicious but is valid — `systemd-analyze verify` passes. Left alone.