### PR TITLE
test(subagent): de-flake test_subagent_wait_polls_cache_after_join_timeout

### DIFF
--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2927,34 +2927,25 @@ class TestMaxTimeWatchdog:
             stop.set()
             t.join(timeout=1)
 
-    def test_subagent_wait_polls_cache_after_join_timeout(self, tmp_path):
+    def test_subagent_wait_polls_cache_after_join_timeout(self, tmp_path, monkeypatch):
         """subagent_wait() handles join returning just before watchdog writes."""
         from gptme.tools.subagent.api import subagent_wait
-        from gptme.tools.subagent.types import (
-            _subagent_results,
-            _subagent_results_lock,
-            _subagents,
-            _subagents_lock,
-        )
+        from gptme.tools.subagent.types import _subagents, _subagents_lock
 
-        writer_threads: list[threading.Thread] = []
-
-        def write_timeout_after_join():
-            import time
-
-            time.sleep(0.01)
-            with _subagent_results_lock:
-                _subagent_results["wait-race-thread"] = ReturnType(
-                    "timeout", "Auto-cancelled after 0.5s (max_time exceeded)"
-                )
-
-        def join_returns_before_watchdog_write(timeout=None):
-            writer = threading.Thread(target=write_timeout_after_join)
-            writer.start()
-            writer_threads.append(writer)
+        # The first cache read misses (the watchdog has not written yet); the
+        # second one hits. Driving the miss from the read side keeps this
+        # deterministic: an earlier version raced a writer thread sleeping 10ms
+        # against the 50ms poll window in _wait_for_cached_subagent_result(),
+        # and thread wakeup under CI load overshoots that window often enough
+        # to flake (measured median 38ms, p95 172ms under GIL contention).
+        cache = MagicMock()
+        cache.get.side_effect = [
+            None,
+            ReturnType("timeout", "Auto-cancelled after 0.5s (max_time exceeded)"),
+        ]
+        monkeypatch.setattr(subagent_api, "_subagent_results", cache)
 
         mock_thread = MagicMock(spec=threading.Thread)
-        mock_thread.join.side_effect = join_returns_before_watchdog_write
         mock_thread.is_alive.return_value = True
 
         sa = Subagent(
@@ -2968,12 +2959,10 @@ class TestMaxTimeWatchdog:
         with _subagents_lock:
             _subagents.append(sa)
 
-        try:
-            result = subagent_wait("wait-race-thread", timeout=0)
-        finally:
-            for writer in writer_threads:
-                writer.join(timeout=1)
+        result = subagent_wait("wait-race-thread", timeout=0)
 
+        # Two reads prove the result came from the retry loop, not the first read.
+        assert cache.get.call_count == 2
         assert result["status"] == "timeout"
         assert "max_time exceeded" in (result["result"] or "")
 


### PR DESCRIPTION
## Problem

`tests/test_subagent_unit.py::TestMaxTimeWatchdog::test_subagent_wait_polls_cache_after_join_timeout`
fails intermittently in the `Test without API keys or extras` job, blocking unrelated PRs:

```
FAILED tests/test_subagent_unit.py::TestMaxTimeWatchdog::test_subagent_wait_polls_cache_after_join_timeout
  - AssertionError: assert 'running' == 'timeout'
```

Most recent hit: gptme/gptme#3606, a webui/bearer-handshake PR that touches only
`gptme/server/cli.py` and `webui/**` — nothing on the subagent path.

## Root cause

The test raced a writer thread against a production constant:

- the mocked `join()` spawns a writer that does `time.sleep(0.01)` then writes the
  timeout result into `_subagent_results`
- `subagent_wait()` → `_wait_for_cached_subagent_result()` polls that cache for
  **50ms** (`timeout=0.05`)

A 5x margin is not enough on a loaded CI runner. Measured on a contended box
(6 CPU-burning threads, i.e. what 16-way xdist + coverage tracing looks like):

```
writer 10ms-sleep actual latency: median=38.1ms p95=171.9ms max=460.6ms
exceeded the 50ms production poll window: 81/200 runs
```

When the window expires the poll returns `None`, `subagent_wait()` falls back to
`sa.status()`, and the mock's `is_alive=True` yields `"running"` — the observed failure.

## Fix

Drive the cache miss from the **read** side rather than racing a sleeping thread:
the first read returns `None` (watchdog hasn't written yet), the second returns
the timeout result. No wall clock involved.

Coverage is unchanged and the assertion is actually stronger — `call_count == 2`
now proves the result came from the retry loop rather than the first read, which
the old version couldn't distinguish.

Also removes one spawned thread from the suite.

## Verification

A/B against the real `subagent_wait()` code path under GIL contention, 40 runs each:

```
OLD (writer-thread race)      timeout=39/40  WRONG='running'= 1/40
NEW (deterministic)           timeout=40/40  WRONG='running'= 0/40
```

- `pytest tests/test_subagent_unit.py` — 276 passed
- `ruff check` / `ruff format` clean

Note the A/B load is milder than CI's coverage-instrumented parallel run, so the
1/40 understates the real-world rate.