### PR TITLE
fix(server): treat missing X display as screenshot-unavailable

### DIFF
--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -43,14 +43,25 @@ _DISPLAY_UNAVAILABLE_MARKERS = (
     "can't open x display",
     "cannot open display",
     "unable to open display",
+    "failed to open display",
+    "could not open display",
     "no display",
 )
 
 
 def _is_display_unavailable_error(exc: BaseException) -> bool:
     """Return True when a screenshot failure is 'no usable display', not a 500."""
-    msg = str(exc).lower()
-    return any(marker in msg for marker in _DISPLAY_UNAVAILABLE_MARKERS)
+    import subprocess
+
+    texts = [str(exc).lower()]
+    if isinstance(exc, subprocess.CalledProcessError) and exc.stderr:
+        stderr = exc.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        texts.append(stderr.lower())
+    return any(
+        marker in text for text in texts for marker in _DISPLAY_UNAVAILABLE_MARKERS
+    )
 
 
 def _native_screenshot_available() -> bool:
@@ -65,8 +76,9 @@ def _native_screenshot_available() -> bool:
     if system == "Linux":
         is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
         has_display = bool(os.environ.get("DISPLAY"))
+        has_wayland_display = bool(os.environ.get("WAYLAND_DISPLAY"))
         has_gnome = bool(shutil.which("gnome-screenshot")) and (
-            is_wayland or has_display
+            (is_wayland and has_wayland_display) or has_display
         )
         has_scrot = bool(shutil.which("scrot")) and not is_wayland and has_display
         return has_gnome or has_scrot

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -39,22 +39,57 @@ logger = logging.getLogger(__name__)
 computer_api = flask.Blueprint("computer_api", __name__)
 
 
+_DISPLAY_UNAVAILABLE_MARKERS = (
+    "can't open x display",
+    "cannot open display",
+    "unable to open display",
+    "no display",
+)
+
+
+def _is_display_unavailable_error(exc: BaseException) -> bool:
+    """Return True when a screenshot failure is 'no usable display', not a 500."""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _DISPLAY_UNAVAILABLE_MARKERS)
+
+
 def _native_screenshot_available() -> bool:
     """Return True when the native screenshot backend is available.
 
     Mirrors the logic in ``gptme.tools.screenshot._is_available`` to ensure
     the API endpoint's availability check matches the actual screenshot tool
-    backends.
+    backends. scrot is X11-only and needs ``$DISPLAY``; a binary on PATH is
+    not enough on a headless host.
     """
     system = platform.system()
     if system == "Linux":
         has_gnome = bool(shutil.which("gnome-screenshot"))
         is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
-        has_scrot = bool(shutil.which("scrot")) and not is_wayland
+        has_scrot = (
+            bool(shutil.which("scrot"))
+            and not is_wayland
+            and bool(os.environ.get("DISPLAY"))
+        )
         return has_gnome or has_scrot
     if system == "Darwin":
         return bool(shutil.which("screencapture"))
     return False
+
+
+def _linux_unavailable_hint() -> str:
+    """Actionable 503 body when Linux cannot actually take a screenshot."""
+    has_scrot = bool(shutil.which("scrot"))
+    is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
+    if has_scrot and not is_wayland and not os.environ.get("DISPLAY"):
+        return (
+            "scrot is installed but $DISPLAY is unset, so screenshots cannot "
+            "be taken. Set DISPLAY to a running X11 server (or start Xvfb), "
+            "or install gnome-screenshot for a Wayland session."
+        )
+    return (
+        "No supported Linux screenshot backend available. "
+        "Install gnome-screenshot, or install scrot and run under X11/Xvfb."
+    )
 
 
 def _screenshot_available() -> bool:
@@ -109,10 +144,7 @@ def screenshot():
         if not _screenshot_available():
             system = platform.system()
             if system == "Linux":
-                hint = (
-                    "No supported Linux screenshot backend available. "
-                    "Install gnome-screenshot, or install scrot and run under X11/Xvfb."
-                )
+                hint = _linux_unavailable_hint()
             elif system == "Darwin":
                 hint = "screencapture not found (unexpected on macOS)"
             else:
@@ -181,9 +213,11 @@ def screenshot():
         )
     except Exception as exc:
         logger.exception("Screenshot failed")
+        # A missing/dead X display is unavailability (503), not an internal error.
+        status = 503 if _is_display_unavailable_error(exc) else 500
         return flask.Response(
             response=flask.json.dumps({"error": str(exc)}),
-            status=500,
+            status=status,
             content_type="application/json",
         )
 

--- a/gptme/server/computer_api.py
+++ b/gptme/server/computer_api.py
@@ -63,13 +63,12 @@ def _native_screenshot_available() -> bool:
     """
     system = platform.system()
     if system == "Linux":
-        has_gnome = bool(shutil.which("gnome-screenshot"))
         is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
-        has_scrot = (
-            bool(shutil.which("scrot"))
-            and not is_wayland
-            and bool(os.environ.get("DISPLAY"))
+        has_display = bool(os.environ.get("DISPLAY"))
+        has_gnome = bool(shutil.which("gnome-screenshot")) and (
+            is_wayland or has_display
         )
+        has_scrot = bool(shutil.which("scrot")) and not is_wayland and has_display
         return has_gnome or has_scrot
     if system == "Darwin":
         return bool(shutil.which("screencapture"))
@@ -79,13 +78,17 @@ def _native_screenshot_available() -> bool:
 def _linux_unavailable_hint() -> str:
     """Actionable 503 body when Linux cannot actually take a screenshot."""
     has_scrot = bool(shutil.which("scrot"))
+    has_gnome = bool(shutil.which("gnome-screenshot"))
     is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
-    if has_scrot and not is_wayland and not os.environ.get("DISPLAY"):
-        return (
-            "scrot is installed but $DISPLAY is unset, so screenshots cannot "
-            "be taken. Set DISPLAY to a running X11 server (or start Xvfb), "
-            "or install gnome-screenshot for a Wayland session."
-        )
+    has_display = bool(os.environ.get("DISPLAY"))
+    if not is_wayland and not has_display:
+        if has_gnome or has_scrot:
+            installed = "gnome-screenshot" if has_gnome else "scrot"
+            return (
+                f"{installed} is installed but $DISPLAY is unset, so screenshots "
+                "cannot be taken. Set DISPLAY to a running X11 server (or start "
+                "Xvfb), or use a Wayland session with gnome-screenshot."
+            )
     return (
         "No supported Linux screenshot backend available. "
         "Install gnome-screenshot, or install scrot and run under X11/Xvfb."

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -40,14 +40,17 @@ Do **not** use screenshot for:
 def _is_available() -> bool:
     """Check if any screenshot tool is available on the system.
 
-    scrot talks to X11 and needs ``$DISPLAY``. A binary on PATH is not enough
-    on a headless host — claiming availability there makes the computer API
-    report ``screenshot_available: true`` and then 500 on the first capture.
+    Both scrot and gnome-screenshot talk to X11 and need ``$DISPLAY`` on
+    non-Wayland hosts. A binary on PATH is not enough on a headless host —
+    claiming availability there makes the computer API report
+    ``screenshot_available: true`` and then 500 on the first capture.
     """
     if IS_MACOS:
         return shutil.which("screencapture") is not None
     if os.name == "posix":
-        if shutil.which("gnome-screenshot"):
+        if shutil.which("gnome-screenshot") and (
+            IS_WAYLAND or os.environ.get("DISPLAY")
+        ):
             return True
         if not IS_WAYLAND and shutil.which("scrot"):
             return bool(os.environ.get("DISPLAY"))

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -49,7 +49,8 @@ def _is_available() -> bool:
         return shutil.which("screencapture") is not None
     if os.name == "posix":
         if shutil.which("gnome-screenshot") and (
-            IS_WAYLAND or os.environ.get("DISPLAY")
+            (IS_WAYLAND and os.environ.get("WAYLAND_DISPLAY"))
+            or os.environ.get("DISPLAY")
         ):
             return True
         if not IS_WAYLAND and shutil.which("scrot"):

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -38,14 +38,20 @@ Do **not** use screenshot for:
 
 
 def _is_available() -> bool:
-    """Check if any screenshot tool is available on the system."""
+    """Check if any screenshot tool is available on the system.
+
+    scrot talks to X11 and needs ``$DISPLAY``. A binary on PATH is not enough
+    on a headless host — claiming availability there makes the computer API
+    report ``screenshot_available: true`` and then 500 on the first capture.
+    """
     if IS_MACOS:
         return shutil.which("screencapture") is not None
     if os.name == "posix":
-        return bool(
-            shutil.which("gnome-screenshot")
-            or (not IS_WAYLAND and shutil.which("scrot"))
-        )
+        if shutil.which("gnome-screenshot"):
+            return True
+        if not IS_WAYLAND and shutil.which("scrot"):
+            return bool(os.environ.get("DISPLAY"))
+        return False
     return False
 
 

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -418,10 +418,12 @@ class TestScreenshotAvailable:
     def test_linux_wayland_gnome_screenshot_without_display_returns_true(
         self, monkeypatch
     ):
+        """gnome-screenshot on a live Wayland session (WAYLAND_DISPLAY set) is available."""
         if platform.system() != "Linux":
             pytest.skip("Linux-only test")
         monkeypatch.delenv("DISPLAY", raising=False)
         monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
 
         with patch(
             "shutil.which",
@@ -429,9 +431,27 @@ class TestScreenshotAvailable:
                 "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
             ),
         ):
-            from gptme.server.computer_api import _screenshot_available
+            from gptme.server.computer_api import _native_screenshot_available
 
-            assert _screenshot_available() is True
+            assert _native_screenshot_available() is True
+
+    def test_linux_headless_wayland_gnome_screenshot_returns_false(self, monkeypatch):
+        """gnome-screenshot on headless Wayland (no WAYLAND_DISPLAY) reports unavailable."""
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: (
+                "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+            ),
+        ):
+            from gptme.server.computer_api import _native_screenshot_available
+
+            assert _native_screenshot_available() is False
 
     def test_linux_x11_gnome_screenshot_without_display_returns_false(
         self, monkeypatch

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -325,6 +325,25 @@ class TestComputerScreenshot500:
         data = resp.get_json()
         assert data["error"] == "cliclick not found"
 
+    def test_missing_x_display_is_503_not_500(self, client):
+        """scrot 'Can't open X display' is unavailability, not an internal error."""
+        with (
+            patch("gptme.server.computer_api._screenshot_available", return_value=True),
+            patch(
+                "gptme.server.computer_api._take_screenshot",
+                side_effect=RuntimeError(
+                    "Screenshot command failed (exit code 1): "
+                    "scrot: Can't open X display. It *is* running, yeah? [NULL]"
+                ),
+            ),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+
+        assert resp.status_code == 503
+        assert resp.content_type == "application/json"
+        data = resp.get_json()
+        assert "Can't open X display" in data["error"]
+
 
 # ---------------------------------------------------------------------------
 # _screenshot_available helper
@@ -342,6 +361,59 @@ class TestScreenshotAvailable:
             from gptme.server.computer_api import _screenshot_available
 
             assert _screenshot_available() is False
+
+    def test_linux_scrot_without_display_returns_false(self, monkeypatch):
+        """scrot on PATH is not enough on a headless host (no $DISPLAY)."""
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: "/usr/bin/scrot" if cmd == "scrot" else None,
+        ):
+            from gptme.server.computer_api import _screenshot_available
+
+            assert _screenshot_available() is False
+
+    def test_status_scrot_without_display_reports_unavailable(
+        self, client, monkeypatch
+    ):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: "/usr/bin/scrot" if cmd == "scrot" else None,
+        ):
+            resp = client.get("/api/v2/computer/status")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["display"] is None
+        assert data["screenshot_available"] is False
+        assert data["backends"]["scrot"] is True
+
+    def test_screenshot_scrot_without_display_returns_503(self, client, monkeypatch):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: "/usr/bin/scrot" if cmd == "scrot" else None,
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+
+        assert resp.status_code == 503
+        data = resp.get_json()
+        error = data["error"].lower()
+        assert "display" in error
+        assert "scrot" in error
 
     def test_linux_wayland_gnome_screenshot_without_display_returns_true(
         self, monkeypatch

--- a/tests/test_computer_api.py
+++ b/tests/test_computer_api.py
@@ -433,6 +433,47 @@ class TestScreenshotAvailable:
 
             assert _screenshot_available() is True
 
+    def test_linux_x11_gnome_screenshot_without_display_returns_false(
+        self, monkeypatch
+    ):
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: (
+                "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+            ),
+        ):
+            from gptme.server.computer_api import _native_screenshot_available
+
+            assert _native_screenshot_available() is False
+
+    def test_linux_x11_gnome_screenshot_without_display_hint_mentions_gnome(
+        self, client, monkeypatch
+    ):
+        """Hint body should call out gnome-screenshot, not say 'install gnome-screenshot'."""
+        if platform.system() != "Linux":
+            pytest.skip("Linux-only test")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda cmd: (
+                "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+            ),
+        ):
+            resp = client.get("/api/v2/computer/screenshot")
+
+        assert resp.status_code == 503
+        data = resp.get_json()
+        error = data["error"].lower()
+        assert "display" in error
+        assert "gnome-screenshot" in error
+
     def test_linux_with_display_and_scrot_returns_true(self, monkeypatch):
         if platform.system() != "Linux":
             pytest.skip("Linux-only test")

--- a/tests/test_tools_screenshot.py
+++ b/tests/test_tools_screenshot.py
@@ -132,12 +132,25 @@ class TestIsAvailable:
     @patch("gptme.tools.screenshot.IS_WAYLAND", False)
     @patch("os.name", "posix")
     @patch("shutil.which")
-    def test_linux_with_scrot_x11(self, mock_which):
-        """Available on Linux/X11 with scrot."""
+    def test_linux_with_scrot_x11(self, mock_which, monkeypatch):
+        """Available on Linux/X11 with scrot when $DISPLAY is set."""
+        monkeypatch.setenv("DISPLAY", ":1")
         mock_which.side_effect = lambda cmd: (
             "/usr/bin/scrot" if cmd == "scrot" else None
         )
         assert _is_available() is True
+
+    @patch("gptme.tools.screenshot.IS_MACOS", False)
+    @patch("gptme.tools.screenshot.IS_WAYLAND", False)
+    @patch("os.name", "posix")
+    @patch("shutil.which")
+    def test_linux_scrot_without_display(self, mock_which, monkeypatch):
+        """scrot without $DISPLAY is not available (headless host)."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        mock_which.side_effect = lambda cmd: (
+            "/usr/bin/scrot" if cmd == "scrot" else None
+        )
+        assert _is_available() is False
 
     @patch("gptme.tools.screenshot.IS_MACOS", False)
     @patch("gptme.tools.screenshot.IS_WAYLAND", True)

--- a/tests/test_tools_screenshot.py
+++ b/tests/test_tools_screenshot.py
@@ -121,8 +121,33 @@ class TestIsAvailable:
     @patch("gptme.tools.screenshot.IS_WAYLAND", False)
     @patch("os.name", "posix")
     @patch("shutil.which")
-    def test_linux_with_gnome_screenshot(self, mock_which):
-        """Available on Linux with gnome-screenshot."""
+    def test_linux_with_gnome_screenshot(self, mock_which, monkeypatch):
+        """Available on Linux/X11 with gnome-screenshot when $DISPLAY is set."""
+        monkeypatch.setenv("DISPLAY", ":1")
+        mock_which.side_effect = lambda cmd: (
+            "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+        )
+        assert _is_available() is True
+
+    @patch("gptme.tools.screenshot.IS_MACOS", False)
+    @patch("gptme.tools.screenshot.IS_WAYLAND", False)
+    @patch("os.name", "posix")
+    @patch("shutil.which")
+    def test_linux_gnome_screenshot_without_display(self, mock_which, monkeypatch):
+        """gnome-screenshot without $DISPLAY is not available on X11 (headless host)."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        mock_which.side_effect = lambda cmd: (
+            "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+        )
+        assert _is_available() is False
+
+    @patch("gptme.tools.screenshot.IS_MACOS", False)
+    @patch("gptme.tools.screenshot.IS_WAYLAND", True)
+    @patch("os.name", "posix")
+    @patch("shutil.which")
+    def test_linux_wayland_gnome_screenshot_no_display(self, mock_which, monkeypatch):
+        """gnome-screenshot is available on Wayland even without $DISPLAY."""
+        monkeypatch.delenv("DISPLAY", raising=False)
         mock_which.side_effect = lambda cmd: (
             "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
         )

--- a/tests/test_tools_screenshot.py
+++ b/tests/test_tools_screenshot.py
@@ -146,12 +146,28 @@ class TestIsAvailable:
     @patch("os.name", "posix")
     @patch("shutil.which")
     def test_linux_wayland_gnome_screenshot_no_display(self, mock_which, monkeypatch):
-        """gnome-screenshot is available on Wayland even without $DISPLAY."""
+        """gnome-screenshot is available on Wayland when WAYLAND_DISPLAY is set."""
         monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
         mock_which.side_effect = lambda cmd: (
             "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
         )
         assert _is_available() is True
+
+    @patch("gptme.tools.screenshot.IS_MACOS", False)
+    @patch("gptme.tools.screenshot.IS_WAYLAND", True)
+    @patch("os.name", "posix")
+    @patch("shutil.which")
+    def test_linux_headless_wayland_gnome_screenshot_unavailable(
+        self, mock_which, monkeypatch
+    ):
+        """gnome-screenshot is not available on headless Wayland (no WAYLAND_DISPLAY)."""
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        mock_which.side_effect = lambda cmd: (
+            "/usr/bin/gnome-screenshot" if cmd == "gnome-screenshot" else None
+        )
+        assert _is_available() is False
 
     @patch("gptme.tools.screenshot.IS_MACOS", False)
     @patch("gptme.tools.screenshot.IS_WAYLAND", False)


### PR DESCRIPTION
## Summary

Dogfood of `GET /api/v2/computer/status` + `GET /api/v2/computer/screenshot` on a headless Linux host (scrot on PATH, `$DISPLAY` unset).

**Before**
- `/api/v2/computer/status` → 200 `{screenshot_available: true, display: null, backends.scrot: true}`
- `/api/v2/computer/screenshot` → **500** `scrot: Can't open X display. It *is* running, yeah? [NULL]`

The availability check treated "scrot is installed" as "a screenshot will succeed". The API contract already says 503 when no screenshot backend is usable; a missing X display is unavailability, not an internal error.

**After**
- Status reports `screenshot_available: false` (scrot still listed under `backends`)
- Screenshot returns **503** with an actionable hint: set `$DISPLAY` / Xvfb, or use gnome-screenshot on Wayland
- If a capture still fails with a display error (stale `$DISPLAY`), that is also 503 rather than 500

Related: #216 / #3140 (screenshot polling API). Does not close those.

## How to reproduce (before)

```bash
# headless host with scrot installed and DISPLAY unset
unset DISPLAY WAYLAND_DISPLAY
GPTME_SERVER_TOKEN=dogfood gptme-server serve --host 127.0.0.1 --port 5798 --tools none
curl -s -H "Authorization: Bearer dogfood" http://127.0.0.1:5798/api/v2/computer/status
# screenshot_available: true, display: null
curl -s -w "\nHTTP %{http_code}\n" -H "Authorization: Bearer dogfood" \
  http://127.0.0.1:5798/api/v2/computer/screenshot
# HTTP 500
```

With this PR: `screenshot_available: false`, screenshot is HTTP 503.

## Test plan

- [x] `pytest tests/test_computer_api.py tests/test_tools_screenshot.py` (55 passed)
- [x] Live re-probe on headless host: status false + screenshot 503
- [ ] CI