### PR TITLE
refactor(service-init): consolidate and document gptme-agent-template reference

### DIFF
--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -37,15 +37,8 @@ from pathlib import Path
 from xml.sax.saxutils import escape as _xml_escape
 
 # XML 1.0 permits only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
-# Strip control characters and lone UTF-16 surrogates — both survive saxutils.escape unchanged
-# and cause launchctl to reject the generated plist.
+# Reject control characters and lone UTF-16 surrogates before generating launchd plists.
 _XML10_FORBIDDEN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]")
-
-
-def _xml_safe(value: str) -> str:
-    """Strip XML 1.0-forbidden control characters, then XML-escape special chars."""
-    return _xml_escape(_XML10_FORBIDDEN.sub("", value))
-
 
 import click
 
@@ -219,8 +212,13 @@ This file is auto-loaded by gptme and other agent runtimes.
 
 ## Role
 
-{name} is a persistent headless gptme agent. It runs on a systemd timer and
-executes its work loop non-interactively.
+{name} is a persistent headless gptme agent. It runs non-interactively from a
+Linux systemd user unit or a macOS launchd agent.
+
+`gptme service init` intentionally creates a minimal scaffold. For the full
+batteries-included workspace (richer task loop, production run scripts,
+monitoring, and service examples), use gptme-agent-template:
+https://github.com/gptme/gptme-agent-template
 
 ## Core Rules
 
@@ -300,7 +298,7 @@ def _generate_launchd_plist(
     run_at_load = "false" if timer_schedule == "on-demand" else "true"
 
     return LAUNCHD_PLIST_TEMPLATE.format(
-        name=_xml_safe(name),
+        name=_xml_escape(name),
         model=_xml_escape(model),
         work_dir=_xml_escape(work_dir),
         schedule_section=schedule_section,
@@ -323,7 +321,11 @@ def cli() -> None:
 
 @cli.command(
     name="init",
-    help="Scaffold a persistent service for a headless gptme agent.",
+    help=(
+        "Scaffold a minimal persistent service for a headless gptme agent "
+        "(systemd on Linux, launchd on macOS). For the full workspace template, "
+        "see gptme/gptme-agent-template."
+    ),
 )
 @click.option(
     "--name",
@@ -411,7 +413,8 @@ def init(
         gptme service init --name myagent --platform macos --work-dir ~/gptme-agent
         launchctl load ~/Library/LaunchAgents/com.gptme.myagent.plist
 
-    For the full agent workspace template, see:
+    This command intentionally creates a minimal scaffold. For the full
+    batteries-included agent workspace template, see:
     https://github.com/gptme/gptme-agent-template
     """
     if not _NAME_RE.match(name):
@@ -636,7 +639,7 @@ def init(
         click.echo(f"  journalctl --user -u {name}.service -f  # follow logs")
 
     click.echo()
-    click.echo("For the full agent workspace template with examples, see:")
+    click.echo("For the full batteries-included agent workspace template, see:")
     click.echo("  https://github.com/gptme/gptme-agent-template")
 
 

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -51,6 +51,19 @@ def test_generates_service_and_timer(tmp_path: Path) -> None:
     assert (work / "gptme-agent-run.sh").exists()
 
 
+def test_agents_md_references_template_and_multiple_service_managers(
+    tmp_path: Path,
+) -> None:
+    """Generated agent instructions should not imply systemd is the only runtime."""
+    _run_init(tmp_path)
+    agents_md = (tmp_path / "AGENTS.md").read_text()
+
+    assert "Linux systemd user unit or a macOS launchd agent" in agents_md
+    assert "gptme-agent-template" in agents_md
+    assert "batteries-included workspace" in agents_md
+    assert "It runs on a systemd timer" not in agents_md
+
+
 def test_startup_script_is_executable_and_valid_bash(tmp_path: Path) -> None:
     _run_init(tmp_path)
     startup = tmp_path / "gptme-agent-run.sh"
@@ -536,6 +549,18 @@ def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
     )
 
 
+def test_help_references_launchd_and_full_template() -> None:
+    """CLI help should name the minimal/full-template boundary."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "systemd on" in result.output
+    assert "Linux, launchd on macOS" in result.output
+    assert "gptme/gptme-" in result.output
+    assert "agent-template" in result.output
+
+
 def test_launchd_plist_generated_on_macos_platform(tmp_path: Path) -> None:
     """When --platform=macos, a launchd plist should be generated instead of systemd files."""
     out_dir = tmp_path / "launchd"
@@ -570,6 +595,10 @@ def test_launchd_plist_generated_on_macos_platform(tmp_path: Path) -> None:
     assert (work / "gptme.toml").exists()
     assert (work / "AGENTS.md").exists()
     assert (work / "gptme-agent-run.sh").exists()
+
+    agents_md = (work / "AGENTS.md").read_text()
+    assert "macOS launchd agent" in agents_md
+    assert "gptme-agent-template" in agents_md
 
 
 def test_launchd_plist_is_valid_xml(tmp_path: Path) -> None:


### PR DESCRIPTION
Completes follow-up to gptme#3574. Consolidates XML escaping (removes _xml_safe helper), updates CLI help and generated scaffold to reference gptme-agent-template as batteries-included version, adds verification tests. All work items (1.1-1.5) complete. Unblocks 13 parallel sessions.