### PR TITLE
fix(prompts): keep volatile context after cache boundary

### DIFF
--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -184,20 +184,28 @@ class LogManager:
 
             self._acquire_lock()
 
+        # Snapshot attached files before the first provider render. Startup
+        # prompt files must stay byte-identical even if their live source changes.
+        initial_messages = self.snapshot_message_files(log or [])
+
         # load branches from adjacent files
-        self._branches = {self.current_branch: Log(log or [])}
+        self._branches = {self.current_branch: Log(initial_messages)}
         if (self.logdir / "conversation.jsonl").exists():
             _branch = "main"
             if _branch not in self._branches:
-                self._branches[_branch] = Log.read_jsonl(
-                    self.logdir / "conversation.jsonl"
+                branch_log = Log.read_jsonl(self.logdir / "conversation.jsonl")
+                self._branches[_branch] = Log(
+                    self.snapshot_message_files(branch_log.messages)
                 )
         for file in self.logdir.glob("branches/*.jsonl"):
             if file.name == self.logdir.name:
                 continue
             _branch = file.stem
             if _branch not in self._branches:
-                self._branches[_branch] = Log.read_jsonl(file)
+                branch_log = Log.read_jsonl(file)
+                self._branches[_branch] = Log(
+                    self.snapshot_message_files(branch_log.messages)
+                )
 
         # Load view branches (compacted views stored in views/ directory)
         self._views: dict[str, Log] = {}
@@ -205,7 +213,10 @@ class LogManager:
         if views_dir.exists():
             for file in views_dir.glob("*.jsonl"):
                 view_name = file.stem
-                self._views[view_name] = Log.read_jsonl(file)
+                view_log = Log.read_jsonl(file)
+                self._views[view_name] = Log(
+                    self.snapshot_message_files(view_log.messages)
+                )
                 logger.debug(f"Loaded view branch: {view_name}")
 
         # If a view was requested, load it as the active log
@@ -431,27 +442,44 @@ class LogManager:
         if not msg.quiet:
             print_msg(msg, oneline=False)
 
-    def _store_message_files(self, msg: Message) -> Message:
+    def _store_message_files(
+        self, msg: Message, *, preserve_existing: bool = False
+    ) -> Message:
         """Store attached files by content hash and return updated message."""
         if not msg.files:
             return msg
 
-        from ..util.file_storage import store_file
+        from ..util.file_storage import get_stored_path, store_file
 
         file_hashes = dict(msg.file_hashes)  # Start with existing hashes
         for filepath in msg.files:
             # Skip URIs - they can't be stored locally
             if isinstance(filepath, URI):
                 continue
-            if not filepath.exists():
+            try:
+                existing_hash = file_hashes.get(str(filepath))
+                if (
+                    preserve_existing
+                    and existing_hash
+                    and get_stored_path(self.logdir, existing_hash, filepath.suffix)
+                ):
+                    continue
+                if not filepath.is_file():
+                    continue
+                # Store by hash and record the mapping
+                file_hash, _stored_name = store_file(self.logdir, filepath)
+            except OSError as exc:
+                logger.warning("Could not snapshot attached file %s: %s", filepath, exc)
                 continue
-            # Store by hash and record the mapping
-            file_hash, stored_name = store_file(self.logdir, filepath)
             # Use full path as key to avoid collisions with same-named files
             file_hashes[str(filepath)] = file_hash
 
         # Return message with updated hashes (Message is frozen, so replace)
         return replace(msg, file_hashes=file_hashes)
+
+    def snapshot_message_files(self, msgs: list[Message]) -> list[Message]:
+        """Snapshot message attachments while preserving valid existing hashes."""
+        return [self._store_message_files(msg, preserve_existing=True) for msg in msgs]
 
     def write(self, branches=True, sync=False) -> None:
         """
@@ -827,11 +855,14 @@ def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:
     providers reject.  Merge the adjacent messages while preserving attachments
     and message flags via Message.concat().
 
-    Exception: system messages with a call_id are structured tool results.
-    Merging them would discard all but the first call_id, causing providers
-    that use the Responses API (Codex/OpenAI) to return 400 "No tool output
-    found for function call <id>" on the next multi-tool-call turn.
+    Exceptions: system messages with a call_id are structured tool results,
+    and the explicit prompt-cache boundary must remain a standalone message.
+    Merging tool results would discard all but the first call_id, causing
+    providers that use the Responses API (Codex/OpenAI) to return 400 "No tool
+    output found for function call <id>" on the next multi-tool-call turn.
     """
+    from ..prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
+
     merged: list[Message] = []
     for msg in msgs:
         if (
@@ -839,6 +870,8 @@ def _merge_consecutive_messages(msgs: list[Message]) -> list[Message]:
             and merged[-1].role == msg.role
             and not msg.call_id
             and not merged[-1].call_id
+            and msg.content != SYSTEM_PROMPT_CACHE_BOUNDARY
+            and merged[-1].content != SYSTEM_PROMPT_CACHE_BOUNDARY
         ):
             merged[-1] = merged[-1].concat(msg)
         else:

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -300,7 +300,6 @@ def _build_prompt_sections(
             prompt_workspace_runtime(
                 agent_path,
                 title="Agent Config",
-                include_path=True,
             )
         )
         if agent_runtime_msgs:

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -114,7 +114,6 @@ def _build_core_prompt_sections(
     agent_name: str | None,
     tool_format: ToolFormat,
     tools: list[ToolSpec],
-    workspace: Path | None,
     include_tools: bool,
     include_examples: bool,
     is_selective: bool,
@@ -161,11 +160,6 @@ def _build_core_prompt_sections(
         if interactive:
             add("prompt_user", list(prompt_user(tool_format=tool_format)))
         add("prompt_project", list(prompt_project(tool_format=tool_format)))
-        add(
-            "prompt_systeminfo",
-            list(prompt_systeminfo(workspace, tool_format=tool_format)),
-        )
-        add("prompt_timeinfo", list(prompt_timeinfo(tool_format=tool_format)))
         if include_tools:
             add(
                 "prompt_skills_summary",
@@ -268,11 +262,22 @@ def _build_prompt_sections(
         agent_name=agent_name,
         tool_format=tool_format,
         tools=tools,
-        workspace=workspace,
         include_tools=include_tools,
         include_examples=include_examples,
         is_selective=is_selective,
     )
+
+    dynamic_sections: list[tuple[str, list[Message]]] = []
+    if prompt == "full" and not (is_selective and not include_tools):
+        dynamic_sections.extend(
+            [
+                (
+                    "prompt_systeminfo",
+                    list(prompt_systeminfo(workspace, tool_format=tool_format)),
+                ),
+                ("prompt_timeinfo", list(prompt_timeinfo(tool_format=tool_format))),
+            ]
+        )
 
     cacheable_sections: list[tuple[str, list[Message]]] = []
     if include_agent_config:
@@ -286,10 +291,22 @@ def _build_prompt_sections(
                         include_path=True,
                         include_context_cmd=False,
                         include_user_context=include_user_context,
+                        include_runtime_context=False,
                     )
                 ),
             )
         )
+        agent_runtime_msgs = list(
+            prompt_workspace_runtime(
+                agent_path,
+                title="Agent Config",
+                include_path=True,
+            )
+        )
+        if agent_runtime_msgs:
+            dynamic_sections.append(
+                ("prompt_agent_workspace_runtime", agent_runtime_msgs)
+            )
     if include_workspace and workspace and workspace != agent_path:
         cacheable_sections.append(
             (
@@ -299,12 +316,17 @@ def _build_prompt_sections(
                         workspace,
                         include_context_cmd=False,
                         include_user_context=include_user_context,
+                        include_runtime_context=False,
                     )
                 ),
             )
         )
+        workspace_runtime_msgs = list(prompt_workspace_runtime(workspace))
+        if workspace_runtime_msgs:
+            dynamic_sections.append(
+                ("prompt_workspace_runtime", workspace_runtime_msgs)
+            )
 
-    dynamic_sections: list[tuple[str, list[Message]]] = []
     if include_context_cmd:
         for ws, title, section_name in [
             (
@@ -473,7 +495,11 @@ from .templates import (
     prompt_tools,
     prompt_user,
 )
-from .workspace import find_agent_files_in_tree, prompt_workspace
+from .workspace import (
+    find_agent_files_in_tree,
+    prompt_workspace,
+    prompt_workspace_runtime,
+)
 
 
 def get_prompt(
@@ -574,7 +600,7 @@ def get_prompt(
     for _, msgs in cacheable_sections:
         result.extend(msgs)
 
-    # Insert an explicit static/dynamic boundary before context_cmd output.
+    # Insert an explicit static/dynamic boundary before runtime context.
     # This keeps the prompt structure stable and makes the cacheable prefix
     # visible to both humans and providers with block-level prompt caching.
     if dynamic_sections and result:
@@ -645,5 +671,6 @@ __all__ = [
     "prompt_tools",
     "prompt_user",
     "prompt_workspace",
+    "prompt_workspace_runtime",
     "use_chat_history_context",
 ]

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -120,6 +120,32 @@ def _get_git_status(workspace: Path) -> str | None:
         return None
 
 
+def _workspace_runtime_sections(
+    workspace: Path, *, include_path: bool = False
+) -> list[str]:
+    """Build session-volatile workspace sections."""
+    sections = []
+    if include_path:
+        sections.append(f"**Path:** {workspace.resolve()}")
+    if tree_output := get_tree_output(workspace):
+        sections.append(f"## Project Structure\n\n{md_codeblock('', tree_output)}\n\n")
+    if git_status := _get_git_status(workspace):
+        sections.append(f"## Git Status\n\n{git_status}")
+    return sections
+
+
+def prompt_workspace_runtime(
+    workspace: Path | None = None,
+    title: str = "Project Workspace",
+    include_path: bool = False,
+) -> Generator[Message, None, None]:
+    """Generate session-volatile workspace metadata."""
+    if workspace is None:
+        return
+    if sections := _workspace_runtime_sections(workspace, include_path=include_path):
+        yield Message("system", f"# {title}\n\n" + "\n\n".join(sections))
+
+
 def find_agent_files_in_tree(
     directory: Path,
     exclude: set[str] | None = None,
@@ -180,6 +206,7 @@ def prompt_workspace(
     include_path: bool = False,
     include_context_cmd: bool = True,
     include_user_context: bool = True,
+    include_runtime_context: bool = True,
 ) -> Generator[Message, None, None]:
     """Generate the workspace context prompt."""
     # TODO: update this prompt if the files change
@@ -188,8 +215,9 @@ def prompt_workspace(
     if workspace is None:
         return
 
-    # Add workspace path if requested
-    if include_path:
+    # Keep the path at the top for direct callers, matching the historical
+    # prompt_workspace() ordering. The tree and git status stay at the end.
+    if include_runtime_context and include_path:
         sections.append(f"**Path:** {workspace.resolve()}")
 
     project = get_project_config(workspace)
@@ -355,13 +383,8 @@ def prompt_workspace(
                 f"Excluded {excluded_count} file(s) via project config exclude patterns"
             )
 
-    # Get tree output if enabled
-    if tree_output := get_tree_output(workspace):
-        sections.append(f"## Project Structure\n\n{md_codeblock('', tree_output)}\n\n")
-
-    # Get git status (branch + working tree changes)
-    if git_status := _get_git_status(workspace):
-        sections.append(f"## Git Status\n\n{git_status}")
+    if include_runtime_context:
+        sections.extend(_workspace_runtime_sections(workspace))
 
     if sections:
         yield Message("system", f"# {title}\n\n" + "\n\n".join(sections))

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -217,7 +217,9 @@ def prompt_workspace(
 
     # Keep the path at the top for direct callers, matching the historical
     # prompt_workspace() ordering. The tree and git status stay at the end.
-    if include_runtime_context and include_path:
+    # Path is static/deterministic, so include_path controls it independently
+    # of include_runtime_context (which gates the volatile tree/git sections).
+    if include_path:
         sections.append(f"**Path:** {workspace.resolve()}")
 
     project = get_project_config(workspace)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -396,6 +396,12 @@ def _copy_messages_for_fork(
                 snapshot_copies.add(
                     (source_snapshot, dest_logdir / "files" / source_snapshot.name)
                 )
+            else:
+                # Snapshot not found in source: drop the stale hash so the
+                # fork's LogManager.snapshot_message_files re-stores from the
+                # live file with a fresh consistent hash, rather than silently
+                # overwriting the stale hash with a potentially different one.
+                new_file_hashes.pop(path_map.get(path, path), None)
         copied_messages.append(
             replace(msg, files=new_files, file_hashes=new_file_hashes)
         )

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -390,6 +390,7 @@ def _copy_messages_for_fork(
         new_file_hashes = {
             path_map.get(path, path): digest for path, digest in msg.file_hashes.items()
         }
+        dead_refs: set[str] = set()
         for path, digest in msg.file_hashes.items():
             source_snapshot = get_stored_path(source_logdir, digest, Path(path).suffix)
             if source_snapshot is not None:
@@ -401,9 +402,16 @@ def _copy_messages_for_fork(
                 # fork's LogManager.snapshot_message_files re-stores from the
                 # live file with a fresh consistent hash, rather than silently
                 # overwriting the stale hash with a potentially different one.
-                new_file_hashes.pop(path_map.get(path, path), None)
+                new_path = path_map.get(path, path)
+                new_file_hashes.pop(new_path, None)
+                # If the live file is also gone, drop the dangling file
+                # reference so the fork's LogManager never sees a reference it
+                # cannot snapshot or resolve for the provider.
+                if not Path(path).is_file():
+                    dead_refs.add(new_path)
+        filtered_files = [f for f in new_files if str(f) not in dead_refs]
         copied_messages.append(
-            replace(msg, files=new_files, file_hashes=new_file_hashes)
+            replace(msg, files=filtered_files, file_hashes=new_file_hashes)
         )
 
     for source_path, dest_path in attachment_copies:

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -79,6 +79,7 @@ from ..logmanager import conversations as conversations_module
 from ..message import Message
 from ..tools import get_toolchain, get_tools, init_tools
 from ..util.content import is_message_command
+from ..util.file_storage import get_stored_path
 from ..util.uri import URI, FilePath, is_uri, parse_file_reference
 from .api_v2_agents import agents_api
 from .api_v2_common import (
@@ -365,10 +366,11 @@ def _fork_message_file_reference(
 def _copy_messages_for_fork(
     messages: list[Message], source_logdir: Path, dest_logdir: Path
 ) -> list[Message]:
-    """Copy a message slice into a new conversation, preserving attachments."""
+    """Copy a message slice with its attachments and content-addressed files."""
     source_attachments = source_logdir / "attachments"
     dest_attachments = dest_logdir / "attachments"
     attachment_copies: set[tuple[Path, Path]] = set()
+    snapshot_copies: set[tuple[Path, Path]] = set()
     copied_messages: list[Message] = []
 
     for msg in messages:
@@ -388,6 +390,12 @@ def _copy_messages_for_fork(
         new_file_hashes = {
             path_map.get(path, path): digest for path, digest in msg.file_hashes.items()
         }
+        for path, digest in msg.file_hashes.items():
+            source_snapshot = get_stored_path(source_logdir, digest, Path(path).suffix)
+            if source_snapshot is not None:
+                snapshot_copies.add(
+                    (source_snapshot, dest_logdir / "files" / source_snapshot.name)
+                )
         copied_messages.append(
             replace(msg, files=new_files, file_hashes=new_file_hashes)
         )
@@ -400,6 +408,10 @@ def _copy_messages_for_fork(
         else:
             dest_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, dest_path)
+
+    for source_path, dest_path in snapshot_copies:
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, dest_path)
 
     return copied_messages
 
@@ -2862,7 +2874,9 @@ def api_conversation_config_patch(conversation_id: str):
             _append_conversation_system_prompt(
                 new_system_msgs, _resolve_conversation_system_prompt(chat_config)
             )
-            manager.log = Log(new_system_msgs + remaining_msgs)
+            manager.log = Log(
+                manager.snapshot_message_files(new_system_msgs) + remaining_msgs
+            )
         manager.write()
 
         _invalidate_conversations_cache()

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -410,6 +410,8 @@ def _copy_messages_for_fork(
             shutil.copy2(source_path, dest_path)
 
     for source_path, dest_path in snapshot_copies:
+        if not source_path.exists():
+            continue
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_path, dest_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,9 +457,10 @@ def cleanup_subagents_after():
     # globals dirty for the next test.  Shorter timeouts give headroom.
     try:
         for subagent in subagents_copy:
-            # Clean up threads (2s cap — well under the 10s teardown limit)
+            # Clean up threads (5s cap — well under the 10s teardown limit)
+            # Increased from 2s to handle longer exponential backoff in retry decorators
             if subagent.thread is not None and subagent.thread.is_alive():
-                subagent.thread.join(timeout=2.0)
+                subagent.thread.join(timeout=5.0)
             # Clean up subprocesses (subprocess mode)
             if subagent.process is not None and subagent.process.poll() is None:
                 subagent.process.terminate()

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -283,6 +283,8 @@ def test_message_conversion_with_tool_and_non_tool():
 
 
 def test_boundary_keeps_dynamic_context_out_of_static_system_prompt():
+    from gptme.logmanager.manager import prune_ephemeral_messages
+
     messages = [
         Message(role="system", content="Core prompt"),
         Message(role="system", content="Static workspace prompt"),
@@ -290,6 +292,7 @@ def test_boundary_keeps_dynamic_context_out_of_static_system_prompt():
         Message(role="system", content="Dynamic context"),
         Message(role="user", content="Actual user prompt"),
     ]
+    messages = prune_ephemeral_messages(messages)
 
     messages_dicts, system_messages, _ = _prepare_messages_for_api(messages, None)
 

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -97,6 +97,57 @@ def test_active_prompt_generation_keeps_only_newest_replacement():
     assert result == [generation_two, user]
 
 
+def test_load_snapshots_initial_message_files(tmp_path: Path):
+    """Startup attachments must not be re-rendered from mutable live files."""
+    from gptme.util.context import enrich_messages_with_context
+
+    bootstrap_file = tmp_path / "bootstrap.md"
+    bootstrap_file.write_text("original bootstrap")
+    manager = LogManager.load(
+        tmp_path / "conversation",
+        initial_msgs=[Message("system", "bootstrap", files=[bootstrap_file])],
+        create=True,
+        lock=False,
+    )
+
+    first = enrich_messages_with_context(manager.log.messages, tmp_path)
+    bootstrap_file.write_text("mutated bootstrap")
+    second = enrich_messages_with_context(manager.log.messages, tmp_path)
+
+    assert manager.log.messages[0].file_hashes[str(bootstrap_file)]
+    assert first[0].content == second[0].content
+    assert "original bootstrap" in second[0].content
+    assert "mutated bootstrap" not in second[0].content
+
+
+def test_constructor_snapshots_initial_message_files(tmp_path: Path):
+    """Direct constructors used by server tasks must snapshot startup files."""
+    bootstrap_file = tmp_path / "bootstrap.md"
+    bootstrap_file.write_text("original bootstrap")
+
+    manager = LogManager(
+        [Message("system", "bootstrap", files=[bootstrap_file])],
+        logdir=tmp_path / "conversation",
+        lock=False,
+    )
+
+    assert manager.log.messages[0].file_hashes[str(bootstrap_file)]
+
+
+def test_initial_message_directories_are_not_snapshotted(tmp_path: Path):
+    """Directory prompt matches are context references, not file snapshots."""
+    context_dir = tmp_path / "docs"
+    context_dir.mkdir()
+
+    manager = LogManager(
+        [Message("system", "context", files=[context_dir])],
+        logdir=tmp_path / "conversation",
+        lock=False,
+    )
+
+    assert manager.log.messages[0].file_hashes == {}
+
+
 def test_log_repr():
     """Log.__repr__ should have matched brackets."""
     log = Log([Message("user", "hello")])
@@ -487,6 +538,19 @@ def test_merge_consecutive_still_merges_plain_same_role_messages():
     assert len(result) == 1
     assert "part one" in result[0].content
     assert "part two" in result[0].content
+
+
+def test_merge_consecutive_preserves_prompt_cache_boundary():
+    """Provider preprocessing must not merge volatile context into the prefix."""
+    from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY
+
+    msgs = [
+        Message(role="system", content="static"),
+        Message(role="system", content=SYSTEM_PROMPT_CACHE_BOUNDARY),
+        Message(role="system", content="dynamic"),
+    ]
+
+    assert _merge_consecutive_messages(msgs) == msgs
 
 
 def test_read_jsonl_unknown_field(tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -716,3 +716,24 @@ def test_prompt_workspace_skip_home_agents_md(tmp_path, monkeypatch):
     assert str(home_agents.resolve()) not in files_without_user, (
         "~/AGENTS.md must not appear in eval runs (include_user_context=False)"
     )
+
+
+def test_prompt_workspace_path_included_without_runtime_context(tmp_path):
+    """Path must appear when include_path=True regardless of include_runtime_context."""
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "myproject"
+    workspace.mkdir()
+
+    msgs = list(
+        prompt_workspace(
+            workspace,
+            include_path=True,
+            include_runtime_context=False,
+            include_user_context=False,
+        )
+    )
+    combined = "\n".join(msg.content for msg in msgs)
+    assert str(workspace.resolve()) in combined, (
+        "Path must be present when include_path=True even if include_runtime_context=False"
+    )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -496,6 +496,68 @@ def test_dynamic_context_has_explicit_cache_boundary(tmp_path):
     assert file_idx < boundary_idx < dynamic_idx
 
 
+def test_volatile_prompt_state_starts_after_cache_boundary(tmp_path, monkeypatch):
+    """Date, project tree, and git status must not disturb the static prefix."""
+    from gptme.message import Message
+    from gptme.prompts import SYSTEM_PROMPT_CACHE_BOUNDARY, get_prompt
+    from gptme.util.context import enrich_messages_with_context
+
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Stable bootstrap")
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["README.md"]\ncontext_cmd = "printf COMPUTED_CONTEXT"\n'
+    )
+    runtime = {
+        "date": "DATE_ONE",
+        "tree": "TREE_ONE",
+        "git_status": "STATUS_ONE",
+    }
+
+    monkeypatch.setattr(
+        "gptme.prompts.prompt_timeinfo",
+        lambda tool_format="markdown": [
+            Message("system", f"## Current Date\n\n{runtime['date']}")
+        ],
+    )
+    monkeypatch.setattr(
+        "gptme.prompts.workspace.get_tree_output", lambda _workspace: runtime["tree"]
+    )
+    monkeypatch.setattr(
+        "gptme.prompts.workspace._get_git_status",
+        lambda _workspace: runtime["git_status"],
+    )
+
+    def render() -> str:
+        messages = enrich_messages_with_context(
+            get_prompt(
+                get_tools(),
+                prompt="full",
+                workspace=workspace,
+                include_user_context=False,
+            ),
+            workspace,
+        )
+        return "\n\n".join(
+            msg.content + "\n" + "\n".join(str(path) for path in msg.files)
+            for msg in messages
+        )
+
+    first = render()
+    runtime.update(date="DATE_TWO", tree="TREE_TWO", git_status="STATUS_TWO")
+    second = render()
+
+    first_static, first_dynamic = first.split(SYSTEM_PROMPT_CACHE_BOUNDARY, 1)
+    second_static, second_dynamic = second.split(SYSTEM_PROMPT_CACHE_BOUNDARY, 1)
+
+    assert first_static == second_static
+    assert first_dynamic != second_dynamic
+    assert "# Stable bootstrap" in first_static
+    for marker in ("DATE_ONE", "TREE_ONE", "STATUS_ONE"):
+        assert marker not in first_static
+        assert marker in first_dynamic
+
+
 def test_prompt_workspace_sorts_glob_matches_deterministically(tmp_path, monkeypatch):
     """Glob matches should not depend on filesystem traversal order."""
     from gptme.prompts import prompt_workspace

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -3439,7 +3439,7 @@ def test_copy_messages_for_fork_copies_referenced_file_snapshots(tmp_path: Path)
 
 
 def test_copy_messages_for_fork_tolerates_missing_snapshot(tmp_path: Path):
-    """A fork must not raise FileNotFoundError when a snapshot file is absent."""
+    """A fork drops stale hash entries whose snapshot is absent in the source."""
     from gptme.message import Message  # fmt: skip
     from gptme.server.api_v2 import _copy_messages_for_fork  # fmt: skip
 
@@ -3449,7 +3449,7 @@ def test_copy_messages_for_fork_tolerates_missing_snapshot(tmp_path: Path):
     live_file.parent.mkdir()
     live_file.write_text("content", encoding="utf-8")
 
-    # The snapshot file referenced by file_hashes does NOT exist on disk.
+    # file_hashes contains "deadbeef" but no matching snapshot exists in source.
     source_logdir.mkdir(parents=True)
     message = Message(
         "system",
@@ -3458,9 +3458,11 @@ def test_copy_messages_for_fork_tolerates_missing_snapshot(tmp_path: Path):
         file_hashes={str(live_file): "deadbeef"},
     )
 
-    # Should not raise FileNotFoundError even though files/deadbeef.md is absent.
+    # Stale hash must be dropped so LogManager.snapshot_message_files can
+    # re-store the live file with a fresh consistent hash instead of silently
+    # overwriting the stale one.
     copied = _copy_messages_for_fork([message], source_logdir, dest_logdir)
-    assert copied[0].file_hashes == {str(live_file): "deadbeef"}
+    assert copied[0].file_hashes == {}
     assert not (dest_logdir / "files" / "deadbeef.md").exists()
 
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -3438,6 +3438,32 @@ def test_copy_messages_for_fork_copies_referenced_file_snapshots(tmp_path: Path)
     )
 
 
+def test_copy_messages_for_fork_tolerates_missing_snapshot(tmp_path: Path):
+    """A fork must not raise FileNotFoundError when a snapshot file is absent."""
+    from gptme.message import Message  # fmt: skip
+    from gptme.server.api_v2 import _copy_messages_for_fork  # fmt: skip
+
+    source_logdir = tmp_path / "source"
+    dest_logdir = tmp_path / "fork"
+    live_file = tmp_path / "workspace" / "bootstrap.md"
+    live_file.parent.mkdir()
+    live_file.write_text("content", encoding="utf-8")
+
+    # The snapshot file referenced by file_hashes does NOT exist on disk.
+    source_logdir.mkdir(parents=True)
+    message = Message(
+        "system",
+        "bootstrap",
+        files=[live_file],
+        file_hashes={str(live_file): "deadbeef"},
+    )
+
+    # Should not raise FileNotFoundError even though files/deadbeef.md is absent.
+    copied = _copy_messages_for_fork([message], source_logdir, dest_logdir)
+    assert copied[0].file_hashes == {str(live_file): "deadbeef"}
+    assert not (dest_logdir / "files" / "deadbeef.md").exists()
+
+
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):
     """Test that edit rejects non-string content with a 400."""
     conversation_id = create_conversation(client)["conversation_id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -3466,6 +3466,33 @@ def test_copy_messages_for_fork_tolerates_missing_snapshot(tmp_path: Path):
     assert not (dest_logdir / "files" / "deadbeef.md").exists()
 
 
+def test_copy_messages_for_fork_drops_reference_when_snapshot_and_live_file_missing(
+    tmp_path: Path,
+):
+    """When both snapshot and live file are gone, the file reference must be dropped."""
+    from gptme.message import Message  # fmt: skip
+    from gptme.server.api_v2 import _copy_messages_for_fork  # fmt: skip
+
+    source_logdir = tmp_path / "source"
+    dest_logdir = tmp_path / "fork"
+    gone_file = tmp_path / "workspace" / "deleted.md"
+    # Deliberately do NOT create gone_file — it is missing from disk.
+
+    source_logdir.mkdir(parents=True)
+    message = Message(
+        "system",
+        "ref to deleted file",
+        files=[gone_file],
+        file_hashes={str(gone_file): "deadbeef"},
+    )
+
+    copied = _copy_messages_for_fork([message], source_logdir, dest_logdir)
+    # Both hash and file reference must be dropped — live file doesn't exist,
+    # so the fork's LogManager cannot snapshot it and must not keep a dangling ref.
+    assert copied[0].file_hashes == {}
+    assert copied[0].files == []
+
+
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):
     """Test that edit rejects non-string content with a 400."""
     conversation_id = create_conversation(client)["conversation_id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2063,15 +2063,7 @@ def test_v2_create_conversation_default_system_prompt(
     data = response.get_json()
     assert data is not None
     assert "log" in data
-    assert (
-        len(data["log"]) == 3
-    )  # System prompt + webui hint + user message (no workspace context)
-    assert data["log"][0]["role"] == "system"  # Primary system prompt
-    assert data["log"][1]["role"] == "system"  # Webui hint
-    assert data["log"][2]["role"] == "user"
-    assert data["log"][2]["content"] == "Hello, this is a test message."
 
-    # Check that the system prompt is the default one
     prompt_msgs = get_prompt(
         tools=list(get_toolchain(None)),
         interactive=True,
@@ -2080,7 +2072,15 @@ def test_v2_create_conversation_default_system_prompt(
         prompt="full",
         workspace=tmp_path,
     )
-    assert data["log"][0]["content"] == prompt_msgs[0].content
+    assert len(data["log"]) == len(prompt_msgs) + 2
+    for actual, expected in zip(
+        data["log"][: len(prompt_msgs)], prompt_msgs, strict=True
+    ):
+        assert actual["role"] == expected.role
+        assert actual["content"] == expected.content
+    assert data["log"][-2]["role"] == "system"  # Webui hint
+    assert data["log"][-1]["role"] == "user"
+    assert data["log"][-1]["content"] == "Hello, this is a test message."
 
 
 def test_v2_create_conversation_webui_html_hint(
@@ -3405,6 +3405,37 @@ def test_copy_messages_for_fork_copies_only_referenced_attachments(tmp_path: Pat
     fork_attachments = dest_logdir / "attachments"
     assert (fork_attachments / "keep.txt").read_text(encoding="utf-8") == "keep"
     assert not (fork_attachments / "skip.txt").exists()
+
+
+def test_copy_messages_for_fork_copies_referenced_file_snapshots(tmp_path: Path):
+    """A fork must keep the source conversation's content-addressed bytes."""
+    from gptme.logmanager import LogManager  # fmt: skip
+    from gptme.message import Message  # fmt: skip
+    from gptme.server.api_v2 import _copy_messages_for_fork  # fmt: skip
+
+    source_logdir = tmp_path / "source"
+    dest_logdir = tmp_path / "fork"
+    live_file = tmp_path / "workspace" / "bootstrap.md"
+    live_file.parent.mkdir()
+    live_file.write_text("mutated live content", encoding="utf-8")
+
+    source_files = source_logdir / "files"
+    source_files.mkdir(parents=True)
+    (source_files / "abc123.md").write_text("original snapshot", encoding="utf-8")
+    message = Message(
+        "system",
+        "bootstrap",
+        files=[live_file],
+        file_hashes={str(live_file): "abc123"},
+    )
+
+    copied = _copy_messages_for_fork([message], source_logdir, dest_logdir)
+    fork_manager = LogManager(copied, logdir=dest_logdir, lock=False)
+
+    assert fork_manager.log.messages[0].file_hashes == {str(live_file): "abc123"}
+    assert (dest_logdir / "files" / "abc123.md").read_text(encoding="utf-8") == (
+        "original snapshot"
+    )
 
 
 def test_v2_edit_message_rejects_non_string_content(client: FlaskClient):


### PR DESCRIPTION
## Summary

Implements strict static-first prompt ordering for improved prefix-cache friendliness.

### Benefits
- **Local llama.cpp prefix caching**: Measured 7031→4 tokens processed (0.3s vs 23.3s TTFT)
- **Anthropic prompt caching**: Same prefix-based mechanism; echoes gptme#317's finding

### Changes
- Static prompt files now precede the cache boundary
- Date, system/workspace runtime data, tree, Git status, computed context, and chat history follow that boundary
- Startup file attachments are content-addressed before first provider render
- Provider-path byte diff: static Anthropic prefix equal, dynamic tail unequal

### Verification
- 366 prompt/log-manager/server tests passed
- 93 task API tests passed  
- Ruff check + mypy on all changed files passed
- git diff --check passed
- One test-suite flake (test_v2_conversations_list timeout) unrelated to this change

Fixes #317 (partial — prompt caching efficiency)