### PR TITLE
refactor(agent-cmd): clarify scan scope and add create cross-references

### DIFF
--- a/gptme/agent/cli.py
+++ b/gptme/agent/cli.py
@@ -118,7 +118,15 @@ def main(verbose: bool = False):
     help="Output as JSON.",
 )
 def scan_cmd(workspace: Path | None, show_all: bool, as_json: bool):
-    """List live agent processes (gptme, claude-code, codex, aider, …)."""
+    """Scan for live agent processes (gptme, claude-code, codex, aider, …).
+
+    Inspects currently running processes on this host. This is about live
+    sessions and processes — NOT about persistent agents, brain-workspaces,
+    or agent identities. A result here means a process is actively running
+    right now; it says nothing about that agent's workspace or identity files.
+
+    To create or manage a persistent agent workspace, see: gptme-agent create
+    """
     sys.exit(run_scan(workspace=workspace, show_all=show_all, as_json=as_json))
 
 
@@ -256,25 +264,28 @@ def create_cmd(
     template_branch: str,
     init_conversation: bool,
 ):
-    """Create a new agent workspace.
+    """Create a new persistent agent workspace.
 
     PATH is the directory where the agent workspace will be created.
-
-    By default, this clones from gptme-agent-template and runs its fork.sh script
-    to create a fully-featured agent workspace. Use --no-template for a minimal
-    workspace without the template.
+    A persistent agent workspace contains identity files (SOUL.md, GOALS.md, …),
+    knowledge, lessons, and automation scaffolding — not just a service runner.
 
     \b
-    Template-based (default):
-    - Clones gptme-agent-template repository
-    - Runs fork.sh to customize for your agent
-    - Includes lessons, knowledge structure, and automation
+    Template-based (default, recommended):
+    - Clones gptme-agent-template (https://github.com/gptme/gptme-agent-template)
+    - Runs fork.sh to customize for your agent name
+    - Includes identity files, lessons, knowledge structure, and automation
 
     \b
     Minimal (--no-template):
-    - Creates basic directory structure
-    - Generates minimal gptme.toml
-    - Creates autonomous run script
+    - Creates basic directory structure (journal/, tasks/, knowledge/, lessons/)
+    - Generates minimal gptme.toml and autonomous run script
+    - Use when you want to supply your own identity/config files
+
+    \b
+    Related:
+      gptme service init  # Lightweight alternative: just systemd service files,
+                          # no persistent workspace or identity files
 
     \b
     Example:

--- a/gptme/agent/cli.py
+++ b/gptme/agent/cli.py
@@ -284,8 +284,8 @@ def create_cmd(
 
     \b
     Related:
-      gptme service init  # Lightweight alternative: just systemd service files,
-                          # no persistent workspace or identity files
+      gptme service init  # Lightweight alternative: minimal service scaffold
+                          # (systemd/launchd) + basic config; no full identity files
 
     \b
     Example:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -622,13 +622,20 @@ class TestCLI:
         """Test scan command help."""
         result = runner.invoke(main, ["scan", "--help"])
         assert result.exit_code == 0
-        assert "List live agent processes" in result.output
+        assert "live agent processes" in result.output
+        # Must clarify scan is about live processes, NOT persistent identities/workspaces
+        assert "NOT about persistent agents" in result.output
 
     def test_create_help(self, runner):
         """Test create command help."""
         result = runner.invoke(main, ["create", "--help"])
         assert result.exit_code == 0
-        assert "Create a new agent workspace" in result.output
+        assert "Create a new persistent agent workspace" in result.output
+        # Must reference gptme-agent-template with URL
+        assert "gptme-agent-template" in result.output
+        assert "github.com/gptme/gptme-agent-template" in result.output
+        # Must cross-reference the lightweight alternative
+        assert "gptme service init" in result.output
 
     def test_install_help(self, runner):
         """Test install command help."""


### PR DESCRIPTION
Follow-up to #3614 (service-init refactor), per Erik's request:

> We need a similar treatment for `gptme-agent` which has similar documentation gaps.
> `gptme-agent create` in particular can be used to directly create a new persistent
> agent not unlike this "service init" in `--no-template` mode but also clones
> gptme-agent-template in default mode. It's a third place that needs
> cross-referencing. (and it has one awkward wart: `gptme-agent scan` is about live
> processes/sessions, not "agents" with identities/brain-workspaces)

## Changes

**`gptme-agent scan`** — docstring now clarifies this inspects live running processes, NOT persistent agents or brain-workspaces:
```
Inspects currently running processes on this host. This is about live
sessions and processes — NOT about persistent agents, brain-workspaces,
or agent identities.
```

**`gptme-agent create`** — renamed to "persistent agent workspace", added template URL, and cross-references `gptme service init` as the lightweight alternative:
- `gptme-agent-template` GitHub URL (`https://github.com/gptme/gptme-agent-template`)
- Explanation of what a persistent workspace contains (identity files, knowledge, lessons)
- `gptme service init` cross-reference for the no-workspace path

**Tests** — updated assertions in `TestCLI::test_scan_help` and `TestCLI::test_create_help` to verify the new clarifying text.

Closes #3617