### PR TITLE
fix(reduce): cache proactive_summarize_log result by middle-message content hash

### DIFF
--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -447,6 +447,10 @@ def proactive_summarize_log(
     # of messages to summarize. Including provider prevents cross-provider cache
     # collisions when two providers expose a model with the same name but produce
     # different summaries (different endpoints, defaults, or prompting behaviour).
+    # model.context (context-window size) is intentionally excluded: it controls
+    # when summarization fires, not what summary the model produces, so two calls
+    # with the same model+provider+messages but different context windows are safe
+    # to share a cached summary.
     key_parts = [model.model, model.provider] + [
         f"{m.role}:{m.content}" for m in summarize_middle
     ]

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -4,6 +4,7 @@ Tools to reduce a log to a smaller size.
 Typically used when the log exceeds a token limit and needs to be shortened.
 """
 
+import hashlib
 import logging
 import re
 from collections.abc import Generator
@@ -15,6 +16,12 @@ from ..message import Message, len_tokens
 from . import console
 
 logger = logging.getLogger(__name__)
+
+# In-process cache for proactive_summarize_log summaries.
+# Key: SHA-256 of (model, role+content of each message to be summarized).
+# Prevents repeated LLM summarize calls when prepare_messages is invoked on the
+# same stored log across consecutive turns (which breaks prompt-cache stability).
+_proactive_summarize_cache: dict[str, "Message"] = {}
 
 
 def message_contains_tool_use(msg: Message) -> bool:
@@ -431,27 +438,41 @@ def proactive_summarize_log(
     # Lazy import avoids circular dependency at module load time.
     from ..llm import summarize as _llm_summarize  # fmt: skip
 
-    logger.info(
-        "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
-        " — summarizing %d middle messages (%d pinned preserved)",
-        tokens // 1000,
-        int(threshold * 100),
-        model.context // 1000,
-        len(summarize_middle),
-        len(pinned_middle),
-    )
-    console.log(
-        f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
-        f" summarizing {len(summarize_middle)} older messages..."
-    )
+    # Build a cache key from the model name and the content of messages to summarize.
+    # An unchanged middle block on consecutive turns produces the same key, so the
+    # LLM call only fires once and prompt-cache stability is preserved.
+    key_parts = [model.model] + [f"{m.role}:{m.content}" for m in summarize_middle]
+    cache_key = hashlib.sha256("\0".join(key_parts).encode()).hexdigest()
 
-    try:
-        summary_msg = _llm_summarize(summarize_middle)
-    except Exception:
-        logger.warning(
-            "Proactive summarize failed; falling back to unreduced log", exc_info=True
+    if cache_key in _proactive_summarize_cache:
+        logger.debug(
+            "Proactive summarize cache hit: %d middle messages → reusing summary",
+            len(summarize_middle),
         )
-        return log
+        summary_msg = _proactive_summarize_cache[cache_key]
+    else:
+        logger.info(
+            "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
+            " — summarizing %d middle messages (%d pinned preserved)",
+            tokens // 1000,
+            int(threshold * 100),
+            model.context // 1000,
+            len(summarize_middle),
+            len(pinned_middle),
+        )
+        console.log(
+            f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
+            f" summarizing {len(summarize_middle)} older messages..."
+        )
+        try:
+            summary_msg = _llm_summarize(summarize_middle)
+        except Exception:
+            logger.warning(
+                "Proactive summarize failed; falling back to unreduced log",
+                exc_info=True,
+            )
+            return log
+        _proactive_summarize_cache[cache_key] = summary_msg
 
     result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Prevents repeated LLM summarize calls when prepare_messages is invoked on the
 # same stored log across consecutive turns (which breaks prompt-cache stability).
 # Capped to avoid unbounded growth in long-lived processes (servers, daemons).
+# Message is a frozen dataclass so sharing the cached instance by reference is safe.
 _PROACTIVE_SUMMARIZE_CACHE_MAX = 256
 _proactive_summarize_cache: dict[str, "Message"] = {}
 
@@ -446,12 +447,14 @@ def proactive_summarize_log(
     key_parts = [model.model] + [f"{m.role}:{m.content}" for m in summarize_middle]
     cache_key = hashlib.sha256("\0".join(key_parts).encode()).hexdigest()
 
-    if cache_key in _proactive_summarize_cache:
+    # Use .get() instead of `in` + `[]` to avoid a TOCTOU race: under concurrent
+    # callers another thread can evict the entry between membership test and lookup.
+    summary_msg = _proactive_summarize_cache.get(cache_key)
+    if summary_msg is not None:
         logger.debug(
             "Proactive summarize cache hit: %d middle messages → reusing summary",
             len(summarize_middle),
         )
-        summary_msg = _proactive_summarize_cache[cache_key]
     else:
         logger.info(
             "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 _PROACTIVE_SUMMARIZE_CACHE_MAX = 256
 _proactive_summarize_cache: dict[str, "Message"] = {}
 _proactive_summarize_cache_lock = threading.Lock()
+# Per-key coordination: at most one thread calls the LLM for a given key;
+# concurrent callers block on the in-flight Event and adopt the stored result.
+_proactive_summarize_cache_pending: dict[str, threading.Event] = {}
 
 
 def message_contains_tool_use(msg: Message) -> bool:
@@ -461,8 +464,7 @@ def proactive_summarize_log(
         json.dumps(key_parts, ensure_ascii=False).encode()
     ).hexdigest()
 
-    # Use .get() instead of `in` + `[]` to avoid a TOCTOU race: under concurrent
-    # callers another thread can evict the entry between membership test and lookup.
+    # Optimistic lock-free read (CPython dict.get is GIL-atomic).
     summary_msg = _proactive_summarize_cache.get(cache_key)
     if summary_msg is not None:
         logger.debug(
@@ -470,38 +472,65 @@ def proactive_summarize_log(
             len(summarize_middle),
         )
     else:
-        logger.info(
-            "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
-            " — summarizing %d middle messages (%d pinned preserved)",
-            tokens // 1000,
-            int(threshold * 100),
-            model.context // 1000,
-            len(summarize_middle),
-            len(pinned_middle),
-        )
-        console.log(
-            f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
-            f" summarizing {len(summarize_middle)} older messages..."
-        )
-        try:
-            summary_msg = _llm_summarize(summarize_middle)
-        except Exception:
-            logger.warning(
-                "Proactive summarize failed; falling back to unreduced log",
-                exc_info=True,
+        # Coordinate concurrent identical requests: only one thread calls the LLM;
+        # all others wait and adopt the stored result.  This eliminates the eviction
+        # race in the old winner-adoption pattern: the result is in the cache and
+        # the Event is set atomically under the lock, so waiters always find it.
+        compute_event = None
+        while summary_msg is None and compute_event is None:
+            with _proactive_summarize_cache_lock:
+                summary_msg = _proactive_summarize_cache.get(cache_key)
+                if summary_msg is not None:
+                    break
+                in_progress = _proactive_summarize_cache_pending.get(cache_key)
+                if in_progress is None:
+                    # Claim this key; we will compute and store the result.
+                    compute_event = threading.Event()
+                    _proactive_summarize_cache_pending[cache_key] = compute_event
+                    break
+            # Another thread claimed the key; wait outside the lock.
+            in_progress.wait(timeout=120)
+            # After the Event fires, loop back to read the result from the cache.
+
+        if summary_msg is not None:
+            logger.debug(
+                "Proactive summarize cache hit: %d middle messages → reusing summary",
+                len(summarize_middle),
             )
-            return log
-        with _proactive_summarize_cache_lock:
-            if cache_key in _proactive_summarize_cache:
-                # A concurrent thread also computed a summary for the same content;
-                # use the cached winner's result so both callers stay consistent.
-                summary_msg = _proactive_summarize_cache[cache_key]
-            else:
+        else:
+            assert compute_event is not None
+            logger.info(
+                "Proactive summarize triggered: %dk tokens (threshold %d%% of %dk context)"
+                " — summarizing %d middle messages (%d pinned preserved)",
+                tokens // 1000,
+                int(threshold * 100),
+                model.context // 1000,
+                len(summarize_middle),
+                len(pinned_middle),
+            )
+            console.log(
+                f"[context] Approaching context limit ({tokens // 1000}k / {int(limit) // 1000}k),"
+                f" summarizing {len(summarize_middle)} older messages..."
+            )
+            try:
+                summary_msg = _llm_summarize(summarize_middle)
+            except Exception:
+                logger.warning(
+                    "Proactive summarize failed; falling back to unreduced log",
+                    exc_info=True,
+                )
+                with _proactive_summarize_cache_lock:
+                    _proactive_summarize_cache_pending.pop(cache_key, None)
+                    compute_event.set()
+                return log
+            with _proactive_summarize_cache_lock:
                 if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
                     _proactive_summarize_cache.pop(
                         next(iter(_proactive_summarize_cache))
                     )
                 _proactive_summarize_cache[cache_key] = summary_msg
+                _proactive_summarize_cache_pending.pop(cache_key, None)
+                compute_event.set()
 
     result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -453,7 +453,7 @@ def proactive_summarize_log(
     # with the same model+provider+messages but different context windows are safe
     # to share a cached summary.
     key_parts = [model.model, model.provider] + [
-        f"{m.role}:{m.content}" for m in summarize_middle
+        [m.role, m.content] for m in summarize_middle
     ]
     # Use json.dumps for unambiguous serialization: a NUL-delimited join would
     # map distinct message sequences containing NUL to the same byte string.

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -519,18 +519,26 @@ def proactive_summarize_log(
                     "Proactive summarize failed; falling back to unreduced log",
                     exc_info=True,
                 )
+                summary_msg = None
+            finally:
+                # Release the claim in `finally` so a BaseException (KeyboardInterrupt
+                # from a Ctrl+C mid-generation, SystemExit) also clears it. Otherwise
+                # the pending entry outlives this thread and every waiter loops on
+                # `wait(timeout=120)` forever, never seeing the key released.
                 with _proactive_summarize_cache_lock:
+                    if summary_msg is not None:
+                        if (
+                            len(_proactive_summarize_cache)
+                            >= _PROACTIVE_SUMMARIZE_CACHE_MAX
+                        ):
+                            _proactive_summarize_cache.pop(
+                                next(iter(_proactive_summarize_cache))
+                            )
+                        _proactive_summarize_cache[cache_key] = summary_msg
                     _proactive_summarize_cache_pending.pop(cache_key, None)
                     compute_event.set()
+            if summary_msg is None:
                 return log
-            with _proactive_summarize_cache_lock:
-                if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
-                    _proactive_summarize_cache.pop(
-                        next(iter(_proactive_summarize_cache))
-                    )
-                _proactive_summarize_cache[cache_key] = summary_msg
-                _proactive_summarize_cache_pending.pop(cache_key, None)
-                compute_event.set()
 
     result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 # Key: SHA-256 of (model, role+content of each message to be summarized).
 # Prevents repeated LLM summarize calls when prepare_messages is invoked on the
 # same stored log across consecutive turns (which breaks prompt-cache stability).
+# Capped to avoid unbounded growth in long-lived processes (servers, daemons).
+_PROACTIVE_SUMMARIZE_CACHE_MAX = 256
 _proactive_summarize_cache: dict[str, "Message"] = {}
 
 
@@ -472,6 +474,8 @@ def proactive_summarize_log(
                 exc_info=True,
             )
             return log
+        if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
+            _proactive_summarize_cache.pop(next(iter(_proactive_summarize_cache)))
         _proactive_summarize_cache[cache_key] = summary_msg
 
     result = initial_system + [summary_msg] + pinned_middle + recent

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -443,10 +443,13 @@ def proactive_summarize_log(
     # Lazy import avoids circular dependency at module load time.
     from ..llm import summarize as _llm_summarize  # fmt: skip
 
-    # Build a cache key from the model name and the content of messages to summarize.
-    # An unchanged middle block on consecutive turns produces the same key, so the
-    # LLM call only fires once and prompt-cache stability is preserved.
-    key_parts = [model.model] + [f"{m.role}:{m.content}" for m in summarize_middle]
+    # Build a cache key from the model identity (name + provider) and the content
+    # of messages to summarize. Including provider prevents cross-provider cache
+    # collisions when two providers expose a model with the same name but produce
+    # different summaries (different endpoints, defaults, or prompting behaviour).
+    key_parts = [model.model, model.provider] + [
+        f"{m.role}:{m.content}" for m in summarize_middle
+    ]
     cache_key = hashlib.sha256("\0".join(key_parts).encode()).hexdigest()
 
     # Use .get() instead of `in` + `[]` to avoid a TOCTOU race: under concurrent

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -5,6 +5,7 @@ Typically used when the log exceeds a token limit and needs to be shortened.
 """
 
 import hashlib
+import json
 import logging
 import re
 import threading
@@ -454,7 +455,11 @@ def proactive_summarize_log(
     key_parts = [model.model, model.provider] + [
         f"{m.role}:{m.content}" for m in summarize_middle
     ]
-    cache_key = hashlib.sha256("\0".join(key_parts).encode()).hexdigest()
+    # Use json.dumps for unambiguous serialization: a NUL-delimited join would
+    # map distinct message sequences containing NUL to the same byte string.
+    cache_key = hashlib.sha256(
+        json.dumps(key_parts, ensure_ascii=False).encode()
+    ).hexdigest()
 
     # Use .get() instead of `in` + `[]` to avoid a TOCTOU race: under concurrent
     # callers another thread can evict the entry between membership test and lookup.

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -7,6 +7,7 @@ Typically used when the log exceeds a token limit and needs to be shortened.
 import hashlib
 import logging
 import re
+import threading
 from collections.abc import Generator
 from typing import Literal
 
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Message is a frozen dataclass so sharing the cached instance by reference is safe.
 _PROACTIVE_SUMMARIZE_CACHE_MAX = 256
 _proactive_summarize_cache: dict[str, "Message"] = {}
+_proactive_summarize_cache_lock = threading.Lock()
 
 
 def message_contains_tool_use(msg: Message) -> bool:
@@ -477,9 +479,10 @@ def proactive_summarize_log(
                 exc_info=True,
             )
             return log
-        if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
-            _proactive_summarize_cache.pop(next(iter(_proactive_summarize_cache)))
-        _proactive_summarize_cache[cache_key] = summary_msg
+        with _proactive_summarize_cache_lock:
+            if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
+                _proactive_summarize_cache.pop(next(iter(_proactive_summarize_cache)))
+            _proactive_summarize_cache[cache_key] = summary_msg
 
     result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)

--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -483,9 +483,16 @@ def proactive_summarize_log(
             )
             return log
         with _proactive_summarize_cache_lock:
-            if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
-                _proactive_summarize_cache.pop(next(iter(_proactive_summarize_cache)))
-            _proactive_summarize_cache[cache_key] = summary_msg
+            if cache_key in _proactive_summarize_cache:
+                # A concurrent thread also computed a summary for the same content;
+                # use the cached winner's result so both callers stay consistent.
+                summary_msg = _proactive_summarize_cache[cache_key]
+            else:
+                if len(_proactive_summarize_cache) >= _PROACTIVE_SUMMARIZE_CACHE_MAX:
+                    _proactive_summarize_cache.pop(
+                        next(iter(_proactive_summarize_cache))
+                    )
+                _proactive_summarize_cache[cache_key] = summary_msg
 
     result = initial_system + [summary_msg] + pinned_middle + recent
     new_tokens = len_tokens(result, model=model.model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -837,5 +837,7 @@ def _clear_proactive_summarize_cache():
     import gptme.util.reduce as reduce_mod
 
     reduce_mod._proactive_summarize_cache.clear()
+    reduce_mod._proactive_summarize_cache_pending.clear()
     yield
     reduce_mod._proactive_summarize_cache.clear()
+    reduce_mod._proactive_summarize_cache_pending.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -822,3 +822,20 @@ def wait_for_event():
         return False
 
     return wait
+
+
+@pytest.fixture(autouse=True)
+def _clear_proactive_summarize_cache():
+    """Clear the proactive-summarize in-process cache between tests.
+
+    The cache is module-level state. Without this fixture a test that calls
+    proactive_summarize_log will populate the cache with whatever fake/mocked
+    summary it used, and a later test that patches gptme.llm.summarize with a
+    *different* mock will silently get the earlier test's cached result instead
+    of its own mock's return value — causing hard-to-diagnose assertion failures.
+    """
+    import gptme.util.reduce as reduce_mod
+
+    reduce_mod._proactive_summarize_cache.clear()
+    yield
+    reduce_mod._proactive_summarize_cache.clear()

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1351,6 +1351,82 @@ def test_proactive_summarize_cache_miss_on_changed_messages(monkeypatch):
         reduce_mod._proactive_summarize_cache.clear()
 
 
+def test_proactive_summarize_concurrent_same_key(monkeypatch):
+    """Concurrent callers with identical input: only one LLM call, both get the same result.
+
+    Regression for the eviction race in the old winner-adoption pattern: a slow
+    second caller could store a different summary if the first caller's entry was
+    evicted from the cache before the second caller checked.  The Event-coordination
+    pattern fixes this: the second thread waits on the first thread's Event and
+    adopts the cached result after the Event fires.
+    """
+    import threading
+
+    import gptme.util.reduce as reduce_mod
+    from gptme.util.reduce import proactive_summarize_log
+
+    tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+    # Patch at the use-site in reduce.py so threads see the same tiny model
+    # regardless of ContextVar inheritance behaviour across threads.
+    monkeypatch.setattr("gptme.util.reduce.get_default_model", lambda: tiny_model)
+
+    call_count = 0
+    llm_started = threading.Event()
+    release_llm = threading.Event()
+
+    def slow_summarize(msgs):
+        nonlocal call_count
+        call_count += 1
+        llm_started.set()
+        release_llm.wait(timeout=5)
+        return Message("system", "The only summary")
+
+    monkeypatch.setattr("gptme.llm.summarize", slow_summarize)
+    reduce_mod._proactive_summarize_cache.clear()
+    reduce_mod._proactive_summarize_cache_pending.clear()
+
+    msgs = [
+        Message("system", "You are helpful."),
+        Message("user", "old content " * 5),
+        Message("assistant", "old reply " * 5),
+        Message("user", "recent q1"),
+        Message("assistant", "recent a1"),
+        Message("user", "recent q2"),
+        Message("assistant", "recent a2"),
+    ]
+
+    results: list = [None, None]
+    errors: list = []
+
+    def call_summarize(idx: int) -> None:
+        try:
+            results[idx] = proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+        except Exception as e:
+            errors.append(e)
+
+    t1 = threading.Thread(target=call_summarize, args=(0,))
+    t2 = threading.Thread(target=call_summarize, args=(1,))
+    t1.start()
+    # Wait until the compute thread has claimed the key and started the LLM call.
+    llm_started.wait(timeout=5)
+    # Thread 2 starts after thread 1 has registered its pending Event, so thread
+    # 2 will wait on that Event rather than making its own LLM call.
+    t2.start()
+    release_llm.set()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert results[0] is not None
+    assert results[1] is not None
+    assert results[0] == results[1], "Concurrent callers must return identical results"
+    assert call_count == 1, (
+        "Only one LLM call should occur for concurrent identical requests"
+    )
+    reduce_mod._proactive_summarize_cache.clear()
+    reduce_mod._proactive_summarize_cache_pending.clear()
+
+
 def test_proactive_summarize_cache_isolated_by_provider(monkeypatch):
     """proactive_summarize_log does NOT reuse a cached summary across different providers.
 

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1481,3 +1481,48 @@ def test_proactive_summarize_cache_isolated_by_provider(monkeypatch):
             None
         )
         reduce_mod._proactive_summarize_cache.clear()
+
+
+def test_proactive_summarize_baseexception_releases_pending(monkeypatch):
+    """A BaseException mid-summarize must still release the pending claim.
+
+    Regression: the release used to live only in the `except Exception` and
+    success paths, so a KeyboardInterrupt (Ctrl+C during generation) left the
+    cache key claimed forever. Concurrent callers then looped on
+    `wait(timeout=120)` indefinitely, never seeing the key released.
+    """
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        def interrupted_summarize(_msgs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("gptme.llm.summarize", interrupted_summarize)
+
+        msgs = [
+            Message("system", "System."),
+            Message("user", "word " * 5),
+            Message("assistant", "word " * 5),
+            Message("user", "recent q"),
+            Message("assistant", "recent a"),
+        ]
+
+        with pytest.raises(KeyboardInterrupt):
+            proactive_summarize_log(msgs, threshold=0.5, recent_keep=2)
+
+        # The claim must be gone, otherwise every waiter hangs forever.
+        assert not reduce_mod._proactive_summarize_cache_pending, (
+            "pending claim must be released on BaseException, "
+            f"still holding {list(reduce_mod._proactive_summarize_cache_pending)}"
+        )
+        # And nothing bogus cached.
+        assert not reduce_mod._proactive_summarize_cache
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1230,3 +1230,122 @@ def test_drop_orphaned_tool_pairs_preserves_pinned_tool_result():
     assert "fn result" in result_contents, (
         "Pinned tool result must survive _drop_orphaned_tool_pairs even when anchor is absent"
     )
+
+
+def test_proactive_summarize_cache_hit_skips_llm(monkeypatch):
+    """proactive_summarize_log reuses the cached summary on a second call with the same log.
+
+    Regression: without the cache, every prepare_messages call (once above the
+    threshold) fires a fresh LLM summarize.  That produces non-deterministic
+    summaries on consecutive turns and breaks prompt-cache stability.
+    """
+    import gptme.util.reduce as reduce_mod
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        call_count = 0
+
+        def counting_summarize(msgs):
+            nonlocal call_count
+            call_count += 1
+            return Message(
+                "system",
+                f"Summary (call {call_count}): user asked about X",
+            )
+
+        monkeypatch.setattr("gptme.llm.summarize", counting_summarize)
+
+        # Clear the module-level cache so this test is independent.
+        reduce_mod._proactive_summarize_cache.clear()
+
+        msgs = [
+            Message("system", "You are helpful."),  # initial system — kept
+            Message("user", "word " * 5),  # old — will be summarized
+            Message("assistant", "word " * 5),  # old — will be summarized
+            Message("user", "recent question one"),  # recent — kept
+            Message("assistant", "recent answer one"),  # recent — kept
+            Message("user", "recent question two"),  # recent — kept
+            Message("assistant", "recent answer two"),  # recent — kept
+        ]
+
+        # First call — LLM is invoked.
+        result1 = proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+        assert call_count == 1, "LLM should be called exactly once on first invocation"
+
+        # Second call with the same log — should hit the cache, not the LLM.
+        result2 = proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+        assert call_count == 1, (
+            "LLM must NOT be called again when the middle messages haven't changed"
+        )
+
+        # Both calls must produce identical summary content.
+        summary1 = next(m for m in result1 if "Summary" in m.content)
+        summary2 = next(m for m in result2 if "Summary" in m.content)
+        assert summary1.content == summary2.content, (
+            "Cached result must be identical to first-call result"
+        )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+        reduce_mod._proactive_summarize_cache.clear()
+
+
+def test_proactive_summarize_cache_miss_on_changed_messages(monkeypatch):
+    """proactive_summarize_log calls the LLM again when the middle messages change."""
+    import gptme.util.reduce as reduce_mod
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        tiny_model = ModelMeta(provider="unknown", model="gpt-4", context=10)
+        set_default_model(tiny_model)
+
+        call_count = 0
+
+        def counting_summarize(msgs):
+            nonlocal call_count
+            call_count += 1
+            return Message("system", f"Summary {call_count}")
+
+        monkeypatch.setattr("gptme.llm.summarize", counting_summarize)
+
+        reduce_mod._proactive_summarize_cache.clear()
+
+        base = [
+            Message("system", "You are helpful."),
+            Message("user", "old turn A " * 5),
+            Message("assistant", "old reply A " * 5),
+            Message("user", "recent q1"),
+            Message("assistant", "recent a1"),
+            Message("user", "recent q2"),
+            Message("assistant", "recent a2"),
+        ]
+        changed = [
+            Message("system", "You are helpful."),
+            Message("user", "DIFFERENT old content " * 5),  # changed middle
+            Message("assistant", "old reply A " * 5),
+            Message("user", "recent q1"),
+            Message("assistant", "recent a1"),
+            Message("user", "recent q2"),
+            Message("assistant", "recent a2"),
+        ]
+
+        proactive_summarize_log(base, threshold=0.5, recent_keep=4)
+        assert call_count == 1
+
+        proactive_summarize_log(changed, threshold=0.5, recent_keep=4)
+        assert call_count == 2, (
+            "LLM must be called again when the middle messages differ"
+        )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+        reduce_mod._proactive_summarize_cache.clear()

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1349,3 +1349,59 @@ def test_proactive_summarize_cache_miss_on_changed_messages(monkeypatch):
             None
         )
         reduce_mod._proactive_summarize_cache.clear()
+
+
+def test_proactive_summarize_cache_isolated_by_provider(monkeypatch):
+    """proactive_summarize_log does NOT reuse a cached summary across different providers.
+
+    Regression: if two providers expose a model with the same name (e.g. a local
+    proxy and OpenAI both calling it "gpt-4"), the cache key must not collide.
+    Without provider in the key, the first provider's summary is silently returned
+    for the second, even though the providers may return different summaries due to
+    different endpoints or parameter defaults.
+    """
+    import gptme.util.reduce as reduce_mod
+    from gptme.llm.models.resolution import _default_model_var
+    from gptme.util.reduce import proactive_summarize_log
+
+    original_model = _default_model_var.get()
+    try:
+        call_count = 0
+
+        def counting_summarize(msgs):
+            nonlocal call_count
+            call_count += 1
+            return Message("system", f"Summary (call {call_count})")
+
+        monkeypatch.setattr("gptme.llm.summarize", counting_summarize)
+        reduce_mod._proactive_summarize_cache.clear()
+
+        msgs = [
+            Message("system", "You are helpful."),
+            Message("user", "old content " * 5),
+            Message("assistant", "old reply " * 5),
+            Message("user", "recent q1"),
+            Message("assistant", "recent a1"),
+            Message("user", "recent q2"),
+            Message("assistant", "recent a2"),
+        ]
+
+        # First call with provider "openai".
+        provider_a = ModelMeta(provider="openai", model="gpt-4", context=10)
+        set_default_model(provider_a)
+        proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+        assert call_count == 1
+
+        # Second call with provider "local" — same model name, same content.
+        # The LLM must be invoked again; providers must not share a cache entry.
+        provider_b = ModelMeta(provider="local", model="gpt-4", context=10)
+        set_default_model(provider_b)
+        proactive_summarize_log(msgs, threshold=0.5, recent_keep=4)
+        assert call_count == 2, (
+            "LLM must be called again for a different provider even with the same model name"
+        )
+    finally:
+        set_default_model(original_model) if original_model else _default_model_var.set(
+            None
+        )
+        reduce_mod._proactive_summarize_cache.clear()


### PR DESCRIPTION
## Summary

- Adds a module-level SHA-256 content-hash cache to `proactive_summarize_log` in `gptme/util/reduce.py`
- Without the cache, every `prepare_messages` call (once above the auto-summarize threshold) fires a fresh `_llm_summarize` LLM call on the same middle-block messages — producing non-deterministic summaries on consecutive turns and breaking prompt-cache stability
- A cache hit returns the memoized `Message` without any LLM call; a miss calls `_llm_summarize` and stores the result keyed on `SHA-256(model + role:content of each summarized message)`
- Adds an autouse `conftest.py` fixture that clears the cache between tests (prevents cross-test monkeypatch interference with the module-level dict)
- Adds two regression tests: `test_proactive_summarize_cache_hit_skips_llm` and `test_proactive_summarize_cache_miss_on_changed_messages`

Phase 4.1 of the append-only request construction audit. Phases 2+3 landed in #3616.

## Test plan

- [ ] `pytest tests/test_reduce.py -k proactive_summarize` — all 14 tests pass
- [ ] `pytest tests/test_reduce.py` — full reduce suite green