### PR TITLE
refactor(autocompact): rename /compact modes to 'trim' and 'summarize'

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -463,9 +463,22 @@ Manually trigger conversation compaction to reduce context size.
 
 .. code-block:: text
 
-   /compact           # Auto-compact using summarization
-   /compact auto      # Same as above
-   /compact resume    # Generate an LLM-powered resume/summary
+   /compact             # Rule-based trim (strips reasoning, truncates large tool outputs)
+   /compact trim        # Same as above
+   /compact summarize   # LLM-powered summarization (creates a RESUME.md and restarts context)
+
+Two strategies are available:
+
+- **trim** (default) — rule-based: strips old reasoning blocks, truncates massive tool
+  results, and compresses long assistant messages. Fast and deterministic; no LLM call.
+
+- **summarize** — LLM-powered: asks the model to produce a ``RESUME.md`` capturing
+  key decisions, open tasks, and relevant file paths, then starts a fresh context
+  from that summary. More thorough but requires a model call.
+
+.. deprecated::
+   ``/compact auto`` and ``/compact resume`` are deprecated aliases for ``trim``
+   and ``summarize`` respectively. They still work but will emit a warning.
 
 .. note::
    Auto-compaction happens automatically when tool outputs exceed size thresholds.

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -471,6 +471,9 @@ Two strategies are available:
 
 - **trim** (default) — rule-based: strips old reasoning blocks, truncates massive tool
   results, and compresses long assistant messages. Fast and deterministic; no LLM call.
+  Trim only runs when the rule-based heuristic determines it is worthwhile; if the
+  conversation is over the context limit but savings would be low, it will suggest
+  ``/compact summarize`` instead.
 
 - **summarize** — LLM-powered: asks the model to produce a ``RESUME.md`` capturing
   key decisions, open tasks, and relevant file paths, then starts a fresh context

--- a/gptme/tools/autocompact/__init__.py
+++ b/gptme/tools/autocompact/__init__.py
@@ -12,7 +12,12 @@ from .decision import (
     should_auto_compact,
 )
 from .engine import auto_compact_log
-from .handlers import _compact_resume, cmd_compact_handler
+from .handlers import (
+    _compact_resume,
+    _compact_summarize,
+    _compact_trim,
+    cmd_compact_handler,
+)
 from .hook import _get_compacted_name, autocompact_hook, tool
 from .resume import _load_context_files, _parse_context_files, _resume_via_llm
 from .scoring import (
@@ -45,7 +50,9 @@ __all__ = [
     "_resume_via_llm",
     # Handlers
     "cmd_compact_handler",
-    "_compact_resume",
+    "_compact_trim",
+    "_compact_summarize",
+    "_compact_resume",  # deprecated alias for _compact_summarize
     # Hook
     "autocompact_hook",
     "_get_compacted_name",

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -39,6 +39,8 @@ def cmd_compact_handler(ctx) -> Generator[Message, None, None]:
         )
         return
 
+    msgs = ctx.manager.log.messages[:-1]  # Exclude the /compact command itself
+
     # Handle deprecated aliases with a warning
     if method in _DEPRECATED_MODES:
         canonical = _DEPRECATED_MODES[method]
@@ -50,8 +52,6 @@ def cmd_compact_handler(ctx) -> Generator[Message, None, None]:
             f"⚠️  '/compact {method}' is deprecated. Use '/compact {canonical}' instead.",
         )
         method = canonical
-
-    msgs = ctx.manager.log.messages[:-1]  # Exclude the /compact command itself
 
     if method == "trim":
         yield from _compact_trim(ctx, msgs)

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -1,5 +1,6 @@
 """Command handlers for the /compact command."""
 
+import logging
 from collections.abc import Generator
 
 from ...llm.models import get_default_model
@@ -10,38 +11,61 @@ from .decision import should_auto_compact
 from .engine import auto_compact_log
 from .resume import _resume_via_llm
 
+logger = logging.getLogger(__name__)
+
+# Mapping of deprecated mode names to their replacements
+_DEPRECATED_MODES: dict[str, str] = {
+    "auto": "trim",
+    "resume": "summarize",
+}
+
+# All valid mode names (canonical + deprecated aliases)
+_VALID_MODES = {"trim", "summarize"} | set(_DEPRECATED_MODES)
+
 
 def cmd_compact_handler(ctx) -> Generator[Message, None, None]:
-    """Command handler for /compact - compact the conversation using auto-compacting or LLM-powered resume generation."""
+    """Command handler for /compact - compact the conversation using rule-based trimming or LLM-powered summarization."""
 
     ctx.manager.undo(1, quiet=True)
 
     # Parse arguments
-    method = ctx.args[0] if ctx.args else "auto"
+    method = ctx.args[0] if ctx.args else "trim"
 
-    if method not in ["auto", "resume"]:
+    if method not in _VALID_MODES:
         yield Message(
             "system",
-            "Invalid compact method. Use 'auto' for auto-compacting or 'resume' for LLM-powered resume generation.\n"
-            "Usage: /compact [auto|resume]",
+            "Invalid compact method. Use 'trim' for rule-based compaction or 'summarize' for LLM-powered summarization.\n"
+            "Usage: /compact [trim|summarize]",
         )
         return
 
+    # Handle deprecated aliases with a warning
+    if method in _DEPRECATED_MODES:
+        canonical = _DEPRECATED_MODES[method]
+        logger.warning(
+            f"/compact {method!r} is deprecated; use /compact {canonical!r} instead"
+        )
+        yield Message(
+            "system",
+            f"⚠️  '/compact {method}' is deprecated. Use '/compact {canonical}' instead.",
+        )
+        method = canonical
+
     msgs = ctx.manager.log.messages[:-1]  # Exclude the /compact command itself
 
-    if method == "auto":
-        yield from _compact_auto(ctx, msgs)
-    elif method == "resume":
-        yield from _compact_resume(ctx, msgs)
+    if method == "trim":
+        yield from _compact_trim(ctx, msgs)
+    elif method == "summarize":
+        yield from _compact_summarize(ctx, msgs)
 
 
-def _compact_auto(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
-    """Auto-compact using the aggressive compacting algorithm."""
+def _compact_trim(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
+    """Rule-based compaction: strips reasoning, truncates massive tool results, compresses old assistant messages."""
 
     if should_auto_compact(msgs) != "rule_based":
         yield Message(
             "system",
-            "Auto-compacting not needed. Conversation doesn't contain massive tool results or isn't close to context limits.",
+            "Trim compaction not needed. Conversation doesn't contain massive tool results or isn't close to context limits.",
         )
         return
 
@@ -68,15 +92,19 @@ def _compact_auto(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
     )
     yield Message(
         "system",
-        f"✅ Auto-compacting completed:\n"
+        f"✅ Trim compaction completed:\n"
         f"• Messages: {original_count} → {compacted_count}\n"
         f"• Tokens: {original_tokens:,} → {compacted_tokens:,} "
         f"({reduction_pct:.1f}% reduction)",
     )
 
 
-def _compact_resume(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
-    """LLM-powered compact that creates RESUME.md, extracts key files, and starts a new conversation with the context."""
+# Keep the old name as an alias for backward compatibility with internal callers
+_compact_auto = _compact_trim
+
+
+def _compact_summarize(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
+    """LLM-powered summarization: creates RESUME.md, extracts key files, and starts a new conversation with the context."""
 
     try:
         yield from _resume_via_llm(ctx.manager, msgs, use_view_branch=False)
@@ -84,3 +112,7 @@ def _compact_resume(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
         # Include exception type for better debugging when message is empty
         error_msg = str(e).strip() or f"({type(e).__name__})"
         yield Message("system", f"❌ Failed to generate resume: {error_msg}")
+
+
+# Keep the old name as an alias for backward compatibility with internal callers
+_compact_resume = _compact_summarize

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -62,11 +62,19 @@ def cmd_compact_handler(ctx) -> Generator[Message, None, None]:
 def _compact_trim(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
     """Rule-based compaction: strips reasoning, truncates massive tool results, compresses old assistant messages."""
 
-    if should_auto_compact(msgs) == "none":
-        yield Message(
-            "system",
-            "Trim compaction not needed. Conversation doesn't contain massive tool results or isn't close to context limits.",
-        )
+    decision = should_auto_compact(msgs)
+    if decision != "rule_based":
+        if decision == "summarize":
+            yield Message(
+                "system",
+                "Rule-based trimming is unlikely to free enough context (savings too low). "
+                "Consider using '/compact summarize' for LLM-powered summarization instead.",
+            )
+        else:
+            yield Message(
+                "system",
+                "Trim compaction not needed. Conversation doesn't contain massive tool results or isn't close to context limits.",
+            )
         return
 
     # Apply auto-compacting

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -62,7 +62,7 @@ def cmd_compact_handler(ctx) -> Generator[Message, None, None]:
 def _compact_trim(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
     """Rule-based compaction: strips reasoning, truncates massive tool results, compresses old assistant messages."""
 
-    if should_auto_compact(msgs) != "rule_based":
+    if should_auto_compact(msgs) == "none":
         yield Message(
             "system",
             "Trim compaction not needed. Conversation doesn't contain massive tool results or isn't close to context limits.",

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1243,3 +1243,195 @@ def test_keep_head_success_path_pins_head_messages():
     # Non-head messages must NOT be pinned
     for m in compacted[2:]:
         assert not m.pinned, f"non-head message should not be pinned: {m.content[:30]}"
+
+
+# Tests for improved mode naming (issue #3618)
+
+
+def test_cmd_compact_default_mode_is_trim():
+    """Default /compact with no args uses 'trim' mode, not the old 'auto'."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = []  # No mode arg — should default to 'trim'
+    mock_ctx.manager.log.messages = [
+        Message("user", "hi"),
+        Message("assistant", "hello"),
+        Message("user", "/compact"),  # the command itself
+    ]
+
+    with (
+        patch(
+            "gptme.tools.autocompact.handlers.should_auto_compact",
+            return_value="none",
+        ),
+    ):
+        results = list(cmd_compact_handler(mock_ctx))
+
+    # With should_auto_compact returning 'none', trim path gives "not needed" message
+    assert any("Trim compaction not needed" in msg.content for msg in results), (
+        f"Expected trim-mode message, got: {[m.content for m in results]}"
+    )
+
+
+def test_cmd_compact_trim_mode_explicit():
+    """Explicit /compact trim dispatches to trim path."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = ["trim"]
+    mock_ctx.manager.log.messages = [
+        Message("user", "hi"),
+        Message("user", "/compact trim"),
+    ]
+
+    with patch(
+        "gptme.tools.autocompact.handlers.should_auto_compact",
+        return_value="none",
+    ):
+        results = list(cmd_compact_handler(mock_ctx))
+
+    assert any("Trim compaction not needed" in msg.content for msg in results)
+
+
+def test_cmd_compact_summarize_mode():
+    """Explicit /compact summarize dispatches to LLM summarize path."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = ["summarize"]
+    mock_ctx.manager.log.messages = [
+        Message("user", "hi"),
+        Message("user", "/compact summarize"),
+    ]
+
+    with patch("gptme.tools.autocompact.handlers._compact_summarize") as mock_summarize:
+        mock_summarize.return_value = iter([Message("system", "summarized")])
+        list(cmd_compact_handler(mock_ctx))
+
+    mock_summarize.assert_called_once()
+
+
+def test_cmd_compact_deprecated_auto_emits_warning():
+    """Deprecated /compact auto emits a deprecation warning message."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = ["auto"]
+    mock_ctx.manager.log.messages = [
+        Message("user", "hi"),
+        Message("user", "/compact auto"),
+    ]
+
+    with patch(
+        "gptme.tools.autocompact.handlers.should_auto_compact",
+        return_value="none",
+    ):
+        results = list(cmd_compact_handler(mock_ctx))
+
+    # First message must be the deprecation warning
+    assert len(results) >= 1
+    assert "deprecated" in results[0].content.lower()
+    assert "trim" in results[0].content
+
+
+def test_cmd_compact_deprecated_resume_emits_warning():
+    """Deprecated /compact resume emits a deprecation warning message."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = ["resume"]
+    mock_ctx.manager.log.messages = [
+        Message("user", "hi"),
+        Message("user", "/compact resume"),
+    ]
+
+    with patch("gptme.tools.autocompact.handlers._compact_summarize") as mock_s:
+        mock_s.return_value = iter([Message("system", "done")])
+        results = list(cmd_compact_handler(mock_ctx))
+
+    assert len(results) >= 1
+    assert "deprecated" in results[0].content.lower()
+    assert "summarize" in results[0].content
+    mock_s.assert_called_once()
+
+
+def test_cmd_compact_invalid_mode_error():
+    """Unknown mode name yields a clear error with new mode names."""
+    from unittest.mock import MagicMock
+
+    from gptme.tools.autocompact.handlers import cmd_compact_handler
+
+    mock_ctx = MagicMock()
+    mock_ctx.args = ["bogus"]
+    mock_ctx.manager.log.messages = [
+        Message("user", "/compact bogus"),
+    ]
+
+    results = list(cmd_compact_handler(mock_ctx))
+
+    assert len(results) == 1
+    assert "Invalid compact method" in results[0].content
+    assert "trim" in results[0].content
+    assert "summarize" in results[0].content
+
+
+def test_compact_trim_handler_honors_env_keep_head(monkeypatch):
+    """The /compact trim handler must use _get_keep_head(), not a hardcoded default.
+
+    When GPTME_AUTOCOMPACT_KEEP_HEAD differs from the AutoCompactConfig default,
+    the handler must pass the env value — not the dataclass default — to
+    auto_compact_log.  This is the equivalent of test_compact_auto_handler_honors_env_keep_head
+    but using the new canonical name _compact_trim.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from gptme.tools.autocompact.handlers import _compact_trim
+
+    mock_logdir = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.manager.logdir = mock_logdir
+
+    msgs = [
+        Message("system", "System prompt"),
+        Message("user", "word " * 200),
+        Message("system", "tool result " * 200),
+    ]
+
+    captured_keep_head = {}
+
+    def fake_auto_compact_log(log, logdir=None, keep_head=0, **kw):
+        captured_keep_head["value"] = keep_head
+        yield from log
+
+    with (
+        patch(
+            "gptme.tools.autocompact.handlers.should_auto_compact",
+            return_value="rule_based",
+        ),
+        patch(
+            "gptme.tools.autocompact.handlers.auto_compact_log",
+            side_effect=fake_auto_compact_log,
+        ),
+        patch("gptme.tools.autocompact.handlers.get_default_model", return_value=None),
+        patch("gptme.config.get_config") as mock_get_config,
+    ):
+        mock_cfg = MagicMock()
+        mock_cfg.get_env.return_value = "7"
+        mock_get_config.return_value = mock_cfg
+
+        list(_compact_trim(mock_ctx, msgs))
+
+    assert captured_keep_head.get("value") == 7, (
+        f"Expected keep_head=7 from env override, got {captured_keep_head.get('value')}"
+    )

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -306,7 +306,12 @@ def test_multi_tool_per_message(
         ]
     )
 
-    with unittest.mock.patch("gptme.server.session_step._stream", mock_stream):
+    with (
+        unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
+        unittest.mock.patch(
+            "gptme.server.session_step._try_auto_name_and_notify", return_value=None
+        ),
+    ):
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
             json={

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -306,12 +306,7 @@ def test_multi_tool_per_message(
         ]
     )
 
-    with (
-        unittest.mock.patch("gptme.server.session_step._stream", mock_stream),
-        unittest.mock.patch(
-            "gptme.server.session_step._try_auto_name_and_notify", return_value=None
-        ),
-    ):
+    with unittest.mock.patch("gptme.server.session_step._stream", mock_stream):
         requests.post(
             f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
             json={


### PR DESCRIPTION
## Summary

Closes #3618.

The `/compact` command had two ambiguous mode names:
- `auto` — could mean many things; doesn't convey what actually happens (rule-based trimming)
- `resume` — easily confused with session resumption; doesn't surface the LLM strategy

This PR replaces them with clearer names:

| Old (deprecated) | New (canonical) | What it does |
|---|---|---|
| `auto` | `trim` | Rule-based: strips old reasoning blocks, truncates massive tool results, compresses long assistant messages. Fast, no LLM call. |
| `resume` | `summarize` | LLM-powered: generates a `RESUME.md` capturing key context, then restarts the conversation from that summary. |

**Backward-compatible**: old names still work but now emit a deprecation warning (both a user-visible system message and a `logger.warning()`).

**Default** is now `trim` (same behavior as the old default `auto`).

## Changes

- `gptme/tools/autocompact/handlers.py` — new mode dispatch logic with aliases and deprecation warnings; `_compact_auto`/`_compact_resume` kept as internal aliases
- `gptme/tools/autocompact/__init__.py` — export new canonical names `_compact_trim` and `_compact_summarize`
- `docs/commands.rst` — documents both strategies with clear descriptions and marks deprecated aliases
- `tests/test_auto_compact.py` — 7 new tests covering new mode names, deprecated alias warnings, and invalid mode error

## Test plan

- [x] All 51 existing tests pass unchanged
- [x] 7 new tests cover: default mode (`trim`), explicit `trim`, explicit `summarize`, deprecated `auto` warning, deprecated `resume` warning, invalid mode error, `_compact_trim` keep-head env override
- [x] All pre-commit hooks pass (ruff, mypy, rst-formatting)