### PR TITLE
feat(knowledge): cross-session KB save/retrieve as gptme-util CLI

### DIFF
--- a/gptme/__init__.pyi
+++ b/gptme/__init__.pyi
@@ -1,8 +1,0 @@
-from .__version__ import __version__ as __version__
-from .chat import chat as chat
-from .codeblock import Codeblock as Codeblock
-from .logmanager import LogManager as LogManager
-from .message import Message as Message
-from .prompts import get_prompt as get_prompt
-
-__all__ = ["Codeblock", "LogManager", "Message", "__version__", "chat", "get_prompt"]

--- a/gptme/__init__.pyi
+++ b/gptme/__init__.pyi
@@ -1,17 +1,8 @@
 from .__version__ import __version__ as __version__
 from .chat import chat as chat
 from .codeblock import Codeblock as Codeblock
-from .k_best import k_best_guess as k_best_guess
 from .logmanager import LogManager as LogManager
 from .message import Message as Message
 from .prompts import get_prompt as get_prompt
 
-__all__ = [
-    "Codeblock",
-    "LogManager",
-    "Message",
-    "__version__",
-    "chat",
-    "get_prompt",
-    "k_best_guess",
-]
+__all__ = ["Codeblock", "LogManager", "Message", "__version__", "chat", "get_prompt"]

--- a/gptme/__init__.pyi
+++ b/gptme/__init__.pyi
@@ -1,0 +1,17 @@
+from .__version__ import __version__ as __version__
+from .chat import chat as chat
+from .codeblock import Codeblock as Codeblock
+from .k_best import k_best_guess as k_best_guess
+from .logmanager import LogManager as LogManager
+from .message import Message as Message
+from .prompts import get_prompt as get_prompt
+
+__all__ = [
+    "Codeblock",
+    "LogManager",
+    "Message",
+    "__version__",
+    "chat",
+    "get_prompt",
+    "k_best_guess",
+]

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -61,13 +61,13 @@ def knowledge_save_cmd(
 
     if as_json:
         click.echo(json.dumps(entry, indent=2))
-        # Suppress gptme-rag reindex noise when caller expects pure JSON on stdout.
-        return
-    click.echo(f"Saved knowledge entry {entry['id'][:8]}")
-    if entry["tags"]:
-        click.echo(f"  Tags: {', '.join(entry['tags'])}")
+    else:
+        click.echo(f"Saved knowledge entry {entry['id'][:8]}")
+        if entry["tags"]:
+            click.echo(f"  Tags: {', '.join(entry['tags'])}")
 
-    # Optionally re-index with gptme-rag so semantic search stays current.
+    # Re-index with gptme-rag regardless of output mode so the mirror stays
+    # in sync whether the caller asked for JSON or human-readable output.
     if shutil.which("gptme-rag"):
         from ..knowledge import _knowledge_dir  # fmt: skip
 
@@ -110,7 +110,11 @@ def _export_for_rag(kb_dir: Path) -> None:
 @knowledge.command("search")
 @click.argument("query")
 @click.option(
-    "--top-k", default=5, show_default=True, type=int, help="Number of results."
+    "--top-k",
+    default=5,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Number of results.",
 )
 @click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
@@ -151,7 +155,11 @@ def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json:
 @knowledge.command("list")
 @click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
 @click.option(
-    "--limit", default=20, show_default=True, type=int, help="Maximum entries."
+    "--limit",
+    default=20,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Maximum entries.",
 )
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
@@ -198,6 +206,25 @@ def knowledge_delete_cmd(entry_id: str):
     full_id = matches[0]["id"]
     if knowledge_delete(full_id):
         click.echo(f"Deleted entry {full_id[:8]}")
+        # Remove the RAG mirror file so semantic retrieval doesn't return stale results.
+        if shutil.which("gptme-rag"):
+            from ..knowledge import _knowledge_dir  # fmt: skip
+
+            mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
+            if mirror.exists():
+                mirror.unlink()
+                try:
+                    subprocess.run(
+                        ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
+                        check=True,
+                        capture_output=True,
+                        timeout=30,
+                    )
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                    click.echo(
+                        f"Warning: gptme-rag re-index after delete failed: {e}",
+                        err=True,
+                    )
     else:
         click.echo(f"Failed to delete entry {full_id[:8]}")
         sys.exit(1)

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -92,6 +92,11 @@ def _export_for_rag(kb_dir: Path) -> None:
     rag_dir = kb_dir / "rag"
     rag_dir.mkdir(parents=True, exist_ok=True)
     entries = _load_entries()
+    live_ids = {e["id"] for e in entries}
+    # Remove orphan mirror files left by prior deletions.
+    for existing in rag_dir.glob("*.md"):
+        if existing.stem not in live_ids:
+            existing.unlink()
     for entry in entries:
         eid = entry.get("id", "unknown")
         fpath = rag_dir / f"{eid}.md"
@@ -206,25 +211,28 @@ def knowledge_delete_cmd(entry_id: str):
     full_id = matches[0]["id"]
     if knowledge_delete(full_id):
         click.echo(f"Deleted entry {full_id[:8]}")
-        # Remove the RAG mirror file so semantic retrieval doesn't return stale results.
-        if shutil.which("gptme-rag"):
-            from ..knowledge import _knowledge_dir  # fmt: skip
+        from ..knowledge import _knowledge_dir  # fmt: skip
 
-            mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
-            if mirror.exists():
-                mirror.unlink()
-                try:
-                    subprocess.run(
-                        ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
-                        check=True,
-                        capture_output=True,
-                        timeout=30,
-                    )
-                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                    click.echo(
-                        f"Warning: gptme-rag re-index after delete failed: {e}",
-                        err=True,
-                    )
+        # Always remove the mirror file regardless of whether gptme-rag is
+        # installed — the file lives on disk independently and must be cleaned
+        # up so that a later install of gptme-rag does not index stale entries.
+        mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
+        if mirror.exists():
+            mirror.unlink()
+        # Re-index only when gptme-rag is available.
+        if shutil.which("gptme-rag"):
+            try:
+                subprocess.run(
+                    ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                click.echo(
+                    f"Warning: gptme-rag re-index after delete failed: {e}",
+                    err=True,
+                )
     else:
         click.echo(f"Failed to delete entry {full_id[:8]}")
         sys.exit(1)

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -1,0 +1,203 @@
+"""
+gptme-util knowledge — cross-session knowledge base CLI.
+
+Saves and retrieves problem/resolution pairs backed by JSONL storage at
+``~/.local/share/gptme/knowledge/entries.jsonl``.
+
+When ``gptme-rag`` is available the knowledge directory is also re-indexed
+after each ``save`` so semantic search stays current.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@click.group("knowledge")
+def knowledge():
+    """Cross-session knowledge base: save and retrieve problem/resolution pairs."""
+
+
+@knowledge.command("save")
+@click.argument("problem")
+@click.argument("resolution")
+@click.option(
+    "--tag",
+    "-t",
+    "tags",
+    multiple=True,
+    help="Tag to attach (repeatable: -t git -t pytest).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Print saved entry as JSON.")
+def knowledge_save_cmd(
+    problem: str, resolution: str, tags: tuple[str, ...], as_json: bool
+):
+    """Save a PROBLEM/RESOLUTION pair to the knowledge base.
+
+    Example:
+
+    \b
+        gptme-util knowledge save \\
+          "pytest discovers no tests despite test file existing" \\
+          "The test function was not prefixed with test_; rename it." \\
+          -t pytest -t testing
+    """
+    from ..knowledge import knowledge_save  # fmt: skip
+
+    try:
+        entry = knowledge_save(problem, resolution, list(tags))
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if as_json:
+        click.echo(json.dumps(entry, indent=2))
+        # Suppress gptme-rag reindex noise when caller expects pure JSON on stdout.
+        return
+    click.echo(f"Saved knowledge entry {entry['id'][:8]}")
+    if entry["tags"]:
+        click.echo(f"  Tags: {', '.join(entry['tags'])}")
+
+    # Optionally re-index with gptme-rag so semantic search stays current.
+    if shutil.which("gptme-rag"):
+        from ..knowledge import _knowledge_dir  # fmt: skip
+
+        kb_dir = _knowledge_dir()
+        # Export entries as markdown files that gptme-rag can index.
+        _export_for_rag(kb_dir)
+        try:
+            subprocess.run(
+                ["gptme-rag", "index", str(kb_dir / "rag")],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            click.echo(f"Warning: gptme-rag index failed: {e}", err=True)
+
+
+def _export_for_rag(kb_dir: Path) -> None:
+    """Write entries as markdown files under kb_dir/rag/ for gptme-rag indexing."""
+    from ..knowledge import _load_entries  # fmt: skip
+
+    rag_dir = kb_dir / "rag"
+    rag_dir.mkdir(parents=True, exist_ok=True)
+    entries = _load_entries()
+    for entry in entries:
+        eid = entry.get("id", "unknown")
+        fpath = rag_dir / f"{eid}.md"
+        tags_line = ""
+        if entry.get("tags"):
+            tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
+        content = (
+            f"# Knowledge Entry\n\n"
+            f"**Problem**: {entry.get('problem', '')}\n\n"
+            f"**Resolution**: {entry.get('resolution', '')}\n"
+            f"{tags_line}"
+        )
+        fpath.write_text(content, encoding="utf-8")
+
+
+@knowledge.command("search")
+@click.argument("query")
+@click.option(
+    "--top-k", default=5, show_default=True, type=int, help="Number of results."
+)
+@click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json: bool):
+    """Search the knowledge base for QUERY.
+
+    Example:
+
+    \b
+        gptme-util knowledge search "pytest test discovery"
+    """
+    from ..knowledge import knowledge_search  # fmt: skip
+
+    try:
+        results = knowledge_search(
+            query, top_k=top_k, tags=list(tags) if tags else None
+        )
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if as_json:
+        click.echo(json.dumps(results, indent=2))
+        return
+
+    if not results:
+        click.echo("No matching entries found.")
+        return
+
+    for i, entry in enumerate(results, 1):
+        click.echo(f"\n[{i}] {entry['id'][:8]}  {entry.get('created_at', '')[:10]}")
+        if entry.get("tags"):
+            click.echo(f"    Tags: {', '.join(entry['tags'])}")
+        click.echo(f"    Problem:    {entry['problem']}")
+        click.echo(f"    Resolution: {entry['resolution']}")
+
+
+@knowledge.command("list")
+@click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
+@click.option(
+    "--limit", default=20, show_default=True, type=int, help="Maximum entries."
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
+    """List knowledge entries, newest first."""
+    from ..knowledge import knowledge_list  # fmt: skip
+
+    entries = knowledge_list(tags=list(tags) if tags else None, limit=limit)
+
+    if as_json:
+        click.echo(json.dumps(entries, indent=2))
+        return
+
+    if not entries:
+        click.echo("No entries in knowledge base.")
+        return
+
+    click.echo(f"Knowledge base ({len(entries)} entries):\n")
+    for entry in entries:
+        eid = entry.get("id", "")[:8]
+        date = entry.get("created_at", "")[:10]
+        tags_str = f"  [{', '.join(entry['tags'])}]" if entry.get("tags") else ""
+        click.echo(f"  {eid}  {date}{tags_str}")
+        click.echo(f"    {entry['problem'][:80]}")
+
+
+@knowledge.command("delete")
+@click.argument("entry_id")
+def knowledge_delete_cmd(entry_id: str):
+    """Delete a knowledge entry by ID (or ID prefix)."""
+    from ..knowledge import _load_entries, knowledge_delete  # fmt: skip
+
+    # Support prefix matching
+    entries = _load_entries()
+    matches = [e for e in entries if e.get("id", "").startswith(entry_id)]
+    if len(matches) > 1:
+        click.echo(f"Ambiguous prefix '{entry_id}' — matches {len(matches)} entries:")
+        for m in matches:
+            click.echo(f"  {m['id']}")
+        sys.exit(1)
+    if not matches:
+        click.echo(f"No entry found with ID or prefix '{entry_id}'")
+        sys.exit(1)
+
+    full_id = matches[0]["id"]
+    if knowledge_delete(full_id):
+        click.echo(f"Deleted entry {full_id[:8]}")
+    else:
+        click.echo(f"Failed to delete entry {full_id[:8]}")
+        sys.exit(1)

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -226,9 +226,10 @@ def knowledge_delete_cmd(entry_id: str):
         # Always remove the mirror file regardless of whether gptme-rag is
         # installed — the file lives on disk independently and must be cleaned
         # up so that a later install of gptme-rag does not index stale entries.
+        # Use missing_ok=True to avoid a TOCTOU race: _export_for_rag's orphan
+        # sweep (inside the exclusive lock) can unlink the same file concurrently.
         mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
-        if mirror.exists():
-            mirror.unlink()
+        mirror.unlink(missing_ok=True)
         # Re-index only when gptme-rag is available.
         if shutil.which("gptme-rag"):
             try:

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -182,7 +182,11 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
     """List knowledge entries, newest first."""
     from ..knowledge import knowledge_list  # fmt: skip
 
-    entries = knowledge_list(tags=list(tags) if tags else None, limit=limit)
+    try:
+        entries = knowledge_list(tags=list(tags) if tags else None, limit=limit)
+    except OSError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
 
     if as_json:
         click.echo(json.dumps(entries, indent=2))

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -55,7 +55,7 @@ def knowledge_save_cmd(
 
     try:
         entry = knowledge_save(problem, resolution, list(tags))
-    except ValueError as e:
+    except (ValueError, OSError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
@@ -143,7 +143,7 @@ def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json:
         results = knowledge_search(
             query, top_k=top_k, tags=list(tags) if tags else None
         )
-    except ValueError as e:
+    except (ValueError, OSError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
@@ -203,7 +203,11 @@ def knowledge_delete_cmd(entry_id: str):
     from ..knowledge import _load_entries, knowledge_delete  # fmt: skip
 
     # Support prefix matching
-    entries = _load_entries()
+    try:
+        entries = _load_entries()
+    except OSError as e:
+        click.echo(f"Error reading knowledge base: {e}", err=True)
+        sys.exit(1)
     matches = [e for e in entries if e.get("id", "").startswith(entry_id)]
     if len(matches) > 1:
         click.echo(f"Ambiguous prefix '{entry_id}' — matches {len(matches)} entries:")

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -212,8 +212,8 @@ def knowledge_delete_cmd(entry_id: str):
     # prefix lookup and the actual write.
     try:
         full_id, status, matches = knowledge_delete_by_prefix(entry_id)
-    except OSError as e:
-        click.echo(f"Error reading knowledge base: {e}", err=True)
+    except (ValueError, OSError) as e:
+        click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
     if status == "ambiguous":

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -86,30 +86,36 @@ def knowledge_save_cmd(
 
 
 def _export_for_rag(kb_dir: Path) -> None:
-    """Write entries as markdown files under kb_dir/rag/ for gptme-rag indexing."""
-    from ..knowledge import _load_entries  # fmt: skip
+    """Write entries as markdown files under kb_dir/rag/ for gptme-rag indexing.
+
+    Loads the entry snapshot under the exclusive lock so the orphan sweep and
+    mirror writes reflect the same consistent view of the JSONL file, preventing
+    a concurrent delete from being resurrected by a stale export snapshot.
+    """
+    from ..knowledge import _exclusive_lock, _load_entries  # fmt: skip
 
     rag_dir = kb_dir / "rag"
     rag_dir.mkdir(parents=True, exist_ok=True)
-    entries = _load_entries()
-    live_ids = {e["id"] for e in entries}
-    # Remove orphan mirror files left by prior deletions.
-    for existing in rag_dir.glob("*.md"):
-        if existing.stem not in live_ids:
-            existing.unlink()
-    for entry in entries:
-        eid = entry.get("id", "unknown")
-        fpath = rag_dir / f"{eid}.md"
-        tags_line = ""
-        if entry.get("tags"):
-            tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
-        content = (
-            f"# Knowledge Entry\n\n"
-            f"**Problem**: {entry.get('problem', '')}\n\n"
-            f"**Resolution**: {entry.get('resolution', '')}\n"
-            f"{tags_line}"
-        )
-        fpath.write_text(content, encoding="utf-8")
+    with _exclusive_lock():
+        entries = _load_entries()
+        live_ids = {e["id"] for e in entries}
+        # Remove orphan mirror files left by prior deletions.
+        for existing in rag_dir.glob("*.md"):
+            if existing.stem not in live_ids:
+                existing.unlink()
+        for entry in entries:
+            eid = entry.get("id", "unknown")
+            fpath = rag_dir / f"{eid}.md"
+            tags_line = ""
+            if entry.get("tags"):
+                tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
+            content = (
+                f"# Knowledge Entry\n\n"
+                f"**Problem**: {entry.get('problem', '')}\n\n"
+                f"**Resolution**: {entry.get('resolution', '')}\n"
+                f"{tags_line}"
+            )
+            fpath.write_text(content, encoding="utf-8")
 
 
 @knowledge.command("search")

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -205,55 +205,54 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
 @click.argument("entry_id")
 def knowledge_delete_cmd(entry_id: str):
     """Delete a knowledge entry by ID (or ID prefix)."""
-    from ..knowledge import _load_entries, knowledge_delete  # fmt: skip
+    from ..knowledge import knowledge_delete_by_prefix  # fmt: skip
 
-    # Support prefix matching
+    # Prefix resolution and delete are done atomically under the exclusive lock
+    # so a concurrent save or delete cannot change the entry set between the
+    # prefix lookup and the actual write.
     try:
-        entries = _load_entries()
+        full_id, status, matches = knowledge_delete_by_prefix(entry_id)
     except OSError as e:
         click.echo(f"Error reading knowledge base: {e}", err=True)
         sys.exit(1)
-    matches = [e for e in entries if e.get("id", "").startswith(entry_id)]
-    if len(matches) > 1:
+
+    if status == "ambiguous":
         click.echo(f"Ambiguous prefix '{entry_id}' — matches {len(matches)} entries:")
         for m in matches:
             click.echo(f"  {m['id']}")
         sys.exit(1)
-    if not matches:
+    if status == "not_found":
         click.echo(f"No entry found with ID or prefix '{entry_id}'")
         sys.exit(1)
 
-    full_id = matches[0]["id"]
-    if knowledge_delete(full_id):
-        click.echo(f"Deleted entry {full_id[:8]}")
-        from ..knowledge import _knowledge_dir  # fmt: skip
+    # status == 'deleted'
+    assert full_id is not None
+    click.echo(f"Deleted entry {full_id[:8]}")
+    from ..knowledge import _knowledge_dir  # fmt: skip
 
-        # Always remove the mirror file regardless of whether gptme-rag is
-        # installed — the file lives on disk independently and must be cleaned
-        # up so that a later install of gptme-rag does not index stale entries.
-        # Use missing_ok=True to avoid a TOCTOU race: _export_for_rag's orphan
-        # sweep (inside the exclusive lock) can unlink the same file concurrently.
-        # Catch OSError: the entry is already deleted; a permission or I/O error
-        # on the mirror should warn, not crash and confuse the user about success.
-        mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
+    # Always remove the mirror file regardless of whether gptme-rag is
+    # installed — the file lives on disk independently and must be cleaned
+    # up so that a later install of gptme-rag does not index stale entries.
+    # Use missing_ok=True to avoid a TOCTOU race: _export_for_rag's orphan
+    # sweep (inside the exclusive lock) can unlink the same file concurrently.
+    # Catch OSError: the entry is already deleted; a permission or I/O error
+    # on the mirror should warn, not crash and confuse the user about success.
+    mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
+    try:
+        mirror.unlink(missing_ok=True)
+    except OSError as e:
+        click.echo(f"Warning: could not remove mirror file {mirror}: {e}", err=True)
+    # Re-index only when gptme-rag is available.
+    if shutil.which("gptme-rag"):
         try:
-            mirror.unlink(missing_ok=True)
-        except OSError as e:
-            click.echo(f"Warning: could not remove mirror file {mirror}: {e}", err=True)
-        # Re-index only when gptme-rag is available.
-        if shutil.which("gptme-rag"):
-            try:
-                subprocess.run(
-                    ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
-                    check=True,
-                    capture_output=True,
-                    timeout=30,
-                )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                click.echo(
-                    f"Warning: gptme-rag re-index after delete failed: {e}",
-                    err=True,
-                )
-    else:
-        click.echo(f"Failed to delete entry {full_id[:8]}")
-        sys.exit(1)
+            subprocess.run(
+                ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            click.echo(
+                f"Warning: gptme-rag re-index after delete failed: {e}",
+                err=True,
+            )

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -11,6 +11,7 @@ after each ``save`` so semantic search stays current.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -20,6 +21,14 @@ import click
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _strip_controls(value: str) -> str:
+    """Strip terminal control characters from human-readable output."""
+    return _CONTROL_CHARS_RE.sub("", value)
 
 
 @click.group("knowledge")
@@ -86,7 +95,7 @@ def knowledge_save_cmd(
                 capture_output=True,
                 timeout=30,
             )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: gptme-rag index failed: {e}", err=True)
 
 
@@ -163,9 +172,9 @@ def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json:
     for i, entry in enumerate(results, 1):
         click.echo(f"\n[{i}] {entry['id'][:8]}  {entry.get('created_at', '')[:10]}")
         if entry.get("tags"):
-            click.echo(f"    Tags: {', '.join(entry['tags'])}")
-        click.echo(f"    Problem:    {entry['problem']}")
-        click.echo(f"    Resolution: {entry['resolution']}")
+            click.echo(f"    Tags: {_strip_controls(', '.join(entry['tags']))}")
+        click.echo(f"    Problem:    {_strip_controls(entry['problem'])}")
+        click.echo(f"    Resolution: {_strip_controls(entry['resolution'])}")
 
 
 @knowledge.command("list")
@@ -200,9 +209,13 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
     for entry in entries:
         eid = entry.get("id", "")[:8]
         date = entry.get("created_at", "")[:10]
-        tags_str = f"  [{', '.join(entry['tags'])}]" if entry.get("tags") else ""
+        tags_str = (
+            f"  [{_strip_controls(', '.join(entry['tags']))}]"
+            if entry.get("tags")
+            else ""
+        )
         click.echo(f"  {eid}  {date}{tags_str}")
-        click.echo(f"    {entry['problem'][:80]}")
+        click.echo(f"    {_strip_controls(entry['problem'][:80])}")
 
 
 @knowledge.command("delete")
@@ -255,7 +268,7 @@ def knowledge_delete_cmd(entry_id: str):
                 capture_output=True,
                 timeout=30,
             )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(
                 f"Warning: gptme-rag re-index after delete failed: {e}",
                 err=True,

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -73,7 +73,12 @@ def knowledge_save_cmd(
 
         kb_dir = _knowledge_dir()
         # Export entries as markdown files that gptme-rag can index.
-        _export_for_rag(kb_dir)
+        # Wrap in OSError handler: the entry is already persisted; a non-writable
+        # rag directory should warn, not crash and mislead the user.
+        try:
+            _export_for_rag(kb_dir)
+        except OSError as e:
+            click.echo(f"Warning: gptme-rag mirror export failed: {e}", err=True)
         try:
             subprocess.run(
                 ["gptme-rag", "index", str(kb_dir / "rag")],
@@ -228,8 +233,13 @@ def knowledge_delete_cmd(entry_id: str):
         # up so that a later install of gptme-rag does not index stale entries.
         # Use missing_ok=True to avoid a TOCTOU race: _export_for_rag's orphan
         # sweep (inside the exclusive lock) can unlink the same file concurrently.
+        # Catch OSError: the entry is already deleted; a permission or I/O error
+        # on the mirror should warn, not crash and confuse the user about success.
         mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
-        mirror.unlink(missing_ok=True)
+        try:
+            mirror.unlink(missing_ok=True)
+        except OSError as e:
+            click.echo(f"Warning: could not remove mirror file {mirror}: {e}", err=True)
         # Re-index only when gptme-rag is available.
         if shutil.which("gptme-rag"):
             try:

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -73,7 +73,9 @@ def knowledge_save_cmd(
     else:
         click.echo(f"Saved knowledge entry {entry['id'][:8]}")
         if entry["tags"]:
-            click.echo(f"  Tags: {', '.join(entry['tags'])}")
+            click.echo(
+                f"  Tags: {', '.join(_strip_controls(t) for t in entry['tags'])}"
+            )
 
     # Re-index with gptme-rag regardless of output mode so the mirror stays
     # in sync whether the caller asked for JSON or human-readable output.
@@ -116,7 +118,7 @@ def _export_for_rag(kb_dir: Path) -> None:
         # Remove orphan mirror files left by prior deletions.
         for existing in rag_dir.glob("*.md"):
             if existing.stem not in live_ids:
-                existing.unlink()
+                existing.unlink(missing_ok=True)
         for entry in entries:
             eid = entry.get("id", "unknown")
             fpath = rag_dir / f"{eid}.md"
@@ -255,12 +257,15 @@ def knowledge_delete_cmd(entry_id: str):
     # Catch OSError: the entry is already deleted; a permission or I/O error
     # on the mirror should warn, not crash and confuse the user about success.
     mirror = _knowledge_dir() / "rag" / f"{full_id}.md"
+    mirror_removed = True
     try:
         mirror.unlink(missing_ok=True)
     except OSError as e:
+        mirror_removed = False
         click.echo(f"Warning: could not remove mirror file {mirror}: {e}", err=True)
-    # Re-index only when gptme-rag is available.
-    if shutil.which("gptme-rag"):
+    # Re-index only when the mirror is clean; otherwise indexing would preserve
+    # the deleted entry in semantic search.
+    if mirror_removed and shutil.which("gptme-rag"):
         try:
             subprocess.run(
                 ["gptme-rag", "index", str(_knowledge_dir() / "rag")],

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -88,7 +88,7 @@ def knowledge_save_cmd(
         # rag directory should warn, not crash and mislead the user.
         try:
             _export_for_rag(kb_dir)
-        except OSError as e:
+        except (OSError, ValueError) as e:
             click.echo(f"Warning: gptme-rag mirror export failed: {e}", err=True)
         else:
             try:
@@ -200,7 +200,7 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
 
     try:
         entries = knowledge_list(tags=list(tags) if tags else None, limit=limit)
-    except OSError as e:
+    except (OSError, ValueError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
@@ -240,13 +240,14 @@ def knowledge_delete_cmd(entry_id: str):
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
+    safe_id = _strip_controls(entry_id)
     if status == "ambiguous":
-        click.echo(f"Ambiguous prefix '{entry_id}' — matches {len(matches)} entries:")
+        click.echo(f"Ambiguous prefix '{safe_id}' — matches {len(matches)} entries:")
         for m in matches:
             click.echo(f"  {m['id']}")
         sys.exit(1)
     if status == "not_found":
-        click.echo(f"No entry found with ID or prefix '{entry_id}'")
+        click.echo(f"No entry found with ID or prefix '{safe_id}'")
         sys.exit(1)
 
     # status == 'deleted'
@@ -268,12 +269,15 @@ def knowledge_delete_cmd(entry_id: str):
     except OSError as e:
         mirror_removed = False
         click.echo(f"Warning: could not remove mirror file {mirror}: {e}", err=True)
-    # Re-index only when the mirror is clean; otherwise indexing would preserve
-    # the deleted entry in semantic search.
-    if mirror_removed and shutil.which("gptme-rag"):
+    # Re-index only when the mirror is clean and the rag directory actually
+    # exists. unlink(missing_ok=True) succeeds when gptme-rag was never
+    # installed, so indexing a missing directory would only emit a misleading
+    # "re-index failed" warning after a successful JSONL delete.
+    rag_dir = _knowledge_dir() / "rag"
+    if mirror_removed and shutil.which("gptme-rag") and rag_dir.is_dir():
         try:
             subprocess.run(
-                ["gptme-rag", "index", str(_knowledge_dir() / "rag")],
+                ["gptme-rag", "index", str(rag_dir)],
                 check=True,
                 capture_output=True,
                 timeout=30,

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -90,15 +90,20 @@ def knowledge_save_cmd(
             _export_for_rag(kb_dir)
         except OSError as e:
             click.echo(f"Warning: gptme-rag mirror export failed: {e}", err=True)
-        try:
-            subprocess.run(
-                ["gptme-rag", "index", str(kb_dir / "rag")],
-                check=True,
-                capture_output=True,
-                timeout=30,
-            )
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            click.echo(f"Warning: gptme-rag index failed: {e}", err=True)
+        else:
+            try:
+                subprocess.run(
+                    ["gptme-rag", "index", str(kb_dir / "rag")],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (
+                OSError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ) as e:
+                click.echo(f"Warning: gptme-rag index failed: {e}", err=True)
 
 
 def _export_for_rag(kb_dir: Path) -> None:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -55,6 +55,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "computer": (".cmd_computer", "computer"),
     "explain": (".cmd_explain", "explain"),
     "hooks": (".cmd_hooks", "hooks"),
+    "knowledge": (".cmd_knowledge", "knowledge"),
     "mcp": (".cmd_mcp", "mcp"),
     "resume": (".cmd_resume", "resume"),
     # Unified review group (gptme#3442): ``gptme-util review watch``

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -12,7 +12,9 @@ problem + resolution text.
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, TypedDict
@@ -182,7 +184,10 @@ def knowledge_list(
 
 
 def knowledge_delete(entry_id: str) -> bool:
-    """Remove an entry by ID, rewriting the JSONL file.
+    """Remove an entry by ID, rewriting the JSONL file atomically.
+
+    Uses a temp-file-and-rename pattern so a concurrent save cannot be
+    silently overwritten by a delete that started from an older snapshot.
 
     Returns True if the entry was found and deleted, False otherwise.
     """
@@ -193,7 +198,15 @@ def knowledge_delete(entry_id: str) -> bool:
 
     path = _entries_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+        suffix=".tmp",
+    ) as tf:
         for e in kept:
-            f.write(json.dumps(e) + "\n")
+            tf.write(json.dumps(e) + "\n")
+        tmp_path = tf.name
+    os.replace(tmp_path, path)
     return True

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -11,6 +11,7 @@ problem + resolution text.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -20,6 +21,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 from .dirs import get_data_dir
@@ -43,6 +45,29 @@ def _entries_file() -> Path:
     return _knowledge_dir() / "entries.jsonl"
 
 
+@contextlib.contextmanager
+def _exclusive_lock() -> Iterator[None]:
+    """Advisory exclusive lock protecting concurrent saves and deletes.
+
+    Uses fcntl.flock on Unix.  On Windows (no fcntl) the context manager is a
+    no-op — cross-process mutual exclusion is not enforced, which is acceptable
+    for a personal single-user tool on that platform.
+    """
+    lock_path = _knowledge_dir() / ".entries.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl as _fcntl  # Unix only
+
+        with lock_path.open("w") as lf:
+            _fcntl.flock(lf, _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lf, _fcntl.LOCK_UN)
+    except ImportError:
+        yield  # Windows: no cross-process locking
+
+
 def _load_entries() -> list[KnowledgeEntry]:
     path = _entries_file()
     if not path.exists():
@@ -61,7 +86,7 @@ def _load_entries() -> list[KnowledgeEntry]:
 def _append_entry(entry: KnowledgeEntry) -> None:
     path = _entries_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as f:
+    with _exclusive_lock(), path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
 
 
@@ -186,27 +211,29 @@ def knowledge_list(
 def knowledge_delete(entry_id: str) -> bool:
     """Remove an entry by ID, rewriting the JSONL file atomically.
 
-    Uses a temp-file-and-rename pattern so a concurrent save cannot be
-    silently overwritten by a delete that started from an older snapshot.
+    Holds an exclusive advisory lock (Unix: fcntl.flock) for the entire
+    read-filter-write cycle so a concurrent save cannot append between the
+    snapshot read and the atomic replace.
 
     Returns True if the entry was found and deleted, False otherwise.
     """
-    entries = _load_entries()
-    kept = [e for e in entries if e.get("id") != entry_id]
-    if len(kept) == len(entries):
-        return False
+    with _exclusive_lock():
+        entries = _load_entries()
+        kept = [e for e in entries if e.get("id") != entry_id]
+        if len(kept) == len(entries):
+            return False
 
-    path = _entries_file()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        delete=False,
-        suffix=".tmp",
-    ) as tf:
-        for e in kept:
-            tf.write(json.dumps(e) + "\n")
-        tmp_path = tf.name
-    os.replace(tmp_path, path)
+        path = _entries_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+            suffix=".tmp",
+        ) as tf:
+            for e in kept:
+                tf.write(json.dumps(e) + "\n")
+            tmp_path = tf.name
+        os.replace(tmp_path, path)
     return True

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -1,0 +1,199 @@
+"""
+Cross-session knowledge base: save and retrieve problem/resolution pairs.
+
+Entries are stored as JSONL at ``~/.local/share/gptme/knowledge/entries.jsonl``
+(respects XDG_DATA_HOME).  Each entry carries enough metadata for gptme-rag to
+index it as a ``knowledge_entry`` source once that upstreaming work lands.
+
+Retrieval without gptme-rag falls back to a simple keyword search over the
+problem + resolution text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from .dirs import get_data_dir
+
+
+class KnowledgeEntry(TypedDict):
+    id: str
+    problem: str
+    resolution: str
+    tags: list[str]
+    keywords: list[str]
+    created_at: str
+    memory_type: str  # always "knowledge_entry" — used by gptme-rag source filter
+
+
+def _knowledge_dir() -> Path:
+    return get_data_dir() / "knowledge"
+
+
+def _entries_file() -> Path:
+    return _knowledge_dir() / "entries.jsonl"
+
+
+def _load_entries() -> list[KnowledgeEntry]:
+    path = _entries_file()
+    if not path.exists():
+        return []
+    entries = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return entries
+
+
+def _append_entry(entry: KnowledgeEntry) -> None:
+    path = _entries_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _extract_keywords(text: str) -> list[str]:
+    """Extract meaningful words (length ≥ 4) from text for fast filtering."""
+    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{3,}", text.lower())
+    seen: set[str] = set()
+    result = []
+    for w in words:
+        if w not in seen:
+            seen.add(w)
+            result.append(w)
+    return result[:30]
+
+
+def knowledge_save(
+    problem: str,
+    resolution: str,
+    tags: list[str] | None = None,
+) -> KnowledgeEntry:
+    """Save a problem/resolution pair to the cross-session knowledge base.
+
+    Args:
+        problem: Description of the problem or question.
+        resolution: How it was resolved or answered.
+        tags: Optional list of topic tags (e.g. ["git", "pytest"]).
+
+    Returns:
+        The saved entry dict.
+    """
+    if not problem.strip():
+        raise ValueError("problem cannot be empty")
+    if not resolution.strip():
+        raise ValueError("resolution cannot be empty")
+
+    keywords = _extract_keywords(f"{problem} {resolution}")
+    entry: KnowledgeEntry = {
+        "id": str(uuid.uuid4()),
+        "problem": problem.strip(),
+        "resolution": resolution.strip(),
+        "tags": [t.strip() for t in (tags or []) if t.strip()],
+        "keywords": keywords,
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+        "memory_type": "knowledge_entry",
+    }
+    _append_entry(entry)
+    return entry
+
+
+def knowledge_search(
+    query: str,
+    top_k: int = 5,
+    tags: list[str] | None = None,
+) -> list[KnowledgeEntry]:
+    """Search the knowledge base with simple keyword matching.
+
+    Scores entries by counting how many query words appear in the combined
+    problem + resolution + tags text.  Returns the top-k by score.
+
+    Args:
+        query: Free-text search query.
+        top_k: Maximum number of results.
+        tags: If given, only return entries that have ALL of these tags.
+
+    Returns:
+        Matching entries, highest-score first.
+    """
+    if not query.strip():
+        raise ValueError("query cannot be empty")
+
+    query_words = set(_extract_keywords(query))
+    entries = _load_entries()
+
+    # Tag filter
+    if tags:
+        required = {t.lower() for t in tags}
+        entries = [
+            e
+            for e in entries
+            if required.issubset({t.lower() for t in e.get("tags", [])})
+        ]
+
+    scored: list[tuple[int, KnowledgeEntry]] = []
+    for entry in entries:
+        haystack = " ".join(
+            [entry.get("problem", ""), entry.get("resolution", "")]
+            + entry.get("tags", [])
+        ).lower()
+        score = sum(1 for w in query_words if w in haystack)
+        if score > 0:
+            scored.append((score, entry))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [e for _, e in scored[:top_k]]
+
+
+def knowledge_list(
+    tags: list[str] | None = None,
+    limit: int = 50,
+) -> list[KnowledgeEntry]:
+    """List knowledge entries, newest first.
+
+    Args:
+        tags: If given, only return entries that have ALL of these tags.
+        limit: Maximum number of entries to return.
+
+    Returns:
+        Entries sorted by creation date descending.
+    """
+    entries = _load_entries()
+    if tags:
+        required = {t.lower() for t in tags}
+        entries = [
+            e
+            for e in entries
+            if required.issubset({t.lower() for t in e.get("tags", [])})
+        ]
+    entries = sorted(entries, key=lambda e: e.get("created_at", ""), reverse=True)
+    return entries[:limit]
+
+
+def knowledge_delete(entry_id: str) -> bool:
+    """Remove an entry by ID, rewriting the JSONL file.
+
+    Returns True if the entry was found and deleted, False otherwise.
+    """
+    entries = _load_entries()
+    kept = [e for e in entries if e.get("id") != entry_id]
+    if len(kept) == len(entries):
+        return False
+
+    path = _entries_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for e in kept:
+            f.write(json.dumps(e) + "\n")
+    return True

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import tempfile
+import threading
 import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, TypedDict
@@ -45,27 +46,32 @@ def _entries_file() -> Path:
     return _knowledge_dir() / "entries.jsonl"
 
 
+_thread_lock = threading.Lock()
+
+
 @contextlib.contextmanager
 def _exclusive_lock() -> Iterator[None]:
     """Advisory exclusive lock protecting concurrent saves and deletes.
 
-    Uses fcntl.flock on Unix.  On Windows (no fcntl) the context manager is a
-    no-op — cross-process mutual exclusion is not enforced, which is acceptable
-    for a personal single-user tool on that platform.
+    Uses fcntl.flock on Unix for cross-process mutual exclusion.  On Windows
+    (no fcntl), falls back to a module-level threading.Lock which prevents
+    same-process thread races; cross-process races on Windows are accepted as
+    the tool is designed for single-user personal use.
     """
     lock_path = _knowledge_dir() / ".entries.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         import fcntl as _fcntl  # Unix only
 
-        with lock_path.open("w") as lf:
+        with _thread_lock, lock_path.open("w") as lf:
             _fcntl.flock(lf, _fcntl.LOCK_EX)
             try:
                 yield
             finally:
                 _fcntl.flock(lf, _fcntl.LOCK_UN)
     except ImportError:
-        yield  # Windows: no cross-process locking
+        with _thread_lock:
+            yield  # Windows: thread-safe, not cross-process-safe
 
 
 def _load_entries() -> list[KnowledgeEntry]:
@@ -91,8 +97,8 @@ def _append_entry(entry: KnowledgeEntry) -> None:
 
 
 def _extract_keywords(text: str) -> list[str]:
-    """Extract meaningful words (length ≥ 4) from text for fast filtering."""
-    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{3,}", text.lower())
+    """Extract meaningful words (length ≥ 2) from text for fast filtering."""
+    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{1,}", text.lower())
     seen: set[str] = set()
     result = []
     for w in words:

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -19,11 +19,11 @@ import tempfile
 import threading
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 from .dirs import get_data_dir
 
@@ -118,15 +118,9 @@ def _append_entry(entry: KnowledgeEntry) -> None:
 
 
 def _extract_keywords(text: str) -> list[str]:
-    """Extract words and numeric identifiers from text for fast filtering."""
+    """Extract unique words and numeric identifiers from text."""
     words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
-    seen: set[str] = set()
-    result = []
-    for w in words:
-        if w not in seen:
-            seen.add(w)
-            result.append(w)
-    return result[:30]
+    return list(dict.fromkeys(words))
 
 
 def knowledge_save(
@@ -241,6 +235,30 @@ def knowledge_list(
     return entries[:limit]
 
 
+def _replace_entries(path: Path, entries: list[KnowledgeEntry]) -> None:
+    """Atomically replace the entry store and clean up failed temp writes."""
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+            suffix=".tmp",
+        ) as tf:
+            tmp_path = tf.name
+            for entry in entries:
+                tf.write(json.dumps(entry) + "\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        if tmp_path is not None:
+            try:
+                Path(tmp_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+
+
 def knowledge_delete(entry_id: str) -> bool:
     """Remove an entry by ID, rewriting the JSONL file atomically.
 
@@ -258,17 +276,7 @@ def knowledge_delete(entry_id: str) -> bool:
 
         path = _entries_file()
         path.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=path.parent,
-            delete=False,
-            suffix=".tmp",
-        ) as tf:
-            for e in kept:
-                tf.write(json.dumps(e) + "\n")
-            tmp_path = tf.name
-        os.replace(tmp_path, path)
+        _replace_entries(path, kept)
     return True
 
 
@@ -303,15 +311,5 @@ def knowledge_delete_by_prefix(
 
         path = _entries_file()
         path.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=path.parent,
-            delete=False,
-            suffix=".tmp",
-        ) as tf:
-            for e in kept:
-                tf.write(json.dumps(e) + "\n")
-            tmp_path = tf.name
-        os.replace(tmp_path, path)
+        _replace_entries(path, kept)
     return full_id, "deleted", []

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -245,3 +245,46 @@ def knowledge_delete(entry_id: str) -> bool:
             tmp_path = tf.name
         os.replace(tmp_path, path)
     return True
+
+
+def knowledge_delete_by_prefix(
+    prefix: str,
+) -> tuple[str | None, str, list[KnowledgeEntry]]:
+    """Delete an entry by ID prefix, atomically under the exclusive lock.
+
+    Holds the exclusive lock for the entire prefix-resolve + delete cycle so
+    that a concurrent save or delete cannot change the entry set between the
+    prefix lookup and the actual write.
+
+    Returns:
+        (deleted_id, status, matches) where status is one of:
+        - ``'deleted'``: entry found and removed; ``deleted_id`` is the full ID.
+        - ``'ambiguous'``: prefix matched more than one entry; ``matches``
+          contains all candidates so the caller can list them.
+        - ``'not_found'``: no entry matched the prefix.
+    """
+    with _exclusive_lock():
+        entries = _load_entries()
+        matches = [e for e in entries if e.get("id", "").startswith(prefix)]
+        if len(matches) > 1:
+            return None, "ambiguous", matches
+        if not matches:
+            return None, "not_found", []
+
+        full_id = matches[0]["id"]
+        kept = [e for e in entries if e.get("id") != full_id]
+
+        path = _entries_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+            suffix=".tmp",
+        ) as tf:
+            for e in kept:
+                tf.write(json.dumps(e) + "\n")
+            tmp_path = tf.name
+        os.replace(tmp_path, path)
+    return full_id, "deleted", []

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -74,6 +74,25 @@ def _exclusive_lock() -> Iterator[None]:
             yield  # Windows: thread-safe, not cross-process-safe
 
 
+def _is_valid_entry(parsed: object) -> bool:
+    """Return whether parsed JSON has the fields required by the store."""
+    if not isinstance(parsed, dict):
+        return False
+    try:
+        uuid.UUID(parsed.get("id", ""))
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return all(
+        isinstance(parsed.get(key), expected_type)
+        for key, expected_type in (
+            ("problem", str),
+            ("resolution", str),
+            ("tags", list),
+            ("created_at", str),
+        )
+    )
+
+
 def _load_entries() -> list[KnowledgeEntry]:
     path = _entries_file()
     if not path.exists():
@@ -84,7 +103,7 @@ def _load_entries() -> list[KnowledgeEntry]:
         if line:
             try:
                 parsed = json.loads(line)
-                if isinstance(parsed, dict):
+                if _is_valid_entry(parsed):
                     entries.append(cast(KnowledgeEntry, parsed))
             except json.JSONDecodeError:
                 pass
@@ -99,8 +118,8 @@ def _append_entry(entry: KnowledgeEntry) -> None:
 
 
 def _extract_keywords(text: str) -> list[str]:
-    """Extract meaningful words (length ≥ 2) from text for fast filtering."""
-    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{1,}", text.lower())
+    """Extract words from text for fast filtering."""
+    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]*", text.lower())
     seen: set[str] = set()
     result = []
     for w in words:
@@ -166,7 +185,8 @@ def knowledge_search(
         raise ValueError("query cannot be empty")
 
     query_words = set(_extract_keywords(query))
-    entries = _load_entries()
+    with _exclusive_lock():
+        entries = _load_entries()
 
     # Tag filter
     if tags:
@@ -206,7 +226,8 @@ def knowledge_list(
     Returns:
         Entries sorted by creation date descending.
     """
-    entries = _load_entries()
+    with _exclusive_lock():
+        entries = _load_entries()
     if tags:
         required = {t.lower() for t in tags}
         entries = [

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -90,7 +90,7 @@ def _is_valid_entry(parsed: object) -> bool:
             ("tags", list),
             ("created_at", str),
         )
-    )
+    ) and all(isinstance(tag, str) for tag in parsed["tags"])
 
 
 def _load_entries() -> list[KnowledgeEntry]:
@@ -183,6 +183,8 @@ def knowledge_search(
     """
     if not query.strip():
         raise ValueError("query cannot be empty")
+    if top_k < 1:
+        raise ValueError("top_k must be at least 1")
 
     query_words = set(_extract_keywords(query))
     with _exclusive_lock():

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -118,8 +118,8 @@ def _append_entry(entry: KnowledgeEntry) -> None:
 
 
 def _extract_keywords(text: str) -> list[str]:
-    """Extract words from text for fast filtering."""
-    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]*", text.lower())
+    """Extract words and numeric identifiers from text for fast filtering."""
+    words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
     seen: set[str] = set()
     result = []
     for w in words:

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -98,7 +98,10 @@ def _load_entries() -> list[KnowledgeEntry]:
     if not path.exists():
         return []
     entries = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    # errors="replace" keeps a corrupted (non-UTF-8) store from crashing
+    # list/search/save; invalid bytes become U+FFFD and those lines fail
+    # json.loads and are skipped, matching the malformed-object policy.
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if line:
             try:
@@ -110,6 +113,20 @@ def _load_entries() -> list[KnowledgeEntry]:
     return entries
 
 
+def _load_entries_locked() -> list[KnowledgeEntry]:
+    """Load entries under the lock, falling back if the directory is read-only.
+
+    Search and list are read paths: a read-only knowledge directory (or a
+    lock file we cannot create) must still return stored entries rather than
+    raising PermissionError from opening the lock with mode ``"w"``.
+    """
+    try:
+        with _exclusive_lock():
+            return _load_entries()
+    except PermissionError:
+        return _load_entries()
+
+
 def _append_entry(entry: KnowledgeEntry) -> None:
     path = _entries_file()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -118,9 +135,19 @@ def _append_entry(entry: KnowledgeEntry) -> None:
 
 
 def _extract_keywords(text: str) -> list[str]:
-    """Extract unique words and numeric identifiers from text."""
+    """Extract unique words, numeric IDs, and underscore-delimited parts.
+
+    ``foo_bar`` yields ``foo_bar``, ``foo``, and ``bar`` so a query for the
+    common prefix ``foo`` still matches without falling back to substring
+    matching (which would also match ``git`` inside ``digit``).
+    """
     words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
-    return list(dict.fromkeys(words))
+    parts: list[str] = []
+    for word in words:
+        parts.append(word)
+        if "_" in word:
+            parts.extend(part for part in word.split("_") if part)
+    return list(dict.fromkeys(parts))
 
 
 def knowledge_save(
@@ -181,27 +208,29 @@ def knowledge_search(
         raise ValueError("top_k must be at least 1")
 
     query_words = set(_extract_keywords(query))
-    with _exclusive_lock():
-        entries = _load_entries()
+    entries = _load_entries_locked()
 
-    # Tag filter
+    # Tag filter (strip to match knowledge_save's stored tags)
     if tags:
-        required = {t.lower() for t in tags}
-        entries = [
-            e
-            for e in entries
-            if required.issubset({t.lower() for t in e.get("tags", [])})
-        ]
+        required = {t.strip().lower() for t in tags if t.strip()}
+        if required:
+            entries = [
+                e
+                for e in entries
+                if required.issubset({t.lower() for t in e.get("tags", [])})
+            ]
 
     scored: list[tuple[int, KnowledgeEntry]] = []
     for entry in entries:
-        haystack = " ".join(
-            [entry.get("problem", ""), entry.get("resolution", "")]
-            + entry.get("tags", [])
-        ).lower()
-        score = sum(
-            1 for w in query_words if re.search(rf"\b{re.escape(w)}\b", haystack)
+        haystack_tokens = set(
+            _extract_keywords(
+                " ".join(
+                    [entry.get("problem", ""), entry.get("resolution", "")]
+                    + entry.get("tags", [])
+                )
+            )
         )
+        score = sum(1 for w in query_words if w in haystack_tokens)
         if score > 0:
             scored.append((score, entry))
 
@@ -222,15 +251,15 @@ def knowledge_list(
     Returns:
         Entries sorted by creation date descending.
     """
-    with _exclusive_lock():
-        entries = _load_entries()
+    entries = _load_entries_locked()
     if tags:
-        required = {t.lower() for t in tags}
-        entries = [
-            e
-            for e in entries
-            if required.issubset({t.lower() for t in e.get("tags", [])})
-        ]
+        required = {t.strip().lower() for t in tags if t.strip()}
+        if required:
+            entries = [
+                e
+                for e in entries
+                if required.issubset({t.lower() for t in e.get("tags", [])})
+            ]
     entries = sorted(entries, key=lambda e: e.get("created_at", ""), reverse=True)
     return entries[:limit]
 

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -181,7 +181,9 @@ def knowledge_search(
             [entry.get("problem", ""), entry.get("resolution", "")]
             + entry.get("tags", [])
         ).lower()
-        score = sum(1 for w in query_words if w in haystack)
+        score = sum(
+            1 for w in query_words if re.search(rf"\b{re.escape(w)}\b", haystack)
+        )
         if score > 0:
             scored.append((score, entry))
 

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -19,7 +19,7 @@ import tempfile
 import threading
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -83,7 +83,9 @@ def _load_entries() -> list[KnowledgeEntry]:
         line = line.strip()
         if line:
             try:
-                entries.append(json.loads(line))
+                parsed = json.loads(line)
+                if isinstance(parsed, dict):
+                    entries.append(cast(KnowledgeEntry, parsed))
             except json.JSONDecodeError:
                 pass
     return entries
@@ -263,6 +265,8 @@ def knowledge_delete_by_prefix(
           contains all candidates so the caller can list them.
         - ``'not_found'``: no entry matched the prefix.
     """
+    if not prefix.strip():
+        raise ValueError("entry_id cannot be empty")
     with _exclusive_lock():
         entries = _load_entries()
         matches = [e for e in entries if e.get("id", "").startswith(prefix)]

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,247 @@
+"""Tests for the cross-session knowledge base (gptme.knowledge + gptme-util knowledge CLI)."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import main
+
+
+@pytest.fixture(autouse=True)
+def isolated_kb(tmp_path, monkeypatch):
+    """Redirect the knowledge store to a temp directory for every test."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    # Clear the lru_cache on get_data_dir so it picks up the new env var.
+    from gptme import dirs
+
+    if hasattr(dirs.get_data_dir, "cache_clear"):
+        dirs.get_data_dir.cache_clear()
+    yield
+    if hasattr(dirs.get_data_dir, "cache_clear"):
+        dirs.get_data_dir.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Core module tests
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_list():
+    from gptme.knowledge import knowledge_list, knowledge_save
+
+    entry = knowledge_save("test problem", "test resolution", tags=["pytest"])
+    assert entry["memory_type"] == "knowledge_entry"
+    assert entry["problem"] == "test problem"
+    assert entry["resolution"] == "test resolution"
+    assert "pytest" in entry["tags"]
+    assert entry["id"]
+
+    entries = knowledge_list()
+    assert len(entries) == 1
+    assert entries[0]["id"] == entry["id"]
+
+
+def test_save_validates_empty_fields():
+    from gptme.knowledge import knowledge_save
+
+    with pytest.raises(ValueError, match="problem"):
+        knowledge_save("", "some resolution")
+    with pytest.raises(ValueError, match="resolution"):
+        knowledge_save("some problem", "")
+
+
+def test_search_returns_relevant():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+    knowledge_save("git merge conflict resolution", "use git mergetool")
+    knowledge_save("something unrelated", "other answer")
+
+    results = knowledge_search("pytest discovery")
+    assert results
+    assert results[0]["problem"] == "pytest test discovery fails"
+
+
+def test_search_validates_empty_query():
+    from gptme.knowledge import knowledge_search
+
+    with pytest.raises(ValueError, match="query"):
+        knowledge_search("")
+
+
+def test_search_tag_filter():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    knowledge_save("problem A", "resolution A", tags=["git"])
+    knowledge_save("problem B", "resolution B", tags=["pytest"])
+
+    results = knowledge_search("problem", tags=["git"])
+    assert len(results) == 1
+    assert results[0]["problem"] == "problem A"
+
+
+def test_list_tag_filter():
+    from gptme.knowledge import knowledge_list, knowledge_save
+
+    knowledge_save("problem A", "resolution A", tags=["git"])
+    knowledge_save("problem B", "resolution B", tags=["pytest"])
+
+    entries = knowledge_list(tags=["git"])
+    assert len(entries) == 1
+    assert entries[0]["problem"] == "problem A"
+
+
+def test_list_newest_first():
+    from gptme.knowledge import knowledge_list, knowledge_save
+
+    knowledge_save("older problem", "older resolution")
+    knowledge_save("newer problem", "newer resolution")
+
+    entries = knowledge_list()
+    assert entries[0]["problem"] == "newer problem"
+
+
+def test_delete():
+    from gptme.knowledge import knowledge_delete, knowledge_list, knowledge_save
+
+    entry = knowledge_save("to delete", "resolution")
+    assert knowledge_delete(entry["id"])
+    assert knowledge_list() == []
+
+    assert not knowledge_delete("nonexistent-id")
+
+
+def test_jsonl_persistence(tmp_path, monkeypatch):
+    """Entries survive across separate function call sequences (JSONL is durable)."""
+    from gptme.knowledge import _entries_file, knowledge_save
+
+    knowledge_save("durable problem", "durable resolution")
+    path = _entries_file()
+    assert path.exists()
+
+    # Parse the raw JSONL line to confirm structure
+    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["memory_type"] == "knowledge_entry"
+    assert parsed["problem"] == "durable problem"
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_save_basic():
+    runner = CliRunner()
+    result = runner.invoke(main, ["knowledge", "save", "a problem", "a resolution"])
+    assert result.exit_code == 0, result.output
+    assert "Saved knowledge entry" in result.output
+
+
+def test_cli_save_with_tags():
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "knowledge",
+            "save",
+            "tagged problem",
+            "tagged resolution",
+            "-t",
+            "git",
+            "-t",
+            "pytest",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Tags: git, pytest" in result.output
+
+
+def test_cli_save_json_output():
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["knowledge", "save", "--json", "json problem", "json resolution"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["problem"] == "json problem"
+    assert data["memory_type"] == "knowledge_entry"
+
+
+def test_cli_search():
+    runner = CliRunner()
+    runner.invoke(
+        main, ["knowledge", "save", "pytest discovery problem", "prefix with test_"]
+    )
+    result = runner.invoke(main, ["knowledge", "search", "pytest"])
+    assert result.exit_code == 0, result.output
+    assert "pytest discovery problem" in result.output
+
+
+def test_cli_search_no_results():
+    runner = CliRunner()
+    result = runner.invoke(main, ["knowledge", "search", "completely obscure term xyz"])
+    assert result.exit_code == 0
+    assert "No matching" in result.output
+
+
+def test_cli_search_json():
+    runner = CliRunner()
+    runner.invoke(main, ["knowledge", "save", "search json problem", "resolution"])
+    result = runner.invoke(main, ["knowledge", "search", "--json", "search json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert data[0]["problem"] == "search json problem"
+
+
+def test_cli_list():
+    runner = CliRunner()
+    runner.invoke(main, ["knowledge", "save", "listed problem", "listed resolution"])
+    result = runner.invoke(main, ["knowledge", "list"])
+    assert result.exit_code == 0, result.output
+    assert "listed problem" in result.output
+
+
+def test_cli_list_empty():
+    runner = CliRunner()
+    result = runner.invoke(main, ["knowledge", "list"])
+    assert result.exit_code == 0
+    assert "No entries" in result.output
+
+
+def test_cli_list_json():
+    runner = CliRunner()
+    runner.invoke(main, ["knowledge", "save", "list json problem", "resolution"])
+    result = runner.invoke(main, ["knowledge", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert data[0]["problem"] == "list json problem"
+
+
+def test_cli_delete():
+    from gptme.knowledge import knowledge_save
+
+    runner = CliRunner()
+    # Use the module API to save so we get a clean ID without CLI noise
+    entry = knowledge_save("delete me", "resolution")
+    entry_id = entry["id"]
+
+    # Delete by prefix (first 8 chars)
+    result = runner.invoke(main, ["knowledge", "delete", entry_id[:8]])
+    assert result.exit_code == 0, result.output
+    assert "Deleted" in result.output
+
+    # Confirm it's gone
+    result = runner.invoke(main, ["knowledge", "list"])
+    assert "No entries" in result.output
+
+
+def test_cli_delete_nonexistent():
+    runner = CliRunner()
+    result = runner.invoke(main, ["knowledge", "delete", "nonexistent"])
+    assert result.exit_code != 0
+    assert "No entry found" in result.output

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -282,6 +282,28 @@ def test_cli_human_output_strips_control_characters():
     assert "\x1b" not in list_result.output
 
 
+def test_cli_save_skips_index_when_mirror_export_fails(monkeypatch):
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
+
+    def fail_export(*args, **kwargs):
+        raise PermissionError("cannot write mirror")
+
+    monkeypatch.setattr("gptme.cli.cmd_knowledge._export_for_rag", fail_export)
+    calls = []
+    monkeypatch.setattr(
+        "gptme.cli.cmd_knowledge.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(
+        main, ["knowledge", "save", "saved problem", "saved resolution"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "mirror export failed" in result.output
+    assert calls == []
+
+
 def test_cli_list():
     runner = CliRunner()
     runner.invoke(main, ["knowledge", "save", "listed problem", "listed resolution"])

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -199,6 +199,57 @@ def test_load_entries_skips_malformed_objects():
     assert knowledge_list() == [entry]
 
 
+def test_load_entries_tolerates_invalid_utf8():
+    from gptme.knowledge import _entries_file, knowledge_list, knowledge_save
+
+    entry = knowledge_save("valid problem", "valid resolution")
+    with _entries_file().open("ab") as f:
+        f.write(b"\xff\xfe not utf-8\n")
+
+    assert knowledge_list() == [entry]
+
+
+def test_search_matches_underscore_delimited_term():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    entry = knowledge_save("foo_bar failure", "restart foo_bar")
+
+    assert knowledge_search("foo") == [entry]
+    assert knowledge_search("foo_bar") == [entry]
+    assert knowledge_search("digit") == []
+
+
+def test_search_does_not_match_embedded_substring():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    knowledge_save("education catalog", "not a feline")
+
+    assert knowledge_search("cat") == []
+
+
+def test_search_and_list_when_lock_not_writable(monkeypatch):
+    import gptme.knowledge as knowledge
+
+    entry = knowledge.knowledge_save("readable problem", "readable resolution")
+
+    def deny_lock():
+        raise PermissionError("read-only knowledge directory")
+
+    monkeypatch.setattr(knowledge, "_exclusive_lock", deny_lock)
+
+    assert knowledge.knowledge_search("readable") == [entry]
+    assert knowledge.knowledge_list() == [entry]
+
+
+def test_search_and_list_strip_tag_filter():
+    from gptme.knowledge import knowledge_list, knowledge_save, knowledge_search
+
+    entry = knowledge_save("tagged problem", "tagged resolution", tags=["git"])
+
+    assert knowledge_search("tagged", tags=[" git "]) == [entry]
+    assert knowledge_list(tags=[" git "]) == [entry]
+
+
 # ---------------------------------------------------------------------------
 # CLI tests
 # ---------------------------------------------------------------------------
@@ -243,7 +294,7 @@ def test_cli_save_json_output():
 
 @pytest.mark.parametrize("command", ["save", "delete"])
 def test_cli_rag_index_oserror_is_nonfatal(monkeypatch, command):
-    from gptme.knowledge import knowledge_save
+    from gptme.knowledge import _knowledge_dir, knowledge_save
 
     monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
     monkeypatch.setattr("gptme.cli.cmd_knowledge._export_for_rag", lambda _: None)
@@ -257,6 +308,9 @@ def test_cli_rag_index_oserror_is_nonfatal(monkeypatch, command):
         result = runner.invoke(main, ["knowledge", "save", "problem", "resolution"])
     else:
         entry = knowledge_save("problem", "resolution")
+        # Re-index is skipped when rag/ does not exist; create it so this
+        # test still exercises the subprocess error path.
+        (_knowledge_dir() / "rag").mkdir(parents=True)
         result = runner.invoke(main, ["knowledge", "delete", entry["id"]])
 
     assert result.exit_code == 0, result.output
@@ -394,6 +448,22 @@ def test_cli_list_reports_io_error(monkeypatch):
     assert not isinstance(result.exception, OSError)
 
 
+def test_cli_list_reports_unicode_error(monkeypatch):
+    def fail(*args, **kwargs):
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
+
+    monkeypatch.setattr("gptme.knowledge.knowledge_list", fail)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["knowledge", "list"])
+
+    assert result.exit_code != 0
+    assert "Error:" in result.output
+    assert result.exception is None or not isinstance(
+        result.exception, UnicodeDecodeError
+    )
+
+
 def test_cli_list_json():
     runner = CliRunner()
     runner.invoke(main, ["knowledge", "save", "list json problem", "resolution"])
@@ -453,3 +523,31 @@ def test_cli_delete_nonexistent():
     result = runner.invoke(main, ["knowledge", "delete", "nonexistent"])
     assert result.exit_code != 0
     assert "No entry found" in result.output
+
+
+def test_cli_delete_strips_control_characters_from_prefix():
+    runner = CliRunner()
+    result = runner.invoke(main, ["knowledge", "delete", "missing\x1b[2Jprefix"])
+
+    assert result.exit_code != 0
+    assert "\x1b" not in result.output
+    assert "No entry found" in result.output
+
+
+def test_cli_delete_skips_reindex_when_rag_dir_missing(monkeypatch):
+    from gptme.knowledge import knowledge_save
+
+    entry = knowledge_save("delete me", "resolution")
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
+    calls = []
+    monkeypatch.setattr(
+        "gptme.cli.cmd_knowledge.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(main, ["knowledge", "delete", entry["id"]])
+
+    assert result.exit_code == 0, result.output
+    assert "Deleted" in result.output
+    assert calls == []
+    assert "re-index" not in result.output

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -159,7 +159,9 @@ def test_cli_save_with_tags():
     assert "Tags: git, pytest" in result.output
 
 
-def test_cli_save_json_output():
+def test_cli_save_json_output(monkeypatch):
+    # Suppress gptme-rag so its stderr warning doesn't mix into result.output.
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: None)
     runner = CliRunner()
     result = runner.invoke(
         main, ["knowledge", "save", "--json", "json problem", "json resolution"]

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -64,11 +64,13 @@ def test_search_returns_relevant():
     assert results[0]["problem"] == "pytest test discovery fails"
 
 
-def test_search_validates_empty_query():
+def test_search_validates_arguments():
     from gptme.knowledge import knowledge_search
 
     with pytest.raises(ValueError, match="query"):
         knowledge_search("")
+    with pytest.raises(ValueError, match="top_k"):
+        knowledge_search("query", top_k=-1)
 
 
 def test_search_matches_single_character_term():
@@ -144,6 +146,12 @@ def test_load_entries_skips_malformed_objects():
     with _entries_file().open("a", encoding="utf-8") as f:
         f.write(json.dumps({"id": "../../outside"}) + "\n")
         f.write(json.dumps({"id": str(entry["id"])}) + "\n")
+        invalid_tags = {
+            **entry,
+            "id": "e8048c53-c70a-4e16-9660-820b9bea29f8",
+            "tags": [1],
+        }
+        f.write(json.dumps(invalid_tags) + "\n")
 
     assert knowledge_list() == [entry]
 
@@ -190,6 +198,29 @@ def test_cli_save_json_output():
     assert data["memory_type"] == "knowledge_entry"
 
 
+@pytest.mark.parametrize("command", ["save", "delete"])
+def test_cli_rag_index_oserror_is_nonfatal(monkeypatch, command):
+    from gptme.knowledge import knowledge_save
+
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
+    monkeypatch.setattr("gptme.cli.cmd_knowledge._export_for_rag", lambda _: None)
+
+    def fail(*args, **kwargs):
+        raise PermissionError("cannot execute gptme-rag")
+
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.subprocess.run", fail)
+    runner = CliRunner()
+    if command == "save":
+        result = runner.invoke(main, ["knowledge", "save", "problem", "resolution"])
+    else:
+        entry = knowledge_save("problem", "resolution")
+        result = runner.invoke(main, ["knowledge", "delete", entry["id"]])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: gptme-rag" in result.output
+    assert "cannot execute gptme-rag" in result.output
+
+
 def test_cli_search():
     runner = CliRunner()
     runner.invoke(
@@ -215,6 +246,30 @@ def test_cli_search_json():
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert data[0]["problem"] == "search json problem"
+
+
+def test_cli_human_output_strips_control_characters():
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "knowledge",
+            "save",
+            "unsafe\x1b[2J problem",
+            "unsafe\x07 resolution",
+            "-t",
+            "tag\x1b[31m",
+        ],
+    )
+
+    search_result = runner.invoke(main, ["knowledge", "search", "unsafe"])
+    list_result = runner.invoke(main, ["knowledge", "list"])
+
+    assert search_result.exit_code == 0, search_result.output
+    assert list_result.exit_code == 0, list_result.output
+    assert "\x1b" not in search_result.output
+    assert "\x07" not in search_result.output
+    assert "\x1b" not in list_result.output
 
 
 def test_cli_list():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -81,6 +81,14 @@ def test_search_matches_single_character_term():
     assert knowledge_search("x") == [entry]
 
 
+def test_search_matches_numeric_identifier():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    entry = knowledge_save("request failed", "server returned 404")
+
+    assert knowledge_search("404") == [entry]
+
+
 def test_search_tag_filter():
     from gptme.knowledge import knowledge_save, knowledge_search
 
@@ -250,7 +258,7 @@ def test_cli_search_json():
 
 def test_cli_human_output_strips_control_characters():
     runner = CliRunner()
-    runner.invoke(
+    save_result = runner.invoke(
         main,
         [
             "knowledge",
@@ -265,8 +273,10 @@ def test_cli_human_output_strips_control_characters():
     search_result = runner.invoke(main, ["knowledge", "search", "unsafe"])
     list_result = runner.invoke(main, ["knowledge", "list"])
 
+    assert save_result.exit_code == 0, save_result.output
     assert search_result.exit_code == 0, search_result.output
     assert list_result.exit_code == 0, list_result.output
+    assert "\x1b" not in save_result.output
     assert "\x1b" not in search_result.output
     assert "\x07" not in search_result.output
     assert "\x1b" not in list_result.output
@@ -327,6 +337,32 @@ def test_cli_delete():
     # Confirm it's gone
     result = runner.invoke(main, ["knowledge", "list"])
     assert "No entries" in result.output
+
+
+def test_cli_delete_skips_reindex_when_mirror_removal_fails(monkeypatch):
+    from gptme.knowledge import _knowledge_dir, knowledge_save
+
+    entry = knowledge_save("delete me", "resolution")
+    mirror = _knowledge_dir() / "rag" / f"{entry['id']}.md"
+    mirror.parent.mkdir(parents=True)
+    mirror.write_text("stale", encoding="utf-8")
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
+
+    def fail_unlink(*args, **kwargs):
+        raise PermissionError("cannot remove mirror")
+
+    monkeypatch.setattr(type(mirror), "unlink", fail_unlink)
+    calls = []
+    monkeypatch.setattr(
+        "gptme.cli.cmd_knowledge.subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(main, ["knowledge", "delete", entry["id"]])
+
+    assert result.exit_code == 0, result.output
+    assert "could not remove mirror" in result.output
+    assert calls == []
 
 
 def test_cli_delete_nonexistent():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -10,8 +10,9 @@ from gptme.cli.util import main
 
 @pytest.fixture(autouse=True)
 def isolated_kb(tmp_path, monkeypatch):
-    """Redirect the knowledge store to a temp directory for every test."""
+    """Redirect the knowledge store and disable external indexing in tests."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: None)
     # Clear the lru_cache on get_data_dir so it picks up the new env var.
     from gptme import dirs
 
@@ -68,6 +69,14 @@ def test_search_validates_empty_query():
 
     with pytest.raises(ValueError, match="query"):
         knowledge_search("")
+
+
+def test_search_matches_single_character_term():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    entry = knowledge_save("x server failure", "restart x")
+
+    assert knowledge_search("x") == [entry]
 
 
 def test_search_tag_filter():
@@ -128,6 +137,17 @@ def test_jsonl_persistence(tmp_path, monkeypatch):
     assert parsed["problem"] == "durable problem"
 
 
+def test_load_entries_skips_malformed_objects():
+    from gptme.knowledge import _entries_file, knowledge_list, knowledge_save
+
+    entry = knowledge_save("valid problem", "valid resolution")
+    with _entries_file().open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"id": "../../outside"}) + "\n")
+        f.write(json.dumps({"id": str(entry["id"])}) + "\n")
+
+    assert knowledge_list() == [entry]
+
+
 # ---------------------------------------------------------------------------
 # CLI tests
 # ---------------------------------------------------------------------------
@@ -159,9 +179,7 @@ def test_cli_save_with_tags():
     assert "Tags: git, pytest" in result.output
 
 
-def test_cli_save_json_output(monkeypatch):
-    # Suppress gptme-rag so its stderr warning doesn't mix into result.output.
-    monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: None)
+def test_cli_save_json_output():
     runner = CliRunner()
     result = runner.invoke(
         main, ["knowledge", "save", "--json", "json problem", "json resolution"]
@@ -212,6 +230,20 @@ def test_cli_list_empty():
     result = runner.invoke(main, ["knowledge", "list"])
     assert result.exit_code == 0
     assert "No entries" in result.output
+
+
+def test_cli_list_reports_io_error(monkeypatch):
+    def fail(*args, **kwargs):
+        raise OSError("cannot read store")
+
+    monkeypatch.setattr("gptme.knowledge.knowledge_list", fail)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["knowledge", "list"])
+
+    assert result.exit_code != 0
+    assert "Error: cannot read store" in result.output
+    assert not isinstance(result.exception, OSError)
 
 
 def test_cli_list_json():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -89,6 +89,15 @@ def test_search_matches_numeric_identifier():
     assert knowledge_search("404") == [entry]
 
 
+def test_search_considers_terms_after_thirtieth():
+    from gptme.knowledge import knowledge_save, knowledge_search
+
+    entry = knowledge_save("zlib failure", "rebuild the archive")
+    query = " ".join([*(f"term{i}" for i in range(30)), "zlib"])
+
+    assert knowledge_search(query) == [entry]
+
+
 def test_search_tag_filter():
     from gptme.knowledge import knowledge_save, knowledge_search
 
@@ -129,6 +138,32 @@ def test_delete():
     assert knowledge_list() == []
 
     assert not knowledge_delete("nonexistent-id")
+
+
+@pytest.mark.parametrize(
+    "delete_func", ["knowledge_delete", "knowledge_delete_by_prefix"]
+)
+def test_delete_cleans_up_temporary_file_on_write_failure(monkeypatch, delete_func):
+    import gptme.knowledge as knowledge
+
+    entry = knowledge.knowledge_save("to delete", "resolution")
+    kept_entry = knowledge.knowledge_save("keep me", "resolution")
+    path = knowledge._entries_file()
+    original_dump = knowledge.json.dumps
+
+    def fail_for_persisted_entry(value):
+        if isinstance(value, dict) and value.get("id") != entry["id"]:
+            raise OSError("disk full")
+        return original_dump(value)
+
+    monkeypatch.setattr(knowledge.json, "dumps", fail_for_persisted_entry)
+    entry_id = entry["id"] if delete_func == "knowledge_delete" else entry["id"][:8]
+
+    with pytest.raises(OSError, match="disk full"):
+        getattr(knowledge, delete_func)(entry_id)
+
+    assert list(path.parent.glob("*.tmp")) == []
+    assert knowledge._load_entries() == [entry, kept_entry]
 
 
 def test_jsonl_persistence(tmp_path, monkeypatch):
@@ -254,6 +289,32 @@ def test_cli_search_json():
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert data[0]["problem"] == "search json problem"
+
+
+def test_cli_json_output_escapes_control_characters():
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        [
+            "knowledge",
+            "save",
+            "unsafe\x1b[2J problem",
+            "unsafe\x07 resolution",
+        ],
+    )
+
+    search_result = runner.invoke(main, ["knowledge", "search", "--json", "unsafe"])
+    list_result = runner.invoke(main, ["knowledge", "list", "--json"])
+
+    assert search_result.exit_code == 0, search_result.output
+    assert list_result.exit_code == 0, list_result.output
+    assert "\x1b" not in search_result.output
+    assert "\x07" not in search_result.output
+    assert "\x1b" not in list_result.output
+    assert "\x07" not in list_result.output
+    assert r"\u001b" in search_result.output
+    assert r"\u0007" in search_result.output
+    assert json.loads(search_result.output)[0]["problem"] == "unsafe\x1b[2J problem"
 
 
 def test_cli_human_output_strips_control_characters():


### PR DESCRIPTION
## Summary

Implements a lightweight personal knowledge base for cross-session problem/resolution storage, addressing #3596.

- **`gptme/knowledge.py`**: Core module backed by JSONL at `~/.local/share/gptme/knowledge/entries.jsonl` (respects XDG_DATA_HOME). Each entry carries `memory_type="knowledge_entry"` metadata for future gptme-rag integration.
- **`gptme/cli/cmd_knowledge.py`**: CLI commands registered as `gptme-util knowledge`
- **`gptme/cli/util.py`**: Registers the new lazy command

New commands:
```
gptme-util knowledge save <problem> <resolution> [-t tag ...]  # save a pair
gptme-util knowledge search <query> [--top-k N] [-t tag ...]   # keyword search
gptme-util knowledge list           [--limit N] [-t tag ...]   # list entries
gptme-util knowledge delete <id>                                # delete by ID prefix
```

## Design decisions

- **No new BM25 scorer**: local search uses simple keyword matching; gptme-rag owns semantic retrieval. When gptme-rag is installed, `save` triggers `gptme-rag index` on an exported markdown mirror of the entries so semantic search stays current.
- **Not lessons**: lessons are human-curated, keyword-triggered, global. Knowledge entries are machine-written, query-retrieved, personal.
- **Distinct from CC memories**: the `~/.claude/projects/…/memory/` system is Claude-Code-only; this store is runtime-agnostic JSONL readable by any gptme session.
- **gptme-rag source hook**: the `memory_type="knowledge_entry"` field is the planned gating predicate for the retrieval hook once Phase 3 of the upstreaming work lands.

## Test plan

- [x] 20 unit + CLI tests in `tests/test_knowledge.py`, all passing
- [x] XDG isolation via `monkeypatch.setenv("XDG_DATA_HOME", ...)` so tests never touch real user data
- [x] Pre-commit (ruff, mypy) passes

<!-- gptme-id:v1:gai_KWOgmMnDI312bfdlOkDOrkPkipDiWtMrE3bd2d8r9Rr -->