### PR TITLE
fix(server): use os.write() and re-entrance guard in SIGTERM handlers

### DIFF
--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -2,10 +2,15 @@ import json
 import logging
 import os
 import signal
-import sys as _sys
 import threading
 import time
 from pathlib import Path
+
+# Re-entrance guard: SIGTERM can fire while a previous invocation is still
+# running (e.g. during a buffered write).  A module-level flag lets the
+# second invocation exit immediately rather than crashing with
+# "RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>".
+_sigterm_received = False
 
 
 # Install a minimal SIGTERM handler at module level — before the slow
@@ -17,8 +22,13 @@ from pathlib import Path
 # _install_sigterm_handler() upgrades it to a logger-aware version once
 # init_logging() has run inside serve().
 def _startup_sigterm_handler(signum: int, frame: object) -> None:
-    _sys.stderr.write("Received SIGTERM during startup, shutting down gracefully\n")
-    _sys.stderr.flush()
+    global _sigterm_received
+    if _sigterm_received:
+        return
+    _sigterm_received = True
+    # os.write() goes directly to the fd without Python's BufferedWriter, so
+    # it is safe to call from a signal handler (POSIX async-signal-safe).
+    os.write(2, b"Received SIGTERM during startup, shutting down gracefully\n")
     raise KeyboardInterrupt
 
 
@@ -142,12 +152,15 @@ def _install_sigterm_handler() -> None:
     """
 
     def _handle_sigterm(signum, frame):
-        # Write directly to stderr and flush before using the logger — Rich's
-        # Console buffers internally and may not flush before process exit,
-        # leaving the pipe empty on fast CI runners (gptme/gptme#3589).
-        _sys.stderr.write("Received SIGTERM, shutting down gracefully\n")
-        _sys.stderr.flush()
-        logger.info("Received SIGTERM, shutting down gracefully")
+        global _sigterm_received
+        if _sigterm_received:
+            return
+        _sigterm_received = True
+        # os.write() is POSIX async-signal-safe: it bypasses Python's
+        # BufferedWriter, which raises RuntimeError on reentrant calls
+        # (gptme/gptme#3589).  logger.info() is NOT safe in signal handlers
+        # (acquires locks, uses buffered I/O) so we omit it here.
+        os.write(2, b"Received SIGTERM, shutting down gracefully\n")
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _handle_sigterm)

--- a/tests/test_server_startup.py
+++ b/tests/test_server_startup.py
@@ -218,6 +218,72 @@ def test_startup_sigterm_handler_installed_at_import():
     )
 
 
+def test_sigterm_handler_survives_rapid_double_signal(tmp_path):
+    """Rapid duplicate SIGTERM must not crash with RuntimeError (reentrant BufferedWriter).
+
+    Regression for gptme/gptme#3589: _handle_sigterm() used _sys.stderr.write()
+    which is NOT async-signal-safe.  When a second SIGTERM arrived while the
+    first invocation was still inside stderr.write(), Python's BufferedWriter
+    raised ``RuntimeError: reentrant call inside <_io.BufferedWriter ...>``
+    instead of shutting down cleanly.
+
+    Fix: the handler now uses os.write(2, ...) (POSIX async-signal-safe, no
+    buffering) and guards against re-entrance with a module-level flag.  Two
+    SIGTERM signals in rapid succession must not crash the process.
+    """
+    import signal
+
+    env = os.environ.copy()
+    env["GPTME_DISABLE_AUTH"] = "1"
+    env["HOME"] = str(tmp_path)
+    for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"):
+        env.pop(key, None)
+    port = _find_free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "gptme.server.cli",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if not _wait_for_port("127.0.0.1", port, _STARTUP_TIMEOUT):
+        proc.terminate()
+        try:
+            stdout, stderr = proc.communicate(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+        pytest.fail(
+            f"Server did not bind to 127.0.0.1:{port} within {_STARTUP_TIMEOUT}s.\n"
+            f"stdout:\n{stdout.decode(errors='replace')}\n"
+            f"stderr:\n{stderr.decode(errors='replace')}"
+        )
+    # Send two SIGTERM signals with minimal delay to trigger the reentrant path
+    proc.send_signal(signal.SIGTERM)
+    time.sleep(0.02)
+    proc.send_signal(signal.SIGTERM)
+    try:
+        stdout, stderr = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+    combined = (stdout + stderr).decode(errors="replace")
+    assert "RuntimeError" not in combined, (
+        "Server crashed with RuntimeError on double SIGTERM — reentrant signal handler bug "
+        "(gptme/gptme#3589).\n"
+        f"stderr:\n{stderr.decode(errors='replace')}"
+    )
+    # The process must have exited — not still running
+    assert proc.returncode is not None, "Server did not exit after two SIGTERM signals"
+
+
 def test_server_exits_nonzero_on_bad_webui_dir(tmp_path):
     env = os.environ.copy()
     env["GPTME_DISABLE_AUTH"] = "1"


### PR DESCRIPTION
## Problem

SIGTERM handlers in `gptme/server/cli.py` used `_sys.stderr.write()` and `logger.info()`, neither of which is safe to call from a signal handler.

When a second SIGTERM arrived while the first invocation was still executing `stderr.write()`, Python's `BufferedWriter` raised:

```
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>
```

This produced a crash traceback instead of a clean shutdown (#3589).

The `logger.info()` call in `_handle_sigterm` was also unsafe: logging acquires locks and uses buffered I/O internally.

Complementary to #3597 (which guards against overriding custom handlers) — these two PRs fix different aspects of #3589.

Closes #3589.

## Fix

- Replace `_sys.stderr.write()` / `_sys.stderr.flush()` with `os.write(2, ...)` in both `_startup_sigterm_handler` and `_handle_sigterm`. `os.write()` is a raw POSIX syscall — it is async-signal-safe and does not use Python's buffered I/O layer.
- Add a module-level `_sigterm_received` flag so a rapid second SIGTERM returns immediately rather than re-entering the handler.
- Remove the `logger.info()` call from `_handle_sigterm`.

## Test

Added `test_sigterm_handler_survives_rapid_double_signal` to `tests/test_server_startup.py`: starts the server, waits for it to bind, then sends two SIGTERM signals 20 ms apart and asserts no `RuntimeError` appears in the output.

All 6 startup tests pass.

<!-- gptme-id:v1:gai_2oU4owBNj1ZyUKJ5bJmtTZlp1JkBQEpN5rupIuugNEE -->