### PR TITLE
feat(memory): load Claude Code memory in gptme workspace context

### DIFF
--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -168,6 +168,40 @@ def get_profile_memory_dir(profile_name: str) -> Path:
     return path
 
 
+def get_cc_memory_dir(workspace: Path) -> Path:
+    """Get the Claude Code memory directory for a given workspace.
+
+    Claude Code stores per-project memories at:
+        ~/.claude/projects/<workspace-hash>/memory/
+
+    where the hash is the absolute workspace path with slashes replaced by dashes,
+    e.g. ``/home/user/myproject`` → ``-home-user-myproject``.
+
+    This allows gptme sessions to read memories written by CC sessions (and vice
+    versa when the memory tool writes to this location).
+
+    Args:
+        workspace: Absolute path to the workspace root
+
+    Returns:
+        Path to the CC memory directory (may not exist)
+    """
+    workspace_hash = str(workspace.resolve()).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / workspace_hash / "memory"
+
+
+def get_cc_memory_file(workspace: Path) -> Path:
+    """Get the Claude Code MEMORY.md file path for a given workspace.
+
+    Args:
+        workspace: Absolute path to the workspace root
+
+    Returns:
+        Path to MEMORY.md inside the CC memory directory (may not exist)
+    """
+    return get_cc_memory_dir(workspace) / "MEMORY.md"
+
+
 def _migrate_readline_history():
     """Migrate readline history from config dir to data dir."""
     old_path = get_config_dir() / "history"

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -185,6 +185,14 @@ def get_cc_memory_dir(workspace: Path) -> Path:
 
     Returns:
         Path to the CC memory directory (may not exist)
+
+    Note:
+        The slash-to-dash encoding is non-injective: paths that differ only by a
+        dash versus a path separator (e.g. ``/a/b`` and ``/a-b``) map to the
+        same identifier. This is CC's own encoding scheme; gptme replicates it
+        faithfully so it reads the correct memory directory. The collision risk is
+        inherited from CC's design and cannot be resolved without diverging from
+        CC's path formula.
     """
     workspace_hash = str(workspace.resolve()).replace("/", "-")
     return Path.home() / ".claude" / "projects" / workspace_hash / "memory"

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -174,8 +174,9 @@ def get_cc_memory_dir(workspace: Path) -> Path:
     Claude Code stores per-project memories at:
         ~/.claude/projects/<workspace-hash>/memory/
 
-    where the hash is the absolute workspace path with slashes replaced by dashes,
-    e.g. ``/home/user/myproject`` → ``-home-user-myproject``.
+    where the hash is the absolute workspace path with slashes, backslashes, and
+    colons replaced by dashes, e.g. ``/home/user/myproject`` → ``-home-user-myproject``
+    and ``C:\\Users\\user\\project`` → ``C--Users-user-project``.
 
     This allows gptme sessions to read memories written by CC sessions (and vice
     versa when the memory tool writes to this location).
@@ -194,7 +195,9 @@ def get_cc_memory_dir(workspace: Path) -> Path:
         inherited from CC's design and cannot be resolved without diverging from
         CC's path formula.
     """
-    workspace_hash = str(workspace.resolve()).replace("\\", "-").replace("/", "-")
+    workspace_hash = (
+        str(workspace.resolve()).replace("\\", "-").replace("/", "-").replace(":", "-")
+    )
     return Path.home() / ".claude" / "projects" / workspace_hash / "memory"
 
 

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -194,7 +194,7 @@ def get_cc_memory_dir(workspace: Path) -> Path:
         inherited from CC's design and cannot be resolved without diverging from
         CC's path formula.
     """
-    workspace_hash = str(workspace.resolve()).replace("/", "-")
+    workspace_hash = str(workspace.resolve()).replace("\\", "-").replace("/", "-")
     return Path.home() / ".claude" / "projects" / workspace_hash / "memory"
 
 

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -406,7 +406,7 @@ def prompt_workspace(
                         f"CC memory file {cc_memory_file} exceeds "
                         f"{_CC_MEMORY_MAX_BYTES // 1024}KB; truncating"
                     )
-                memory_content = raw.decode("utf-8", errors="ignore").strip()
+                memory_content = raw.decode("utf-8", errors="replace").strip()
                 if memory_content:
                     yield Message(
                         "system",

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -406,7 +406,7 @@ def prompt_workspace(
                         f"CC memory file {cc_memory_file} exceeds "
                         f"{_CC_MEMORY_MAX_BYTES // 1024}KB; truncating"
                     )
-                memory_content = raw.decode("utf-8", errors="replace").strip()
+                memory_content = raw.decode("utf-8", errors="ignore").strip()
                 if memory_content:
                     yield Message(
                         "system",

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..config import config_path, get_config, get_project_config
+from ..dirs import get_cc_memory_file
 from ..message import Message
 from ..util.context import md_codeblock
 from ..util.context_dedup import _content_hash
@@ -388,6 +389,23 @@ def prompt_workspace(
             f"## Selected files\n\nRead more with `cat`.\n\n{context_file_list}",
             files=valid_context_files,
         )
+
+    # Load Claude Code memory if present — makes CC-written memories accessible in gptme
+    if include_user_context:
+        cc_memory_file = get_cc_memory_file(workspace_resolved)
+        if cc_memory_file.exists():
+            try:
+                memory_content = cc_memory_file.read_text(encoding="utf-8").strip()
+                if memory_content:
+                    yield Message(
+                        "system",
+                        f"## Persistent Memory\n\n"
+                        f"The following memory was saved across sessions "
+                        f"(from `{cc_memory_file}`):\n\n{memory_content}",
+                    )
+                    logger.debug(f"Loaded CC memory from {cc_memory_file}")
+            except OSError as e:
+                logger.debug(f"Failed to read CC memory file {cc_memory_file}: {e}")
 
     # Computed context last (changes most often, least cacheable)
     if (

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -396,17 +396,18 @@ def prompt_workspace(
         cc_memory_file = get_cc_memory_file(workspace_resolved)
         if cc_memory_file.exists():
             try:
-                memory_content = cc_memory_file.read_text(encoding="utf-8").strip()
+                # Read at most MAX+1 bytes to detect oversized files without loading them fully
+                with open(cc_memory_file, "rb") as _f:
+                    raw = _f.read(_CC_MEMORY_MAX_BYTES + 1)
+                truncated = len(raw) > _CC_MEMORY_MAX_BYTES
+                if truncated:
+                    raw = raw[:_CC_MEMORY_MAX_BYTES]
+                    logger.warning(
+                        f"CC memory file {cc_memory_file} exceeds "
+                        f"{_CC_MEMORY_MAX_BYTES // 1024}KB; truncating"
+                    )
+                memory_content = raw.decode("utf-8", errors="ignore").strip()
                 if memory_content:
-                    encoded = memory_content.encode("utf-8")
-                    if len(encoded) > _CC_MEMORY_MAX_BYTES:
-                        logger.warning(
-                            f"CC memory file {cc_memory_file} is {len(encoded)} bytes; "
-                            f"truncating to {_CC_MEMORY_MAX_BYTES // 1024}KB"
-                        )
-                        memory_content = encoded[:_CC_MEMORY_MAX_BYTES].decode(
-                            "utf-8", errors="ignore"
-                        )
                     yield Message(
                         "system",
                         f"## Persistent Memory\n\n"

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -16,6 +16,7 @@ from . import AGENT_FILES, DEFAULT_CONTEXT_FILES, _loaded_agent_files_var
 from .context_cmd import get_project_context_cmd_output
 
 _HASH_PREFIX = "ch:"
+_CC_MEMORY_MAX_BYTES = 64 * 1024  # 64 KB cap to avoid consuming excessive prompt budget
 
 if TYPE_CHECKING:
     from ..util.uri import FilePath
@@ -397,6 +398,15 @@ def prompt_workspace(
             try:
                 memory_content = cc_memory_file.read_text(encoding="utf-8").strip()
                 if memory_content:
+                    encoded = memory_content.encode("utf-8")
+                    if len(encoded) > _CC_MEMORY_MAX_BYTES:
+                        logger.warning(
+                            f"CC memory file {cc_memory_file} is {len(encoded)} bytes; "
+                            f"truncating to {_CC_MEMORY_MAX_BYTES // 1024}KB"
+                        )
+                        memory_content = encoded[:_CC_MEMORY_MAX_BYTES].decode(
+                            "utf-8", errors="ignore"
+                        )
                     yield Message(
                         "system",
                         f"## Persistent Memory\n\n"

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -38,6 +38,25 @@ class TestGetCcMemoryDir:
         # Both should resolve to the same hash
         assert cc_dir_real == cc_dir_link
 
+    def test_windows_backslashes_replaced(self):
+        """Windows-style backslashes in resolved path strings are normalised to dashes.
+
+        On Windows, str(Path.resolve()) returns backslash separators. The function
+        must replace them so the resulting hash component contains no backslashes.
+        """
+
+        class _WindowsPath:
+            def __str__(self):
+                return "C:\\Users\\user\\myproject"
+
+        workspace = Path("/irrelevant")
+        with patch.object(Path, "resolve", return_value=_WindowsPath()):
+            cc_dir = get_cc_memory_dir(workspace)
+
+        hash_part = cc_dir.parent.name  # the workspace_hash component
+        assert "\\" not in hash_part
+        assert hash_part == "C:-Users-user-myproject"
+
     def test_path_collision_documented(self):
         """Paths differing only by dash-vs-separator produce the same hash (CC's design).
 
@@ -199,6 +218,44 @@ class TestCcMemoryInWorkspacePrompt:
         contents = [m.content for m in messages]
         combined = "\n".join(contents)
         assert "Persistent Memory" not in combined
+
+    def test_non_utf8_memory_uses_replacement_chars(self, tmp_path):
+        """Non-UTF-8 bytes in MEMORY.md produce replacement chars (U+FFFD), not silent drops."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        cc_memory_file = tmp_path / "MEMORY.md"
+        # Latin-1 encoded text: "café" — 0xe9 is invalid UTF-8 lead byte
+        cc_memory_file.write_bytes(b"# Memory\n\ncaf\xe9\n")
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file",
+                return_value=cc_memory_file,
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
+        assert len(memory_msgs) == 1
+        content = memory_msgs[0].content
+        # The invalid byte is replaced with U+FFFD, not silently dropped
+        assert "�" in content or "caf" in content
+        # Confirm "caf" prefix survived (not silently swallowed)
+        assert "caf" in content
 
     def test_oversized_memory_is_truncated(self, tmp_path):
         """Memory files exceeding the size cap are truncated before injection.

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -220,8 +220,13 @@ class TestCcMemoryInWorkspacePrompt:
         combined = "\n".join(contents)
         assert "Persistent Memory" not in combined
 
-    def test_non_utf8_memory_uses_replacement_chars(self, tmp_path):
-        """Non-UTF-8 bytes in MEMORY.md produce replacement chars (U+FFFD), not silent drops."""
+    def test_non_utf8_memory_drops_invalid_bytes(self, tmp_path):
+        """Non-UTF-8 bytes in MEMORY.md are silently dropped (errors='ignore').
+
+        Using errors='replace' would expand each invalid byte to 3-byte U+FFFD,
+        allowing 64KB of input to produce ~192KB of decoded text — exceeding the
+        intended size cap. errors='ignore' keeps the decoded size bounded.
+        """
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
@@ -253,10 +258,10 @@ class TestCcMemoryInWorkspacePrompt:
         memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
         assert len(memory_msgs) == 1
         content = memory_msgs[0].content
-        # The invalid byte is replaced with U+FFFD, not silently dropped
-        assert "�" in content or "caf" in content
-        # Confirm "caf" prefix survived (not silently swallowed)
+        # The invalid byte is dropped; valid prefix survives
         assert "caf" in content
+        # No U+FFFD replacement chars (that would indicate errors='replace')
+        assert "�" not in content
 
     def test_oversized_memory_is_truncated(self, tmp_path):
         """Memory files exceeding the size cap are truncated before injection.

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -1,0 +1,191 @@
+"""Tests for Claude Code memory integration in gptme workspace context."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from gptme.dirs import get_cc_memory_dir, get_cc_memory_file
+
+
+class TestGetCcMemoryDir:
+    """Tests for get_cc_memory_dir."""
+
+    def test_path_formula(self, tmp_path):
+        """CC memory dir uses workspace path with slashes replaced by dashes."""
+        workspace = Path("/home/user/myproject")
+        cc_dir = get_cc_memory_dir(workspace)
+        assert (
+            cc_dir
+            == Path.home() / ".claude" / "projects" / "-home-user-myproject" / "memory"
+        )
+
+    def test_nested_workspace(self, tmp_path):
+        """Deeper workspace paths produce correct hash."""
+        workspace = Path("/home/alice/code/myorg/myrepo")
+        cc_dir = get_cc_memory_dir(workspace)
+        expected_hash = "-home-alice-code-myorg-myrepo"
+        assert cc_dir.name == "memory"
+        assert cc_dir.parent.name == expected_hash
+
+    def test_resolves_workspace(self, tmp_path):
+        """Workspace is resolved to absolute before hashing."""
+        # tmp_path is already absolute; create a symlink to test resolve
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link"
+        link_dir.symlink_to(real_dir)
+        cc_dir_real = get_cc_memory_dir(real_dir)
+        cc_dir_link = get_cc_memory_dir(link_dir)
+        # Both should resolve to the same hash
+        assert cc_dir_real == cc_dir_link
+
+
+class TestGetCcMemoryFile:
+    """Tests for get_cc_memory_file."""
+
+    def test_returns_memory_md(self):
+        """Returns MEMORY.md inside the CC memory dir."""
+        workspace = Path("/home/user/myproject")
+        cc_file = get_cc_memory_file(workspace)
+        assert cc_file.name == "MEMORY.md"
+        assert cc_file.parent == get_cc_memory_dir(workspace)
+
+
+class TestCcMemoryInWorkspacePrompt:
+    """Tests for CC memory loading in prompt_workspace."""
+
+    def test_loads_cc_memory_when_present(self, tmp_path):
+        """CC memory is included in workspace context when MEMORY.md exists."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        # Create a fake CC memory file
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        workspace_hash = str(workspace.resolve()).replace("/", "-")
+        cc_memory_dir = (
+            tmp_path / "home" / ".claude" / "projects" / workspace_hash / "memory"
+        )
+        cc_memory_dir.mkdir(parents=True)
+        cc_memory_file = cc_memory_dir / "MEMORY.md"
+        cc_memory_file.write_text("# Memory\n\n- Key insight about this project\n")
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file",
+                return_value=cc_memory_file,
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        contents = [m.content for m in messages]
+        combined = "\n".join(contents)
+        assert "Persistent Memory" in combined
+        assert "Key insight about this project" in combined
+
+    def test_no_memory_when_file_missing(self, tmp_path):
+        """No memory message is emitted when CC MEMORY.md doesn't exist."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        nonexistent = tmp_path / "nonexistent" / "MEMORY.md"
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file", return_value=nonexistent
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        contents = [m.content for m in messages]
+        combined = "\n".join(contents)
+        assert "Persistent Memory" not in combined
+
+    def test_skips_memory_when_include_user_context_false(self, tmp_path):
+        """CC memory is not loaded when include_user_context=False (e.g. eval mode)."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        cc_memory_file = tmp_path / "MEMORY.md"
+        cc_memory_file.write_text("# Memory\n\n- Some insight\n")
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file",
+                return_value=cc_memory_file,
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=False,
+                    include_context_cmd=False,
+                )
+            )
+
+        contents = [m.content for m in messages]
+        combined = "\n".join(contents)
+        assert "Persistent Memory" not in combined
+
+    def test_skips_empty_memory_file(self, tmp_path):
+        """Empty MEMORY.md produces no memory message."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        cc_memory_file = tmp_path / "MEMORY.md"
+        cc_memory_file.write_text("   \n   ")  # whitespace only
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file",
+                return_value=cc_memory_file,
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        contents = [m.content for m in messages]
+        combined = "\n".join(contents)
+        assert "Persistent Memory" not in combined

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -38,6 +38,16 @@ class TestGetCcMemoryDir:
         # Both should resolve to the same hash
         assert cc_dir_real == cc_dir_link
 
+    def test_path_collision_documented(self):
+        """Paths differing only by dash-vs-separator produce the same hash (CC's design).
+
+        e.g. /a/b and /a-b both map to '-a-b'. This is an inherent property of
+        CC's own slash-to-dash encoding; gptme replicates it faithfully.
+        """
+        ws_slash = Path("/home/user/a/b")
+        ws_dash = Path("/home/user/a-b")
+        assert get_cc_memory_dir(ws_slash) == get_cc_memory_dir(ws_dash)
+
 
 class TestGetCcMemoryFile:
     """Tests for get_cc_memory_file."""
@@ -189,3 +199,38 @@ class TestCcMemoryInWorkspacePrompt:
         contents = [m.content for m in messages]
         combined = "\n".join(contents)
         assert "Persistent Memory" not in combined
+
+    def test_oversized_memory_is_truncated(self, tmp_path):
+        """Memory files exceeding the size cap are truncated before injection."""
+        from gptme.prompts.workspace import _CC_MEMORY_MAX_BYTES, prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        cc_memory_file = tmp_path / "MEMORY.md"
+        big_content = "# Memory\n\n" + ("x" * (_CC_MEMORY_MAX_BYTES + 10_000))
+        cc_memory_file.write_text(big_content, encoding="utf-8")
+
+        with (
+            patch(
+                "gptme.prompts.workspace.get_cc_memory_file",
+                return_value=cc_memory_file,
+            ),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
+        assert len(memory_msgs) == 1
+        injected = memory_msgs[0].content.encode("utf-8")
+        assert len(injected) < _CC_MEMORY_MAX_BYTES * 2

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -55,7 +55,8 @@ class TestGetCcMemoryDir:
 
         hash_part = cc_dir.parent.name  # the workspace_hash component
         assert "\\" not in hash_part
-        assert hash_part == "C:-Users-user-myproject"
+        assert ":" not in hash_part
+        assert hash_part == "C--Users-user-myproject"
 
     def test_path_collision_documented(self):
         """Paths differing only by dash-vs-separator produce the same hash (CC's design).

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -201,7 +201,12 @@ class TestCcMemoryInWorkspacePrompt:
         assert "Persistent Memory" not in combined
 
     def test_oversized_memory_is_truncated(self, tmp_path):
-        """Memory files exceeding the size cap are truncated before injection."""
+        """Memory files exceeding the size cap are truncated before injection.
+
+        Critically, the file must NOT be fully read — only _CC_MEMORY_MAX_BYTES+1
+        bytes should be consumed so that multi-MB MEMORY.md files cannot stall
+        prompt construction.
+        """
         from gptme.prompts.workspace import _CC_MEMORY_MAX_BYTES, prompt_workspace
 
         workspace = tmp_path / "myproject"
@@ -209,6 +214,23 @@ class TestCcMemoryInWorkspacePrompt:
         cc_memory_file = tmp_path / "MEMORY.md"
         big_content = "# Memory\n\n" + ("x" * (_CC_MEMORY_MAX_BYTES + 10_000))
         cc_memory_file.write_text(big_content, encoding="utf-8")
+
+        max_bytes_read = []
+
+        real_open = open
+
+        def tracking_open(path, mode="r", **kw):
+            fh = real_open(path, mode, **kw)
+            if str(path) == str(cc_memory_file) and "b" in mode:
+                real_read = fh.read
+
+                def bounded_read(n=-1):
+                    data = real_read(n)
+                    max_bytes_read.append(len(data))
+                    return data
+
+                fh.read = bounded_read
+            return fh
 
         with (
             patch(
@@ -220,6 +242,7 @@ class TestCcMemoryInWorkspacePrompt:
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
             patch("gptme.prompts.workspace._get_git_status", return_value=None),
             patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+            patch("builtins.open", side_effect=tracking_open),
         ):
             mock_config.return_value.user = None
             messages = list(
@@ -233,4 +256,8 @@ class TestCcMemoryInWorkspacePrompt:
         memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
         assert len(memory_msgs) == 1
         injected = memory_msgs[0].content.encode("utf-8")
-        assert len(injected) < _CC_MEMORY_MAX_BYTES * 2
+        # Output is bounded
+        assert len(injected) <= _CC_MEMORY_MAX_BYTES * 2
+        # The file was read with a size bound, not in full
+        assert max_bytes_read, "open() was not called on the memory file in binary mode"
+        assert max(max_bytes_read) <= _CC_MEMORY_MAX_BYTES + 1


### PR DESCRIPTION
## Summary

- Adds `get_cc_memory_dir()` and `get_cc_memory_file()` to `gptme/dirs.py`, computing the Claude Code memory path from the workspace absolute path (`/` → `-`)
- In `prompt_workspace()`, auto-loads `~/.claude/projects/<hash>/memory/MEMORY.md` when it exists and `include_user_context=True`
- Adds 8 tests covering path formula, edge cases (empty file, missing file, eval mode)

## Background

Claude Code stores per-project memories at `~/.claude/projects/<workspace-hash>/memory/MEMORY.md`. Previously gptme sessions couldn't read these memories, creating a cross-runtime blind spot. This PR implements Option 2 from #3625: auto-include the CC memory path in gptme's workspace context.

The memory is loaded **read-only** (inline in the system prompt as "Persistent Memory") and only when `include_user_context=True` — the same guard that controls agent instruction files, so eval and isolated modes are unaffected.

## Test plan

- [x] `tests/test_cc_memory.py` — 8 unit tests, all passing
- [x] `tests/test_agent_memory.py` — 12 existing tests still passing
- [x] Pre-commit hooks (ruff, mypy) pass

Closes #3625

<!-- gptme-id:v1:gai_c6M9U0kI1BZWf9G6EAKPldY76LugKd0By1JKkmBkLLW -->