### PR TITLE
docs(tool-formats): refresh coverage numbers after #3566 + pin them with a test

### DIFF
--- a/docs/tool-formats.rst
+++ b/docs/tool-formats.rst
@@ -224,26 +224,38 @@ behaviour silently:
 
 **How well populated is this?** Unevenly, and it is worth being explicit about:
 
-- ``default_tool_format`` is set for the ``openai-subscription`` models only
-  (they default to ``tool``). No other model in the bundled registry declares
-  one, so for almost every model step 4 above is a no-op and you land on
-  ``markdown``.
+- ``default_tool_format`` is set to ``tool`` on 92 of the 111 models in the
+  bundled registry. This is stamped **per provider**, not per model: every
+  provider that talks the OpenAI-compatible function-calling API gets it
+  (``openai``, ``openai-subscription``, ``gemini``, ``xai``, ``groq``,
+  ``deepseek``, ``moonshot``, ``openrouter``, ``requesty``, and the
+  subscription/proxy variants). ``anthropic`` is excluded because it uses the
+  Anthropic SDK rather than the OpenAI-compatible path, and ``mock`` is
+  test-only. An explicit per-model value always wins over the provider stamp.
 
-- ``supports_parallel_tool_calls`` is set on the Claude Opus/Sonnet 4.x families,
-  their OpenRouter aliases, Kimi K3, and the GPT-4.1/GPT-5 families — roughly 30
-  entries. Deliberate omissions are meaningful: Claude Haiku 4.5 carries an
+  Four OpenAI-compatible providers (``azure``, ``local``, ``nvidia``, ``gptme``)
+  ship no static registry entries at all, so there is nothing to stamp; they get
+  the same ``tool`` default applied at resolution time instead, including on
+  dynamic-fetch fallbacks.
+
+- ``supports_parallel_tool_calls`` is set on 29 entries: the Claude Opus/Sonnet
+  4.x families, their OpenRouter aliases, Kimi K3, and the GPT-4.1/GPT-5
+  families. Deliberate omissions are meaningful: Claude Haiku 4.5 carries an
   explicit comment that it does *not* emit multiple tool calls per response.
 
-- ``supports_strict_tools`` is set on the OpenAI models (GPT-4o/4.1/5 families,
-  o-series) and Kimi K3.
+- ``supports_strict_tools`` is set on 23 entries: the OpenAI models (GPT-4o/4.1/5
+  families, o-series) and Kimi K3.
 
 So this is not a complete capability matrix, and an absent flag means "not
 recorded", not "not supported". If a model you use is missing a flag it should
 have, that is a worthwhile contribution.
 
-The :doc:`evals` leaderboard is the natural source for populating
-``default_tool_format``: it already reports the best-performing format per model
-from measured runs.
+One caveat on ``default_tool_format``: the provider-level stamp above encodes
+"this provider can do native tool calls", not "``tool`` measurably beats
+``markdown`` for this model". Those are different claims. The :doc:`evals`
+leaderboard is the source that can settle the second one — it already reports the
+best-performing format per model from measured runs — and per-model values
+derived from it are the intended refinement over the current heuristic.
 
 Troubleshooting
 ---------------

--- a/tests/test_docs_tool_formats_coverage.py
+++ b/tests/test_docs_tool_formats_coverage.py
@@ -24,7 +24,7 @@ def _counts() -> dict[str, int]:
     for models in MODELS.values():
         for props in models.values():
             total += 1
-            tool_format += bool(props.get("default_tool_format"))
+            tool_format += props.get("default_tool_format") == "tool"
             parallel += bool(props.get("supports_parallel_tool_calls"))
             strict += bool(props.get("supports_strict_tools"))
     return {

--- a/tests/test_docs_tool_formats_coverage.py
+++ b/tests/test_docs_tool_formats_coverage.py
@@ -76,3 +76,23 @@ def test_excluded_providers_really_are_excluded():
             f"{provider} models now carry default_tool_format ({stamped}), but "
             "docs/tool-formats.rst documents them as excluded"
         )
+
+
+def test_empty_registry_providers_have_no_static_entries():
+    """azure/local/nvidia/gptme are documented as having no static registry entries.
+
+    These are OpenAI-compat providers that inherit default_tool_format at
+    resolution time rather than from a per-model entry in the static registry.
+    If a static entry is added for any of them, the docs must be updated to
+    reflect it (the count and the explanation both change).
+    """
+    empty_registry: list[Provider] = ["azure", "local", "nvidia", "gptme"]
+    for provider in empty_registry:
+        if provider in MODELS:
+            entries = MODELS[provider]
+            assert not entries, (
+                f"'{provider}' is documented as having no static registry entries "
+                "(docs/tool-formats.rst), but now has "
+                f"{len(entries)} ({list(entries)}) — update the docs to reflect "
+                "the new entries, or keep the provider registry-free"
+            )

--- a/tests/test_docs_tool_formats_coverage.py
+++ b/tests/test_docs_tool_formats_coverage.py
@@ -1,0 +1,78 @@
+"""Guard against docs/tool-formats.rst drifting from the model registry.
+
+The "How well populated is this?" section quotes concrete coverage counts for
+the ModelMeta tool-calling fields. Those numbers went stale once already (they
+described the pre-#3566 state, where only openai-subscription models carried a
+``default_tool_format``). This test fails the moment the registry and the prose
+disagree, so the fix lands with the change that caused it.
+"""
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from gptme.llm.models.data import MODELS
+
+if TYPE_CHECKING:
+    from gptme.llm.models.types import Provider
+
+DOCS = Path(__file__).parent.parent / "docs" / "tool-formats.rst"
+
+
+def _counts() -> dict[str, int]:
+    total = tool_format = parallel = strict = 0
+    for models in MODELS.values():
+        for props in models.values():
+            total += 1
+            tool_format += bool(props.get("default_tool_format"))
+            parallel += bool(props.get("supports_parallel_tool_calls"))
+            strict += bool(props.get("supports_strict_tools"))
+    return {
+        "total": total,
+        "default_tool_format": tool_format,
+        "supports_parallel_tool_calls": parallel,
+        "supports_strict_tools": strict,
+    }
+
+
+def test_documented_coverage_matches_registry():
+    text = DOCS.read_text()
+    counts = _counts()
+
+    # "set to ``tool`` on 92 of the 111 models"
+    m = re.search(
+        r"``default_tool_format`` is set to ``tool`` on (\d+) of the (\d+) models",
+        text,
+    )
+    assert m, "coverage sentence for default_tool_format not found in docs"
+    assert int(m.group(1)) == counts["default_tool_format"], (
+        f"docs say {m.group(1)} models set default_tool_format, "
+        f"registry has {counts['default_tool_format']} — update docs/tool-formats.rst"
+    )
+    assert int(m.group(2)) == counts["total"], (
+        f"docs say {m.group(2)} total models, registry has {counts['total']} "
+        "— update docs/tool-formats.rst"
+    )
+
+    for field in ("supports_parallel_tool_calls", "supports_strict_tools"):
+        m = re.search(rf"``{field}`` is set on (\d+) entries", text)
+        assert m, f"coverage sentence for {field} not found in docs"
+        assert int(m.group(1)) == counts[field], (
+            f"docs say {m.group(1)} entries set {field}, registry has "
+            f"{counts[field]} — update docs/tool-formats.rst"
+        )
+
+
+def test_excluded_providers_really_are_excluded():
+    """anthropic/mock are documented as deliberately not stamped."""
+    excluded: list[Provider] = ["anthropic", "mock"]
+    for provider in excluded:
+        stamped = [
+            name
+            for name, props in MODELS[provider].items()
+            if props.get("default_tool_format")
+        ]
+        assert not stamped, (
+            f"{provider} models now carry default_tool_format ({stamped}), but "
+            "docs/tool-formats.rst documents them as excluded"
+        )


### PR DESCRIPTION
Follow-on to #3566, which merged ~30 minutes ago.

## The problem

#3566 stamped `default_tool_format="tool"` on every OpenAI-compatible provider, taking coverage from **14 models** (openai-subscription only) to **92 of 111**. The "How well populated is this?" section of `docs/tool-formats.rst` still described the pre-#3566 state, so the page actively misinformed:

> `default_tool_format` is set for the `openai-subscription` models only. No other model in the bundled registry declares one, so for almost every model step 4 above is a no-op and you land on `markdown`.

Both sentences are now false.

## Changes

- **Refresh all three coverage counts** against the registry — 92/111 with `default_tool_format`, 29 `supports_parallel_tool_calls`, 23 `supports_strict_tools` (measured, not estimated).
- **Explain the stamp is per-provider, not per-model**, and that an explicit per-model value still wins. `anthropic` (Anthropic SDK, not OpenAI-compat) and `mock` (test-only) are deliberately excluded.
- **Note the four empty-registry providers** (`azure`, `local`, `nvidia`, `gptme`) that are OpenAI-compat but ship no static entries, so they get the default at resolution time instead.
- **Sharpen the evals pointer.** The provider stamp encodes "this provider *can* do native tool calls", not "`tool` measurably beats `markdown` for this model". Those are different claims, and only the leaderboard settles the second — so per-model eval-derived values remain the intended refinement, not a closed question.

## The test

The numbers went stale once already, silently. `tests/test_docs_tool_formats_coverage.py` parses the counts out of the prose and asserts them against the live registry, so the next registry change that moves coverage fails with a message naming the file to update.

Verified it is a real guard rather than a tautology: reverting the doc number to the pre-#3566 value (14) reproduces the exact failure this PR fixes.

```
AssertionError: docs say 14 models set default_tool_format, registry has 92
  — update docs/tool-formats.rst
```

A second test pins the `anthropic`/`mock` exclusion the prose documents.

## Verification

- `pytest tests/test_llm_models.py tests/test_llm_models_resolution.py tests/test_docs_tool_formats_coverage.py` — 167 passed
- `prek run --files ...` — all hooks green
- Docs-and-tests only; no runtime behavior change.