### PR TITLE
feat(models): parallel-tool flags from provider docs; eval-format verdict

### DIFF
--- a/docs/tool-formats.rst
+++ b/docs/tool-formats.rst
@@ -224,26 +224,52 @@ behaviour silently:
 
 **How well populated is this?** Unevenly, and it is worth being explicit about:
 
-- ``default_tool_format`` is set for the ``openai-subscription`` models only
-  (they default to ``tool``). No other model in the bundled registry declares
-  one, so for almost every model step 4 above is a no-op and you land on
-  ``markdown``.
+- ``default_tool_format`` is set to ``tool`` on 92 of the 111 models in the
+  bundled registry. This is stamped **per provider**, not per model: every
+  provider that talks the OpenAI-compatible function-calling API gets it
+  (``openai``, ``openai-subscription``, ``gemini``, ``xai``, ``groq``,
+  ``deepseek``, ``moonshot``, ``openrouter``, ``requesty``, and the
+  subscription/proxy variants). ``anthropic`` is excluded because it uses the
+  Anthropic SDK rather than the OpenAI-compatible path, and ``mock`` is
+  test-only. An explicit per-model value always wins over the provider stamp.
 
-- ``supports_parallel_tool_calls`` is set on the Claude Opus/Sonnet 4.x families,
-  their OpenRouter aliases, Kimi K3, and the GPT-4.1/GPT-5 families — roughly 30
-  entries. Deliberate omissions are meaningful: Claude Haiku 4.5 carries an
-  explicit comment that it does *not* emit multiple tool calls per response.
+  Four OpenAI-compatible providers (``azure``, ``local``, ``nvidia``, ``gptme``)
+  ship no static registry entries at all, so there is nothing to stamp; they get
+  the same ``tool`` default applied at resolution time instead, including on
+  dynamic-fetch fallbacks.
 
-- ``supports_strict_tools`` is set on the OpenAI models (GPT-4o/4.1/5 families,
-  o-series) and Kimi K3.
+- ``supports_parallel_tool_calls`` is set on 56 entries: the Claude Opus/Sonnet
+  4.x families and their OpenRouter aliases, Kimi K3, the GPT-4.1/GPT-5
+  families, all bundled Gemini models (and the OpenRouter Gemini 3.5 Flash
+  alias), xAI Grok (including ``grok-subscription``), Groq's
+  ``llama-3.3-70b-versatile``, DeepSeek chat/reasoner, and the OpenRouter
+  DeepSeek V4 aliases. Deliberate omissions are meaningful: Claude Haiku 4.5
+  carries an explicit comment that it does *not* emit multiple tool calls per
+  response. Moonshot Kimi K2/K2.6, OpenRouter Qwen/Llama/Kimi K2, and Groq's
+  gpt-oss models (not in this registry) stay unset because provider docs do not
+  clearly document parallel tool calls for those IDs.
+
+- ``supports_strict_tools`` is set on 23 entries: the OpenAI models (GPT-4o/4.1/5
+  families, o-series) and Kimi K3. DeepSeek documents a ``strict`` mode, but it
+  requires ``base_url=https://api.deepseek.com/beta``, which gptme does not use,
+  so the flag stays unset rather than sending ``strict=True`` on the production
+  endpoint. xAI tool arguments are implicitly schema-strict; that is not the
+  OpenAI ``strict=True`` request field, so it is also left unset.
 
 So this is not a complete capability matrix, and an absent flag means "not
 recorded", not "not supported". If a model you use is missing a flag it should
 have, that is a worthwhile contribution.
 
-The :doc:`evals` leaderboard is the natural source for populating
-``default_tool_format``: it already reports the best-performing format per model
-from measured runs.
+One caveat on ``default_tool_format``: the provider-level stamp above encodes
+"this provider can do native tool calls", not "``tool`` measurably beats
+``markdown`` for this model". Those are different claims. The :doc:`evals`
+leaderboard is the source that can settle the second one — it already reports the
+best-performing format per model from measured runs. Consulted 2026-08-25: no
+registry model had a trustworthy disagreement with the provider heuristic
+(override bar: both the candidate format and the heuristic tested on ≥10 unique
+tests, a strict Wilson-score win, and a valid ``markdown``/``xml``/``tool``
+value), so no per-model overrides were added. The leaderboard's display cutoff
+of 4 tests is too weak to change a production default.
 
 Troubleshooting
 ---------------

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -26,6 +26,20 @@ def _set_tool_format(
     }
 
 
+def _mark_parallel(models: dict[str, _ModelDictMeta]) -> dict[str, _ModelDictMeta]:
+    """Stamp supports_parallel_tool_calls=True unless the model already sets it.
+
+    An explicit per-model value still wins, so a later model that does *not*
+    support parallel can opt out by setting the key to False.
+    """
+    return {
+        name: props
+        if "supports_parallel_tool_calls" in props
+        else {**props, "supports_parallel_tool_calls": True}
+        for name, props in models.items()
+    }
+
+
 # Providers that route through the OpenAI-compatible function-calling API — stamp
 # default_tool_format="tool" on every model that doesn't already have one set.
 # Anthropic and mock are excluded: anthropic uses the Anthropic SDK (not OpenAI-compat),
@@ -50,6 +64,24 @@ OPENAI_COMPAT_PROVIDERS: frozenset[str] = frozenset(
         # via the OpenAI-compatible API (see llm_openai.py) — same fallback applies
         # when dynamic fetch fails/misses and no static registry entry exists.
         "gptme",
+    }
+)
+
+# Providers whose official docs state that current models can emit multiple
+# tool calls in one response. Applied at MODELS construction so it cannot
+# drift from the static dicts. Mixed providers (openrouter, groq) are stamped
+# per-model instead: Groq's own table is model-specific (llama-3.3 Yes,
+# gpt-oss No), and OpenRouter aliases a mix of backends.
+# Docs:
+#   gemini: https://ai.google.dev/gemini-api/docs/function-calling#parallel_function_calling
+#   xai / grok-subscription: https://docs.x.ai/developers/tools/function-calling#parallel-function-calling
+#   deepseek: https://api-docs.deepseek.com/news/news0725/
+PARALLEL_TOOL_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "gemini",
+        "deepseek",
+        "xai",
+        "grok-subscription",
     }
 )
 
@@ -313,6 +345,11 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
         },
     },
     # https://api-docs.deepseek.com/quick_start/pricing
+    # Parallel: stamped via PARALLEL_TOOL_PROVIDERS.
+    # `strict` mode exists but requires base_url=.../beta, which gptme does not
+    # use — leave supports_strict_tools unset rather than send a flag the
+    # production endpoint may reject.
+    # https://api-docs.deepseek.com/guides/tool_calls/#strict-mode-beta
     "deepseek": {
         "deepseek-chat": {
             "context": 128_000,
@@ -332,6 +369,9 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
         },
     },
     # https://groq.com/pricing/
+    # Parallel tool use is model-specific on Groq (llama-3.3-70b-versatile Yes,
+    # openai/gpt-oss-* No). Stamp per-model, not via PARALLEL_TOOL_PROVIDERS.
+    # https://console.groq.com/docs/tool-use/overview#supported-models
     "groq": {
         "llama-3.3-70b-versatile": {
             "context": 128_000,
@@ -339,6 +379,7 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.59,
             "price_output": 0.79,
             "preferred_edit_format": "diff",
+            "supports_parallel_tool_calls": True,
         },
     },
     # https://docs.x.ai/docs/models
@@ -346,6 +387,10 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
     # Uses OAuth tokens from the grok CLI (~/.grok/auth.json) — $0 marginal.
     # Prices reflect xAI API-equivalent cost for comparison purposes.
     # Auth: run `grok login` or `gptme auth grok-subscription`.
+    # Parallel: stamped via PARALLEL_TOOL_PROVIDERS (xAI default).
+    # Tool-arg schemas are implicitly strict; gptme's supports_strict_tools flag
+    # sends OpenAI `strict=True`, which xAI does not document as an accepted
+    # request field, so that flag stays unset.
     "grok-subscription": _mark_subscription(
         {
             # grok-4.6 — current frontier model on SuperGrok subscription and
@@ -502,6 +547,7 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 9,
             "supports_vision": True,
             "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,  # Gemini parallel function calling
             "preferred_edit_format": "diff",
         },
         "moonshotai/kimi-k2": {
@@ -528,6 +574,7 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.435,
             "price_output": 0.87,
             "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,  # DeepSeek API supports parallel tool calls
             "preferred_edit_format": "diff",
         },
         "deepseek/deepseek-v4-flash": {
@@ -536,6 +583,7 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.0983,
             "price_output": 0.1966,
             "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,  # DeepSeek API supports parallel tool calls
             "preferred_edit_format": "diff",
         },
     },
@@ -614,13 +662,24 @@ _MODELS_RAW: dict[Provider, dict[str, _ModelDictMeta]] = {
 # check that all providers have a _MODELS_RAW entry
 assert set(PROVIDERS) == set(_MODELS_RAW.keys())
 
-# Stamp default_tool_format="tool" on all OpenAI-compatible providers at construction
+
+def _stamp_provider(
+    provider: str, models: dict[str, _ModelDictMeta]
+) -> dict[str, _ModelDictMeta]:
+    """Apply construction-time stamps so static dicts and MODELS stay consistent."""
+    if provider in PARALLEL_TOOL_PROVIDERS:
+        models = _mark_parallel(models)
+    if provider in OPENAI_COMPAT_PROVIDERS:
+        models = _set_tool_format(models, "tool")
+    return models
+
+
+# Stamp default_tool_format="tool" on all OpenAI-compatible providers, and
+# supports_parallel_tool_calls on PARALLEL_TOOL_PROVIDERS, at construction
 # time. Building MODELS in one step (rather than reassigning it) ensures that any
 # code reading the intermediate dicts (OPENAI_MODELS, etc.) and any code reading
 # MODELS see a consistent value with no ordering hazard.
 MODELS = {
-    provider: _set_tool_format(models, "tool")
-    if provider in OPENAI_COMPAT_PROVIDERS
-    else models
+    provider: _stamp_provider(provider, models)
     for provider, models in _MODELS_RAW.items()
 }

--- a/tests/test_docs_tool_formats_coverage.py
+++ b/tests/test_docs_tool_formats_coverage.py
@@ -1,0 +1,98 @@
+"""Guard against docs/tool-formats.rst drifting from the model registry.
+
+The "How well populated is this?" section quotes concrete coverage counts for
+the ModelMeta tool-calling fields. Those numbers went stale once already (they
+described the pre-#3566 state, where only openai-subscription models carried a
+``default_tool_format``). This test fails the moment the registry and the prose
+disagree, so the fix lands with the change that caused it.
+"""
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from gptme.llm.models.data import MODELS
+
+if TYPE_CHECKING:
+    from gptme.llm.models.types import Provider
+
+DOCS = Path(__file__).parent.parent / "docs" / "tool-formats.rst"
+
+
+def _counts() -> dict[str, int]:
+    total = tool_format = parallel = strict = 0
+    for models in MODELS.values():
+        for props in models.values():
+            total += 1
+            tool_format += props.get("default_tool_format") == "tool"
+            parallel += bool(props.get("supports_parallel_tool_calls"))
+            strict += bool(props.get("supports_strict_tools"))
+    return {
+        "total": total,
+        "default_tool_format": tool_format,
+        "supports_parallel_tool_calls": parallel,
+        "supports_strict_tools": strict,
+    }
+
+
+def test_documented_coverage_matches_registry():
+    text = DOCS.read_text()
+    counts = _counts()
+
+    # "set to ``tool`` on 92 of the 111 models"
+    m = re.search(
+        r"``default_tool_format`` is set to ``tool`` on (\d+) of the (\d+) models",
+        text,
+    )
+    assert m, "coverage sentence for default_tool_format not found in docs"
+    assert int(m.group(1)) == counts["default_tool_format"], (
+        f"docs say {m.group(1)} models set default_tool_format, "
+        f"registry has {counts['default_tool_format']} — update docs/tool-formats.rst"
+    )
+    assert int(m.group(2)) == counts["total"], (
+        f"docs say {m.group(2)} total models, registry has {counts['total']} "
+        "— update docs/tool-formats.rst"
+    )
+
+    for field in ("supports_parallel_tool_calls", "supports_strict_tools"):
+        m = re.search(rf"``{field}`` is set on (\d+) entries", text)
+        assert m, f"coverage sentence for {field} not found in docs"
+        assert int(m.group(1)) == counts[field], (
+            f"docs say {m.group(1)} entries set {field}, registry has "
+            f"{counts[field]} — update docs/tool-formats.rst"
+        )
+
+
+def test_excluded_providers_really_are_excluded():
+    """anthropic/mock are documented as deliberately not stamped."""
+    excluded: list[Provider] = ["anthropic", "mock"]
+    for provider in excluded:
+        stamped = [
+            name
+            for name, props in MODELS[provider].items()
+            if props.get("default_tool_format")
+        ]
+        assert not stamped, (
+            f"{provider} models now carry default_tool_format ({stamped}), but "
+            "docs/tool-formats.rst documents them as excluded"
+        )
+
+
+def test_empty_registry_providers_have_no_static_entries():
+    """azure/local/nvidia/gptme are documented as having no static registry entries.
+
+    These are OpenAI-compat providers that inherit default_tool_format at
+    resolution time rather than from a per-model entry in the static registry.
+    If a static entry is added for any of them, the docs must be updated to
+    reflect it (the count and the explanation both change).
+    """
+    empty_registry: list[Provider] = ["azure", "local", "nvidia", "gptme"]
+    for provider in empty_registry:
+        if provider in MODELS:
+            entries = MODELS[provider]
+            assert not entries, (
+                f"'{provider}' is documented as having no static registry entries "
+                "(docs/tool-formats.rst), but now has "
+                f"{len(entries)} ({list(entries)}) — update the docs to reflect "
+                "the new entries, or keep the provider registry-free"
+            )

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -15,6 +15,7 @@ from gptme.llm.models import (
     get_recommended_model,
     list_models,
 )
+from gptme.llm.models.data import _mark_parallel
 
 
 def test_get_static_model():
@@ -489,10 +490,57 @@ class TestSupportsParallelToolCalls:
         model = get_model("openrouter/anthropic/claude-sonnet-4.6")
         assert model.supports_parallel_tool_calls is True
 
+    def test_gemini_supports_parallel(self):
+        """Gemini docs document parallel function calling for current models."""
+        model = get_model("gemini/gemini-2.5-flash")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_xai_grok_supports_parallel(self):
+        """xAI docs: parallel function calling is enabled by default."""
+        model = get_model("xai/grok-4")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_grok_subscription_supports_parallel(self):
+        model = get_model("grok-subscription/grok-4.6")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_groq_llama_33_supports_parallel(self):
+        """Groq's supported-models table lists llama-3.3-70b-versatile as Yes."""
+        model = get_model("groq/llama-3.3-70b-versatile")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_deepseek_supports_parallel(self):
+        model = get_model("deepseek/deepseek-chat")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_openrouter_gemini_alias_supports_parallel(self):
+        model = get_model("openrouter/google/gemini-3.5-flash")
+        assert model.supports_parallel_tool_calls is True
+
+    def test_moonshot_kimi_k2_parallel_not_recorded(self):
+        """Kimi K2/K2.6 stay unset: official tool-call docs do not document parallel."""
+        model = get_model("moonshot/kimi-k2")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_deepseek_strict_not_recorded(self):
+        """DeepSeek strict mode needs the /beta base URL, which gptme does not use."""
+        model = get_model("deepseek/deepseek-chat")
+        assert model.supports_strict_tools is False
+
     def test_unknown_model_defaults_to_false(self):
         """Unknown models fall back to False (safe default — don't break things)."""
         model = get_model("unknown-provider/unknown-model")
         assert model.supports_parallel_tool_calls is False
+
+    def test_mark_parallel_does_not_overwrite_explicit_false(self):
+        stamped = _mark_parallel(
+            {
+                "a": {"context": 1, "supports_parallel_tool_calls": False},
+                "b": {"context": 1},
+            }
+        )
+        assert stamped["a"]["supports_parallel_tool_calls"] is False
+        assert stamped["b"]["supports_parallel_tool_calls"] is True
 
 
 class TestSupportsResponsesAPI:


### PR DESCRIPTION
Follow-on to #3566 (provider-level `default_tool_format="tool"`) and overlapping with #3627 (docs coverage refresh).

## Phase 1 — eval signal, no per-model overrides

Ran `python -m gptme.eval.leaderboard --results-dir eval_results --format json --min-tests 4` (24,815 rows). The leaderboard's display cutoff of 4 tests is **not** a trustworthy override bar: n=4 is usually basic-only, "best format" is often the only format that was run, and Wilson ties are not disagreements.

**Bar used:** both the candidate format and the current heuristic tested on ≥10 unique tests, a strict Wilson-score win, a valid `markdown`/`xml`/`tool` value, and the model in the static registry.

**Verdict:** no registry model clears that bar. The #3566 provider heuristic stays. Apparent n=4 disagreements (`openai/gpt-5` markdown 4/5 vs tool 3/5, `qwen3-max` 4/4 tie, `gemini-2.5-flash` markdown with `tool` never tested, etc.) are noise or missing A/B.

Write-up: this is the "no disagreement" outcome #3566 deferred. Do not manufacture per-model overrides that restate the provider default.

## Phase 3 — capability-flag audit

`supports_parallel_tool_calls` is what makes gptme *not* stop after the first tool call. It was unset for every non-OpenAI/Anthropic provider, which meant Gemini/Grok/Groq/DeepSeek users got one tool per turn even when the provider documents parallel calls.

Set `True` only where official docs document support:

| Provider | Source | Change |
|---|---|---|
| gemini (all 12) | [Gemini parallel function calling](https://ai.google.dev/gemini-api/docs/function-calling#parallel_function_calling) | stamp via `PARALLEL_TOOL_PROVIDERS` |
| xai (7) + grok-subscription (2) | [xAI: parallel enabled by default](https://docs.x.ai/developers/tools/function-calling#parallel-function-calling) | stamp via `PARALLEL_TOOL_PROVIDERS` |
| groq `llama-3.3-70b-versatile` | [Groq supported-models table](https://console.groq.com/docs/tool-use/overview#supported-models) (Yes for llama-3.3, **No** for gpt-oss) | per-model, not provider-wide |
| deepseek chat/reasoner | [DeepSeek 2024-07-25 API upgrade](https://api-docs.deepseek.com/news/news0725/) | stamp via `PARALLEL_TOOL_PROVIDERS` |
| openrouter `google/gemini-3.5-flash`, `deepseek/deepseek-v4-*` | inherit the above | per-model |

Left **unset** (not recorded, not "unsupported"):

- Moonshot Kimi K2/K2.6 — official tool-call guide does not document parallel (K3 already has the flag)
- `supports_strict_tools` for DeepSeek — docs require `base_url=.../beta`, which gptme does not use
- `supports_strict_tools` for xAI — tool args are implicitly schema-strict; that is not the OpenAI `strict=True` request field

Coverage: parallel **29 → 56**, strict stays 23, `default_tool_format` stays 92/111.

## Docs

Refreshes the "How well populated is this?" section (still described the pre-#3566 state on master) and pins the counts with `tests/test_docs_tool_formats_coverage.py`.

This is a superset of #3627: same docs+test files, with the post-audit parallel count (56, not 29) and the eval-verdict caveat. **#3627 should close as superseded** once this is up; merging #3627 first would immediately fail its own coverage test after this lands.

## Tests

- `tests/test_llm_models.py::TestSupportsParallelToolCalls` — gemini, xAI, grok-subscription, groq llama-3.3, deepseek, OpenRouter Gemini alias, Kimi K2 still unset, DeepSeek strict still unset, `_mark_parallel` does not overwrite explicit False
- `tests/test_docs_tool_formats_coverage.py` — docs counts match the live registry

```
uv run pytest tests/test_llm_models.py::TestSupportsParallelToolCalls tests/test_docs_tool_formats_coverage.py
# 20 passed
```