### PR TITLE
docs: add Browser Use Cloud CDP setup

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -144,8 +144,8 @@ cleanup_browser
 trap - EXIT INT TERM
 ```
 
-Create an API key in the [Browser Use Cloud
-dashboard](https://cloud.browser-use.com) and export it as
+Create an API key on the [Browser Use Cloud API key
+page](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and export it as
 `BROWSER_USE_API_KEY` first. The managed browser includes a hardened Chromium
 build and residential proxy; gptme keeps using its existing Playwright tools.
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -112,6 +112,34 @@ export GPTME_BROWSER_CDP_URL=http://127.0.0.1:9222
 gptme "read https://example.com"
 ```
 
+### Use Browser Use Cloud
+
+For sites that block local headless Chromium, create a managed Browser Use
+Cloud browser and give its CDP URL to gptme:
+
+```bash
+session=$(curl -sS https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"proxyCountryCode":"us"}')
+
+export BROWSER_SESSION_ID=$(echo "$session" | jq -r .id)
+export GPTME_BROWSER_CDP_URL=$(echo "$session" | jq -r .cdpUrl)
+gptme "read https://example.com"
+
+# Stop the managed browser when finished.
+curl -X PATCH \
+  "https://api.browser-use.com/api/v4/browsers/$BROWSER_SESSION_ID" \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"stop"}'
+```
+
+Create an API key in the [Browser Use Cloud
+dashboard](https://cloud.browser-use.com) and export it as
+`BROWSER_USE_API_KEY` first. The managed browser includes a hardened Chromium
+build and residential proxy; gptme keeps using its existing Playwright tools.
+
 > **Note:** CDP only works with Chromium-based browsers.  `GPTME_BROWSER_ENGINE`
 > is ignored in CDP mode.
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -118,21 +118,30 @@ For sites that block local headless Chromium, create a managed Browser Use
 Cloud browser and give its CDP URL to gptme:
 
 ```bash
-session=$(curl -sS https://api.browser-use.com/api/v4/browsers \
+session=$(curl -fsS https://api.browser-use.com/api/v4/browsers \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"proxyCountryCode":"us"}')
 
-export BROWSER_SESSION_ID=$(echo "$session" | jq -r .id)
-export GPTME_BROWSER_CDP_URL=$(echo "$session" | jq -r .cdpUrl)
+BROWSER_SESSION_ID=$(echo "$session" | jq -er .id)
+GPTME_BROWSER_CDP_URL=$(echo "$session" | jq -er .cdpUrl)
+export BROWSER_SESSION_ID GPTME_BROWSER_CDP_URL
+
+cleanup_browser() {
+  [ -z "${BROWSER_SESSION_ID:-}" ] && return
+  curl -fsS -X PATCH \
+    "https://api.browser-use.com/api/v4/browsers/$BROWSER_SESSION_ID" \
+    -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"action":"stop"}' >/dev/null || true
+  BROWSER_SESSION_ID=
+}
+trap cleanup_browser EXIT INT TERM
+
 gptme "read https://example.com"
 
-# Stop the managed browser when finished.
-curl -X PATCH \
-  "https://api.browser-use.com/api/v4/browsers/$BROWSER_SESSION_ID" \
-  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"action":"stop"}'
+cleanup_browser
+trap - EXIT INT TERM
 ```
 
 Create an API key in the [Browser Use Cloud


### PR DESCRIPTION
## Summary

- document how to create a Browser Use Cloud browser and connect gptme over CDP
- parse session fields strictly and fail on a bad API response
- always stop the managed browser on normal exit, Ctrl-C, or termination

## Checks

- `uv run --with pytest --with pytest-mock --with pytest-timeout --with pytest-retry --with pytest-asyncio pytest tests/test_tools_browser_thread.py -q`: 54 passed
- real local Chromium CDP: gptme BrowserThread connected, opened an isolated context, and read `Browser Use price: USD 49` from a live local page
- the shell block parses with `bash -n`; Markdown fences and create → ID → CDP → trap → gptme → cleanup order were checked
- `git diff --check`
- one file: `docs/browser.md`
- no credentials in the diff

## Test boundary

The real CDP path was tested with local Chromium. The live Browser Use Cloud create/connect/stop path was not run because no authorized `BROWSER_USE_API_KEY` is available locally. No production or customer credential was used.