### PR TITLE
fix(cli): forward nested help to utility shortcuts

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -120,6 +120,10 @@ class _DynamicHelpCommand(click.Command):
             if skip_next:
                 skip_next = False
                 continue
+            if a == "--":
+                # End-of-options delimiter: don't intercept positionals after it.
+                # `gptme -- chats list` must NOT dispatch to gptme-util.
+                break
             if a.startswith("-"):
                 # --opt=val form carries its value inline; bare --opt consumes next token.
                 opt_name = a.split("=")[0] if "=" in a else a

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -100,10 +100,12 @@ class _DynamicHelpCommand(click.Command):
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """Keep arguments after a mirrored utility command opaque to Click."""
-        if args and not args[0].startswith("-"):
+        # Scan past any leading top-level flags to find the first positional.
+        first_positional = next((a for a in args if not a.startswith("-")), None)
+        if first_positional is not None:
             from .util import UTIL_SUBCOMMANDS
 
-            if args[0] in UTIL_SUBCOMMANDS:
+            if first_positional in UTIL_SUBCOMMANDS:
                 # Otherwise eager or recognized top-level options such as --help
                 # are consumed before main() can forward them to gptme-util.
                 ctx.allow_interspersed_args = False

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -98,6 +98,17 @@ class _DynamicHelpCommand(click.Command):
 
     _help_expanded = False
 
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """Keep arguments after a mirrored utility command opaque to Click."""
+        if args and not args[0].startswith("-"):
+            from .util import UTIL_SUBCOMMANDS
+
+            if args[0] in UTIL_SUBCOMMANDS:
+                # Otherwise eager or recognized top-level options such as --help
+                # are consumed before main() can forward them to gptme-util.
+                ctx.allow_interspersed_args = False
+        return super().parse_args(ctx, args)
+
     def _expand_dynamic_help(self) -> None:
         if self._help_expanded:
             return

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -121,8 +121,11 @@ class _DynamicHelpCommand(click.Command):
                 skip_next = False
                 continue
             if a == "--":
-                # End-of-options delimiter: don't intercept positionals after it.
-                # `gptme -- chats list` must NOT dispatch to gptme-util.
+                # End-of-options delimiter: stop scanning for a subcommand name.
+                # With allow_interspersed_args still True, Click treats everything
+                # after '--' as positionals.  main() will still see the first
+                # positional as prompts[0] and forward to gptme-util, so dispatch
+                # does occur for `gptme -- chats list --help`.
                 break
             if a.startswith("-"):
                 # --opt=val form carries its value inline; bare --opt consumes next token.

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -100,8 +100,35 @@ class _DynamicHelpCommand(click.Command):
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """Keep arguments after a mirrored utility command opaque to Click."""
-        # Scan past any leading top-level flags to find the first positional.
-        first_positional = next((a for a in args if not a.startswith("-")), None)
+        # Build the set of option names that consume a following value token
+        # (non-flag options).  These must be skipped over when scanning for
+        # the first true positional so that option *values* are not mistaken
+        # for subcommands (e.g. `--model gpt-4` must not yield 'gpt-4').
+        value_opts: set[str] = set()
+        for param in self.params:
+            if (
+                isinstance(param, click.Option)
+                and not param.is_flag
+                and param.nargs != 0
+            ):
+                value_opts.update(param.opts)
+
+        # Scan past leading option/value pairs to find the first positional.
+        skip_next = False
+        first_positional: str | None = None
+        for a in args:
+            if skip_next:
+                skip_next = False
+                continue
+            if a.startswith("-"):
+                # --opt=val form carries its value inline; bare --opt consumes next token.
+                opt_name = a.split("=")[0] if "=" in a else a
+                if "=" not in a and opt_name in value_opts:
+                    skip_next = True
+                continue
+            first_positional = a
+            break
+
         if first_positional is not None:
             from .util import UTIL_SUBCOMMANDS
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -880,7 +880,12 @@ def main(
 
     # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
     # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.
-    if prompts and not show_version:
+    # Suppressed after '--' for the same literal-prompt semantics as util dispatch.
+    if (
+        prompts
+        and not show_version
+        and not _ctx.meta.get("util_dispatch_suppressed", False)
+    ):
         plugin = f"gptme-{prompts[0]}"
         if plugin_path := shutil.which(plugin):
             sys.exit(subprocess.call([plugin_path, *prompts[1:]]))

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -145,19 +145,28 @@ class _DynamicHelpCommand(click.Command):
                         skip_next = True
                     continue
                 # Short option, possibly grouped (e.g. -vm where -m takes a value).
-                # Two forms have the value embedded in the token and do NOT consume
-                # the next token:
-                #   -t=read-only  → '=' separates the inline value
-                #   -mgpt-4       → value is embedded directly after the option char
-                # Only skip the next token when the value-taker is the last char
-                # in the cluster (e.g. -vm where -m needs the next token).
-                if "=" not in a:
-                    chars = a[1:]
-                    for idx, ch in enumerate(chars):
-                        if f"-{ch}" in value_opts:
-                            if idx == len(chars) - 1:
-                                skip_next = True
-                            break
+                # Inspect flags from left to right, as Click does.  The remainder
+                # of the token becomes an attached value as soon as a value-taking
+                # option is found; otherwise every character must be a known flag.
+                chars = a[1:]
+                for idx, ch in enumerate(chars):
+                    opt_name = f"-{ch}"
+                    if opt_name not in known_opts:
+                        # With ignore_unknown_options=True, Click preserves an
+                        # unknown short option as a positional argument.  Stop
+                        # here rather than treating a later utility name as the
+                        # first positional (e.g. `-x chats list --help`).
+                        first_positional = a
+                        break
+                    if opt_name in value_opts:
+                        # No characters after the option means its value is the
+                        # next token.  Otherwise the remainder (including an '='
+                        # prefix) is the attached value.
+                        if idx == len(chars) - 1:
+                            skip_next = True
+                        break
+                if first_positional is not None:
+                    break
                 continue
             first_positional = a
             break

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -143,21 +143,21 @@ class _DynamicHelpCommand(click.Command):
                         break
                     if "=" not in a and opt_name in value_opts:
                         skip_next = True
-                else:
-                    # Short option, possibly grouped (e.g. -vm where -m takes a value).
-                    # Two forms have the value embedded in the token and do NOT consume
-                    # the next token:
-                    #   -t=read-only  → '=' separates the inline value
-                    #   -mgpt-4       → value is embedded directly after the option char
-                    # Only skip the next token when the value-taker is the last char
-                    # in the cluster (e.g. -vm where -m needs the next token).
-                    if "=" not in a:
-                        chars = a[1:]
-                        for idx, ch in enumerate(chars):
-                            if f"-{ch}" in value_opts:
-                                if idx == len(chars) - 1:
-                                    skip_next = True
-                                break
+                    continue
+                # Short option, possibly grouped (e.g. -vm where -m takes a value).
+                # Two forms have the value embedded in the token and do NOT consume
+                # the next token:
+                #   -t=read-only  → '=' separates the inline value
+                #   -mgpt-4       → value is embedded directly after the option char
+                # Only skip the next token when the value-taker is the last char
+                # in the cluster (e.g. -vm where -m needs the next token).
+                if "=" not in a:
+                    chars = a[1:]
+                    for idx, ch in enumerate(chars):
+                        if f"-{ch}" in value_opts:
+                            if idx == len(chars) - 1:
+                                skip_next = True
+                            break
                 continue
             first_positional = a
             break

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -141,11 +141,19 @@ class _DynamicHelpCommand(click.Command):
                         skip_next = True
                 else:
                     # Short option, possibly grouped (e.g. -vm where -m takes a value).
-                    # If any char in the group is a value consumer, skip the next token.
-                    for ch in a[1:]:
-                        if f"-{ch}" in value_opts:
-                            skip_next = True
-                            break
+                    # Two forms have the value embedded in the token and do NOT consume
+                    # the next token:
+                    #   -t=read-only  → '=' separates the inline value
+                    #   -mgpt-4       → value is embedded directly after the option char
+                    # Only skip the next token when the value-taker is the last char
+                    # in the cluster (e.g. -vm where -m needs the next token).
+                    if "=" not in a:
+                        chars = a[1:]
+                        for idx, ch in enumerate(chars):
+                            if f"-{ch}" in value_opts:
+                                if idx == len(chars) - 1:
+                                    skip_next = True
+                                break
                 continue
             first_positional = a
             break

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -105,13 +105,12 @@ class _DynamicHelpCommand(click.Command):
         # the first true positional so that option *values* are not mistaken
         # for subcommands (e.g. `--model gpt-4` must not yield 'gpt-4').
         value_opts: set[str] = set()
+        known_opts: set[str] = set()  # all known option names (flags + value-takers)
         for param in self.params:
-            if (
-                isinstance(param, click.Option)
-                and not param.is_flag
-                and param.nargs != 0
-            ):
-                value_opts.update(param.opts)
+            if isinstance(param, click.Option):
+                known_opts.update(param.opts)
+                if not param.is_flag and param.nargs != 0:
+                    value_opts.update(param.opts)
 
         # Scan past leading option/value pairs to find the first positional.
         skip_next = False
@@ -121,11 +120,10 @@ class _DynamicHelpCommand(click.Command):
                 skip_next = False
                 continue
             if a == "--":
-                # End-of-options delimiter: stop scanning for a subcommand name.
-                # With allow_interspersed_args still True, Click treats everything
-                # after '--' as positionals.  main() will still see the first
-                # positional as prompts[0] and forward to gptme-util, so dispatch
-                # does occur for `gptme -- chats list --help`.
+                # '--' is the POSIX end-of-options sentinel: the user wants
+                # everything after it treated as literal prompts, not as a
+                # utility shortcut.  Signal main() to skip util dispatch.
+                ctx.meta["util_dispatch_suppressed"] = True
                 break
             if a == "-":
                 # '-' is gptme's MULTIPROMPT_SEPARATOR, not an option prefix.
@@ -137,6 +135,12 @@ class _DynamicHelpCommand(click.Command):
                 if a.startswith("--"):
                     # Long option: --opt=val (inline) or --opt val (next token).
                     opt_name = a.split("=")[0]
+                    if opt_name not in known_opts:
+                        # Unknown long option: with ignore_unknown_options=True,
+                        # Click treats it as a positional.  Mirror that here so
+                        # the scan doesn't skip past the real first positional.
+                        first_positional = a
+                        break
                     if "=" not in a and opt_name in value_opts:
                         skip_next = True
                 else:
@@ -847,10 +851,14 @@ def main(
 
     # gptme-util subcommand mirroring: `gptme chats [...]` → `gptme-util chats [...]`
     # Any top-level gptme-util subcommand can be invoked without typing 'gptme-util'.
+    # Suppressed when '--' was used (parse_args sets util_dispatch_suppressed).
     if prompts and not show_version:
         from .util import UTIL_SUBCOMMANDS  # cheap: just a sorted list constant
 
-        if prompts[0] in UTIL_SUBCOMMANDS:
+        _ctx = click.get_current_context()
+        if prompts[0] in UTIL_SUBCOMMANDS and not _ctx.meta.get(
+            "util_dispatch_suppressed", False
+        ):
             if util_exec := shutil.which("gptme-util"):
                 sys.exit(subprocess.call([util_exec, *prompts]))
             else:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -127,11 +127,25 @@ class _DynamicHelpCommand(click.Command):
                 # positional as prompts[0] and forward to gptme-util, so dispatch
                 # does occur for `gptme -- chats list --help`.
                 break
+            if a == "-":
+                # '-' is gptme's MULTIPROMPT_SEPARATOR, not an option prefix.
+                # Treat as a positional; it is never a UTIL_SUBCOMMAND so the
+                # scan stops here without enabling the gptme-util forward path.
+                first_positional = a
+                break
             if a.startswith("-"):
-                # --opt=val form carries its value inline; bare --opt consumes next token.
-                opt_name = a.split("=")[0] if "=" in a else a
-                if "=" not in a and opt_name in value_opts:
-                    skip_next = True
+                if a.startswith("--"):
+                    # Long option: --opt=val (inline) or --opt val (next token).
+                    opt_name = a.split("=")[0]
+                    if "=" not in a and opt_name in value_opts:
+                        skip_next = True
+                else:
+                    # Short option, possibly grouped (e.g. -vm where -m takes a value).
+                    # If any char in the group is a value consumer, skip the next token.
+                    for ch in a[1:]:
+                        if f"-{ch}" in value_opts:
+                            skip_next = True
+                            break
                 continue
             first_positional = a
             break

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -164,6 +164,21 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list"]
         )
 
+    def test_util_subcmd_forwards_nested_help(self, runner: CliRunner):
+        """gptme chats list --help shows the mirrored command's help."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["chats", "list", "--help"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""
         with patch("gptme.cli.main.subprocess.call") as mock_call:

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -179,6 +179,23 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
+    def test_util_subcmd_forwards_nested_help_with_leading_flag(
+        self, runner: CliRunner
+    ):
+        """gptme --verbose chats list --help forwards --help to gptme-util."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["--verbose", "chats", "list", "--help"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""
         with patch("gptme.cli.main.subprocess.call") as mock_call:

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -218,6 +218,28 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
+    def test_util_subcmd_after_double_dash_forwards_help(self, runner: CliRunner):
+        """gptme -- chats list --help still forwards --help to gptme-util.
+
+        '--' ends option processing: Click treats 'chats', 'list', and '--help' all
+        as positionals.  The parse_args fix ensures '--' is recognised as the
+        end-of-options delimiter (not mis-classified as a bare option flag), so
+        allow_interspersed_args is never incorrectly set to False.  The observable
+        result is unchanged: gptme-util still receives chats list --help.
+        """
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["--", "chats", "list", "--help"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""
         with patch("gptme.cli.main.subprocess.call") as mock_call:

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -196,6 +196,28 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
+    def test_util_subcmd_forwards_nested_help_with_leading_value_option(
+        self, runner: CliRunner
+    ):
+        """gptme --model gpt-4 chats list --help forwards --help to gptme-util.
+
+        The option value 'gpt-4' must not be mistaken for the first positional.
+        """
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(
+                main, ["--model", "gpt-4", "chats", "list", "--help"]
+            )
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""
         with patch("gptme.cli.main.subprocess.call") as mock_call:

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -218,6 +218,28 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
+    def test_util_subcmd_forwards_nested_help_with_grouped_short_option(
+        self, runner: CliRunner
+    ):
+        """gptme -vm gpt-4 chats list --help forwards --help to gptme-util.
+
+        '-v' is a flag and '-m' is a value option; the grouped token '-vm' must
+        cause the scanner to skip the next token ('gpt-4') so that 'chats' is
+        found as the first positional.
+        """
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["-vm", "gpt-4", "chats", "list", "--help"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_after_double_dash_forwards_help(self, runner: CliRunner):
         """gptme -- chats list --help still forwards --help to gptme-util.
 

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -240,6 +240,28 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
+    def test_util_subcmd_forwards_nested_help_with_inline_value_short_option(
+        self, runner: CliRunner
+    ):
+        """gptme -mgpt-4 chats list --help forwards --help to gptme-util.
+
+        '-mgpt-4' is a short option with the value attached inline (no space).
+        The scanner must not skip the next token ('chats') — the value is already
+        embedded in the token, so 'chats' is the first true positional.
+        """
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-util",
+            ),
+            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
+        ):
+            result = runner.invoke(main, ["-mgpt-4", "chats", "list", "--help"])
+        assert result.exit_code == 0
+        mock_call.assert_called_once_with(
+            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
+        )
+
     def test_util_subcmd_after_double_dash_forwards_help(self, runner: CliRunner):
         """gptme -- chats list --help still forwards --help to gptme-util.
 

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -128,6 +128,20 @@ class TestPluginDispatch:
         assert result.exit_code == 0
         mock_call.assert_not_called()
 
+    def test_plugin_dispatch_suppressed_after_double_dash(self, runner: CliRunner):
+        """gptme -- sessions treats sessions as a prompt, not a plugin."""
+        with (
+            patch(
+                "gptme.cli.main.shutil.which",
+                return_value="/usr/local/bin/gptme-sessions",
+            ),
+            patch("gptme.cli.main.subprocess.call") as mock_call,
+            patch.object(importlib.import_module("gptme.chat"), "chat"),
+        ):
+            result = runner.invoke(main, ["--", "sessions"])
+        assert result.exit_code == 0
+        mock_call.assert_not_called()
+
     def test_help_mentions_plugin_dispatch(self, runner: CliRunner):
         """gptme --help mentions the plugin dispatch mechanism."""
         result = runner.invoke(main, ["--help"])

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -262,27 +262,35 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
-    def test_util_subcmd_after_double_dash_forwards_help(self, runner: CliRunner):
-        """gptme -- chats list --help still forwards --help to gptme-util.
+    def test_util_subcmd_after_double_dash_suppresses_dispatch(self, runner: CliRunner):
+        """gptme -- chats list sets util_dispatch_suppressed in ctx.meta.
 
-        '--' ends option processing: Click treats 'chats', 'list', and '--help' all
-        as positionals.  The parse_args fix ensures '--' is recognised as the
-        end-of-options delimiter (not mis-classified as a bare option flag), so
-        allow_interspersed_args is never incorrectly set to False.  The observable
-        result is unchanged: gptme-util still receives chats list --help.
+        '--' is the POSIX end-of-options sentinel: everything after it is treated
+        as a literal prompt, not as a utility shortcut (same intuition as '-' for
+        multi-prompt chaining).  parse_args sets util_dispatch_suppressed so
+        main() skips the UTIL_SUBCOMMANDS check.
+
+        We test parse_args via make_context (which runs parse_args but NOT the
+        main() body) to avoid triggering LLM initialisation in the test.
         """
-        with (
-            patch(
-                "gptme.cli.main.shutil.which",
-                return_value="/usr/local/bin/gptme-util",
-            ),
-            patch("gptme.cli.main.subprocess.call", return_value=0) as mock_call,
-        ):
-            result = runner.invoke(main, ["--", "chats", "list", "--help"])
+        with patch("gptme.cli.main.shutil.which", return_value=None):
+            ctx = main.make_context("gptme", ["--", "chats", "list"])
+        assert ctx.meta.get("util_dispatch_suppressed", False)
+
+    def test_util_subcmd_after_unknown_option_does_not_dispatch(
+        self, runner: CliRunner
+    ):
+        """gptme --bogus chats list --help shows gptme help, not gptme-util.
+
+        With ignore_unknown_options=True, Click treats '--bogus' as a positional.
+        The scanner mirrors this: unknown long options stop the scan without
+        enabling util dispatch, so allow_interspersed_args stays True and
+        --help fires as an eager option showing gptme's top-level help.
+        """
+        with patch("gptme.cli.main.shutil.which", return_value=None):
+            result = runner.invoke(main, ["--bogus", "chats", "list", "--help"])
+        assert "Usage:" in result.output
         assert result.exit_code == 0
-        mock_call.assert_called_once_with(
-            ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
-        )
 
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -287,10 +287,21 @@ class TestUtilSubcommandMirroring:
         enabling util dispatch, so allow_interspersed_args stays True and
         --help fires as an eager option showing gptme's top-level help.
         """
-        with patch("gptme.cli.main.shutil.which", return_value=None):
+        with patch("gptme.cli.main.subprocess.call") as mock_call:
             result = runner.invoke(main, ["--bogus", "chats", "list", "--help"])
         assert "Usage:" in result.output
         assert result.exit_code == 0
+        mock_call.assert_not_called()
+
+    def test_util_subcmd_after_unknown_short_option_does_not_dispatch(
+        self, runner: CliRunner
+    ):
+        """gptme -x chats list --help shows gptme help, not gptme-util."""
+        with patch("gptme.cli.main.subprocess.call") as mock_call:
+            result = runner.invoke(main, ["-x", "chats", "list", "--help"])
+        assert "Usage:" in result.output
+        assert result.exit_code == 0
+        mock_call.assert_not_called()
 
     def test_util_subcmd_skipped_for_version_flag(self, runner: CliRunner):
         """gptme --version chats does not trigger gptme-util dispatch."""


### PR DESCRIPTION
## Problem

The documented gptme utility shortcut did not forward nested help. `gptme chats list --help` exited successfully but rendered top-level gptme help instead of the `chats list` options because Click consumed the eager help flag before shortcut dispatch.

## Fix

Stop interspersed top-level option parsing when the first token is a known mirrored gptme-util command. Arguments after that command remain opaque and reach gptme-util unchanged. Normal chat parsing and leading gptme flags are unaffected.

## Verification

- `pytest tests/test_search_alias.py` — 20 passed
- targeted regression test — passed
- live `gptme chats list --help` now renders `Usage: gptme-util chats list [OPTIONS]`
- ruff check and format — clean
- mypy on changed files — clean