### PR TITLE
docs(getting-started): add free cloud providers section

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -84,6 +84,8 @@ Here are some compelling examples to get you started:
     # Resume conversations
     gptme -r
 
+.. _local-models:
+
 Local Models (No API Key Required)
 -----------------------------------
 
@@ -121,6 +123,52 @@ For better results on coding tasks, use a larger model:
 
 See :doc:`providers` for Groq and all other built-in provider options, or :doc:`providers-custom`
 for Ollama, vLLM, and custom server setup.
+
+Free Cloud Providers (No Credit Card Required)
+----------------------------------------------
+
+Several cloud providers offer free tiers that work with gptme out of the box:
+
+**OpenRouter** (recommended: largest free model catalog)
+
+OpenRouter aggregates free model tiers from Google, Meta, Mistral, and others behind one API key:
+
+.. code-block:: bash
+
+    # Sign in with browser — no credit card required
+    gptme '/account setup openrouter'
+
+    # Then use any :free-tagged model
+    gptme "hello" -m openrouter/google/gemini-2.5-flash:free
+    gptme "hello" -m openrouter/meta-llama/llama-3.3-70b-instruct:free
+
+Free OpenRouter models are rate-limited but sufficient for personal use. The ``:free`` suffix selects
+the free tier; omitting it routes to paid inference.
+
+**Google Gemini** (generous free quota, 1 M token context)
+
+.. code-block:: bash
+
+    # Get a free API key at https://aistudio.google.com/apikey (no credit card)
+    export GEMINI_API_KEY="your-key"
+    gptme "hello" -m gemini/gemini-2.5-flash
+
+**Groq** (fast inference, free tier)
+
+.. code-block:: bash
+
+    # Get a free API key at https://console.groq.com (no credit card)
+    export GROQ_API_KEY="your-key"
+    gptme "hello" -m groq/llama-3.3-70b-versatile
+
+.. tip::
+
+   Free cloud tiers give better results than local small models for most tasks, while still
+   requiring zero spend. OpenRouter's ``/account setup`` is the fastest path — one browser
+   sign-in configures everything.
+
+   For truly private workflows, prefer :ref:`local models <local-models>` or a self-hosted
+   server. Cloud providers receive your prompts on their infrastructure.
 
 
 Next Steps


### PR DESCRIPTION
## Summary

- Adds a **Free Cloud Providers (No Credit Card Required)** section to `docs/getting-started.rst`
- Documents OpenRouter (recommended, browser OAuth via `/account setup`), Google Gemini free tier, and Groq free tier
- Adds `.. _local-models:` anchor so the new tip cross-references the existing Ollama section

## Motivation

The current getting-started doc covers local Ollama models as a no-API-key path, but omits free cloud providers entirely. New users drop off when they see "API key required" without knowing that free tiers with no credit card exist. OpenRouter in particular has a browser-based OAuth flow already wired into gptme (`/account setup openrouter`), making it the lowest-friction zero-cost starting point and removing the most common onboarding objection before it forms.

## What changed

`docs/getting-started.rst`: 48 lines added after the existing Ollama section:
- OpenRouter: `/account setup openrouter` + `:free`-suffix model examples  
- Gemini: free API key at aistudio.google.com + `gemini/gemini-2.5-flash`
- Groq: free API key at console.groq.com + `groq/llama-3.3-70b-versatile`
- Tip contrasting free-cloud vs local-private tradeoffs

## Test plan

- [ ] `make docs` builds without warnings
- [ ] `:ref:\`local models <local-models>\`` cross-reference resolves correctly