### PR TITLE
fix(models): per-model parallel-tool opt-out via PARALLEL_TOOL_CALL_EXCEPTIONS

### DIFF
--- a/docs/tool-formats.rst
+++ b/docs/tool-formats.rst
@@ -238,10 +238,12 @@ behaviour silently:
   the same ``tool`` default applied at resolution time instead, including on
   dynamic-fetch fallbacks.
 
-- ``supports_parallel_tool_calls`` is set on 56 entries: the Claude Opus/Sonnet
+- ``supports_parallel_tool_calls`` is set on 51 entries: the Claude Opus/Sonnet
   4.x families and their OpenRouter aliases, Kimi K3, the GPT-4.1/GPT-5
-  families, all bundled Gemini models (and the OpenRouter Gemini 3.5 Flash
-  alias), xAI Grok (including ``grok-subscription``), Groq's
+  families, verified Gemini models (and the OpenRouter Gemini 3.5 Flash alias;
+  lite and experimental Gemini variants are excluded via
+  ``PARALLEL_TOOL_CALL_EXCEPTIONS``), xAI Grok (excluding the older
+  ``grok-2-vision-1212``; including ``grok-subscription``), Groq's
   ``llama-3.3-70b-versatile``, DeepSeek chat/reasoner, and the OpenRouter
   DeepSeek V4 aliases. Deliberate omissions are meaningful: Claude Haiku 4.5
   carries an explicit comment that it does *not* emit multiple tool calls per

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -26,19 +26,44 @@ def _set_tool_format(
     }
 
 
-def _mark_parallel(models: dict[str, _ModelDictMeta]) -> dict[str, _ModelDictMeta]:
-    """Stamp supports_parallel_tool_calls=True unless the model already sets it.
+def _mark_parallel(
+    models: dict[str, _ModelDictMeta],
+    exceptions: frozenset[str] = frozenset(),
+) -> dict[str, _ModelDictMeta]:
+    """Stamp supports_parallel_tool_calls=True unless the model already sets it
+    or its name is in the exceptions set.
 
     An explicit per-model value still wins, so a later model that does *not*
     support parallel can opt out by setting the key to False.
+    The exceptions set lets a provider-wide stamp skip models that are not
+    individually verified (e.g. older or lite variants).
     """
     return {
         name: props
-        if "supports_parallel_tool_calls" in props
+        if "supports_parallel_tool_calls" in props or name in exceptions
         else {**props, "supports_parallel_tool_calls": True}
         for name, props in models.items()
     }
 
+
+# Models within PARALLEL_TOOL_PROVIDERS that are NOT individually verified to
+# support parallel tool calls. Provider-wide stamping is skipped for these.
+# Keys match the model name as it appears in _MODELS_RAW (no provider prefix).
+# Docs audited 2026-08:
+#   gemini lite/experimental: not listed at
+#     https://ai.google.dev/gemini-api/docs/function-calling#parallel_function_calling
+#   grok-2-vision-1212: older vision model predating xAI's parallel tool-call support
+PARALLEL_TOOL_CALL_EXCEPTIONS: frozenset[str] = frozenset(
+    {
+        # Gemini — older / lite / experimental variants not individually verified
+        "gemini-1.5-flash-latest",
+        "gemini-2.0-flash-lite",
+        "gemini-2.0-flash-thinking-exp-01-21",
+        "gemini-2.5-flash-lite",
+        # xAI — grok-2 vision is an older model predating parallel tool-call docs
+        "grok-2-vision-1212",
+    }
+)
 
 # Providers that route through the OpenAI-compatible function-calling API — stamp
 # default_tool_format="tool" on every model that doesn't already have one set.
@@ -668,7 +693,7 @@ def _stamp_provider(
 ) -> dict[str, _ModelDictMeta]:
     """Apply construction-time stamps so static dicts and MODELS stay consistent."""
     if provider in PARALLEL_TOOL_PROVIDERS:
-        models = _mark_parallel(models)
+        models = _mark_parallel(models, exceptions=PARALLEL_TOOL_CALL_EXCEPTIONS)
     if provider in OPENAI_COMPAT_PROVIDERS:
         models = _set_tool_format(models, "tool")
     return models

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -15,7 +15,7 @@ from gptme.llm.models import (
     get_recommended_model,
     list_models,
 )
-from gptme.llm.models.data import _mark_parallel
+from gptme.llm.models.data import PARALLEL_TOOL_CALL_EXCEPTIONS, _mark_parallel
 
 
 def test_get_static_model():
@@ -541,6 +541,67 @@ class TestSupportsParallelToolCalls:
         )
         assert stamped["a"]["supports_parallel_tool_calls"] is False
         assert stamped["b"]["supports_parallel_tool_calls"] is True
+
+    def test_mark_parallel_skips_exceptions(self):
+        """Models in the exceptions set are not stamped True."""
+        stamped = _mark_parallel(
+            {
+                "a": {"context": 1},
+                "b": {"context": 1},
+            },
+            exceptions=frozenset({"a"}),
+        )
+        assert "supports_parallel_tool_calls" not in stamped["a"]
+        assert stamped["b"]["supports_parallel_tool_calls"] is True
+
+    def test_mark_parallel_exception_does_not_override_explicit_true(self):
+        """An explicit True in a model dict wins over being in the exceptions set."""
+        stamped = _mark_parallel(
+            {"a": {"context": 1, "supports_parallel_tool_calls": True}},
+            exceptions=frozenset({"a"}),
+        )
+        assert stamped["a"]["supports_parallel_tool_calls"] is True
+
+    # --- Per-model exception spot checks ---
+
+    def test_gemini_1_5_flash_latest_not_stamped_parallel(self):
+        """gemini-1.5-flash-latest is in PARALLEL_TOOL_CALL_EXCEPTIONS — not stamped."""
+        model = get_model("gemini/gemini-1.5-flash-latest")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_gemini_2_0_flash_lite_not_stamped_parallel(self):
+        """gemini-2.0-flash-lite is in PARALLEL_TOOL_CALL_EXCEPTIONS — not stamped."""
+        model = get_model("gemini/gemini-2.0-flash-lite")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_gemini_2_0_flash_thinking_exp_not_stamped_parallel(self):
+        """gemini-2.0-flash-thinking-exp is in exceptions — not stamped."""
+        model = get_model("gemini/gemini-2.0-flash-thinking-exp-01-21")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_gemini_2_5_flash_lite_not_stamped_parallel(self):
+        """gemini-2.5-flash-lite is in PARALLEL_TOOL_CALL_EXCEPTIONS — not stamped."""
+        model = get_model("gemini/gemini-2.5-flash-lite")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_grok_2_vision_not_stamped_parallel(self):
+        """grok-2-vision-1212 is in PARALLEL_TOOL_CALL_EXCEPTIONS — not stamped."""
+        model = get_model("xai/grok-2-vision-1212")
+        assert model.supports_parallel_tool_calls is False
+
+    def test_exceptions_set_is_subset_of_provider_models(self):
+        """Every name in PARALLEL_TOOL_CALL_EXCEPTIONS must exist in a stamped provider."""
+        from gptme.llm.models.data import PARALLEL_TOOL_PROVIDERS
+
+        all_provider_model_names: set[str] = set()
+        for provider_str in PARALLEL_TOOL_PROVIDERS:
+            models_for_provider = MODELS.get(provider_str)  # type: ignore[call-overload]
+            if models_for_provider:
+                all_provider_model_names.update(models_for_provider.keys())
+        unknown = PARALLEL_TOOL_CALL_EXCEPTIONS - all_provider_model_names
+        assert not unknown, (
+            f"PARALLEL_TOOL_CALL_EXCEPTIONS contains names not in any stamped provider: {unknown}"
+        )
 
 
 class TestSupportsResponsesAPI:


### PR DESCRIPTION
## Summary

Resolves #3632 (follows up on #3628).

PR #3628 introduced provider-wide stamping of `supports_parallel_tool_calls=True`
via `PARALLEL_TOOL_PROVIDERS`. This was grounded in official docs but stamped every
model in those providers unconditionally — including older, lite, and experimental
variants that are not individually verified.

This PR implements **Option 1** from the issue: an opt-out list.

### Changes

- **`gptme/llm/models/data.py`** — adds `PARALLEL_TOOL_CALL_EXCEPTIONS: frozenset[str]`
  with models that should NOT receive the provider-wide stamp. Updates `_mark_parallel()`
  with an optional `exceptions` parameter, and wires it into `_stamp_provider()`.
  An explicit per-model `True`/`False` always wins over both the provider-wide stamp
  and the exceptions set.

- **`tests/test_llm_models.py`** — adds 9 new tests:
  - Unit tests for the exceptions mechanism in `_mark_parallel()`
  - Per-model spot-checks for each excepted model
  - Structural guard: `PARALLEL_TOOL_CALL_EXCEPTIONS` must be a strict subset of the
    stamped providers' model keys (prevents stale entries after model list changes)

### Excepted models (not individually verified)

| Model | Provider | Reason |
|---|---|---|
| `gemini-1.5-flash-latest` | gemini | Older, not listed in current parallel docs |
| `gemini-2.0-flash-lite` | gemini | Lite variant, may lack full tool-call features |
| `gemini-2.0-flash-thinking-exp-01-21` | gemini | Experimental reasoning model |
| `gemini-2.5-flash-lite` | gemini | Lite variant, may lack full tool-call features |
| `grok-2-vision-1212` | xai | Older vision model, predates parallel tool-call docs |

## Test plan

- [x] All 182 model tests pass (`tests/test_llm_models.py` + `tests/test_llm_models_resolution.py`)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] New tests cover the mechanism, per-model exceptions, and structural consistency

<!-- gptme-id:v1:gai_oiCg69XZQDfBB1BnPGBGT00CvXO9J87NfLsB9TnwWnW -->