### PR TITLE
fix(tests): scope pytest timeouts to the function so retries can't INTERNALERROR the run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,24 @@ markers = [
 ]
 asyncio_default_fixture_loop_scope = "function"
 
+# Scope --timeout to the test function only, NOT the whole runtest protocol.
+#
+# With the default (protocol-wide) scoping, pytest-timeout's SIGALRM stays armed
+# across pytest-retry's retry loop -- which sleeps `--retry-delay` between
+# attempts inside pytest_runtest_makereport. When a retried test's cumulative
+# sleep+rerun time crosses the item's timeout, the alarm fires *inside a report
+# hook*, raising Failed where nothing catches it. That crashes the xdist worker
+# and INTERNALERRORs the entire session: every other test passes and the job
+# still exits non-zero.
+#
+# CI runs `--timeout 60 --retries 2 --retry-delay 5` while several modules set a
+# much tighter per-module timeout (tests/test_server_v2.py uses 10s), so 10s of
+# retry sleep alone exceeded the budget -- any single flaky test there took down
+# the whole run. Scoping to the function makes each attempt get its own fresh
+# timeout and keeps the retry delay outside the armed window, while still
+# catching a hanging test body.
+timeout_func_only = true
+
 [tool.coverage.run]
 # Needed to get playwright to play nice with coverage
 # https://stackoverflow.com/a/28589618/965332

--- a/tests/test_pytest_timeout_retry_interaction.py
+++ b/tests/test_pytest_timeout_retry_interaction.py
@@ -1,0 +1,114 @@
+"""Regression guard for the pytest-timeout x pytest-retry interaction.
+
+pytest-timeout's default (protocol-wide) SIGALRM stays armed across
+pytest-retry's retry loop, which sleeps ``--retry-delay`` between attempts
+inside ``pytest_runtest_makereport``. If the alarm fires during that sleep it
+raises ``Failed`` from inside a report hook, crashing the xdist worker and
+turning the whole session into an INTERNALERROR (exit 3) -- even when every
+other test passed.
+
+``timeout_func_only = true`` in ``[tool.pytest.ini_options]`` scopes the alarm
+to the test function, so retry delays fall outside the armed window.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+FAILING_TEST = "def test_always_fails():\n    assert False, 'boom'\n"
+
+# Small enough to keep the test fast; retry sleep (2s) still exceeds timeout (1s),
+# which is the condition that triggers the crash.
+RETRY_ARGS = ["--timeout", "1", "--retries", "1", "--retry-delay", "2"]
+
+
+def _run_isolated_pytest(tmp_path: Path, ini_body: str) -> subprocess.CompletedProcess:
+    (tmp_path / "test_flake.py").write_text(FAILING_TEST)
+    (tmp_path / "pytest.ini").write_text(f"[pytest]\n{ini_body}")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_flake.py",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            *RETRY_ARGS,
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_retry_delay_does_not_internalerror_with_func_only_timeout(tmp_path):
+    """A retried failure must report as a plain failure, not crash the session."""
+    result = _run_isolated_pytest(tmp_path, "timeout_func_only = true\n")
+
+    assert "INTERNALERROR" not in result.stdout + result.stderr, result.stdout
+    # exit 1 == tests failed (expected); exit 3 == internal error (the bug)
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}\n{result.stdout}"
+    )
+
+
+@pytest.mark.slow
+def test_protocol_scoped_timeout_still_reproduces_the_crash(tmp_path):
+    """Falsifies the guard above: without func_only the crash still happens.
+
+    If pytest-timeout or pytest-retry ever fixes this upstream, this test fails
+    and ``timeout_func_only`` can be reconsidered.
+    """
+    result = _run_isolated_pytest(tmp_path, "")
+
+    assert "INTERNALERROR" in result.stdout + result.stderr, result.stdout
+    assert result.returncode == 3, (
+        f"expected exit 3, got {result.returncode}\n{result.stdout}"
+    )
+
+
+def test_hanging_test_body_is_still_caught(tmp_path):
+    """func_only must not disable timeouts for the thing they exist to catch."""
+    (tmp_path / "test_hang.py").write_text(
+        textwrap.dedent(
+            """
+            import time
+
+            def test_hangs():
+                time.sleep(30)
+            """
+        )
+    )
+    (tmp_path / "pytest.ini").write_text("[pytest]\ntimeout_func_only = true\n")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_hang.py",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--timeout",
+            "1",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert "Timeout (>1.0s) from pytest-timeout" in result.stdout, result.stdout
+    assert result.returncode == 1
+
+
+def test_repo_config_scopes_timeouts_to_the_function(pytestconfig):
+    """The actual protection: gptme's own pytest config must keep this on."""
+    assert pytestconfig.getini("timeout_func_only") is True

--- a/tests/test_pytest_timeout_retry_interaction.py
+++ b/tests/test_pytest_timeout_retry_interaction.py
@@ -11,6 +11,7 @@ other test passed.
 to the test function, so retry delays fall outside the armed window.
 """
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -59,6 +60,10 @@ def test_retry_delay_does_not_internalerror_with_func_only_timeout(tmp_path):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="SIGALRM-based xdist crash is POSIX-only; thread timer on Windows behaves differently",
+)
 def test_protocol_scoped_timeout_still_reproduces_the_crash(tmp_path):
     """Falsifies the guard above: without func_only the crash still happens.
 


### PR DESCRIPTION
## Problem

A green test suite can still fail the job. On #3622:

```
= 6524 passed, 31 skipped, 2 xfailed, 2 xpassed, 214 warnings, 6 subtests passed, 1 retried in 687.83s =
make: *** [Makefile:59: test] Error 3
```

Exit 3 = pytest INTERNALERROR. The worker crash:

```
INTERNALERROR> AssertionError: ('tests/test_server_v2.py::test_v2_conversations_list_exposes_message_count_and_last_updated', <WorkerController gw7>)
...
  File ".../pytest_retry/retry_plugin.py", line 233, in pytest_runtest_makereport
    sleep(delay)
  File ".../pytest_timeout.py", line 317, in handler
    timeout_sigalrm(item, settings)
Failed: Timeout (>10.0s) from pytest-timeout.
```

## Root cause

pytest-timeout arms its SIGALRM in `pytest_runtest_protocol` (`func_only=False`
by default), so the alarm covers the **entire** item protocol — including
pytest-retry's retry loop, which sleeps `--retry-delay` inside
`pytest_runtest_makereport`.

When a retried test's cumulative sleep + rerun time crosses the item timeout, the
alarm fires *inside a report hook* and raises `Failed` where nothing catches it.
That crashes the xdist worker, and the master's `assert not crashitem` turns the
whole session into an INTERNALERROR.

The numbers make this unavoidable, not unlucky: CI runs `--timeout 60 --retries 2
--retry-delay 5`, while `tests/test_server_v2.py` sets `pytestmark =
[pytest.mark.timeout(10)]`. Two retries sleep 10s — the entire budget — before the
test body gets to run at all. **Any** flaky test in that module takes down the run.

## Fix

`timeout_func_only = true` scopes the alarm to `pytest_runtest_call`. Each retry
attempt gets a fresh timeout, and the retry delay falls outside the armed window.

Tradeoff: hangs in *setup/teardown* are no longer covered by `--timeout`. That's
the accepted cost — the timeout exists to catch hanging test bodies, and today it
converts those into a whole-run crash instead.

## Verification

Reproduced standalone (`--timeout 3 --retries 2 --retry-delay 4`, one always-failing test):

| config | result |
|---|---|
| default (protocol-scoped) | `INTERNALERROR ... Failed: Timeout (>3.0s)`, **exit 3** |
| `timeout_func_only = true` | `1 failed, 1 retried`, **exit 1** |
| `timeout_func_only = true`, hanging body | `Failed: Timeout (>3.0s)`, exit 1 — still caught |

`tests/test_pytest_timeout_retry_interaction.py` encodes all three as subprocess
tests, plus a guard that reads the repo's own `timeout_func_only` ini value. The
guard was watched failing with the pyproject change reverted; the falsification
test (`@pytest.mark.slow`) asserts the crash *still* reproduces without the fix,
so it will go red if this is ever fixed upstream and the workaround can be dropped.