### PR TITLE
fix(tests): assert webui html hint by content, not by index

### DIFF
--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -2552,10 +2552,14 @@ def test_v2_chat_config_patch_preserves_webui_html_hint(
     assert create_response.status_code == 200
     conversation_id = create_response.get_json()["conversation_id"]
 
+    hint = "Output format: you are in a web interface."
+
     before = client.get(f"/api/v2/conversations/{conversation_id}").get_json()
     before_system_msgs = [m["content"] for m in before["log"] if m["role"] == "system"]
-    assert len(before_system_msgs) == 2
-    assert "Output format: you are in a web interface." in before_system_msgs[1]
+    # Locate the hint by content, not by index: the system prompt is split into
+    # several messages (cache boundary, system info, date, ...) and that layout
+    # is free to change without affecting the invariant this test guards.
+    assert sum(hint in m for m in before_system_msgs) == 1
 
     config_payload = client.get(
         f"/api/v2/conversations/{conversation_id}/config"
@@ -2571,7 +2575,7 @@ def test_v2_chat_config_patch_preserves_webui_html_hint(
     after_system_msgs = [m["content"] for m in after["log"] if m["role"] == "system"]
     assert after["name"] == "after rename"
     assert len(after_system_msgs) == len(before_system_msgs)
-    assert "Output format: you are in a web interface." in after_system_msgs[1]
+    assert sum(hint in m for m in after_system_msgs) == 1
     assert [m["role"] for m in after["log"]] == [m["role"] for m in before["log"]]
     assert after["log"][-1]["content"] == "Rename/config patch sweep"
 


### PR DESCRIPTION
## Problem

`master` is red. `tests/test_server_v2.py::test_v2_chat_config_patch_preserves_webui_html_hint` fails with `assert 5 == 2`.

This is a **semantic merge conflict**, not a bug in either PR:

- #3615 (`fix(prompts): keep volatile context after cache boundary`) split the system prompt into 5 messages: prompt, cache boundary, system info, current date, webui hint.
- #3521 (`fix(server): preserve webui html hint on config patch`) added this test while master still produced 2 system messages, asserting `len(before_system_msgs) == 2` and reading the hint at index `[1]`.

#3521 merged **after** #3615 without a re-run against the merged result, so the stale positional expectations landed red.

## Fix

Match the hint by **content** instead of by count/index, and assert it appears exactly once before and after the config PATCH. That is the invariant the test actually guards — the section layout of the system prompt is free to change.

## Verification

- Reproduced locally on clean `origin/master` (`assert 5 == 2`), fixed after the change.
- **Falsifiability checked**: stubbing out the server-side `_append_webui_html_hint(..., preserve=True)` branch in `api_v2.py` still makes the test fail, so it keeps its regression-catching power.
- `ruff check` / `ruff format --check` clean; full `tests/test_server_v2.py` passes (233 passed) apart from three `test_v2_conversations_list*` timeouts that are local-environment only — those enumerate a large real conversation-log dir against the module's `pytest.mark.timeout(10)`, and they pass in CI.

## Note

`tests/test_server_v2_auto_stepping.py::test_multi_tool_per_message` also failed on the same master run but passed on other branches at the same head — that one looks flaky and is out of scope here.