### PR TITLE
test(codeblock): load fixture files with pathlib so tests pass on Windows

### DIFF
--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from gptme.codeblock import Codeblock, _extract_codeblocks
+
+EXAMPLES_DIR = Path(__file__).parent / "data"
 
 
 def test_extract_codeblocks_basic():
@@ -174,10 +178,7 @@ def test_extract_codeblocks_streaming_interrupted():
     Reproduces issue where bare ``` after descriptive text was incorrectly
     treated as closing delimiter instead of opening a nested code block.
     """
-    # Read the actual interrupted example relative to this test file
-    script_dir = __file__.rsplit("/", 1)[0]
-    with open(f"{script_dir}/data/example-interrupted.txt") as f:
-        content = f.read()
+    content = (EXAMPLES_DIR / "example-interrupted.txt").read_text(encoding="utf-8")
 
     # Extract just the markdown part (after "create a journal entry")
     # This should parse as a single append block with nested code blocks inside
@@ -377,10 +378,7 @@ def test_extract_patch_codeblock_with_nested_backticks():
     This reproduces an issue where patch blocks with code examples
     inside them (using ```) were incorrectly parsed during streaming.
     """
-    # Read the actual example that failed
-    script_dir = __file__.rsplit("/", 1)[0]
-    with open(f"{script_dir}/data/example-patch-codeblock.txt") as f:
-        content = f.read()
+    content = (EXAMPLES_DIR / "example-patch-codeblock.txt").read_text(encoding="utf-8")
 
     # Add a blank line after the closing ``` to confirm block closure in streaming mode.
     # (end-of-file-fixer strips trailing blank lines from the file, so we add it here)


### PR DESCRIPTION
## What Problem This Solves

Two regression tests in `tests/test_codeblock.py` construct their fixture paths with a POSIX-only idiom:

```python
script_dir = __file__.rsplit("/", 1)[0]
with open(f"{script_dir}/data/example-interrupted.txt") as f:
```

On Windows, `__file__` contains backslashes, so `rsplit("/", 1)` never splits and the resulting path is `...\tests\test_codeblock.py/data/example-interrupted.txt` -> `FileNotFoundError`. Both tests therefore cannot run on Windows at all.

## Why This Change Was Made

These two tests guard real streaming-parsing regressions (bare backticks after prose opening a nested block; patch blocks containing nested backticks), but they silently fail on Windows contributors' machines before ever exercising that logic. Linux CI stays green, so the breakage is invisible to CI. Fixes the path construction so the fixtures load portably; no production code is touched.

## User Impact

Windows contributors get a working `pytest tests/test_codeblock.py` out of the box instead of 2 spurious failures. Net -2 lines; test-only change.

## How Tested

Reproduced on Windows 11, Python 3.13.13, current `master` (`fc98c881a`):

**Before fix:**
```
$ python -m pytest tests/test_codeblock.py -q
FAILED tests/test_codeblock.py::test_extract_codeblocks_streaming_interrupted
FAILED tests/test_codeblock.py::test_extract_patch_codeblock_with_nested_backticks
E   FileNotFoundError: [Errno 2] No such file or directory:
    '...\\tests\\test_codeblock.py/data/example-interrupted.txt'
2 failed, 66 passed
```

**After fix:**
```
$ python -m pytest tests/test_codeblock.py -q --no-header -p no:cacheprovider --timeout 120
68 passed in 13.30s
```

Fix reverts to failing when stashed (`2 failed in 15.47s`), confirming the fix is what makes them pass.

**Lint:**
```
$ ruff check tests/test_codeblock.py        # All checks passed!
$ ruff format --check tests/test_codeblock.py  # 1 file already formatted
```

The new code follows the existing convention in `tests/test_tools_shell.py` (`Path(__file__).parent / "data" / name`).

## Demo

N/A -- no user-facing change; test-only.

## Trade-offs

- Verified only on Windows; Linux CI stays green with the old code, and `pathlib` joins are platform-neutral -- the old string-split happens to work only where `/` separators exist, which pathlib preserves exactly.
- No upstream issue exists to link; if maintainers prefer, an issue can be opened first.
