### PR TITLE
fix(cli): reject unknown bare --model names before get_prompt()

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1010,8 +1010,9 @@ def main(
     from ..chat import chat
     from ..config import ensure_workspace_dir, get_config, setup_config_from_cli
     from ..init import init_logging
-    from ..llm import get_provider_from_model
+    from ..llm import get_provider_from_model, is_custom_provider
     from ..llm import reply as llm_reply
+    from ..llm.models import PROVIDERS, get_model
     from ..message import Message
     from ..profiles import get_profile
     from ..prompts import (
@@ -1342,11 +1343,27 @@ def main(
         sys.exit(1)
 
     # Validate model early to fail fast before the expensive get_prompt() call.
-    # Only check models with a provider/ prefix; bare provider names (e.g. "anthropic")
-    # and model aliases (e.g. "gpt-4o") are left for init_model() to resolve.
-    if config.chat.model and "/" in config.chat.model:
+    # Slash-prefixed names are checked via provider lookup. Bare provider names
+    # (e.g. "anthropic") and resolvable aliases (e.g. "gpt-4o") still pass
+    # through to init_model(); unresolvable bare names used to skip this block
+    # and pay get_prompt() (workspace context_cmd, 10s+) before init_model()
+    # rejected them.
+    if config.chat.model:
         try:
-            get_provider_from_model(config.chat.model)
+            if "/" in config.chat.model:
+                get_provider_from_model(config.chat.model)
+            elif config.chat.model not in PROVIDERS and not is_custom_provider(
+                config.chat.model
+            ):
+                resolved = get_model(config.chat.model)
+                if resolved.provider == "unknown":
+                    raise ValueError(
+                        f"Unknown model {config.chat.model!r}. Use 'provider/model' "
+                        "with a known provider "
+                        f"(e.g. 'openai/{config.chat.model}'), or configure a "
+                        "custom provider. Run 'gptme-util models list' to see "
+                        "available models."
+                    )
         except ValueError as e:
             _cleanup_aborted_new_logdir(logdir, preexisting=logdir_preexisting)
             raise click.UsageError(f"--model: {e}") from e

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1343,18 +1343,24 @@ def main(
         sys.exit(1)
 
     # Validate model early to fail fast before the expensive get_prompt() call.
-    # Slash-prefixed names are checked via provider lookup. Bare provider names
-    # (e.g. "anthropic") and resolvable aliases (e.g. "gpt-4o") still pass
-    # through to init_model(); unresolvable bare names used to skip this block
-    # and pay get_prompt() (workspace context_cmd, 10s+) before init_model()
-    # rejected them. Existing conversations already skip get_prompt(), and their
-    # saved aliases may outlive the current registry, so preserve resume behavior.
-    if config.chat.model and not is_existing_conversation:
+    # Slash-prefixed names are always checked via provider lookup — that was the
+    # original behavior, including when resuming (`gptme --resume --model
+    # badprovider/x` must still be a UsageError, not a later generic crash).
+    # Bare provider names (e.g. "anthropic") and resolvable aliases (e.g.
+    # "gpt-4o") still pass through to init_model(); unresolvable bare names used
+    # to skip this block and pay get_prompt() (workspace context_cmd, 10s+)
+    # before init_model() rejected them. Saved aliases on existing conversations
+    # may outlive the current registry, so skip the new bare-name check unless
+    # --model was explicitly passed on the command line.
+    model_from_cli = ctx.get_parameter_source("model") == ParameterSource.COMMANDLINE
+    if config.chat.model:
         try:
             if "/" in config.chat.model:
                 get_provider_from_model(config.chat.model)
-            elif config.chat.model not in PROVIDERS and not is_custom_provider(
-                config.chat.model
+            elif (
+                (not is_existing_conversation or model_from_cli)
+                and config.chat.model not in PROVIDERS
+                and not is_custom_provider(config.chat.model)
             ):
                 resolved = get_model(config.chat.model)
                 if resolved.provider == "unknown":

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1347,8 +1347,9 @@ def main(
     # (e.g. "anthropic") and resolvable aliases (e.g. "gpt-4o") still pass
     # through to init_model(); unresolvable bare names used to skip this block
     # and pay get_prompt() (workspace context_cmd, 10s+) before init_model()
-    # rejected them.
-    if config.chat.model:
+    # rejected them. Existing conversations already skip get_prompt(), and their
+    # saved aliases may outlive the current registry, so preserve resume behavior.
+    if config.chat.model and not is_existing_conversation:
         try:
             if "/" in config.chat.model:
                 get_provider_from_model(config.chat.model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -586,9 +586,13 @@ def test_model_rejects_unknown_bare_name_before_context_cmd(
 def test_model_allows_bare_alias_through_validation_block(
     monkeypatch, tmp_path: Path, runner: CliRunner
 ):
-    """A resolvable bare alias (gpt-4o) should still reach get_prompt()."""
+    """A resolvable bare alias should still reach get_prompt()."""
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        "gptme.llm.models.get_model",
+        lambda model: SimpleNamespace(provider="openai", model=model),
+    )
 
     called: dict[str, bool] = {"get_prompt": False}
 
@@ -604,7 +608,7 @@ def test_model_allows_bare_alias_through_validation_block(
 
     result = runner.invoke(
         cli.main,
-        ["--model", "gpt-4o", "--non-interactive", "hello"],
+        ["--model", "known-alias", "--non-interactive", "hello"],
     )
 
     assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -551,6 +551,66 @@ def test_model_rejects_unknown_provider_before_context_cmd(
     assert "Traceback" not in result.output
 
 
+def test_model_rejects_unknown_bare_name_before_context_cmd(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """--model with an unresolvable bare name should fail fast before get_prompt().
+
+    Regression: the early check only ran for slash-prefixed provider/model
+    strings, so `gptme --model nosuch` paid the full workspace context_cmd
+    cost (often looking like a hang) before init_model() rejected it.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        "gptme.prompts.get_prompt",
+        lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
+    )
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        ["--model", "definitely-not-a-model-7f83", "--non-interactive", "hello"],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Unknown model 'definitely-not-a-model-7f83'" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_model_allows_bare_alias_through_validation_block(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """A resolvable bare alias (gpt-4o) should still reach get_prompt()."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    called: dict[str, bool] = {"get_prompt": False}
+
+    def _fake_get_prompt(**kwargs):
+        called["get_prompt"] = True
+        return []
+
+    monkeypatch.setattr("gptme.prompts.get_prompt", _fake_get_prompt)
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"), "chat", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        ["--model", "gpt-4o", "--non-interactive", "hello"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert called["get_prompt"], "resolvable aliases must still reach get_prompt"
+
+
 @pytest.mark.parametrize(
     ("bad_name", "expected_message"),
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,7 @@ def test_model_rejects_unknown_bare_name_before_context_cmd(
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr("gptme.llm.is_custom_provider", lambda name: False)
     monkeypatch.setattr(
         "gptme.prompts.get_prompt",
         lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
@@ -589,6 +590,7 @@ def test_model_allows_bare_alias_through_validation_block(
     """A resolvable bare alias should still reach get_prompt()."""
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr("gptme.llm.is_custom_provider", lambda name: False)
     monkeypatch.setattr(
         "gptme.llm.models.get_model",
         lambda model: SimpleNamespace(provider="openai", model=model),
@@ -613,6 +615,50 @@ def test_model_allows_bare_alias_through_validation_block(
 
     assert result.exit_code == 0, result.output
     assert called["get_prompt"], "resolvable aliases must still reach get_prompt"
+
+
+def test_model_validation_preserves_existing_conversation_alias(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """A saved alias may outlive the registry and must not block resuming."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    logdir = tmp_path / "existing-conversation"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+    (logdir / "config.toml").write_text(
+        f'[chat]\nmodel = "retired-alias"\ntool_format = "markdown"\n'
+        f'workspace = "{tmp_path}"\n'
+    )
+
+    monkeypatch.setattr(cli, "get_logdir", lambda name: logdir)
+    monkeypatch.setattr("gptme.llm.is_custom_provider", lambda name: False)
+    monkeypatch.setattr(
+        "gptme.llm.models.get_model",
+        lambda model: pytest.fail("saved aliases must not be prevalidated on resume"),
+    )
+    monkeypatch.setattr(
+        "gptme.prompts.get_prompt",
+        lambda **kwargs: pytest.fail("get_prompt ran for an existing conversation"),
+    )
+
+    seen_models: list[str | None] = []
+
+    def _fake_chat(*args, **kwargs):
+        seen_models.append(args[4])
+
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", _fake_chat)
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        ["--name", "existing-conversation", "--non-interactive", "hello"],
+        env={"GPTME_MODEL": ""},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen_models == ["retired-alias"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -661,6 +661,100 @@ def test_model_validation_preserves_existing_conversation_alias(
     assert seen_models == ["retired-alias"]
 
 
+def test_model_rejects_explicit_unknown_provider_on_existing_conversation(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """Resuming with an explicit slash-prefixed --model must still fail fast.
+
+    The existing-conversation skip only protects saved aliases; passing
+    `--model badprovider/x` on the command line used to (and must still)
+    raise UsageError before chat()/init_model().
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    logdir = tmp_path / "existing-conversation"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+    (logdir / "config.toml").write_text(
+        f'[chat]\nmodel = "retired-alias"\ntool_format = "markdown"\n'
+        f'workspace = "{tmp_path}"\n'
+    )
+
+    monkeypatch.setattr(cli, "get_logdir", lambda name: logdir)
+    monkeypatch.setattr(
+        "gptme.prompts.get_prompt",
+        lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
+    )
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--name",
+            "existing-conversation",
+            "--model",
+            "badprovider/some-model",
+            "--non-interactive",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Unknown provider: badprovider" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_model_rejects_explicit_unknown_bare_name_on_existing_conversation(
+    monkeypatch, tmp_path: Path, runner: CliRunner
+):
+    """Resuming with an explicit unknown bare --model must still fail fast."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    logdir = tmp_path / "existing-conversation"
+    logdir.mkdir()
+    (logdir / "conversation.jsonl").write_text('{"role":"user","content":"hello"}\n')
+    (logdir / "config.toml").write_text(
+        f'[chat]\nmodel = "retired-alias"\ntool_format = "markdown"\n'
+        f'workspace = "{tmp_path}"\n'
+    )
+
+    monkeypatch.setattr(cli, "get_logdir", lambda name: logdir)
+    monkeypatch.setattr("gptme.llm.is_custom_provider", lambda name: False)
+    monkeypatch.setattr(
+        "gptme.prompts.get_prompt",
+        lambda **kwargs: pytest.fail("get_prompt was called before model validation"),
+    )
+    monkeypatch.setattr(
+        importlib.import_module("gptme.chat"),
+        "chat",
+        lambda *args, **kwargs: pytest.fail("chat ran"),
+    )
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "--name",
+            "existing-conversation",
+            "--model",
+            "definitely-not-a-model-7f83",
+            "--non-interactive",
+            "hello",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Unknown model 'definitely-not-a-model-7f83'" in result.output
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize(
     ("bad_name", "expected_message"),
     [


### PR DESCRIPTION
## Summary

`gptme --model nosuch --non-interactive "hi"` used to look like a hang: the early `--model` check only ran for slash-prefixed `provider/model` strings, so a bare typo skipped validation, paid `get_prompt()` (workspace `context_cmd`, often 10s+), and only then failed in `init_model()`.

`gptme-util llm generate -m nosuch` already rejected this immediately. The top-level CLI now does the same: resolve bare names that aren't a known/custom provider via `get_model()`, and raise `UsageError` when the fallback provider is `unknown`. Aliases such as `gpt-4o` and bare provider names such as `anthropic` still pass through to `init_model()`.

Dogfood session 7f83 (`dogfood-gptme-cli-surface-2026-08-26`).

## Reproduction (before)

```bash
timeout 8 gptme --non-interactive --no-stream --model nosuch -- "hi"
# exit 124, no error — still inside get_prompt()
```

## After

```bash
gptme --non-interactive --no-stream --model nosuch -- "hi"
# exit 2, ~1s
# Error: --model: Unknown model 'nosuch'. Use 'provider/model' with a known provider ...
```

## Test plan

- [x] `test_model_rejects_unknown_bare_name_before_context_cmd` — `get_prompt` is not called
- [x] `test_model_allows_bare_alias_through_validation_block` — `gpt-4o` still reaches `get_prompt`
- [x] Existing slash-path tests still pass (`unknown provider`, empty path components, nested `openrouter/...`)
- [x] Live: unknown bare name exits 2 in ~1s; unknown provider still fails fast