### PR TITLE
feat(doctor): add proxy URL format check (LLM_PROXY_URL)

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -427,14 +427,15 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
     if port is not None:
         display_host = f"{display_host}:{port}"
 
-    # Path should be empty or just "/" — the Anthropic SDK appends its own paths
+    # Path should be empty or just "/" — the Anthropic SDK appends its own paths.
+    # Do not include it in diagnostics because proxy paths may contain credentials.
     if parsed.path and parsed.path != "/":
         results.append(
             CheckResult(
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.WARNING,
-                message=f"URL has a non-root path {parsed.path!r} — may conflict with SDK routing",
-                details=f"Proxy: {parsed.scheme}://{display_host}{parsed.path}"
+                message="URL has a non-root path — may conflict with SDK routing",
+                details=f"Proxy: {parsed.scheme}://{display_host}/[path redacted]"
                 if verbose
                 else None,
                 fix_hint="Consider removing the path component; the Anthropic SDK appends its own paths",

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -378,7 +378,22 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
         ]
 
     results = []
-    parsed = urlparse(proxy_url)
+    try:
+        parsed = urlparse(proxy_url)
+        hostname = parsed.hostname
+        # Accessing port validates malformed/non-numeric/out-of-range values.
+        _ = parsed.port
+    except ValueError as exc:
+        results.append(
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.ERROR,
+                message=f"Malformed URL — {exc}",
+                details=f"URL: {proxy_url}" if verbose else None,
+                fix_hint="Set LLM_PROXY_URL to a valid http or https URL",
+            )
+        )
+        return results
 
     # Scheme must be http or https
     if parsed.scheme not in ("http", "https"):
@@ -394,12 +409,12 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
         return results
 
     # Host must be non-empty
-    if not parsed.netloc:
+    if not hostname:
         results.append(
             CheckResult(
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.ERROR,
-                message="Missing host — URL has no netloc",
+                message="Missing host",
                 details=f"URL: {proxy_url}" if verbose else None,
                 fix_hint="Set LLM_PROXY_URL to a full URL, e.g. https://my-proxy.example.com",
             )

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -358,6 +358,78 @@ def _check_config(verbose: bool = False) -> list[CheckResult]:
     return results
 
 
+def _check_proxy(verbose: bool = False) -> list[CheckResult]:
+    """Check proxy URL configuration."""
+    from urllib.parse import urlparse
+
+    config = get_config()
+    proxy_url = config.get_env("LLM_PROXY_URL", None)
+
+    if not proxy_url:
+        return [
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.SKIPPED,
+                message="Not configured",
+                details="Set LLM_PROXY_URL to route LLM requests through a proxy"
+                if verbose
+                else None,
+            )
+        ]
+
+    results = []
+    parsed = urlparse(proxy_url)
+
+    # Scheme must be http or https
+    if parsed.scheme not in ("http", "https"):
+        results.append(
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.ERROR,
+                message=f"Invalid scheme {parsed.scheme!r} — must be http or https",
+                details=f"URL: {proxy_url}" if verbose else None,
+                fix_hint="Set LLM_PROXY_URL to a URL starting with http:// or https://",
+            )
+        )
+        return results
+
+    # Host must be non-empty
+    if not parsed.netloc:
+        results.append(
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.ERROR,
+                message="Missing host — URL has no netloc",
+                details=f"URL: {proxy_url}" if verbose else None,
+                fix_hint="Set LLM_PROXY_URL to a full URL, e.g. https://my-proxy.example.com",
+            )
+        )
+        return results
+
+    # Path should be empty or just "/" — the Anthropic SDK appends its own paths
+    if parsed.path and parsed.path != "/":
+        results.append(
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.WARNING,
+                message=f"URL has a non-root path {parsed.path!r} — may conflict with SDK routing",
+                details=f"URL: {proxy_url}" if verbose else None,
+                fix_hint="Consider removing the path component; the Anthropic SDK appends its own paths",
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="Proxy: LLM_PROXY_URL",
+                status=CheckStatus.OK,
+                message=f"Configured ({parsed.netloc})",
+                details=f"URL: {proxy_url}" if verbose else None,
+            )
+        )
+
+    return results
+
+
 def _check_permissions(verbose: bool = False) -> list[CheckResult]:
     """Check file and directory permissions."""
     results = []
@@ -992,6 +1064,7 @@ def run_diagnostics(verbose: bool = False) -> tuple[list[CheckResult], dict]:
     all_results.extend(_check_python_version(verbose))
     all_results.extend(_check_version(verbose))
     all_results.extend(_check_config(verbose))
+    all_results.extend(_check_proxy(verbose))
     all_results.extend(_check_api_keys(verbose))
     all_results.extend(_check_tools(verbose))
     all_results.extend(_check_python_deps(verbose))

--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -382,14 +382,14 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
         parsed = urlparse(proxy_url)
         hostname = parsed.hostname
         # Accessing port validates malformed/non-numeric/out-of-range values.
-        _ = parsed.port
-    except ValueError as exc:
+        port = parsed.port
+    except ValueError:
         results.append(
             CheckResult(
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.ERROR,
-                message=f"Malformed URL — {exc}",
-                details=f"URL: {proxy_url}" if verbose else None,
+                message="Malformed URL",
+                details=None,
                 fix_hint="Set LLM_PROXY_URL to a valid http or https URL",
             )
         )
@@ -402,7 +402,7 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.ERROR,
                 message=f"Invalid scheme {parsed.scheme!r} — must be http or https",
-                details=f"URL: {proxy_url}" if verbose else None,
+                details=None,
                 fix_hint="Set LLM_PROXY_URL to a URL starting with http:// or https://",
             )
         )
@@ -415,11 +415,17 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.ERROR,
                 message="Missing host",
-                details=f"URL: {proxy_url}" if verbose else None,
+                details=None,
                 fix_hint="Set LLM_PROXY_URL to a full URL, e.g. https://my-proxy.example.com",
             )
         )
         return results
+
+    display_host = hostname
+    if ":" in display_host:
+        display_host = f"[{display_host}]"
+    if port is not None:
+        display_host = f"{display_host}:{port}"
 
     # Path should be empty or just "/" — the Anthropic SDK appends its own paths
     if parsed.path and parsed.path != "/":
@@ -428,7 +434,9 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.WARNING,
                 message=f"URL has a non-root path {parsed.path!r} — may conflict with SDK routing",
-                details=f"URL: {proxy_url}" if verbose else None,
+                details=f"Proxy: {parsed.scheme}://{display_host}{parsed.path}"
+                if verbose
+                else None,
                 fix_hint="Consider removing the path component; the Anthropic SDK appends its own paths",
             )
         )
@@ -437,8 +445,8 @@ def _check_proxy(verbose: bool = False) -> list[CheckResult]:
             CheckResult(
                 name="Proxy: LLM_PROXY_URL",
                 status=CheckStatus.OK,
-                message=f"Configured ({parsed.netloc})",
-                details=f"URL: {proxy_url}" if verbose else None,
+                message=f"Configured ({display_host})",
+                details=f"Proxy: {parsed.scheme}://{display_host}" if verbose else None,
             )
         )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -536,9 +536,18 @@ class TestCheckProxy:
 
     def test_included_in_run_diagnostics(self):
         """_check_proxy results appear in run_diagnostics output."""
-        results, _ = run_diagnostics()
-        proxy_results = [r for r in results if r.name.startswith("Proxy:")]
-        assert len(proxy_results) >= 1
+        proxy_result = CheckResult(
+            name="Proxy: test marker",
+            status=CheckStatus.OK,
+            message="called",
+        )
+        with patch(
+            "gptme.cli.doctor._check_proxy", return_value=[proxy_result]
+        ) as mock_check:
+            results, _ = run_diagnostics()
+
+        assert proxy_result in results
+        mock_check.assert_called_once_with(False)
 
 
 class TestCheckPermissions:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -464,6 +464,38 @@ class TestCheckProxy:
         assert len(results) == 1
         assert results[0].status == CheckStatus.OK
 
+    def test_credentials_are_redacted(self):
+        """Proxy credentials never appear in diagnostic output."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = (
+                "https://user:secret@proxy.example.com:8443"
+            )
+            results = _check_proxy(verbose=True)
+
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+        assert results[0].message == "Configured (proxy.example.com:8443)"
+        assert results[0].details == "Proxy: https://proxy.example.com:8443"
+        assert "secret" not in f"{results[0].message} {results[0].details}"
+
+    @pytest.mark.parametrize(
+        "proxy_url",
+        [
+            "secret://user:password@proxy.example.com",
+            "https://user:password@",
+            "https://user:password@proxy.example.com:not-a-port",
+        ],
+    )
+    def test_credentials_are_redacted_from_errors(self, proxy_url: str):
+        """Invalid proxy URLs do not expose credentials in verbose details."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = proxy_url
+            results = _check_proxy(verbose=True)
+
+        output = f"{results[0].message} {results[0].details}"
+        assert results[0].status == CheckStatus.ERROR
+        assert "password" not in output
+
     def test_missing_scheme(self):
         """A URL without a scheme (no http/https) is an error — gptme#3526 case."""
         with patch("gptme.cli.doctor.get_config") as mock_cfg:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,6 +5,7 @@ from collections import UserDict
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 from rich.console import Console
 
@@ -480,13 +481,31 @@ class TestCheckProxy:
         assert len(results) == 1
         assert results[0].status == CheckStatus.ERROR
 
-    def test_scheme_only_no_host(self):
-        """A scheme with no host is an error."""
+    @pytest.mark.parametrize(
+        "proxy_url",
+        ["https://", "https://:8080", "https://user@"],
+    )
+    def test_missing_host(self, proxy_url: str):
+        """An authority without a hostname is an error."""
         with patch("gptme.cli.doctor.get_config") as mock_cfg:
-            mock_cfg.return_value.get_env.return_value = "https://"
+            mock_cfg.return_value.get_env.return_value = proxy_url
             results = _check_proxy()
         assert len(results) == 1
         assert results[0].status == CheckStatus.ERROR
+        assert results[0].message == "Missing host"
+
+    @pytest.mark.parametrize(
+        "proxy_url",
+        ["http://[::1", "https://proxy.example.com:not-a-port"],
+    )
+    def test_malformed_url(self, proxy_url: str):
+        """Malformed URLs produce an error instead of aborting diagnostics."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = proxy_url
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.ERROR
+        assert "Malformed URL" in results[0].message
 
     def test_non_root_path_warns(self):
         """A URL with a trailing path warns — may conflict with SDK routing."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -17,6 +17,7 @@ from gptme.cli.doctor import (
     _check_config,
     _check_mcp,
     _check_permissions,
+    _check_proxy,
     _check_python_deps,
     _check_python_version,
     _check_tools,
@@ -432,6 +433,93 @@ class TestCheckConfig:
         results = _check_config()
         config_results = [r for r in results if "User" in r.name]
         assert len(config_results) == 1
+
+
+class TestCheckProxy:
+    """Test _check_proxy function."""
+
+    def test_no_proxy_configured(self):
+        """When LLM_PROXY_URL is not set, check is skipped."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = None
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.SKIPPED
+        assert "Proxy" in results[0].name
+
+    def test_valid_https_url(self):
+        """A well-formed https:// proxy URL passes."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "https://proxy.example.com"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+
+    def test_valid_http_url_with_port(self):
+        """A well-formed http:// URL with port passes."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "http://localhost:8080"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+
+    def test_missing_scheme(self):
+        """A URL without a scheme (no http/https) is an error — gptme#3526 case."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "proxy.example.com"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.ERROR
+        assert results[0].fix_hint is not None
+
+    def test_wrong_scheme(self):
+        """A non-http/https scheme is an error."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "ftp://proxy.example.com"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.ERROR
+
+    def test_scheme_only_no_host(self):
+        """A scheme with no host is an error."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "https://"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.ERROR
+
+    def test_non_root_path_warns(self):
+        """A URL with a trailing path warns — may conflict with SDK routing."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = (
+                "https://proxy.example.com/v1/api"
+            )
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.WARNING
+        assert results[0].fix_hint is not None
+
+    def test_root_path_ok(self):
+        """A URL with a trailing slash (root path) passes."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "https://proxy.example.com/"
+            results = _check_proxy()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+
+    def test_verbose_shows_details(self):
+        """Verbose mode includes URL details."""
+        with patch("gptme.cli.doctor.get_config") as mock_cfg:
+            mock_cfg.return_value.get_env.return_value = "https://proxy.example.com"
+            results = _check_proxy(verbose=True)
+        assert results[0].details is not None
+        assert "proxy.example.com" in results[0].details
+
+    def test_included_in_run_diagnostics(self):
+        """_check_proxy results appear in run_diagnostics output."""
+        results, _ = run_diagnostics()
+        proxy_results = [r for r in results if r.name.startswith("Proxy:")]
+        assert len(proxy_results) >= 1
 
 
 class TestCheckPermissions:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -539,15 +539,23 @@ class TestCheckProxy:
         assert results[0].status == CheckStatus.ERROR
         assert "Malformed URL" in results[0].message
 
-    def test_non_root_path_warns(self):
-        """A URL with a trailing path warns — may conflict with SDK routing."""
+    def test_non_root_path_warns_without_exposing_path(self):
+        """A proxy path warns without exposing a potential path credential."""
         with patch("gptme.cli.doctor.get_config") as mock_cfg:
             mock_cfg.return_value.get_env.return_value = (
-                "https://proxy.example.com/v1/api"
+                "https://proxy.example.com/secret-token"
             )
-            results = _check_proxy()
+            results = _check_proxy(verbose=True)
+
         assert len(results) == 1
         assert results[0].status == CheckStatus.WARNING
+        assert results[0].message == (
+            "URL has a non-root path — may conflict with SDK routing"
+        )
+        assert results[0].details == (
+            "Proxy: https://proxy.example.com/[path redacted]"
+        )
+        assert "secret-token" not in f"{results[0].message} {results[0].details}"
         assert results[0].fix_hint is not None
 
     def test_root_path_ok(self):


### PR DESCRIPTION
## Summary

- Adds `_check_proxy()` to `gptme/cli/doctor.py` that validates `LLM_PROXY_URL` when configured
- Registers the new check in `run_diagnostics()` between `_check_config` and `_check_api_keys`
- 10 new tests covering all branches, including the malformed-URL case from #3526

## Motivation

`gptme-doctor` had zero proxy-related checks (`grep -c -i proxy gptme/cli/doctor.py` returns 0 before this PR). The proxy-detection logic in `gptme/llm/llm_anthropic.py` sets `_is_proxy = proxy_url is not None`, which silently changes model ID formatting (`api_model = f"anthropic/{model}" if (via_gptme or _is_proxy) else model`) even for malformed URLs.

illiand's failure in #3526 is exactly this case — a misconfigured `LLM_PROXY_URL` changed routing with no diagnostic surface.

## What the check does

| URL | Result |
|-----|--------|
| Not set | SKIPPED — no proxy configured |
| `https://proxy.example.com` | OK |
| `http://localhost:8080` | OK |
| `proxy.example.com` (no scheme) | ERROR — must be http/https |
| `https://` (no host) | ERROR — missing host |
| `https://proxy.example.com/v1/api` | WARNING — trailing path may conflict with SDK routing |

## Test plan

- [ ] `env -u VIRTUAL_ENV uv run python -m pytest tests/test_doctor.py::TestCheckProxy -v` — all 10 tests pass
- [ ] `env -u VIRTUAL_ENV uv run python -m pytest tests/test_doctor.py -q` — all 88 tests pass
- [ ] `LLM_PROXY_URL=not-a-url gptme-doctor` surfaces an ERROR check for the proxy