### PR TITLE
feat(cli): add --track-tokens flag to print running token count per LLM call

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -80,9 +80,13 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
             session_tokens = [0]
             _session_tokens.set(session_tokens)
 
-        n_in = len_tokens(msgs, model)
-        n_out = len_tokens(msg_response, model)
-        context_limit = get_model(model).context
+        # Resolve once from the caller-supplied name (alias or full). Tokenizer
+        # and context metadata then share that ModelMeta; passing .full back
+        # into get_model() is the lookup 48225d823 avoided.
+        resolved = get_model(model)
+        n_in = len_tokens(msgs, resolved.full)
+        n_out = len_tokens(msg_response, resolved.full)
+        context_limit = resolved.context
         n_used = n_in + n_out
         session_tokens[0] += n_used
 
@@ -264,8 +268,11 @@ def chat(
         # Restore the caller's format so nested chat() calls (inline subagents)
         # don't clobber the parent's JSON mode when they exit.
         set_output_format(_prev_output_format)
-        # Restore the outer chat's token accumulator so nested chat() calls
-        # (inline subagents) don't corrupt the parent's running total.
+        # Restore the outer chat's token accumulator so same-context nested
+        # chat() calls don't corrupt the parent's running total.
+        # Thread-mode subagents start with a fresh contextvars context, so
+        # their totals are already isolated; folding inner into parent here
+        # would not see the parent list across threads.
         _session_tokens.set(_prev_tokens)
 
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -119,7 +119,10 @@ def chat(
 
     Callable from other modules.
     """
-    # Reset the per-session token accumulator for --track-tokens
+    # Reset the per-session token accumulator for --track-tokens.
+    # Save the previous value so nested chat() calls (inline subagents) restore
+    # the outer chat's running total on return instead of leaving [0] behind.
+    _prev_tokens = _session_tokens.get()
     _reset_token_accumulator()
 
     # Set initial terminal title with conversation name
@@ -248,6 +251,9 @@ def chat(
         # Restore the caller's format so nested chat() calls (inline subagents)
         # don't clobber the parent's JSON mode when they exit.
         set_output_format(_prev_output_format)
+        # Restore the outer chat's token accumulator so nested chat() calls
+        # (inline subagents) don't corrupt the parent's running total.
+        _session_tokens.set(_prev_tokens)
 
 
 def _run_chat_loop(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -55,31 +55,26 @@ from .util.terminal import flush_stdin, set_current_conv_name, terminal_state_ti
 
 logger = logging.getLogger(__name__)
 
-# A mutable value in a ContextVar keeps each chat isolated while allowing all
-# step() calls in that chat to contribute to one running total.
-_session_tokens: ContextVar[list[int] | None] = ContextVar(
-    "session_tokens", default=None
-)
+# Store an immutable int. copy_context() (server/TUI/ACP step threads) copies
+# the binding, not the value: a list would be shared by reference and a child
+# step() would mutate the parent's running total. Rebinding via .set() keeps
+# each context isolated while still letting every step() in the same context
+# contribute to one total.
+_session_tokens: ContextVar[int | None] = ContextVar("session_tokens", default=None)
 
 
 def _reset_token_accumulator() -> None:
-    _session_tokens.set([0])
+    _session_tokens.set(0)
 
 
 def _get_session_tokens() -> int:
     """Return the running total for the current chat context."""
-    session_tokens = _session_tokens.get()
-    return session_tokens[0] if session_tokens is not None else 0
+    return _session_tokens.get() or 0
 
 
 def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> None:
     """Print running token totals after each LLM call (enabled by GPTME_TRACK_TOKENS)."""
     try:
-        session_tokens = _session_tokens.get()
-        if session_tokens is None:
-            session_tokens = [0]
-            _session_tokens.set(session_tokens)
-
         # Resolve once from the caller-supplied name (alias or full). Tokenizer
         # and context metadata then share that ModelMeta; passing .full back
         # into get_model() is the lookup 48225d823 avoided.
@@ -88,7 +83,8 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
         n_out = len_tokens(msg_response, resolved.full)
         context_limit = resolved.context
         n_used = n_in + n_out
-        session_tokens[0] += n_used
+        session_tokens = (_session_tokens.get() or 0) + n_used
+        _session_tokens.set(session_tokens)
 
         # Occupancy is input+output: output tokens also consume the context
         # window, so an n_in-only percentage understates how close we are to
@@ -99,7 +95,7 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
         )
         print(
             f"[track-tokens] context: {n_used:,} / {context_display}{pct_display} | "
-            f"+{n_out:,} out | session total: {session_tokens[0]:,}",
+            f"+{n_out:,} out | session total: {session_tokens:,}",
             file=sys.stderr,
             flush=True,
         )
@@ -273,7 +269,7 @@ def chat(
         # chat() calls don't corrupt the parent's running total.
         # Thread-mode subagents start with a fresh contextvars context, so
         # their totals are already isolated; folding inner into parent here
-        # would not see the parent list across threads.
+        # would not see the parent total across threads.
         _session_tokens.set(_prev_tokens)
 
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -82,9 +82,9 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
 
         n_in = len_tokens(msgs, model)
         n_out = len_tokens(msg_response, model)
+        context_limit = get_model(model).context
         session_tokens[0] += n_in + n_out
 
-        context_limit = get_model(model).context
         context_display = f"{context_limit:,}" if context_limit else "unknown"
         pct_display = f" ({100.0 * n_in / context_limit:.1f}%)" if context_limit else ""
         print(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -1,9 +1,11 @@
 import copy
 import logging
 import os
+import sys
 import threading
 from collections.abc import Callable, Generator
 from contextlib import ExitStack
+from contextvars import ContextVar
 from pathlib import Path
 
 from .commands import execute_cmd
@@ -53,29 +55,42 @@ from .util.terminal import flush_stdin, set_current_conv_name, terminal_state_ti
 
 logger = logging.getLogger(__name__)
 
-# Session-scoped token accumulator for --track-tokens.
-# Sums (input + output) tokens across all LLM calls in a session.
-_session_tokens: int = 0
+# A mutable value in a ContextVar keeps each chat isolated while allowing all
+# step() calls in that chat to contribute to one running total.
+_session_tokens: ContextVar[list[int] | None] = ContextVar(
+    "session_tokens", default=None
+)
 
 
 def _reset_token_accumulator() -> None:
-    global _session_tokens
-    _session_tokens = 0
+    _session_tokens.set([0])
+
+
+def _get_session_tokens() -> int:
+    """Return the running total for the current chat context."""
+    session_tokens = _session_tokens.get()
+    return session_tokens[0] if session_tokens is not None else 0
 
 
 def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> None:
     """Print running token totals after each LLM call (enabled by --track-tokens)."""
-    global _session_tokens
+    session_tokens = _session_tokens.get()
+    if session_tokens is None:
+        session_tokens = [0]
+        _session_tokens.set(session_tokens)
+
     n_in = len_tokens(msgs, model)
     n_out = len_tokens(msg_response, model)
-    _session_tokens += n_in + n_out
+    session_tokens[0] += n_in + n_out
 
-    model_meta = get_model(model)
-    context_limit = model_meta.context
-    pct = 100.0 * n_in / context_limit if context_limit else 0.0
-    console.log(
-        f"[track-tokens] context: {n_in:,} / {context_limit:,} ({pct:.1f}%) | "
-        f"+{n_out:,} out | session total: {_session_tokens:,}"
+    context_limit = get_model(model).context
+    context_display = f"{context_limit:,}" if context_limit else "unknown"
+    pct_display = f" ({100.0 * n_in / context_limit:.1f}%)" if context_limit else ""
+    print(
+        f"[track-tokens] context: {n_in:,} / {context_display}{pct_display} | "
+        f"+{n_out:,} out | session total: {session_tokens[0]:,}",
+        file=sys.stderr,
+        flush=True,
     )
 
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -73,7 +73,7 @@ def _get_session_tokens() -> int:
 
 
 def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> None:
-    """Print running token totals after each LLM call (enabled by --track-tokens)."""
+    """Print running token totals after each LLM call (enabled by GPTME_TRACK_TOKENS)."""
     try:
         session_tokens = _session_tokens.get()
         if session_tokens is None:

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -29,6 +29,7 @@ from .message import (
     get_output_format,
     is_output_json,
     is_output_quiet,
+    len_tokens,
     set_output_format,
 )
 from .prompt_queue import drain_prompt_queue
@@ -51,6 +52,31 @@ from .util.sound import print_bell
 from .util.terminal import flush_stdin, set_current_conv_name, terminal_state_title
 
 logger = logging.getLogger(__name__)
+
+# Session-scoped token accumulator for --track-tokens.
+# Sums (input + output) tokens across all LLM calls in a session.
+_session_tokens: int = 0
+
+
+def _reset_token_accumulator() -> None:
+    global _session_tokens
+    _session_tokens = 0
+
+
+def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> None:
+    """Print running token totals after each LLM call (enabled by --track-tokens)."""
+    global _session_tokens
+    n_in = len_tokens(msgs, model)
+    n_out = len_tokens(msg_response, model)
+    _session_tokens += n_in + n_out
+
+    model_meta = get_model(model)
+    context_limit = model_meta.context
+    pct = 100.0 * n_in / context_limit if context_limit else 0.0
+    console.log(
+        f"[track-tokens] context: {n_in:,} / {context_limit:,} ({pct:.1f}%) | "
+        f"+{n_out:,} out | session total: {_session_tokens:,}"
+    )
 
 
 @trace_function(name="chat.main", attributes={"component": "chat"})
@@ -78,6 +104,9 @@ def chat(
 
     Callable from other modules.
     """
+    # Reset the per-session token accumulator for --track-tokens
+    _reset_token_accumulator()
+
     # Set initial terminal title with conversation name
     conv_name = logdir.name
     set_current_conv_name(conv_name)
@@ -671,6 +700,8 @@ def step(
             )
         if get_config().get_env_bool("GPTME_COSTS"):
             log_costs(msgs + [msg_response])
+        if get_config().get_env_bool("GPTME_TRACK_TOKENS"):
+            _log_token_usage(msgs, msg_response, get_model(model).full)
 
         # Trigger generation post hooks (e.g., TTS)
         if generation_post_msgs := trigger_hook(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -74,24 +74,28 @@ def _get_session_tokens() -> int:
 
 def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> None:
     """Print running token totals after each LLM call (enabled by --track-tokens)."""
-    session_tokens = _session_tokens.get()
-    if session_tokens is None:
-        session_tokens = [0]
-        _session_tokens.set(session_tokens)
+    try:
+        session_tokens = _session_tokens.get()
+        if session_tokens is None:
+            session_tokens = [0]
+            _session_tokens.set(session_tokens)
 
-    n_in = len_tokens(msgs, model)
-    n_out = len_tokens(msg_response, model)
-    session_tokens[0] += n_in + n_out
+        n_in = len_tokens(msgs, model)
+        n_out = len_tokens(msg_response, model)
+        session_tokens[0] += n_in + n_out
 
-    context_limit = get_model(model).context
-    context_display = f"{context_limit:,}" if context_limit else "unknown"
-    pct_display = f" ({100.0 * n_in / context_limit:.1f}%)" if context_limit else ""
-    print(
-        f"[track-tokens] context: {n_in:,} / {context_display}{pct_display} | "
-        f"+{n_out:,} out | session total: {session_tokens[0]:,}",
-        file=sys.stderr,
-        flush=True,
-    )
+        context_limit = get_model(model).context
+        context_display = f"{context_limit:,}" if context_limit else "unknown"
+        pct_display = f" ({100.0 * n_in / context_limit:.1f}%)" if context_limit else ""
+        print(
+            f"[track-tokens] context: {n_in:,} / {context_display}{pct_display} | "
+            f"+{n_out:,} out | session total: {session_tokens[0]:,}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception:
+        # Informational only — never crash the main chat loop over token display.
+        pass
 
 
 @trace_function(name="chat.main", attributes={"component": "chat"})
@@ -119,11 +123,11 @@ def chat(
 
     Callable from other modules.
     """
-    # Reset the per-session token accumulator for --track-tokens.
-    # Save the previous value so nested chat() calls (inline subagents) restore
-    # the outer chat's running total on return instead of leaving [0] behind.
+    # Save the previous token accumulator so nested chat() calls (inline subagents)
+    # restore the outer chat's running total on return.  The actual reset is
+    # deferred to inside the try block so the finally clause always runs to
+    # restore _prev_tokens even if pre-try setup code raises an exception.
     _prev_tokens = _session_tokens.get()
-    _reset_token_accumulator()
 
     # Set initial terminal title with conversation name
     conv_name = logdir.name
@@ -144,6 +148,9 @@ def chat(
     _prev_output_format = get_output_format()
     skill_lifecycle = ExitStack()
     try:
+        # Reset here (inside try) so the finally clause always restores
+        # _prev_tokens if any setup code above raises before reaching this point.
+        _reset_token_accumulator()
         set_output_format(output_format)
 
         # init

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -701,7 +701,7 @@ def step(
         if get_config().get_env_bool("GPTME_COSTS"):
             log_costs(msgs + [msg_response])
         if get_config().get_env_bool("GPTME_TRACK_TOKENS"):
-            _log_token_usage(msgs, msg_response, get_model(model).full)
+            _log_token_usage(msgs, msg_response, model)
 
         # Trigger generation post hooks (e.g., TTS)
         if generation_post_msgs := trigger_hook(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -83,12 +83,18 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
         n_in = len_tokens(msgs, model)
         n_out = len_tokens(msg_response, model)
         context_limit = get_model(model).context
-        session_tokens[0] += n_in + n_out
+        n_used = n_in + n_out
+        session_tokens[0] += n_used
 
+        # Occupancy is input+output: output tokens also consume the context
+        # window, so an n_in-only percentage understates how close we are to
+        # the limit (and to overflow on the next turn).
         context_display = f"{context_limit:,}" if context_limit else "unknown"
-        pct_display = f" ({100.0 * n_in / context_limit:.1f}%)" if context_limit else ""
+        pct_display = (
+            f" ({100.0 * n_used / context_limit:.1f}%)" if context_limit else ""
+        )
         print(
-            f"[track-tokens] context: {n_in:,} / {context_display}{pct_display} | "
+            f"[track-tokens] context: {n_used:,} / {context_display}{pct_display} | "
             f"+{n_out:,} out | session total: {session_tokens[0]:,}",
             file=sys.stderr,
             flush=True,

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -103,9 +103,10 @@ def _log_token_usage(msgs: list[Message], msg_response: Message, model: str) -> 
             file=sys.stderr,
             flush=True,
         )
-    except Exception:
+    except Exception as e:
         # Informational only — never crash the main chat loop over token display.
-        pass
+        # KeyboardInterrupt/SystemExit are BaseException and still propagate.
+        logger.warning("track-tokens failed: %s", e)
 
 
 @trace_function(name="chat.main", attributes={"component": "chat"})

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1140,7 +1140,7 @@ def main(
 
     # Everything below is an actual chat session: import the heavy parts of
     # gptme now, after the cheap early-exit paths (--help/--version/dispatch).
-    from ..chat import chat
+    from ..chat import _log_token_usage, chat
     from ..config import ensure_workspace_dir, get_config, setup_config_from_cli
     from ..init import init_logging
     from ..llm import get_provider_from_model, is_custom_provider
@@ -1643,6 +1643,12 @@ def main(
             tools=None,  # architect has no tools (planning only)
             workspace=workspace_path,
         )
+        # Architect calls llm_reply outside chat()/step(), so the per-step
+        # track-tokens hook never sees this turn. Log it here when enabled.
+        # chat() then resets the accumulator for the editor session — the
+        # planning context is a different window/model, not editor occupancy.
+        if get_config().get_env_bool("GPTME_TRACK_TOKENS"):
+            _log_token_usage(architect_msgs, architect_response, _arch_model)
 
         plan_text = architect_response.content.strip()
         logger.info("Architect plan generated (%d chars)", len(plan_text))

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1001,8 +1001,10 @@ def main(
     if injection_hygiene is not None:
         os.environ["GPTME_INJECTION_HYGIENE"] = injection_hygiene
 
-    # Propagate --track-tokens to the env var checked per-step.
-    if track_tokens:
+    # Propagate an explicit --track-tokens flag to the env var checked per-step.
+    # Preserve the original env string otherwise so get_env_bool() can interpret
+    # falsy values such as GPTME_TRACK_TOKENS=0 correctly.
+    if ctx.get_parameter_source("track_tokens") == ParameterSource.COMMANDLINE:
         os.environ["GPTME_TRACK_TOKENS"] = "1"
 
     # Convert tool_allowlist from tuple to string or None

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -806,6 +806,13 @@ Run 'gptme-util --help' for all utility commands."""
     help="Write a JSON record before and after each tool call to this directory. "
     "Records can be committed alongside session artifacts for tool-call-level attribution.",
 )
+@click.option(
+    "--track-tokens",
+    "track_tokens",
+    is_flag=True,
+    envvar="GPTME_TRACK_TOKENS",
+    help="After each LLM call, print running token count and percent of the model's context window.",
+)
 def main(
     ctx: click.Context,
     prompts: list[str],
@@ -840,6 +847,7 @@ def main(
     output_schema: str | None,
     injection_hygiene: str | None,
     manifest_dir: Path | None,
+    track_tokens: bool,
 ):
     """Main entrypoint for the CLI."""
     show_version = version or version_json
@@ -992,6 +1000,10 @@ def main(
     # so this only fires when the flag was explicitly passed on the command line.
     if injection_hygiene is not None:
         os.environ["GPTME_INJECTION_HYGIENE"] = injection_hygiene
+
+    # Propagate --track-tokens to the env var checked per-step.
+    if track_tokens:
+        os.environ["GPTME_TRACK_TOKENS"] = "1"
 
     # Convert tool_allowlist from tuple to string or None
     # Use get_parameter_source to distinguish between default (None) and explicit empty list

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -806,13 +806,6 @@ Run 'gptme-util --help' for all utility commands."""
     help="Write a JSON record before and after each tool call to this directory. "
     "Records can be committed alongside session artifacts for tool-call-level attribution.",
 )
-@click.option(
-    "--track-tokens",
-    "track_tokens",
-    is_flag=True,
-    envvar="GPTME_TRACK_TOKENS",
-    help="After each LLM call, print running token count and percent of the model's context window.",
-)
 def main(
     ctx: click.Context,
     prompts: list[str],
@@ -847,7 +840,6 @@ def main(
     output_schema: str | None,
     injection_hygiene: str | None,
     manifest_dir: Path | None,
-    track_tokens: bool,
 ):
     """Main entrypoint for the CLI."""
     show_version = version or version_json
@@ -1000,12 +992,6 @@ def main(
     # so this only fires when the flag was explicitly passed on the command line.
     if injection_hygiene is not None:
         os.environ["GPTME_INJECTION_HYGIENE"] = injection_hygiene
-
-    # Propagate an explicit --track-tokens flag to the env var checked per-step.
-    # Preserve the original env string otherwise so get_env_bool() can interpret
-    # falsy values such as GPTME_TRACK_TOKENS=0 correctly.
-    if ctx.get_parameter_source("track_tokens") == ParameterSource.COMMANDLINE:
-        os.environ["GPTME_TRACK_TOKENS"] = "1"
 
     # Convert tool_allowlist from tuple to string or None
     # Use get_parameter_source to distinguish between default (None) and explicit empty list

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -96,8 +96,29 @@ def test_output_shows_context_percentage_on_stderr(capsys):
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert "10.0%" in captured.err
+    # Occupancy is input+output (1000+50) against the 10k window.
+    assert "context: 1,050 / 10,000 (10.5%)" in captured.err
+    assert "+50 out" in captured.err
     assert "session total: 1,050" in captured.err
+
+
+def test_output_percentage_includes_output_tokens(capsys):
+    """Percentage uses n_in+n_out so a large completion cannot hide overflow."""
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[9_000, 2_000]),
+    ):
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
+        )
+
+    captured = capsys.readouterr()
+    # n_in-only would show 90.0%; occupancy after the call is 110.0%.
+    assert "context: 11,000 / 10,000 (110.0%)" in captured.err
+    assert "+2,000 out" in captured.err
+    assert "90.0%" not in captured.err
 
 
 def test_reset_clears_accumulator():
@@ -131,7 +152,8 @@ def test_output_handles_unknown_context_limit(capsys):
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert "context: 100 / unknown" in captured.err
+    assert "context: 120 / unknown" in captured.err
+    assert "+20 out" in captured.err
     assert "session total: 120" in captured.err
 
 

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -208,3 +208,28 @@ def test_accumulator_isolated_across_chat_contexts():
         child_context.run(run_child)
 
     assert _get_session_tokens() == 120
+
+
+def test_log_token_usage_survives_len_tokens_error():
+    """_log_token_usage never raises; errors are swallowed so the chat loop continues."""
+    with patch.object(
+        chat_module, "len_tokens", side_effect=ValueError("unsupported model")
+    ):
+        # Must not raise — informational display errors must not crash the main loop.
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "unknown/model"
+        )
+    # Accumulator stays at 0 (not incremented on error).
+    assert _get_session_tokens() == 0
+
+
+def test_log_token_usage_survives_get_model_error():
+    """_log_token_usage survives get_model() raising (e.g. unknown model registry)."""
+    with (
+        patch.object(chat_module, "len_tokens", side_effect=[10, 5]),
+        patch.object(chat_module, "get_model", side_effect=KeyError("unknown model")),
+    ):
+        # Must not raise.
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "unknown/model"
+        )

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -1,0 +1,108 @@
+"""Tests for --track-tokens / GPTME_TRACK_TOKENS token-accumulation logic."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gptme.chat as chat_module
+from gptme.chat import _log_token_usage, _reset_token_accumulator
+from gptme.message import Message
+
+
+@pytest.fixture(autouse=True)
+def reset_accumulator():
+    """Reset the session token accumulator before each test."""
+    _reset_token_accumulator()
+    yield
+    _reset_token_accumulator()
+
+
+def _make_model_meta(model_name: str = "mock/gpt-mock", context: int = 10_000):
+    """Return a lightweight ModelMeta stub."""
+    meta = MagicMock()
+    meta.model = model_name
+    meta.full = model_name
+    meta.context = context
+    return meta
+
+
+def test_accumulator_sums_across_turns(capsys):
+    """_session_tokens grows with each _log_token_usage call."""
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch("gptme.chat.get_model", return_value=meta),
+        patch("gptme.chat.len_tokens", side_effect=[100, 20, 200, 30]),
+    ):
+        msgs1 = [Message("user", "hello")]
+        resp1 = Message("assistant", "world")
+        _log_token_usage(msgs1, resp1, "mock/gpt-mock")
+        assert chat_module._session_tokens == 120  # 100 in + 20 out
+
+        msgs2 = [
+            Message("user", "hello"),
+            Message("assistant", "world"),
+            Message("user", "more"),
+        ]
+        resp2 = Message("assistant", "done")
+        _log_token_usage(msgs2, resp2, "mock/gpt-mock")
+        assert chat_module._session_tokens == 350  # 120 + 200 in + 30 out
+
+
+def test_accumulator_includes_tool_result_content(capsys):
+    """Token count includes tool-result messages (as system msgs) that land in msgs."""
+    meta = _make_model_meta(context=10_000)
+
+    # Tool results are injected as system messages in gptme's conversation format
+    tool_result = Message("system", "```\nls output: file1 file2\n```")
+    msgs = [
+        Message("user", "list files"),
+        Message("assistant", "ok"),
+        tool_result,
+    ]
+    resp = Message("assistant", "done")
+
+    with (
+        patch("gptme.chat.get_model", return_value=meta),
+        patch("gptme.chat.len_tokens", side_effect=[150, 10]) as mock_len_tokens,
+    ):
+        _log_token_usage(msgs, resp, "mock/gpt-mock")
+
+    # len_tokens was called with the full msgs list (which includes the tool result)
+    first_call_msgs = mock_len_tokens.call_args_list[0][0][0]
+    assert len(first_call_msgs) == 3
+    assert chat_module._session_tokens == 160
+
+
+def test_output_shows_context_percentage(capsys):
+    """The printed line includes percent-of-context."""
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch("gptme.chat.get_model", return_value=meta),
+        patch("gptme.chat.len_tokens", side_effect=[1000, 50]),
+    ):
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
+        )
+
+    captured = capsys.readouterr()
+    # 1000 / 10_000 = 10.0%
+    assert "10.0%" in captured.out or "10.0%" in captured.err
+
+
+def test_reset_clears_accumulator():
+    """_reset_token_accumulator brings the counter back to zero."""
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch("gptme.chat.get_model", return_value=meta),
+        patch("gptme.chat.len_tokens", side_effect=[50, 10]),
+    ):
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
+        )
+
+    assert chat_module._session_tokens == 60
+    _reset_token_accumulator()
+    assert chat_module._session_tokens == 0

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -135,47 +135,44 @@ def test_output_handles_unknown_context_limit(capsys):
     assert "session total: 120" in captured.err
 
 
-def test_accumulator_restored_after_nested_chat_same_context():
-    """Nested chat() in the same context restores the parent's running total.
-
-    The existing copy_context test is insufficient: production subagents run
-    chat() in the *same* context (same thread, no copy_context barrier).
-    _reset_token_accumulator() inside the inner chat() would clobber the outer
-    total.  The fix saves _prev_tokens before resetting and restores on exit.
-    """
-    meta = _make_model_meta(context=10_000)
-
+def test_accumulator_restored_after_chat_returns(tmp_path):
+    """chat() restores its caller's token accumulator in its finally block."""
+    meta = _make_model_meta()
     with (
         patch.object(chat_module, "get_model", return_value=meta),
         patch.object(chat_module, "len_tokens", side_effect=[100, 20, 50, 10]),
     ):
-        # Outer chat: accumulate 120 tokens.
         _log_token_usage(
             [Message("user", "outer")],
             Message("assistant", "reply"),
             "mock/gpt-mock",
         )
-        assert _get_session_tokens() == 120
+    assert _get_session_tokens() == 120
 
-        # Simulate what the fixed chat() does at nested-call entry:
-        # save outer state, reset for inner chat.
-        prev_tokens = chat_module._session_tokens.get()
-        _reset_token_accumulator()
-        assert _get_session_tokens() == 0  # inner chat starts fresh
-
-        # Inner chat: accumulate 60 tokens.
-        _log_token_usage(
+    with (
+        patch.object(chat_module, "set_current_conv_name"),
+        patch.object(chat_module, "set_conversation_context"),
+        patch.object(chat_module, "init"),
+        patch.object(chat_module, "trigger_hook", return_value=[]),
+        patch.object(chat_module, "get_default_model", return_value=None),
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[50, 10]),
+        patch.object(chat_module, "_run_chat_loop") as run_chat_loop,
+    ):
+        run_chat_loop.side_effect = lambda *args, **kwargs: _log_token_usage(
             [Message("user", "inner")],
             Message("assistant", "reply"),
             "mock/gpt-mock",
         )
-        assert _get_session_tokens() == 60
+        chat_module.chat(
+            prompt_msgs=[],
+            initial_msgs=[],
+            logdir=tmp_path,
+            workspace=tmp_path,
+            model="mock/gpt-mock",
+            tool_format="markdown",
+        )
 
-        # Simulate what the fixed chat() does at nested-call exit (finally block):
-        # restore the outer total.
-        chat_module._session_tokens.set(prev_tokens)
-
-    # Outer running total is intact — inner chat left no trace.
     assert _get_session_tokens() == 120
 
 
@@ -229,7 +226,8 @@ def test_log_token_usage_survives_get_model_error():
         patch.object(chat_module, "len_tokens", side_effect=[10, 5]),
         patch.object(chat_module, "get_model", side_effect=KeyError("unknown model")),
     ):
-        # Must not raise.
+        # Must not raise or commit a partial count.
         _log_token_usage(
             [Message("user", "hi")], Message("assistant", "ok"), "unknown/model"
         )
+    assert _get_session_tokens() == 0

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -1,12 +1,17 @@
 """Tests for --track-tokens / GPTME_TRACK_TOKENS token-accumulation logic."""
 
 import importlib
+from contextvars import copy_context
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 chat_module = importlib.import_module("gptme.chat")
-from gptme.chat import _log_token_usage, _reset_token_accumulator
+from gptme.chat import (
+    _get_session_tokens,
+    _log_token_usage,
+    _reset_token_accumulator,
+)
 from gptme.message import Message
 
 
@@ -18,7 +23,7 @@ def reset_accumulator():
     _reset_token_accumulator()
 
 
-def _make_model_meta(model_name: str = "mock/gpt-mock", context: int = 10_000):
+def _make_model_meta(model_name: str = "mock/gpt-mock", context: int | None = 10_000):
     """Return a lightweight ModelMeta stub."""
     meta = MagicMock()
     meta.model = model_name
@@ -38,7 +43,7 @@ def test_accumulator_sums_across_turns(capsys):
         msgs1 = [Message("user", "hello")]
         resp1 = Message("assistant", "world")
         _log_token_usage(msgs1, resp1, "mock/gpt-mock")
-        assert chat_module._session_tokens == 120  # 100 in + 20 out
+        assert _get_session_tokens() == 120  # 100 in + 20 out
 
         msgs2 = [
             Message("user", "hello"),
@@ -47,7 +52,7 @@ def test_accumulator_sums_across_turns(capsys):
         ]
         resp2 = Message("assistant", "done")
         _log_token_usage(msgs2, resp2, "mock/gpt-mock")
-        assert chat_module._session_tokens == 350  # 120 + 200 in + 30 out
+        assert _get_session_tokens() == 350  # 120 + 200 in + 30 out
 
 
 def test_accumulator_includes_tool_result_content(capsys):
@@ -74,11 +79,11 @@ def test_accumulator_includes_tool_result_content(capsys):
     # len_tokens was called with the full msgs list (which includes the tool result)
     first_call_msgs = mock_len_tokens.call_args_list[0][0][0]
     assert len(first_call_msgs) == 3
-    assert chat_module._session_tokens == 160
+    assert _get_session_tokens() == 160
 
 
-def test_output_shows_context_percentage(capsys):
-    """The printed line includes percent-of-context."""
+def test_output_shows_context_percentage_on_stderr(capsys):
+    """Tracking is human-readable stderr output, preserving structured stdout."""
     meta = _make_model_meta(context=10_000)
 
     with (
@@ -90,8 +95,9 @@ def test_output_shows_context_percentage(capsys):
         )
 
     captured = capsys.readouterr()
-    # 1000 / 10_000 = 10.0%
-    assert "10.0%" in captured.out or "10.0%" in captured.err
+    assert captured.out == ""
+    assert "10.0%" in captured.err
+    assert "session total: 1,050" in captured.err
 
 
 def test_reset_clears_accumulator():
@@ -106,6 +112,55 @@ def test_reset_clears_accumulator():
             [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
         )
 
-    assert chat_module._session_tokens == 60
+    assert _get_session_tokens() == 60
     _reset_token_accumulator()
-    assert chat_module._session_tokens == 0
+    assert _get_session_tokens() == 0
+
+
+def test_output_handles_unknown_context_limit(capsys):
+    """Models without known context metadata still report usage."""
+    meta = _make_model_meta(context=None)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[100, 20]),
+    ):
+        _log_token_usage(
+            [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "context: 100 / unknown" in captured.err
+    assert "session total: 120" in captured.err
+
+
+def test_accumulator_isolated_across_chat_contexts():
+    """A nested/concurrent chat reset cannot modify its parent's running total."""
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[100, 20, 50, 10]),
+    ):
+        _log_token_usage(
+            [Message("user", "parent")],
+            Message("assistant", "reply"),
+            "mock/gpt-mock",
+        )
+        assert _get_session_tokens() == 120
+
+        child_context = copy_context()
+
+        def run_child() -> None:
+            _reset_token_accumulator()
+            _log_token_usage(
+                [Message("user", "child")],
+                Message("assistant", "reply"),
+                "mock/gpt-mock",
+            )
+            assert _get_session_tokens() == 60
+
+        child_context.run(run_child)
+
+    assert _get_session_tokens() == 120

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -135,6 +135,50 @@ def test_output_handles_unknown_context_limit(capsys):
     assert "session total: 120" in captured.err
 
 
+def test_accumulator_restored_after_nested_chat_same_context():
+    """Nested chat() in the same context restores the parent's running total.
+
+    The existing copy_context test is insufficient: production subagents run
+    chat() in the *same* context (same thread, no copy_context barrier).
+    _reset_token_accumulator() inside the inner chat() would clobber the outer
+    total.  The fix saves _prev_tokens before resetting and restores on exit.
+    """
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[100, 20, 50, 10]),
+    ):
+        # Outer chat: accumulate 120 tokens.
+        _log_token_usage(
+            [Message("user", "outer")],
+            Message("assistant", "reply"),
+            "mock/gpt-mock",
+        )
+        assert _get_session_tokens() == 120
+
+        # Simulate what the fixed chat() does at nested-call entry:
+        # save outer state, reset for inner chat.
+        prev_tokens = chat_module._session_tokens.get()
+        _reset_token_accumulator()
+        assert _get_session_tokens() == 0  # inner chat starts fresh
+
+        # Inner chat: accumulate 60 tokens.
+        _log_token_usage(
+            [Message("user", "inner")],
+            Message("assistant", "reply"),
+            "mock/gpt-mock",
+        )
+        assert _get_session_tokens() == 60
+
+        # Simulate what the fixed chat() does at nested-call exit (finally block):
+        # restore the outer total.
+        chat_module._session_tokens.set(prev_tokens)
+
+    # Outer running total is intact — inner chat left no trace.
+    assert _get_session_tokens() == 120
+
+
 def test_accumulator_isolated_across_chat_contexts():
     """A nested/concurrent chat reset cannot modify its parent's running total."""
     meta = _make_model_meta(context=10_000)

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -1,10 +1,11 @@
 """Tests for --track-tokens / GPTME_TRACK_TOKENS token-accumulation logic."""
 
+import importlib
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-import gptme.chat as chat_module
+chat_module = importlib.import_module("gptme.chat")
 from gptme.chat import _log_token_usage, _reset_token_accumulator
 from gptme.message import Message
 
@@ -31,8 +32,8 @@ def test_accumulator_sums_across_turns(capsys):
     meta = _make_model_meta(context=10_000)
 
     with (
-        patch("gptme.chat.get_model", return_value=meta),
-        patch("gptme.chat.len_tokens", side_effect=[100, 20, 200, 30]),
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[100, 20, 200, 30]),
     ):
         msgs1 = [Message("user", "hello")]
         resp1 = Message("assistant", "world")
@@ -63,8 +64,10 @@ def test_accumulator_includes_tool_result_content(capsys):
     resp = Message("assistant", "done")
 
     with (
-        patch("gptme.chat.get_model", return_value=meta),
-        patch("gptme.chat.len_tokens", side_effect=[150, 10]) as mock_len_tokens,
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(
+            chat_module, "len_tokens", side_effect=[150, 10]
+        ) as mock_len_tokens,
     ):
         _log_token_usage(msgs, resp, "mock/gpt-mock")
 
@@ -79,8 +82,8 @@ def test_output_shows_context_percentage(capsys):
     meta = _make_model_meta(context=10_000)
 
     with (
-        patch("gptme.chat.get_model", return_value=meta),
-        patch("gptme.chat.len_tokens", side_effect=[1000, 50]),
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[1000, 50]),
     ):
         _log_token_usage(
             [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"
@@ -96,8 +99,8 @@ def test_reset_clears_accumulator():
     meta = _make_model_meta(context=10_000)
 
     with (
-        patch("gptme.chat.get_model", return_value=meta),
-        patch("gptme.chat.len_tokens", side_effect=[50, 10]),
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[50, 10]),
     ):
         _log_token_usage(
             [Message("user", "hi")], Message("assistant", "ok"), "mock/gpt-mock"

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -179,6 +179,7 @@ def test_accumulator_restored_after_chat_returns(tmp_path):
         patch.object(chat_module, "get_default_model", return_value=None),
         patch.object(chat_module, "get_model", return_value=meta),
         patch.object(chat_module, "len_tokens", side_effect=[50, 10]),
+        patch.object(chat_module.os, "chdir"),
         patch.object(chat_module, "_run_chat_loop") as run_chat_loop,
     ):
         run_chat_loop.side_effect = lambda *args, **kwargs: _log_token_usage(
@@ -231,8 +232,11 @@ def test_accumulator_isolated_across_chat_contexts():
 
 def test_log_token_usage_survives_len_tokens_error():
     """_log_token_usage never raises; errors are swallowed so the chat loop continues."""
-    with patch.object(
-        chat_module, "len_tokens", side_effect=ValueError("unsupported model")
+    with (
+        patch.object(chat_module, "get_model", return_value=_make_model_meta()),
+        patch.object(
+            chat_module, "len_tokens", side_effect=ValueError("unsupported model")
+        ),
     ):
         # Must not raise — informational display errors must not crash the main loop.
         _log_token_usage(
@@ -253,3 +257,19 @@ def test_log_token_usage_survives_get_model_error():
             [Message("user", "hi")], Message("assistant", "ok"), "unknown/model"
         )
     assert _get_session_tokens() == 0
+
+
+def test_log_token_usage_counts_with_resolved_model_name():
+    """Tokenizer uses get_model(alias).full, not the raw CLI alias."""
+    meta = _make_model_meta(model_name="openai/gpt-4o", context=10_000)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta) as mock_get,
+        patch.object(chat_module, "len_tokens", side_effect=[10, 5]) as mock_len,
+    ):
+        _log_token_usage([Message("user", "hi")], Message("assistant", "ok"), "gpt-4o")
+
+    mock_get.assert_called_once_with("gpt-4o")
+    assert mock_len.call_args_list[0].args[1] == "openai/gpt-4o"
+    assert mock_len.call_args_list[1].args[1] == "openai/gpt-4o"
+    assert _get_session_tokens() == 15

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -277,3 +277,24 @@ def test_log_token_usage_counts_with_resolved_model_name():
     assert mock_len.call_args_list[0].args[1] == "openai/gpt-4o"
     assert mock_len.call_args_list[1].args[1] == "openai/gpt-4o"
     assert _get_session_tokens() == 15
+
+
+def test_log_token_usage_before_chat_when_accumulator_unset(capsys):
+    """Architect logs before chat() starts, when the ContextVar is still None."""
+    meta = _make_model_meta(context=10_000)
+    chat_module._session_tokens.set(None)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[80, 20]),
+    ):
+        _log_token_usage(
+            [Message("system", "plan"), Message("user", "do the thing")],
+            Message("assistant", "step 1 then step 2"),
+            "mock/gpt-mock",
+        )
+
+    err = capsys.readouterr().err
+    assert "[track-tokens]" in err
+    assert "session total: 100" in err
+    assert _get_session_tokens() == 100

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -230,13 +230,14 @@ def test_accumulator_isolated_across_chat_contexts():
     assert _get_session_tokens() == 120
 
 
-def test_log_token_usage_survives_len_tokens_error():
-    """_log_token_usage never raises; errors are swallowed so the chat loop continues."""
+def test_log_token_usage_survives_len_tokens_error(caplog):
+    """_log_token_usage never raises; errors are logged so the chat loop continues."""
     with (
         patch.object(chat_module, "get_model", return_value=_make_model_meta()),
         patch.object(
             chat_module, "len_tokens", side_effect=ValueError("unsupported model")
         ),
+        caplog.at_level("WARNING", logger="gptme.chat"),
     ):
         # Must not raise — informational display errors must not crash the main loop.
         _log_token_usage(
@@ -244,19 +245,22 @@ def test_log_token_usage_survives_len_tokens_error():
         )
     # Accumulator stays at 0 (not incremented on error).
     assert _get_session_tokens() == 0
+    assert any("track-tokens failed" in rec.message for rec in caplog.records)
 
 
-def test_log_token_usage_survives_get_model_error():
+def test_log_token_usage_survives_get_model_error(caplog):
     """_log_token_usage survives get_model() raising (e.g. unknown model registry)."""
     with (
         patch.object(chat_module, "len_tokens", side_effect=[10, 5]),
         patch.object(chat_module, "get_model", side_effect=KeyError("unknown model")),
+        caplog.at_level("WARNING", logger="gptme.chat"),
     ):
         # Must not raise or commit a partial count.
         _log_token_usage(
             [Message("user", "hi")], Message("assistant", "ok"), "unknown/model"
         )
     assert _get_session_tokens() == 0
+    assert any("track-tokens failed" in rec.message for rec in caplog.records)
 
 
 def test_log_token_usage_counts_with_resolved_model_name():

--- a/tests/test_track_tokens.py
+++ b/tests/test_track_tokens.py
@@ -230,6 +230,43 @@ def test_accumulator_isolated_across_chat_contexts():
     assert _get_session_tokens() == 120
 
 
+def test_copied_context_does_not_mutate_parent_accumulator():
+    """copy_context() children must not share the parent's running total.
+
+    Server/TUI/ACP step threads run under copy_context(). A mutable list stored
+    in the ContextVar would be shared by reference, so a child step() that
+    calls _log_token_usage without going through chat()'s reset would inflate
+    the parent's session total. An immutable int rebind isolates them.
+    """
+    meta = _make_model_meta(context=10_000)
+
+    with (
+        patch.object(chat_module, "get_model", return_value=meta),
+        patch.object(chat_module, "len_tokens", side_effect=[100, 20, 50, 10]),
+    ):
+        _log_token_usage(
+            [Message("user", "parent")],
+            Message("assistant", "reply"),
+            "mock/gpt-mock",
+        )
+        assert _get_session_tokens() == 120
+
+        child_context = copy_context()
+
+        def run_child() -> None:
+            # No reset — this is the step()-outside-chat() path.
+            _log_token_usage(
+                [Message("user", "child")],
+                Message("assistant", "reply"),
+                "mock/gpt-mock",
+            )
+            assert _get_session_tokens() == 180
+
+        child_context.run(run_child)
+
+    assert _get_session_tokens() == 120
+
+
 def test_log_token_usage_survives_len_tokens_error(caplog):
     """_log_token_usage never raises; errors are logged so the chat loop continues."""
     with (


### PR DESCRIPTION
## Summary

- Adds `GPTME_TRACK_TOKENS=1` env var that prints a running token-usage line after each LLM call
- Each line shows: context window usage (`N / limit (pct%)`), output tokens from the current call, and cumulative session total
- Session accumulator resets at the start of each `chat()` call
- Follows the same pattern as the existing env-only `GPTME_COSTS` mechanism
- `len_tokens` moved to module-level import in `chat.py` so tests can patch it cleanly

**2026-09-07 trim**: dropped the `--track-tokens` CLI flag per triage — Erik has objected to new default-CLI flags for this kind of opt-in toggle three times before (#3209, #3296, #1821) and never to an env-only one. `GPTME_TRACK_TOKENS` already drove the hook directly in `chat.py`'s `step()`; the flag was a second, redundant way to set the same env var.

## Motivation

Silent token overflow is a known pain point — gptme-discussions#138 describes a `/shell ls -R` call that silently failed at 289k tokens with no user-visible warning. This env var gives users a lightweight way to monitor context growth without committing to a full TUI redesign.

## Example output

```
[track-tokens] context: 12,450 / 200,000 (6.2%) | +328 out | session total: 25,106
```

## Test plan

- [x] `poetry run pytest tests/test_track_tokens.py -v` — 12 tests, all pass (accumulation across turns, tool-result content, percent output, reset, nested-chat isolation, error handling)
- [ ] Manual: `GPTME_TRACK_TOKENS=1 gptme 'hello'` prints the tracking line after each LLM call
- [ ] Default behaviour (env var unset) is byte-identical to today
