### PR TITLE
feat(browser): skip html→markdown when server returns text/markdown

### DIFF
--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -339,6 +339,7 @@ def _extract_main_content(page: Page) -> str:
 
 def read_url(url: str) -> str:
     """Read the text of a webpage and return the text in Markdown format."""
+    global _last_response_content_type
     body_content = _execute_with_retry(_load_page, url)
     # Server responded with markdown directly — return as-is (skip html→markdown)
     if "text/markdown" in _last_response_content_type:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -33,6 +33,7 @@ from ._computer_gate import sensitive_action_gate
 
 _browser: BrowserThread | None = None
 _last_logs: dict = {"logs": [], "errors": [], "url": None}
+_last_response_content_type: str = ""
 # Persistent page state for interactive browsing (open_page/click/fill/scroll)
 _current_page: Page | None = None
 _current_context: BrowserContext | None = None
@@ -158,8 +159,8 @@ def _execute_with_retry(
 
 
 def _load_page(browser: Browser, url: str) -> str:
-    """Load a page and return its body HTML, always capturing logs"""
-    global _last_logs
+    """Load a page and return its body HTML (or markdown text), always capturing logs"""
+    global _last_logs, _last_response_content_type
 
     managed = _create_page(
         browser,
@@ -196,21 +197,29 @@ def _load_page(browser: Browser, url: str) -> str:
     page.on("pageerror", on_page_error)
 
     # Navigate to the page
+    nav_response = None
     try:
-        page.goto(url)
+        nav_response = page.goto(url)
         # Wait for page to be fully loaded (includes network idle)
         page.wait_for_load_state("networkidle")
     except Exception as e:
         page_errors.append(f"Navigation error: {e}")
         # Don't re-raise, just capture the error
 
+    # Track content type so read_url can skip html→markdown when not needed
+    _last_response_content_type = (
+        nav_response.headers.get("content-type", "") if nav_response else ""
+    )
+
     # Store logs globally
     _last_logs = {"logs": logs, "errors": page_errors, "url": url}
 
     try:
-        # Try to extract main content area first, falling back to body
-        html = _extract_main_content(page)
-        return html
+        # Server returned markdown directly — use plain text, skip HTML extraction
+        if "text/markdown" in _last_response_content_type:
+            return page.inner_text("body")
+        # Otherwise extract main content HTML for html_to_markdown conversion
+        return _extract_main_content(page)
     finally:
         managed.close()
 
@@ -330,8 +339,11 @@ def _extract_main_content(page: Page) -> str:
 
 def read_url(url: str) -> str:
     """Read the text of a webpage and return the text in Markdown format."""
-    body_html = _execute_with_retry(_load_page, url)
-    return html_to_markdown(body_html)
+    body_content = _execute_with_retry(_load_page, url)
+    # Server responded with markdown directly — return as-is (skip html→markdown)
+    if "text/markdown" in _last_response_content_type:
+        return body_content
+    return html_to_markdown(body_content)
 
 
 def read_logs() -> str:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -213,9 +213,9 @@ def _load_page(browser: Browser, url: str) -> tuple[str, bool]:
     _last_logs = {"logs": logs, "errors": page_errors, "url": url}
 
     try:
-        # Server returned markdown directly — use plain text, skip HTML extraction
+        # Server returned markdown directly — preserve source whitespace and skip HTML extraction
         if is_markdown:
-            return page.inner_text("body"), True
+            return page.text_content("body") or "", True
         # Otherwise extract main content HTML for html_to_markdown conversion
         return _extract_main_content(page), False
     finally:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -37,6 +37,7 @@ _last_logs: dict = {"logs": [], "errors": [], "url": None}
 _current_page: Page | None = None
 _current_context: BrowserContext | None = None
 logger = logging.getLogger(__name__)
+_inline_data_image = re.compile(r"!\[[^\]]*\]\(data:image[^)]*\)")
 
 
 def _is_cdp_connection() -> bool:
@@ -338,7 +339,7 @@ def read_url(url: str) -> str:
     """Read the text of a webpage and return the text in Markdown format."""
     body_content, is_markdown = _execute_with_retry(_load_page, url)
     if is_markdown:
-        return body_content
+        return _inline_data_image.sub("", body_content)
     return html_to_markdown(body_content)
 
 
@@ -1169,12 +1170,6 @@ def html_to_markdown(html):
     markdown = re.sub(r"\{(#|style|target|\.)[^}]*\}", "", markdown)
 
     # strip inline images, like: data:image/png;base64,...
-    re_strip_data = re.compile(r"!\[[^\]]*\]\(data:image[^)]*\)")
-
-    # test cases
-    assert re_strip_data.sub("", "![test](data:image/png;base64,123)") == ""
-    assert re_strip_data.sub("", "![test](data:image/png;base64,123) test") == " test"
-
-    markdown = re_strip_data.sub("", markdown)
+    markdown = _inline_data_image.sub("", markdown)
 
     return markdown

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -33,7 +33,6 @@ from ._computer_gate import sensitive_action_gate
 
 _browser: BrowserThread | None = None
 _last_logs: dict = {"logs": [], "errors": [], "url": None}
-_last_response_content_type: str = ""
 # Persistent page state for interactive browsing (open_page/click/fill/scroll)
 _current_page: Page | None = None
 _current_context: BrowserContext | None = None
@@ -158,9 +157,9 @@ def _execute_with_retry(
     raise last_error
 
 
-def _load_page(browser: Browser, url: str) -> str:
-    """Load a page and return its body HTML (or markdown text), always capturing logs"""
-    global _last_logs, _last_response_content_type
+def _load_page(browser: Browser, url: str) -> tuple[str, bool]:
+    """Load a page and return its content plus whether it is Markdown."""
+    global _last_logs
 
     managed = _create_page(
         browser,
@@ -206,20 +205,18 @@ def _load_page(browser: Browser, url: str) -> str:
         page_errors.append(f"Navigation error: {e}")
         # Don't re-raise, just capture the error
 
-    # Track content type so read_url can skip html→markdown when not needed
-    _last_response_content_type = (
-        nav_response.headers.get("content-type", "") if nav_response else ""
-    )
+    content_type = nav_response.headers.get("content-type", "") if nav_response else ""
+    is_markdown = content_type.partition(";")[0].strip().lower() == "text/markdown"
 
     # Store logs globally
     _last_logs = {"logs": logs, "errors": page_errors, "url": url}
 
     try:
         # Server returned markdown directly — use plain text, skip HTML extraction
-        if "text/markdown" in _last_response_content_type:
-            return page.inner_text("body")
+        if is_markdown:
+            return page.inner_text("body"), True
         # Otherwise extract main content HTML for html_to_markdown conversion
-        return _extract_main_content(page)
+        return _extract_main_content(page), False
     finally:
         managed.close()
 
@@ -339,10 +336,8 @@ def _extract_main_content(page: Page) -> str:
 
 def read_url(url: str) -> str:
     """Read the text of a webpage and return the text in Markdown format."""
-    global _last_response_content_type
-    body_content = _execute_with_retry(_load_page, url)
-    # Server responded with markdown directly — return as-is (skip html→markdown)
-    if "text/markdown" in _last_response_content_type:
+    body_content, is_markdown = _execute_with_retry(_load_page, url)
+    if is_markdown:
         return body_content
     return html_to_markdown(body_content)
 

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -987,6 +987,49 @@ class TestExamples:
         assert "pdf" in result.lower() or "PDF" in result
 
 
+# ── Playwright Markdown response handling ────────────────────────────
+
+
+@pytest.mark.skipif(not has_playwright(), reason="playwright not installed")
+class TestPlaywrightMarkdownResponse:
+    @pytest.mark.parametrize(
+        "content_type",
+        ["text/markdown", "Text/Markdown", "text/markdown; charset=utf-8"],
+    )
+    def test_load_page_returns_markdown_with_per_call_metadata(self, content_type):
+        from gptme.tools import _browser_playwright as bp
+
+        page = MagicMock()
+        page.goto.return_value.headers = {"content-type": content_type}
+        page.inner_text.return_value = "# Already Markdown"
+        managed = MagicMock(page=page)
+
+        with (
+            patch.object(bp, "_create_page", return_value=managed),
+            patch.object(bp, "get_context_options", return_value={}),
+        ):
+            result = bp._load_page(MagicMock(), "https://example.com")
+
+        assert result == ("# Already Markdown", True)
+        page.inner_text.assert_called_once_with("body")
+        managed.close.assert_called_once_with()
+
+    def test_read_url_uses_markdown_flag_from_same_load(self):
+        from gptme.tools import _browser_playwright as bp
+
+        with (
+            patch.object(
+                bp,
+                "_execute_with_retry",
+                return_value=("# Already Markdown", True),
+            ),
+            patch.object(bp, "html_to_markdown") as convert,
+        ):
+            assert bp.read_url("https://example.com") == "# Already Markdown"
+
+        convert.assert_not_called()
+
+
 # ── _create_page (CDP tab reuse vs launched contexts) ─────────────────
 
 

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -999,9 +999,10 @@ class TestPlaywrightMarkdownResponse:
     def test_load_page_returns_markdown_with_per_call_metadata(self, content_type):
         from gptme.tools import _browser_playwright as bp
 
+        markdown = "    indented code\n\n| a  | b |\n| -- | - |"
         page = MagicMock()
         page.goto.return_value.headers = {"content-type": content_type}
-        page.inner_text.return_value = "# Already Markdown"
+        page.text_content.return_value = markdown
         managed = MagicMock(page=page)
 
         with (
@@ -1010,8 +1011,9 @@ class TestPlaywrightMarkdownResponse:
         ):
             result = bp._load_page(MagicMock(), "https://example.com")
 
-        assert result == ("# Already Markdown", True)
-        page.inner_text.assert_called_once_with("body")
+        assert result == (markdown, True)
+        page.text_content.assert_called_once_with("body")
+        page.inner_text.assert_not_called()
         managed.close.assert_called_once_with()
 
     def test_read_url_uses_markdown_flag_from_same_load(self):

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -1029,6 +1029,17 @@ class TestPlaywrightMarkdownResponse:
 
         convert.assert_not_called()
 
+    def test_read_url_strips_inline_data_images_from_markdown(self):
+        from gptme.tools import _browser_playwright as bp
+
+        markdown = "before ![inline](data:image/png;base64,abc123) after"
+        with patch.object(
+            bp,
+            "_execute_with_retry",
+            return_value=(markdown, True),
+        ):
+            assert bp.read_url("https://example.com") == "before  after"
+
 
 # ── _create_page (CDP tab reuse vs launched contexts) ─────────────────
 


### PR DESCRIPTION
## Summary

Completes the `Accept: text/markdown` content negotiation round-trip in the Playwright browser backend.

The `Accept: text/markdown, text/plain, text/html;q=0.9, */*;q=0.8` header was already being sent on every page load (see `_load_page` and `_open_page`). But the response handling always ran `html_to_markdown()` regardless of what the server returned.

When a server honours the `Accept` header and responds with `Content-Type: text/markdown` (Cloudflare's [Markdown for Agents](https://developers.cloudflare.com/changelog/2026-02-12-markdown-for-agents) feature, adopted by many documentation sites since Feb 2026), the browser renders it as plain text in `<body>`. Piping that through `html_to_markdown` is redundant and can introduce artifacts.

## Changes

- Capture and normalize the navigation response's `Content-Type` in `_load_page`
- Return the Markdown classification alongside the content so metadata stays scoped to the corresponding read
- If the response is `text/markdown`, return `page.inner_text("body")` directly instead of extracting HTML
- In `read_url`, skip Pandoc for direct Markdown while retaining inline data-image sanitization
- Cover media-type variants, per-call metadata propagation, conversion bypass, and data-image stripping

## Fallback

No change to existing behaviour for any server that returns `text/html`, `406 Not Acceptable`, or any other content type. The Accept header is still sent; this only changes what happens when the server honours it.

## References

- Fixes #3644
- https://acceptmarkdown.com/ — spec and adoption tracker
- https://developers.cloudflare.com/changelog/2026-02-12-markdown-for-agents
