### PR TITLE
feat(daemon): Phase 1 MVP — persistent background session daemon

### DIFF
--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -1,0 +1,208 @@
+"""gptme daemon — persistent background session management.
+
+Commands:
+  gptme daemon start [--session NAME] [PROMPT...]  Start a daemon session
+  gptme daemon attach NAME                         Attach to a running daemon
+  gptme daemon list                                List running daemons
+  gptme daemon stop NAME                           Stop a daemon session
+  gptme daemon status NAME                         Show daemon status
+
+Design notes:
+- attach auto-starts a daemon when the session does not yet exist
+- Single-client MVP: only one attach at a time (Phase 3 adds multi-client)
+- Non-interactive mode: prompts are passed as arguments, not typed interactively
+  (PTY/interactive support is Phase 2)
+"""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group("daemon")
+def cli() -> None:
+    """Manage persistent background gptme sessions."""
+
+
+@cli.command("start")
+@click.option(
+    "--session",
+    "-s",
+    default=None,
+    help="Session name (defaults to a timestamp-based name)",
+)
+@click.option("--model", "-m", default=None, help="Model to use")
+@click.option("--workspace", "-w", default=None, help="Workspace directory")
+@click.argument("prompts", nargs=-1)
+def start(
+    session: str | None,
+    model: str | None,
+    workspace: str | None,
+    prompts: tuple[str, ...],
+) -> None:
+    """Start a gptme session as a background daemon.
+
+    The session runs non-interactively in the background and writes to its
+    conversation log. Attach later with 'gptme daemon attach NAME' to watch
+    output or inject additional prompts.
+
+    Example:
+
+        gptme daemon start --session mywork "Implement feature X"
+        gptme daemon attach mywork
+    """
+    from ..server.daemon import SessionDaemon, get_socket_path
+
+    if session is None:
+        from datetime import datetime, timezone
+
+        session = datetime.now(timezone.utc).strftime("daemon-%Y%m%dT%H%M%S")
+
+    sock_path = get_socket_path(session)
+    if sock_path.exists():
+        daemon = SessionDaemon(session)
+        if daemon.is_running():
+            click.echo(
+                f"Daemon '{session}' is already running (socket: {sock_path})", err=True
+            )
+            raise SystemExit(1)
+
+    # Build gptme args
+    gptme_args: list[str] = ["--name", session]
+    if model:
+        gptme_args += ["--model", model]
+    if workspace:
+        gptme_args += ["--workspace", workspace]
+    gptme_args += list(prompts)
+
+    daemon = SessionDaemon(session)
+    click.echo(f"Starting daemon '{session}'...")
+
+    # daemonize=True → double-fork; parent returns here, child runs the daemon
+    daemon.start(gptme_args, daemonize=True)
+
+    # Parent continues here
+    click.echo(f"Daemon started. Attach with: gptme daemon attach {session}")
+    click.echo(f"Socket: {sock_path}")
+
+
+@cli.command("attach")
+@click.argument("session")
+@click.option(
+    "--start-if-missing",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Auto-start the daemon if the session is not running (default: on)",
+)
+def attach_cmd(session: str, start_if_missing: bool) -> None:
+    """Attach to a running daemon session.
+
+    Prints buffered output from session start, then relays stdin/stdout in
+    real-time. Detach with Ctrl-D or Ctrl-C — the daemon keeps running.
+    """
+    from ..server.daemon import SessionDaemon, attach, get_socket_path
+
+    sock_path = get_socket_path(session)
+    if not sock_path.exists():
+        if not start_if_missing:
+            click.echo(
+                f"No running daemon for session '{session}'. Start with: gptme daemon start --session {session}",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        click.echo(f"Session '{session}' not running — starting it now...", err=True)
+        daemon = SessionDaemon(session)
+        daemon.start(["--name", session], daemonize=True)
+
+        # Wait briefly for the socket to appear
+        import time
+
+        for _ in range(20):
+            if sock_path.exists():
+                break
+            time.sleep(0.2)
+        else:
+            click.echo("Daemon did not start in time (socket not found).", err=True)
+            raise SystemExit(1)
+
+    try:
+        attach(session)
+    except FileNotFoundError as e:
+        click.echo(str(e), err=True)
+        raise SystemExit(1) from e
+    except ConnectionRefusedError as e:
+        click.echo(
+            f"Could not connect to daemon '{session}'. It may have exited.", err=True
+        )
+        raise SystemExit(1) from e
+
+
+@cli.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def list_cmd(as_json: bool) -> None:
+    """List running daemon sessions."""
+    from ..server.daemon import list_daemons
+
+    daemons = list_daemons()
+    if as_json:
+        import json
+
+        click.echo(json.dumps(daemons, indent=2))
+        return
+
+    if not daemons:
+        click.echo("No daemon sessions found.")
+        return
+
+    click.echo(f"{'SESSION':<20} {'PID':<8} {'STATUS':<10} SOCKET")
+    for d in daemons:
+        pid = str(d["pid"]) if d["pid"] else "-"
+        status = "running" if d["running"] else "stopped"
+        sock = d["socket"] or "-"
+        click.echo(f"{d['session']:<20} {pid:<8} {status:<10} {sock}")
+
+
+@cli.command("stop")
+@click.argument("session")
+def stop_cmd(session: str) -> None:
+    """Stop a running daemon session (sends SIGTERM)."""
+    from ..server.daemon import SessionDaemon
+
+    daemon = SessionDaemon(session)
+    if not daemon.is_running():
+        click.echo(f"Daemon '{session}' is not running.", err=True)
+        raise SystemExit(1)
+
+    daemon.stop()
+    click.echo(f"Stopped daemon '{session}'.")
+
+
+@cli.command("status")
+@click.argument("session")
+def status_cmd(session: str) -> None:
+    """Show status of a daemon session."""
+    from ..server.daemon import SessionDaemon, get_socket_path
+
+    daemon = SessionDaemon(session)
+    sock_path = get_socket_path(session)
+    running = daemon.is_running()
+    click.echo(f"Session:  {session}")
+    click.echo(f"Status:   {'running' if running else 'stopped'}")
+    click.echo(
+        f"Socket:   {sock_path} ({'exists' if sock_path.exists() else 'missing'})"
+    )
+
+
+# Allow `gptme-daemon` as a standalone entry point
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -23,6 +23,22 @@ import click
 logger = logging.getLogger(__name__)
 
 
+class SessionName(click.ParamType):
+    """Click type for daemon session names stored as path components."""
+
+    name = "TEXT"
+
+    def convert(self, value, param, ctx):
+        from ..util.conversation_ids import conversation_id_error
+
+        if error := conversation_id_error(value):
+            self.fail(error, param, ctx)
+        return value
+
+
+_SESSION_NAME = SessionName()
+
+
 @click.group("daemon")
 def cli() -> None:
     """Manage persistent background gptme sessions."""
@@ -33,6 +49,7 @@ def cli() -> None:
     "--session",
     "-s",
     default=None,
+    type=_SESSION_NAME,
     help="Session name (defaults to a timestamp-based name)",
 )
 @click.option("--model", "-m", default=None, help="Model to use")
@@ -91,7 +108,7 @@ def start(
 
 
 @cli.command("attach")
-@click.argument("session")
+@click.argument("session", type=_SESSION_NAME)
 @click.option(
     "--start-if-missing/--no-start-if-missing",
     default=True,
@@ -136,10 +153,8 @@ def attach_cmd(session: str, start_if_missing: bool) -> None:
     except FileNotFoundError as e:
         click.echo(str(e), err=True)
         raise SystemExit(1) from e
-    except (ConnectionRefusedError, ConnectionResetError) as e:
-        click.echo(
-            f"Could not connect to daemon '{session}'. It may have exited.", err=True
-        )
+    except (ConnectionRefusedError, ConnectionResetError, TimeoutError) as e:
+        click.echo(f"Could not attach to daemon '{session}': {e}", err=True)
         raise SystemExit(1) from e
 
 
@@ -169,7 +184,7 @@ def list_cmd(as_json: bool) -> None:
 
 
 @cli.command("stop")
-@click.argument("session")
+@click.argument("session", type=_SESSION_NAME)
 def stop_cmd(session: str) -> None:
     """Stop a running daemon session (sends SIGTERM)."""
     from ..server.daemon import SessionDaemon
@@ -184,7 +199,7 @@ def stop_cmd(session: str) -> None:
 
 
 @cli.command("status")
-@click.argument("session")
+@click.argument("session", type=_SESSION_NAME)
 def status_cmd(session: str) -> None:
     """Show status of a daemon session."""
     from ..server.daemon import SessionDaemon, get_socket_path

--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -194,7 +194,11 @@ def stop_cmd(session: str) -> None:
         click.echo(f"Daemon '{session}' is not running.", err=True)
         raise SystemExit(1)
 
-    daemon.stop()
+    try:
+        daemon.stop()
+    except TimeoutError as e:
+        click.echo(f"Timed out waiting for daemon '{session}' to stop.", err=True)
+        raise SystemExit(1) from e
     click.echo(f"Stopped daemon '{session}'.")
 
 

--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -199,6 +199,9 @@ def stop_cmd(session: str) -> None:
     except TimeoutError as e:
         click.echo(f"Timed out waiting for daemon '{session}' to stop.", err=True)
         raise SystemExit(1) from e
+    except RuntimeError as e:
+        click.echo(str(e), err=True)
+        raise SystemExit(1) from e
     click.echo(f"Stopped daemon '{session}'.")
 
 

--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -71,19 +71,19 @@ def start(
             )
             raise SystemExit(1)
 
-    # Build gptme args
+    # Build the stable arguments reused for each queued turn. Prompts are kept
+    # separate so later attached input can run as another turn in this session.
     gptme_args: list[str] = ["--name", session]
     if model:
         gptme_args += ["--model", model]
     if workspace:
         gptme_args += ["--workspace", workspace]
-    gptme_args += list(prompts)
 
     daemon = SessionDaemon(session)
     click.echo(f"Starting daemon '{session}'...")
 
     # daemonize=True → double-fork; parent returns here, child runs the daemon
-    daemon.start(gptme_args, daemonize=True)
+    daemon.start(gptme_args, prompts=list(prompts), daemonize=True)
 
     # Parent continues here
     click.echo(f"Daemon started. Attach with: gptme daemon attach {session}")
@@ -118,17 +118,18 @@ def attach_cmd(session: str, start_if_missing: bool) -> None:
 
         click.echo(f"Session '{session}' not running — starting it now...", err=True)
         daemon = SessionDaemon(session)
-        daemon.start(["--name", session], daemonize=True)
+        daemon.start(["--name", session], prompts=[], daemonize=True)
 
-        # Wait briefly for the socket to appear
+        # Wait briefly for the daemon to start accepting connections. Checking
+        # only path existence races with bind/listen and stale socket files.
         import time
 
         for _ in range(20):
-            if sock_path.exists():
+            if daemon.is_running():
                 break
             time.sleep(0.2)
         else:
-            click.echo("Daemon did not start in time (socket not found).", err=True)
+            click.echo("Daemon did not start in time.", err=True)
             raise SystemExit(1)
 
     try:
@@ -136,7 +137,7 @@ def attach_cmd(session: str, start_if_missing: bool) -> None:
     except FileNotFoundError as e:
         click.echo(str(e), err=True)
         raise SystemExit(1) from e
-    except ConnectionRefusedError as e:
+    except (ConnectionRefusedError, ConnectionResetError) as e:
         click.echo(
             f"Could not connect to daemon '{session}'. It may have exited.", err=True
         )

--- a/gptme/cli/cmd_daemon.py
+++ b/gptme/cli/cmd_daemon.py
@@ -93,11 +93,10 @@ def start(
 @cli.command("attach")
 @click.argument("session")
 @click.option(
-    "--start-if-missing",
-    is_flag=True,
+    "--start-if-missing/--no-start-if-missing",
     default=True,
     show_default=True,
-    help="Auto-start the daemon if the session is not running (default: on)",
+    help="Auto-start the daemon if the session is not running",
 )
 def attach_cmd(session: str, start_if_missing: bool) -> None:
     """Attach to a running daemon session.

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -474,6 +474,9 @@ Utilities:
   gptme chats search Q    Search conversations for query (full options)
   gptme chats send ID MSG Queue a prompt for a running chat from another terminal
   gptme chats rename      Rename a conversation
+  gptme daemon start      Start a gptme session as a background daemon
+  gptme daemon attach     Attach to a running daemon session
+  gptme daemon list       List running daemon sessions
   gptme models list       List available models
   gptme snapshot list     List workspace snapshots outside a session
   gptme context index     Index project files for RAG

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -208,6 +208,9 @@ class SessionDaemon:
                 continue
             try:
                 self._run_turn(gptme_args, prompts)
+            except Exception as exc:
+                logger.exception("Daemon turn failed")
+                self._publish_output(b"", f"\n[daemon error] Turn failed: {exc}\n")
             finally:
                 self._turn_queue.task_done()
 
@@ -215,7 +218,10 @@ class SessionDaemon:
         # stdin must be DEVNULL.  A PIPE is non-TTY input, so gptme would wait for
         # EOF while trying to consume piped input before processing CLI prompts.
         proc = subprocess.Popen(
-            [sys.executable, "-m", "gptme", "--non-interactive"] + gptme_args + prompts,
+            [sys.executable, "-m", "gptme", "--non-interactive"]
+            + gptme_args
+            + ["--"]
+            + prompts,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -278,7 +284,13 @@ class SessionDaemon:
             if not rlist:
                 continue
 
-            client, _ = server_sock.accept()
+            try:
+                client, _ = server_sock.accept()
+            except OSError:
+                if self._stop_event.is_set():
+                    break
+                logger.warning("Daemon accept failed", exc_info=True)
+                continue
             client.setblocking(True)
             try:
                 self._serve_client(client)
@@ -311,9 +323,10 @@ class SessionDaemon:
                 return
             self._client = client
 
+        recv_buffer = bytearray()
         while not self._stop_event.is_set():
             try:
-                msg = recv_msg(client)
+                msg = recv_msg(client, recv_buffer)
             except TimeoutError:
                 continue
             except (OSError, ValueError):

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -19,6 +19,7 @@ later attachments continue the conversation after earlier turns have exited.
 from __future__ import annotations
 
 import codecs
+import fcntl
 import logging
 import os
 import queue
@@ -33,7 +34,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Protocol
+    from typing import IO, Protocol
 
     class _ReadableFD(Protocol):
         def fileno(self) -> int: ...
@@ -86,6 +87,7 @@ class SessionDaemon:
         self._stop_event = threading.Event()
         self._proc_lock = threading.Lock()
         self._proc: subprocess.Popen[bytes] | None = None
+        self._pid_file: IO[str] | None = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -114,28 +116,48 @@ class SessionDaemon:
         try:
             pid = int(self.pid_path.read_text())
             os.kill(pid, 0)
+            pid_file = self.pid_path.open()
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             return False
-        # The MVP intentionally serves one attached client at a time. A handshake
-        # probe would therefore time out while that client is attached even though
-        # the daemon is healthy. The PID and bound socket are the daemon-owned
-        # lifecycle markers; cleanup removes both when the process exits.
-        return True
+        try:
+            fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        else:
+            fcntl.flock(pid_file, fcntl.LOCK_UN)
+            return False
+        finally:
+            pid_file.close()
 
     def stop(self) -> None:
-        """Send SIGTERM to the daemon process."""
+        """Send SIGTERM only to the process that owns the daemon PID file."""
+        if not self.is_running():
+            return
         try:
             pid = int(self.pid_path.read_text())
             os.kill(pid, signal.SIGTERM)
-        except (FileNotFoundError, ProcessLookupError, ValueError):
+        except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             pass
 
     # ------------------------------------------------------------------
     # Internal — runs in the daemon process
     # ------------------------------------------------------------------
 
+    def _acquire_pid_file(self) -> None:
+        pid_file = self.pid_path.open("a+")
+        try:
+            fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            pid_file.close()
+            raise
+        pid_file.seek(0)
+        pid_file.truncate()
+        pid_file.write(str(os.getpid()))
+        pid_file.flush()
+        self._pid_file = pid_file
+
     def _run(self, gptme_args: list[str], prompts: list[str]) -> None:
-        self.pid_path.write_text(str(os.getpid()))
+        self._acquire_pid_file()
 
         server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -336,8 +358,11 @@ class SessionDaemon:
                     self._client = None
 
     def _cleanup(self) -> None:
-        for path in (self.socket_path, self.pid_path):
-            path.unlink(missing_ok=True)
+        self.socket_path.unlink(missing_ok=True)
+        if self._pid_file is not None:
+            self._pid_file.close()
+            self._pid_file = None
+            self.pid_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -439,12 +464,12 @@ def list_daemons() -> list[dict]:
     for pid_file in daemon_dir.glob("*.pid"):
         name = pid_file.stem
         sock = daemon_dir / f"{name}.socket"
+        daemon = SessionDaemon(name)
+        running = daemon.is_running()
         try:
             pid = int(pid_file.read_text())
-            os.kill(pid, 0)
-            running = sock.exists()
-        except (ValueError, ProcessLookupError, PermissionError):
-            running = False
+        except ValueError:
+            pid = 0
         result.append(
             {
                 "session": name,

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -617,7 +617,13 @@ def _stop_via_socket(sock_path: Path) -> None:
     try:
         conn.connect(str(sock_path))
         send_msg(conn, IPCMessage(type="signal", data={"signal": "SIGTERM"}))
-    except OSError:
+        # Keep the receive half open until the daemon consumes the signal.  A
+        # regular client slot sends its ready frame before reading the signal;
+        # closing here could make that write fail and discard the stop request.
+        conn.shutdown(socket.SHUT_WR)
+        while recv_msg(conn) is not None:
+            pass
+    except (OSError, ValueError):
         pass
     finally:
         conn.close()

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -616,14 +616,6 @@ def _stop_via_socket(sock_path: Path) -> None:
     conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
     try:
         conn.connect(str(sock_path))
-        # Check if ready message is available (short timeout for control connections)
-        conn.settimeout(0.1)
-        try:
-            recv_msg(conn)
-        except (OSError, ValueError, TimeoutError):
-            pass
-        # Send stop signal (extend timeout for sending)
-        conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
         send_msg(conn, IPCMessage(type="signal", data={"signal": "SIGTERM"}))
     except OSError:
         pass

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -616,6 +616,14 @@ def _stop_via_socket(sock_path: Path) -> None:
     conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
     try:
         conn.connect(str(sock_path))
+        # Check if ready message is available (short timeout for control connections)
+        conn.settimeout(0.1)
+        try:
+            recv_msg(conn)
+        except (OSError, ValueError, TimeoutError):
+            pass
+        # Send stop signal (extend timeout for sending)
+        conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
         send_msg(conn, IPCMessage(type="signal", data={"signal": "SIGTERM"}))
     except OSError:
         pass

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -138,12 +138,19 @@ class SessionDaemon:
             pid_file.close()
 
     def stop(self) -> None:
-        """Send SIGTERM only to the process that owns the daemon PID file."""
-        if not self.is_running():
+        """Signal the daemon while continuously proving PID-file ownership."""
+        if not self.socket_path.exists():
             return
         try:
-            pid = int(self.pid_path.read_text())
-            os.kill(pid, signal.SIGTERM)
+            with self.pid_path.open() as pid_file:
+                try:
+                    fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pid_file.seek(0)
+                    pid = int(pid_file.read())
+                    os.kill(pid, signal.SIGTERM)
+                else:
+                    fcntl.flock(pid_file, fcntl.LOCK_UN)
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             pass
 
@@ -475,7 +482,7 @@ def attach(session_name: str) -> None:
         while not stop_event.is_set():
             try:
                 msg = recv_msg(conn)
-            except OSError:
+            except (OSError, ValueError):
                 break
             if msg is None:
                 break

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -47,6 +47,13 @@ logger = logging.getLogger(__name__)
 
 # Output ring-buffer: send this many bytes of history to a newly attached client
 _OUTPUT_HISTORY_BYTES = 64 * 1024
+# Short polling timeout keeps disconnect and shutdown detection responsive.
+_CLIENT_READ_TIMEOUT = 0.2
+# Writes are bounded independently: large terminal output may legitimately take
+# longer than one read-poll interval, but a non-reading client cannot block a turn.
+_CLIENT_WRITE_TIMEOUT = 5.0
+# A queued second attach must fail instead of waiting forever for the only client slot.
+_ATTACH_HANDSHAKE_TIMEOUT = 2.0
 
 
 def get_daemon_dir() -> Path:
@@ -255,6 +262,7 @@ class SessionDaemon:
     def _publish_output(self, chunk: bytes, text: str | None = None) -> None:
         if text is None:
             text = chunk.decode("utf-8", errors="replace")
+        failed_client: socket.socket | None = None
         with self._output_lock:
             if text:
                 self._output_buf.append(text)
@@ -264,13 +272,14 @@ class SessionDaemon:
                     self._output_buf_size -= len(dropped.encode())
 
             if self._client is not None and text:
-                try:
-                    send_msg(
-                        self._client,
-                        IPCMessage(type="output", data=text),
-                    )
-                except OSError:
+                if not self._write_client(
+                    self._client, IPCMessage(type="output", data=text)
+                ):
+                    failed_client = self._client
                     self._client = None
+
+        if failed_client is not None:
+            self._disconnect_client(failed_client)
 
     def _accept_loop(self, server_sock: socket.socket) -> None:
         """Accept one client at a time while the daemon remains alive."""
@@ -302,24 +311,18 @@ class SessionDaemon:
 
     def _serve_client(self, client: socket.socket) -> None:
         """Replay output history, then queue prompts received from the client."""
-        # Bound every write, including the initial handshake and history replay.
-        # A client that connects without reading must not stall the daemon worker.
-        client.settimeout(0.2)
+        client.settimeout(_CLIENT_READ_TIMEOUT)
         # Publish the client only after history is fully sent.  Holding the same
         # lock used by _publish_output makes history-before-live ordering atomic.
         with self._output_lock:
             history = "".join(self._output_buf)
-            try:
-                send_msg(
-                    client,
-                    IPCMessage(type="status", data={"ready": True}),
-                )
-                if history:
-                    send_msg(
-                        client,
-                        IPCMessage(type="output", data=history),
-                    )
-            except OSError:
+            if not self._write_client(
+                client, IPCMessage(type="status", data={"ready": True})
+            ):
+                return
+            if history and not self._write_client(
+                client, IPCMessage(type="output", data=history)
+            ):
                 return
             self._client = client
 
@@ -363,12 +366,33 @@ class SessionDaemon:
                 break
 
     def _send_to_client(self, client: socket.socket, msg: IPCMessage) -> None:
+        failed = False
         with self._output_lock:
-            if self._client is client:
-                try:
-                    send_msg(client, msg)
-                except OSError:
-                    self._client = None
+            if self._client is client and not self._write_client(client, msg):
+                self._client = None
+                failed = True
+        if failed:
+            self._disconnect_client(client)
+
+    @staticmethod
+    def _write_client(client: socket.socket, msg: IPCMessage) -> bool:
+        """Send one frame with a write-specific timeout."""
+        client.settimeout(_CLIENT_WRITE_TIMEOUT)
+        try:
+            send_msg(client, msg)
+        except OSError:
+            return False
+        finally:
+            client.settimeout(_CLIENT_READ_TIMEOUT)
+        return True
+
+    @staticmethod
+    def _disconnect_client(client: socket.socket) -> None:
+        """Wake the synchronous client loop after a write failure."""
+        try:
+            client.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
 
     def _cleanup(self) -> None:
         self.socket_path.unlink(missing_ok=True)
@@ -419,8 +443,15 @@ def attach(session_name: str) -> None:
         raise FileNotFoundError(f"No daemon socket for session '{session_name}'")
 
     conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
     conn.connect(str(sock_path))
-    ready = recv_msg(conn)
+    try:
+        ready = recv_msg(conn)
+    except TimeoutError as exc:
+        conn.close()
+        raise TimeoutError(
+            f"Daemon '{session_name}' already has an attached client"
+        ) from exc
     if (
         ready is None
         or ready.type != "status"
@@ -429,6 +460,7 @@ def attach(session_name: str) -> None:
     ):
         conn.close()
         raise ConnectionResetError(f"Daemon '{session_name}' closed during attach")
+    conn.settimeout(None)
 
     stop_event = threading.Event()
 

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -116,7 +116,11 @@ class SessionDaemon:
             os.kill(pid, 0)
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             return False
-        return _socket_is_accepting(self.socket_path)
+        # The MVP intentionally serves one attached client at a time. A handshake
+        # probe would therefore time out while that client is attached even though
+        # the daemon is healthy. The PID and bound socket are the daemon-owned
+        # lifecycle markers; cleanup removes both when the process exits.
+        return True
 
     def stop(self) -> None:
         """Send SIGTERM to the daemon process."""
@@ -245,6 +249,8 @@ class SessionDaemon:
         while not self._stop_event.is_set():
             try:
                 rlist, _, _ = select.select([server_sock], [], [], 0.2)
+            except InterruptedError:
+                continue
             except OSError:
                 break
             if not rlist:
@@ -262,6 +268,9 @@ class SessionDaemon:
 
     def _serve_client(self, client: socket.socket) -> None:
         """Replay output history, then queue prompts received from the client."""
+        # Bound every write, including the initial handshake and history replay.
+        # A client that connects without reading must not stall the daemon worker.
+        client.settimeout(0.2)
         # Publish the client only after history is fully sent.  Holding the same
         # lock used by _publish_output makes history-before-live ordering atomic.
         with self._output_lock:
@@ -280,7 +289,6 @@ class SessionDaemon:
                 return
             self._client = client
 
-        client.settimeout(0.2)
         while not self._stop_event.is_set():
             try:
                 msg = recv_msg(client)
@@ -424,24 +432,6 @@ def attach(session_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _socket_is_accepting(path: Path) -> bool:
-    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    probe.settimeout(0.5)
-    try:
-        probe.connect(str(path))
-        ready = recv_msg(probe)
-        return (
-            ready is not None
-            and ready.type == "status"
-            and isinstance(ready.data, dict)
-            and bool(ready.data.get("ready"))
-        )
-    except (OSError, ValueError):
-        return False
-    finally:
-        probe.close()
-
-
 def list_daemons() -> list[dict]:
     """Return info dicts for known daemons."""
     daemon_dir = get_daemon_dir()
@@ -452,7 +442,7 @@ def list_daemons() -> list[dict]:
         try:
             pid = int(pid_file.read_text())
             os.kill(pid, 0)
-            running = _socket_is_accepting(sock)
+            running = sock.exists()
         except (ValueError, ProcessLookupError, PermissionError):
             running = False
         result.append(

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -148,7 +148,7 @@ class SessionDaemon:
                 except BlockingIOError:
                     pid_file.seek(0)
                     pid = int(pid_file.read())
-                    os.kill(pid, signal.SIGTERM)
+                    _signal_owned_pid(pid_file, pid)
                 else:
                     fcntl.flock(pid_file, fcntl.LOCK_UN)
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
@@ -410,9 +410,11 @@ class SessionDaemon:
             return
         self.socket_path.unlink(missing_ok=True)
         if self._pid_file is not None:
+            # Unlink while this process still holds the lock on this exact inode.
+            # A successor then creates a new path rather than racing this unlink.
+            self.pid_path.unlink(missing_ok=True)
             self._pid_file.close()
             self._pid_file = None
-            self.pid_path.unlink(missing_ok=True)
         self._owns_paths = False
 
 
@@ -499,16 +501,110 @@ def attach(session_name: str) -> None:
 
     seq = 0
     try:
-        for line in sys.stdin:
-            if stop_event.is_set():
+        while not stop_event.is_set():
+            if not _stdin_has_data(0.2):
+                continue
+            line = sys.stdin.readline()
+            if line == "":
                 break
             seq += 1
-            send_msg(conn, IPCMessage(type="input", data=line, seq=seq))
+            try:
+                send_msg(conn, IPCMessage(type="input", data=line, seq=seq))
+            except OSError:
+                break
     except (KeyboardInterrupt, EOFError):
         pass
     finally:
         stop_event.set()
         conn.close()
+
+
+def _signal_owned_pid(pid_file: IO[str], pid: int) -> None:
+    """Signal ``pid`` only if the same PID-file inode is still lock-owned.
+
+    ``pidfd`` pins process identity on Linux. Rechecking the advisory lock
+    (and the PID bytes on that inode) after the pin aborts if the owner
+    exited and the PID was reused before the signal.
+    """
+    pidfd = _pidfd_open(pid)
+    try:
+        if not _pid_file_lock_held(pid_file):
+            return
+        pid_file.seek(0)
+        current = int(pid_file.read() or "0")
+        if current != pid:
+            return
+        if pidfd is not None:
+            _pidfd_send_signal(pidfd, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
+    finally:
+        if pidfd is not None:
+            os.close(pidfd)
+
+
+def _pid_file_lock_held(pid_file: IO[str]) -> bool:
+    try:
+        fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return True
+    fcntl.flock(pid_file, fcntl.LOCK_UN)
+    return False
+
+
+# Linux asm-generic syscall numbers. Used when the interpreter was built
+# without exposing os.pidfd_open / signal.pidfd_send_signal.
+_SYS_PIDFD_SEND_SIGNAL = 424
+_SYS_PIDFD_OPEN = 434
+
+
+def _pidfd_open(pid: int) -> int | None:
+    """Return a pidfd, or None if this platform cannot pin process identity."""
+    opener = getattr(os, "pidfd_open", None)
+    if opener is not None:
+        return opener(pid)
+    return _linux_syscall(_SYS_PIDFD_OPEN, pid, 0)
+
+
+def _pidfd_send_signal(pidfd: int, signum: int) -> None:
+    sender = getattr(signal, "pidfd_send_signal", None)
+    if sender is not None:
+        sender(pidfd, signum)
+        return
+    result = _linux_syscall(_SYS_PIDFD_SEND_SIGNAL, pidfd, signum, 0, 0)
+    if result is None:
+        raise OSError("pidfd_send_signal is not available")
+
+
+def _linux_syscall(number: int, *args: int) -> int | None:
+    if sys.platform != "linux":
+        return None
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        result = libc.syscall(number, *args)
+    except (OSError, AttributeError):
+        return None
+    if result < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return int(result)
+
+
+def _stdin_has_data(timeout: float) -> bool:
+    """True if stdin is readable, or if it cannot be selected (e.g. StringIO)."""
+    try:
+        fd = sys.stdin.fileno()
+    except (AttributeError, OSError, ValueError):
+        return True
+    try:
+        rlist, _, _ = select.select([fd], [], [], timeout)
+    except InterruptedError:
+        return False
+    except (OSError, ValueError):
+        return True
+    return bool(rlist)
 
 
 # ---------------------------------------------------------------------------

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -166,6 +166,18 @@ class SessionDaemon:
             signaled = _stop_via_socket(self.socket_path)
         if signaled:
             _wait_for_daemon_stop(self.pid_path, self.socket_path)
+            return
+        # Do not report success when a live owner still holds the PID-file lock.
+        # Checking the lock avoids os.kill of a numeric PID (which can race reuse).
+        try:
+            with self.pid_path.open() as pid_file:
+                still_owned = _pid_file_lock_held(pid_file)
+        except FileNotFoundError:
+            return
+        if still_owned:
+            raise RuntimeError(
+                f"Failed to signal daemon '{self.session_name}'; it may still be running"
+            )
 
     # ------------------------------------------------------------------
     # Internal — runs in the daemon process

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -95,6 +95,7 @@ class SessionDaemon:
         self._proc_lock = threading.Lock()
         self._proc: subprocess.Popen[bytes] | None = None
         self._pid_file: IO[str] | None = None
+        self._owns_paths = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -162,6 +163,7 @@ class SessionDaemon:
         pid_file.write(str(os.getpid()))
         pid_file.flush()
         self._pid_file = pid_file
+        self._owns_paths = True
 
     def _run(self, gptme_args: list[str], prompts: list[str]) -> None:
         self._acquire_pid_file()
@@ -395,11 +397,16 @@ class SessionDaemon:
             pass
 
     def _cleanup(self) -> None:
+        # A child that lost PID-file lock acquisition must not remove paths owned
+        # by the competing daemon that won the same-session startup race.
+        if not self._owns_paths:
+            return
         self.socket_path.unlink(missing_ok=True)
         if self._pid_file is not None:
             self._pid_file.close()
             self._pid_file = None
             self.pid_path.unlink(missing_ok=True)
+        self._owns_paths = False
 
 
 # ---------------------------------------------------------------------------

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -1,0 +1,355 @@
+"""gptme session daemon — Phase 1 MVP.
+
+Decouples session lifecycle from terminal attachment using:
+- Unix domain socket for I/O forwarding
+- Simple input/output/signal message protocol
+- Reused session persistence (existing JSONL conversation log)
+
+Design decisions (resolved 2026-08-27):
+- Auto-start on attach: yes (Option A — better UX, matches tmux)
+- Socket location: ~/.config/gptme/daemon/<name>.socket (survives /tmp cleanup)
+- Multi-client: single-client for MVP (Phase 3 for observe-only fan-out)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import select
+import socket
+import subprocess
+import sys
+import threading
+from collections import deque
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import IO
+
+from .ipc_protocol import IPCMessage, recv_msg, send_msg
+
+logger = logging.getLogger(__name__)
+
+# Output ring-buffer: send this many bytes of history to a newly attached client
+_OUTPUT_HISTORY_BYTES = 64 * 1024
+
+
+def get_daemon_dir() -> Path:
+    from ..dirs import get_config_dir
+
+    d = get_config_dir() / "daemon"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def get_socket_path(session_name: str) -> Path:
+    return get_daemon_dir() / f"{session_name}.socket"
+
+
+def get_pid_path(session_name: str) -> Path:
+    return get_daemon_dir() / f"{session_name}.pid"
+
+
+# ---------------------------------------------------------------------------
+# Daemon process
+# ---------------------------------------------------------------------------
+
+
+class SessionDaemon:
+    """Background daemon that owns one gptme session and accepts socket clients."""
+
+    def __init__(self, session_name: str) -> None:
+        self.session_name = session_name
+        self.socket_path = get_socket_path(session_name)
+        self.pid_path = get_pid_path(session_name)
+        self._output_buf: deque[bytes] = deque()
+        self._output_buf_size = 0
+        self._buf_lock = threading.Lock()
+        self._client_lock = threading.Lock()
+        self._client: socket.socket | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self, gptme_args: list[str], daemonize: bool = True) -> None:
+        """Daemonize and run; returns immediately in the parent."""
+        if daemonize:
+            _daemonize()
+        # Now we are the daemon process
+        try:
+            self._run(gptme_args)
+        except Exception:
+            logger.exception("Daemon crashed")
+        finally:
+            self._cleanup()
+
+    def is_running(self) -> bool:
+        if not self.socket_path.exists():
+            return False
+        try:
+            pid = int(self.pid_path.read_text())
+            os.kill(pid, 0)  # check existence
+            return True
+        except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
+            return False
+
+    def stop(self) -> None:
+        """Send SIGTERM to the daemon process."""
+        try:
+            pid = int(self.pid_path.read_text())
+            os.kill(pid, 15)  # SIGTERM
+        except (FileNotFoundError, ProcessLookupError, ValueError):
+            pass
+
+    # ------------------------------------------------------------------
+    # Internal — runs in the daemon process
+    # ------------------------------------------------------------------
+
+    def _run(self, gptme_args: list[str]) -> None:
+        self.pid_path.write_text(str(os.getpid()))
+
+        # Set up Unix socket
+        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+        server_sock.bind(str(self.socket_path))
+        self.socket_path.chmod(0o600)
+        server_sock.listen(1)
+        server_sock.setblocking(False)
+
+        # Start gptme subprocess (non-interactive, stdin/stdout piped)
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "gptme", "--non-interactive"] + gptme_args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        assert proc.stdout is not None
+        assert proc.stdin is not None
+
+        # Thread: read subprocess output → buffer + forward to client
+        output_thread = threading.Thread(
+            target=self._pump_output,
+            args=(proc.stdout,),
+            daemon=True,
+        )
+        output_thread.start()
+
+        # Main loop: accept connections and forward client input to subprocess
+        try:
+            self._accept_loop(server_sock, proc)
+        finally:
+            proc.terminate()
+            proc.wait()
+
+    def _pump_output(self, stdout: IO[bytes]) -> None:
+        """Read subprocess stdout, buffer it, and forward to connected client."""
+        for chunk in iter(lambda: stdout.read(4096), b""):
+            with self._buf_lock:
+                self._output_buf.append(chunk)
+                self._output_buf_size += len(chunk)
+                # Trim ring buffer
+                while self._output_buf_size > _OUTPUT_HISTORY_BYTES:
+                    dropped = self._output_buf.popleft()
+                    self._output_buf_size -= len(dropped)
+
+            # Forward to client if connected
+            with self._client_lock:
+                client = self._client
+            if client is not None:
+                try:
+                    send_msg(
+                        client,
+                        IPCMessage(
+                            type="output", data=chunk.decode("utf-8", errors="replace")
+                        ),
+                    )
+                except OSError:
+                    with self._client_lock:
+                        self._client = None
+
+    def _accept_loop(self, server_sock: socket.socket, proc: subprocess.Popen) -> None:
+        """Accept one client at a time and forward their input to the subprocess."""
+        while proc.poll() is None:
+            try:
+                rlist, _, _ = select.select([server_sock], [], [], 1.0)
+            except OSError:
+                break
+            if not rlist:
+                continue
+
+            client, _ = server_sock.accept()
+            client.setblocking(True)
+            with self._client_lock:
+                self._client = client
+
+            try:
+                self._serve_client(client, proc)
+            finally:
+                with self._client_lock:
+                    self._client = None
+                client.close()
+
+    def _serve_client(self, client: socket.socket, proc: subprocess.Popen) -> None:
+        """Send output history then relay client input → subprocess stdin."""
+        # Send buffered output history to the new client
+        with self._buf_lock:
+            history = b"".join(self._output_buf)
+        if history:
+            try:
+                send_msg(
+                    client,
+                    IPCMessage(
+                        type="output", data=history.decode("utf-8", errors="replace")
+                    ),
+                )
+            except OSError:
+                return
+
+        # Relay client input to subprocess stdin
+        while proc.poll() is None:
+            msg = recv_msg(client)
+            if msg is None:
+                break  # client disconnected
+            if msg.type == "input":
+                data = msg.data if isinstance(msg.data, str) else str(msg.data)
+                try:
+                    assert proc.stdin is not None
+                    proc.stdin.write(data.encode())
+                    proc.stdin.flush()
+                except OSError:
+                    break
+            elif msg.type == "status":
+                try:
+                    send_msg(
+                        client,
+                        IPCMessage(
+                            type="status",
+                            data={
+                                "session": self.session_name,
+                                "pid": os.getpid(),
+                                "running": proc.poll() is None,
+                            },
+                        ),
+                    )
+                except OSError:
+                    break
+            elif (
+                msg.type == "signal"
+                and isinstance(msg.data, dict)
+                and msg.data.get("signal") == "SIGTERM"
+            ):
+                proc.terminate()
+                break
+
+    def _cleanup(self) -> None:
+        for path in (self.socket_path, self.pid_path):
+            path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Daemonization (double-fork on POSIX)
+# ---------------------------------------------------------------------------
+
+
+def _daemonize() -> None:
+    """Double-fork to create a proper daemon process."""
+    if os.fork() > 0:
+        # Parent exits — child continues
+        os._exit(0)
+
+    os.setsid()  # new session leader
+
+    if os.fork() > 0:
+        # Second parent exits — grandchild is fully detached
+        os._exit(0)
+
+    # Redirect stdin/stdout/stderr to /dev/null
+    devnull = os.open(os.devnull, os.O_RDWR)
+    for fd in (0, 1, 2):
+        os.dup2(devnull, fd)
+    os.close(devnull)
+
+
+# ---------------------------------------------------------------------------
+# Attach client
+# ---------------------------------------------------------------------------
+
+
+def attach(session_name: str) -> None:
+    """Connect to a running daemon and relay stdin/stdout."""
+    sock_path = get_socket_path(session_name)
+    if not sock_path.exists():
+        raise FileNotFoundError(f"No daemon socket for session '{session_name}'")
+
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.connect(str(sock_path))
+
+    # Thread: receive daemon output → print to stdout
+    stop_event = threading.Event()
+
+    def _receive() -> None:
+        while not stop_event.is_set():
+            try:
+                msg = recv_msg(conn)
+            except OSError:
+                break
+            if msg is None:
+                break
+            if msg.type in ("output", "error"):
+                data = msg.data if isinstance(msg.data, str) else str(msg.data)
+                sys.stdout.write(data)
+                sys.stdout.flush()
+            elif msg.type == "status":
+                print(f"[daemon status] {msg.data}", flush=True)
+        stop_event.set()
+
+    recv_thread = threading.Thread(target=_receive, daemon=True)
+    recv_thread.start()
+
+    # Main thread: read stdin → send to daemon
+    seq = 0
+    try:
+        for line in sys.stdin:
+            if stop_event.is_set():
+                break
+            seq += 1
+            send_msg(conn, IPCMessage(type="input", data=line, seq=seq))
+    except (KeyboardInterrupt, EOFError):
+        pass
+    finally:
+        stop_event.set()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# List running daemons
+# ---------------------------------------------------------------------------
+
+
+def list_daemons() -> list[dict]:
+    """Return info dicts for running daemons."""
+    daemon_dir = get_daemon_dir()
+    result = []
+    for pid_file in daemon_dir.glob("*.pid"):
+        name = pid_file.stem
+        try:
+            pid = int(pid_file.read_text())
+            os.kill(pid, 0)
+            running = True
+        except (ValueError, ProcessLookupError, PermissionError):
+            running = False
+        sock = daemon_dir / f"{name}.socket"
+        result.append(
+            {
+                "session": name,
+                "pid": pid if running else None,
+                "running": running,
+                "socket": str(sock) if sock.exists() else None,
+            }
+        )
+    return result

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -9,13 +9,21 @@ Design decisions (resolved 2026-08-27):
 - Auto-start on attach: yes (Option A — better UX, matches tmux)
 - Socket location: ~/.config/gptme/daemon/<name>.socket (survives /tmp cleanup)
 - Multi-client: single-client for MVP (Phase 3 for observe-only fan-out)
+
+Each submitted prompt runs as a non-interactive turn against the same named
+conversation.  The daemon, rather than an individual gptme subprocess, owns the
+persistent lifecycle.  This lets an idle daemon accept a first prompt and lets
+later attachments continue the conversation after earlier turns have exited.
 """
 
 from __future__ import annotations
 
+import codecs
 import logging
 import os
+import queue
 import select
+import signal
 import socket
 import subprocess
 import sys
@@ -25,8 +33,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import IO
+    from typing import Protocol
 
+    class _ReadableFD(Protocol):
+        def fileno(self) -> int: ...
+
+
+from ..util.conversation_ids import validate_conversation_id
 from .ipc_protocol import IPCMessage, recv_msg, send_msg
 
 logger = logging.getLogger(__name__)
@@ -44,11 +57,11 @@ def get_daemon_dir() -> Path:
 
 
 def get_socket_path(session_name: str) -> Path:
-    return get_daemon_dir() / f"{session_name}.socket"
+    return get_daemon_dir() / f"{validate_conversation_id(session_name)}.socket"
 
 
 def get_pid_path(session_name: str) -> Path:
-    return get_daemon_dir() / f"{session_name}.pid"
+    return get_daemon_dir() / f"{validate_conversation_id(session_name)}.pid"
 
 
 # ---------------------------------------------------------------------------
@@ -60,26 +73,36 @@ class SessionDaemon:
     """Background daemon that owns one gptme session and accepts socket clients."""
 
     def __init__(self, session_name: str) -> None:
-        self.session_name = session_name
+        self.session_name = validate_conversation_id(session_name)
         self.socket_path = get_socket_path(session_name)
         self.pid_path = get_pid_path(session_name)
-        self._output_buf: deque[bytes] = deque()
+        self._output_buf: deque[str] = deque()
         self._output_buf_size = 0
-        self._buf_lock = threading.Lock()
-        self._client_lock = threading.Lock()
+        # Serializes history replay, client publication, and all framed writes.
+        # A single lock prevents live output from interleaving with history frames.
+        self._output_lock = threading.Lock()
         self._client: socket.socket | None = None
+        self._turn_queue: queue.Queue[list[str]] = queue.Queue()
+        self._stop_event = threading.Event()
+        self._proc_lock = threading.Lock()
+        self._proc: subprocess.Popen[bytes] | None = None
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def start(self, gptme_args: list[str], daemonize: bool = True) -> None:
-        """Daemonize and run; returns immediately in the parent."""
-        if daemonize:
-            _daemonize()
-        # Now we are the daemon process
+    def start(
+        self,
+        gptme_args: list[str],
+        prompts: list[str] | None = None,
+        daemonize: bool = True,
+    ) -> None:
+        """Daemonize and run; return immediately in the original parent."""
+        if daemonize and _daemonize():
+            return
+
         try:
-            self._run(gptme_args)
+            self._run(gptme_args, prompts or [])
         except Exception:
             logger.exception("Daemon crashed")
         finally:
@@ -90,16 +113,16 @@ class SessionDaemon:
             return False
         try:
             pid = int(self.pid_path.read_text())
-            os.kill(pid, 0)  # check existence
-            return True
+            os.kill(pid, 0)
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             return False
+        return _socket_is_accepting(self.socket_path)
 
     def stop(self) -> None:
         """Send SIGTERM to the daemon process."""
         try:
             pid = int(self.pid_path.read_text())
-            os.kill(pid, 15)  # SIGTERM
+            os.kill(pid, signal.SIGTERM)
         except (FileNotFoundError, ProcessLookupError, ValueError):
             pass
 
@@ -107,10 +130,9 @@ class SessionDaemon:
     # Internal — runs in the daemon process
     # ------------------------------------------------------------------
 
-    def _run(self, gptme_args: list[str]) -> None:
+    def _run(self, gptme_args: list[str], prompts: list[str]) -> None:
         self.pid_path.write_text(str(os.getpid()))
 
-        # Set up Unix socket
         server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if self.socket_path.exists():
@@ -120,63 +142,109 @@ class SessionDaemon:
         server_sock.listen(1)
         server_sock.setblocking(False)
 
-        # Start gptme subprocess (non-interactive, stdin/stdout piped)
-        proc = subprocess.Popen(
-            [sys.executable, "-m", "gptme", "--non-interactive"] + gptme_args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+        def request_stop(_signum: int, _frame: object) -> None:
+            self._stop_event.set()
 
-        assert proc.stdout is not None
-        assert proc.stdin is not None
-
-        # Thread: read subprocess output → buffer + forward to client
-        output_thread = threading.Thread(
-            target=self._pump_output,
-            args=(proc.stdout,),
+        old_sigterm = signal.signal(signal.SIGTERM, request_stop)
+        old_sigint = signal.signal(signal.SIGINT, request_stop)
+        worker = threading.Thread(
+            target=self._worker_loop,
+            args=(gptme_args,),
+            name=f"gptme-daemon-{self.session_name}",
             daemon=True,
         )
-        output_thread.start()
+        worker.start()
+        if prompts:
+            self._turn_queue.put(prompts)
 
-        # Main loop: accept connections and forward client input to subprocess
         try:
-            self._accept_loop(server_sock, proc)
+            self._accept_loop(server_sock)
         finally:
-            proc.terminate()
-            proc.wait()
+            self._stop_event.set()
+            self._terminate_process()
+            worker.join(timeout=5)
+            server_sock.close()
+            signal.signal(signal.SIGTERM, old_sigterm)
+            signal.signal(signal.SIGINT, old_sigint)
 
-    def _pump_output(self, stdout: IO[bytes]) -> None:
-        """Read subprocess stdout, buffer it, and forward to connected client."""
-        for chunk in iter(lambda: stdout.read(4096), b""):
-            with self._buf_lock:
-                self._output_buf.append(chunk)
-                self._output_buf_size += len(chunk)
-                # Trim ring buffer
+    def _terminate_process(self) -> None:
+        with self._proc_lock:
+            proc = self._proc
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+
+    def _worker_loop(self, gptme_args: list[str]) -> None:
+        """Run queued prompts as sequential turns in the named conversation."""
+        while not self._stop_event.is_set():
+            try:
+                prompts = self._turn_queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            try:
+                self._run_turn(gptme_args, prompts)
+            finally:
+                self._turn_queue.task_done()
+
+    def _run_turn(self, gptme_args: list[str], prompts: list[str]) -> None:
+        # stdin must be DEVNULL.  A PIPE is non-TTY input, so gptme would wait for
+        # EOF while trying to consume piped input before processing CLI prompts.
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "gptme", "--non-interactive"] + gptme_args + prompts,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+        with self._proc_lock:
+            self._proc = proc
+        try:
+            assert proc.stdout is not None
+            self._pump_output(proc.stdout)
+            proc.wait()
+        finally:
+            with self._proc_lock:
+                if self._proc is proc:
+                    self._proc = None
+
+    def _pump_output(self, stdout: _ReadableFD) -> None:
+        """Read available subprocess output without waiting for a 4 KiB buffer."""
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        while True:
+            try:
+                chunk = os.read(stdout.fileno(), 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            self._publish_output(chunk, decoder.decode(chunk))
+        if tail := decoder.decode(b"", final=True):
+            self._publish_output(b"", tail)
+
+    def _publish_output(self, chunk: bytes, text: str | None = None) -> None:
+        if text is None:
+            text = chunk.decode("utf-8", errors="replace")
+        with self._output_lock:
+            if text:
+                self._output_buf.append(text)
+                self._output_buf_size += len(text.encode())
                 while self._output_buf_size > _OUTPUT_HISTORY_BYTES:
                     dropped = self._output_buf.popleft()
-                    self._output_buf_size -= len(dropped)
+                    self._output_buf_size -= len(dropped.encode())
 
-            # Forward to client if connected
-            with self._client_lock:
-                client = self._client
-            if client is not None:
+            if self._client is not None and text:
                 try:
                     send_msg(
-                        client,
-                        IPCMessage(
-                            type="output", data=chunk.decode("utf-8", errors="replace")
-                        ),
+                        self._client,
+                        IPCMessage(type="output", data=text),
                     )
                 except OSError:
-                    with self._client_lock:
-                        self._client = None
+                    self._client = None
 
-    def _accept_loop(self, server_sock: socket.socket, proc: subprocess.Popen) -> None:
-        """Accept one client at a time and forward their input to the subprocess."""
-        while proc.poll() is None:
+    def _accept_loop(self, server_sock: socket.socket) -> None:
+        """Accept one client at a time while the daemon remains alive."""
+        while not self._stop_event.is_set():
             try:
-                rlist, _, _ = select.select([server_sock], [], [], 1.0)
+                rlist, _, _ = select.select([server_sock], [], [], 0.2)
             except OSError:
                 break
             if not rlist:
@@ -184,67 +252,80 @@ class SessionDaemon:
 
             client, _ = server_sock.accept()
             client.setblocking(True)
-            with self._client_lock:
-                self._client = client
-
             try:
-                self._serve_client(client, proc)
+                self._serve_client(client)
             finally:
-                with self._client_lock:
-                    self._client = None
+                with self._output_lock:
+                    if self._client is client:
+                        self._client = None
                 client.close()
 
-    def _serve_client(self, client: socket.socket, proc: subprocess.Popen) -> None:
-        """Send output history then relay client input → subprocess stdin."""
-        # Send buffered output history to the new client
-        with self._buf_lock:
-            history = b"".join(self._output_buf)
-        if history:
+    def _serve_client(self, client: socket.socket) -> None:
+        """Replay output history, then queue prompts received from the client."""
+        # Publish the client only after history is fully sent.  Holding the same
+        # lock used by _publish_output makes history-before-live ordering atomic.
+        with self._output_lock:
+            history = "".join(self._output_buf)
             try:
                 send_msg(
                     client,
-                    IPCMessage(
-                        type="output", data=history.decode("utf-8", errors="replace")
-                    ),
+                    IPCMessage(type="status", data={"ready": True}),
                 )
-            except OSError:
-                return
-
-        # Relay client input to subprocess stdin
-        while proc.poll() is None:
-            msg = recv_msg(client)
-            if msg is None:
-                break  # client disconnected
-            if msg.type == "input":
-                data = msg.data if isinstance(msg.data, str) else str(msg.data)
-                try:
-                    assert proc.stdin is not None
-                    proc.stdin.write(data.encode())
-                    proc.stdin.flush()
-                except OSError:
-                    break
-            elif msg.type == "status":
-                try:
+                if history:
                     send_msg(
                         client,
-                        IPCMessage(
-                            type="status",
-                            data={
-                                "session": self.session_name,
-                                "pid": os.getpid(),
-                                "running": proc.poll() is None,
-                            },
-                        ),
+                        IPCMessage(type="output", data=history),
                     )
-                except OSError:
-                    break
+            except OSError:
+                return
+            self._client = client
+
+        client.settimeout(0.2)
+        while not self._stop_event.is_set():
+            try:
+                msg = recv_msg(client)
+            except TimeoutError:
+                continue
+            except (OSError, ValueError):
+                break
+            if msg is None:
+                break
+            if msg.type == "input":
+                data = msg.data if isinstance(msg.data, str) else str(msg.data)
+                if data.strip():
+                    self._turn_queue.put([data.strip()])
+            elif msg.type == "status":
+                with self._proc_lock:
+                    proc = self._proc
+                self._send_to_client(
+                    client,
+                    IPCMessage(
+                        type="status",
+                        data={
+                            "session": self.session_name,
+                            "pid": os.getpid(),
+                            "running": True,
+                            "busy": proc is not None and proc.poll() is None,
+                            "queued": self._turn_queue.qsize(),
+                        },
+                    ),
+                )
             elif (
                 msg.type == "signal"
                 and isinstance(msg.data, dict)
                 and msg.data.get("signal") == "SIGTERM"
             ):
-                proc.terminate()
+                self._stop_event.set()
+                self._terminate_process()
                 break
+
+    def _send_to_client(self, client: socket.socket, msg: IPCMessage) -> None:
+        with self._output_lock:
+            if self._client is client:
+                try:
+                    send_msg(client, msg)
+                except OSError:
+                    self._client = None
 
     def _cleanup(self) -> None:
         for path in (self.socket_path, self.pid_path):
@@ -256,23 +337,28 @@ class SessionDaemon:
 # ---------------------------------------------------------------------------
 
 
-def _daemonize() -> None:
-    """Double-fork to create a proper daemon process."""
-    if os.fork() > 0:
-        # Parent exits — child continues
+def _fork() -> int:
+    try:
+        return os.fork()
+    except OSError as exc:
+        raise RuntimeError("failed to fork daemon process") from exc
+
+
+def _daemonize() -> bool:
+    """Double-fork; return True only in the original parent process."""
+    if _fork() > 0:
+        return True
+
+    os.setsid()
+
+    if _fork() > 0:
         os._exit(0)
 
-    os.setsid()  # new session leader
-
-    if os.fork() > 0:
-        # Second parent exits — grandchild is fully detached
-        os._exit(0)
-
-    # Redirect stdin/stdout/stderr to /dev/null
     devnull = os.open(os.devnull, os.O_RDWR)
     for fd in (0, 1, 2):
         os.dup2(devnull, fd)
     os.close(devnull)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -288,8 +374,16 @@ def attach(session_name: str) -> None:
 
     conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     conn.connect(str(sock_path))
+    ready = recv_msg(conn)
+    if (
+        ready is None
+        or ready.type != "status"
+        or not isinstance(ready.data, dict)
+        or not ready.data.get("ready")
+    ):
+        conn.close()
+        raise ConnectionResetError(f"Daemon '{session_name}' closed during attach")
 
-    # Thread: receive daemon output → print to stdout
     stop_event = threading.Event()
 
     def _receive() -> None:
@@ -311,7 +405,6 @@ def attach(session_name: str) -> None:
     recv_thread = threading.Thread(target=_receive, daemon=True)
     recv_thread.start()
 
-    # Main thread: read stdin → send to daemon
     seq = 0
     try:
         for line in sys.stdin:
@@ -331,19 +424,37 @@ def attach(session_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _socket_is_accepting(path: Path) -> bool:
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(0.5)
+    try:
+        probe.connect(str(path))
+        ready = recv_msg(probe)
+        return (
+            ready is not None
+            and ready.type == "status"
+            and isinstance(ready.data, dict)
+            and bool(ready.data.get("ready"))
+        )
+    except (OSError, ValueError):
+        return False
+    finally:
+        probe.close()
+
+
 def list_daemons() -> list[dict]:
-    """Return info dicts for running daemons."""
+    """Return info dicts for known daemons."""
     daemon_dir = get_daemon_dir()
     result = []
     for pid_file in daemon_dir.glob("*.pid"):
         name = pid_file.stem
+        sock = daemon_dir / f"{name}.socket"
         try:
             pid = int(pid_file.read_text())
             os.kill(pid, 0)
-            running = True
+            running = _socket_is_accepting(sock)
         except (ValueError, ProcessLookupError, PermissionError):
             running = False
-        sock = daemon_dir / f"{name}.socket"
         result.append(
             {
                 "session": name,

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -29,6 +29,7 @@ import socket
 import subprocess
 import sys
 import threading
+import time
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -54,6 +55,9 @@ _CLIENT_READ_TIMEOUT = 0.2
 _CLIENT_WRITE_TIMEOUT = 5.0
 # A queued second attach must fail instead of waiting forever for the only client slot.
 _ATTACH_HANDSHAKE_TIMEOUT = 2.0
+# stop() must outwait worker.join(timeout=5) plus path-unlink slack so the CLI
+# does not report success while the daemon is still discoverable.
+_STOP_TEARDOWN_TIMEOUT = 6.0
 
 
 def get_daemon_dir() -> Path:
@@ -138,7 +142,7 @@ class SessionDaemon:
             pid_file.close()
 
     def stop(self) -> None:
-        """Stop the daemon via a pinned pidfd, else a socket SIGTERM frame.
+        """Stop the daemon and wait until it releases its owned paths.
 
         Never ``os.kill`` a numeric PID: without pidfd that can hit a reused
         process. The socket path talks to the listening daemon instead.
@@ -159,7 +163,9 @@ class SessionDaemon:
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             pass
         if not signaled:
-            _stop_via_socket(self.socket_path)
+            signaled = _stop_via_socket(self.socket_path)
+        if signaled:
+            _wait_for_daemon_stop(self.pid_path, self.socket_path)
 
     # ------------------------------------------------------------------
     # Internal — runs in the daemon process
@@ -610,13 +616,20 @@ def _pid_fd_matches_path(pid_file: IO[str], path: Path) -> bool:
     return (fd_stat.st_dev, fd_stat.st_ino) == (path_stat.st_dev, path_stat.st_ino)
 
 
-def _stop_via_socket(sock_path: Path) -> None:
-    """Ask the listening daemon to stop without signaling a numeric PID."""
+def _stop_via_socket(sock_path: Path) -> bool:
+    """Ask the listening daemon to stop without signaling a numeric PID.
+
+    Returns True if the SIGTERM frame was written. Receive timeout is
+    swallowed: teardown is observed by ``_wait_for_daemon_stop``, not by
+    the two-second handshake window.
+    """
     conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
+    sent = False
     try:
         conn.connect(str(sock_path))
         send_msg(conn, IPCMessage(type="signal", data={"signal": "SIGTERM"}))
+        sent = True
         # Keep the receive half open until the daemon consumes the signal.  A
         # regular client slot sends its ready frame before reading the signal;
         # closing here could make that write fail and discard the stop request.
@@ -627,6 +640,16 @@ def _stop_via_socket(sock_path: Path) -> None:
         pass
     finally:
         conn.close()
+    return sent
+
+
+def _wait_for_daemon_stop(pid_path: Path, sock_path: Path) -> None:
+    """Wait for teardown so a successful stop permits an immediate restart."""
+    deadline = time.monotonic() + _STOP_TEARDOWN_TIMEOUT
+    while pid_path.exists() or sock_path.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Daemon did not stop in time")
+        time.sleep(0.05)
 
 
 def _pid_file_lock_held(pid_file: IO[str]) -> bool:

--- a/gptme/server/daemon.py
+++ b/gptme/server/daemon.py
@@ -138,9 +138,14 @@ class SessionDaemon:
             pid_file.close()
 
     def stop(self) -> None:
-        """Signal the daemon while continuously proving PID-file ownership."""
+        """Stop the daemon via a pinned pidfd, else a socket SIGTERM frame.
+
+        Never ``os.kill`` a numeric PID: without pidfd that can hit a reused
+        process. The socket path talks to the listening daemon instead.
+        """
         if not self.socket_path.exists():
             return
+        signaled = False
         try:
             with self.pid_path.open() as pid_file:
                 try:
@@ -148,29 +153,43 @@ class SessionDaemon:
                 except BlockingIOError:
                     pid_file.seek(0)
                     pid = int(pid_file.read())
-                    _signal_owned_pid(pid_file, pid)
+                    signaled = _signal_owned_pid(pid_file, pid)
                 else:
                     fcntl.flock(pid_file, fcntl.LOCK_UN)
         except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
             pass
+        if not signaled:
+            _stop_via_socket(self.socket_path)
 
     # ------------------------------------------------------------------
     # Internal — runs in the daemon process
     # ------------------------------------------------------------------
 
     def _acquire_pid_file(self) -> None:
-        pid_file = self.pid_path.open("a+")
-        try:
-            fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            pid_file.close()
-            raise
-        pid_file.seek(0)
-        pid_file.truncate()
-        pid_file.write(str(os.getpid()))
-        pid_file.flush()
-        self._pid_file = pid_file
-        self._owns_paths = True
+        last_error: OSError | None = None
+        for _ in range(5):
+            pid_file = self.pid_path.open("a+")
+            try:
+                fcntl.flock(pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                pid_file.close()
+                raise
+            if not _pid_fd_matches_path(pid_file, self.pid_path):
+                pid_file.close()
+                last_error = OSError("PID file was unlinked during acquire")
+                continue
+            pid_file.seek(0)
+            pid_file.truncate()
+            pid_file.write(str(os.getpid()))
+            pid_file.flush()
+            if not _pid_fd_matches_path(pid_file, self.pid_path):
+                pid_file.close()
+                last_error = OSError("PID file was unlinked during acquire")
+                continue
+            self._pid_file = pid_file
+            self._owns_paths = True
+            return
+        raise last_error or OSError("failed to acquire live PID file")
 
     def _run(self, gptme_args: list[str], prompts: list[str]) -> None:
         self._acquire_pid_file()
@@ -181,7 +200,7 @@ class SessionDaemon:
             self.socket_path.unlink()
         server_sock.bind(str(self.socket_path))
         self.socket_path.chmod(0o600)
-        server_sock.listen(1)
+        server_sock.listen(2)
         server_sock.setblocking(False)
 
         def request_stop(_signum: int, _frame: object) -> None:
@@ -311,14 +330,18 @@ class SessionDaemon:
                 continue
             client.setblocking(True)
             try:
-                self._serve_client(client)
+                self._serve_client(client, server_sock)
             finally:
                 with self._output_lock:
                     if self._client is client:
                         self._client = None
                 client.close()
 
-    def _serve_client(self, client: socket.socket) -> None:
+    def _serve_client(
+        self,
+        client: socket.socket,
+        server_sock: socket.socket | None = None,
+    ) -> None:
         """Replay output history, then queue prompts received from the client."""
         client.settimeout(_CLIENT_READ_TIMEOUT)
         # Publish the client only after history is fully sent.  Holding the same
@@ -336,7 +359,21 @@ class SessionDaemon:
             self._client = client
 
         recv_buffer = bytearray()
+        client.settimeout(_CLIENT_READ_TIMEOUT)
         while not self._stop_event.is_set():
+            try:
+                watch = [client] if server_sock is None else [client, server_sock]
+                rlist, _, _ = select.select(watch, [], [], _CLIENT_READ_TIMEOUT)
+            except InterruptedError:
+                continue
+            except OSError:
+                break
+            if server_sock is not None and server_sock in rlist:
+                self._handle_control_connection(server_sock)
+                if self._stop_event.is_set():
+                    break
+            if client not in rlist:
+                continue
             try:
                 msg = recv_msg(client, recv_buffer)
             except TimeoutError:
@@ -373,6 +410,29 @@ class SessionDaemon:
                 self._stop_event.set()
                 self._terminate_process()
                 break
+
+    def _handle_control_connection(self, server_sock: socket.socket) -> None:
+        """Accept a one-shot control client (stop) while the slot is occupied."""
+        try:
+            extra, _ = server_sock.accept()
+        except OSError:
+            return
+        extra.settimeout(1.0)
+        try:
+            msg = recv_msg(extra, bytearray())
+            if (
+                msg is not None
+                and msg.type == "signal"
+                and isinstance(msg.data, dict)
+                and msg.data.get("signal") == "SIGTERM"
+            ):
+                self._stop_event.set()
+                self._terminate_process()
+                send_msg(extra, IPCMessage(type="status", data={"stopping": True}))
+        except (OSError, ValueError, TimeoutError):
+            pass
+        finally:
+            extra.close()
 
     def _send_to_client(self, client: socket.socket, msg: IPCMessage) -> None:
         failed = False
@@ -519,28 +579,48 @@ def attach(session_name: str) -> None:
         conn.close()
 
 
-def _signal_owned_pid(pid_file: IO[str], pid: int) -> None:
-    """Signal ``pid`` only if the same PID-file inode is still lock-owned.
+def _signal_owned_pid(pid_file: IO[str], pid: int) -> bool:
+    """Send SIGTERM via pidfd if the PID-file inode is still lock-owned.
 
-    ``pidfd`` pins process identity on Linux. Rechecking the advisory lock
-    (and the PID bytes on that inode) after the pin aborts if the owner
-    exited and the PID was reused before the signal.
+    Returns True only when a pinned pidfd signal was sent. Callers must fall
+    back to the session socket rather than ``os.kill`` of an unpinned PID.
     """
     pidfd = _pidfd_open(pid)
+    if pidfd is None:
+        return False
     try:
         if not _pid_file_lock_held(pid_file):
-            return
+            return False
         pid_file.seek(0)
         current = int(pid_file.read() or "0")
         if current != pid:
-            return
-        if pidfd is not None:
-            _pidfd_send_signal(pidfd, signal.SIGTERM)
-        else:
-            os.kill(pid, signal.SIGTERM)
+            return False
+        _pidfd_send_signal(pidfd, signal.SIGTERM)
+        return True
     finally:
-        if pidfd is not None:
-            os.close(pidfd)
+        os.close(pidfd)
+
+
+def _pid_fd_matches_path(pid_file: IO[str], path: Path) -> bool:
+    try:
+        fd_stat = os.fstat(pid_file.fileno())
+        path_stat = os.stat(path)
+    except OSError:
+        return False
+    return (fd_stat.st_dev, fd_stat.st_ino) == (path_stat.st_dev, path_stat.st_ino)
+
+
+def _stop_via_socket(sock_path: Path) -> None:
+    """Ask the listening daemon to stop without signaling a numeric PID."""
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.settimeout(_ATTACH_HANDSHAKE_TIMEOUT)
+    try:
+        conn.connect(str(sock_path))
+        send_msg(conn, IPCMessage(type="signal", data={"signal": "SIGTERM"}))
+    except OSError:
+        pass
+    finally:
+        conn.close()
 
 
 def _pid_file_lock_held(pid_file: IO[str]) -> bool:

--- a/gptme/server/ipc_protocol.py
+++ b/gptme/server/ipc_protocol.py
@@ -9,7 +9,7 @@ import json
 import struct
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
     import socket
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 _HEADER = struct.Struct("!I")
 
 MessageType = Literal["input", "output", "status", "signal", "error"]
+_MESSAGE_TYPES = frozenset(("input", "output", "status", "signal", "error"))
 
 
 @dataclass
@@ -42,12 +43,31 @@ class IPCMessage:
 
     @classmethod
     def from_bytes(cls, data: bytes) -> IPCMessage:
-        d = json.loads(data)
+        try:
+            decoded = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("invalid IPC message JSON") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError("IPC message must be a JSON object")
+
+        message_type = decoded.get("type")
+        if message_type not in _MESSAGE_TYPES:
+            raise ValueError(f"invalid IPC message type: {message_type!r}")
+        seq = decoded.get("seq", 0)
+        if not isinstance(seq, int):
+            raise ValueError("IPC message seq must be an integer")
+        timestamp = decoded.get("timestamp", "")
+        if not isinstance(timestamp, str):
+            raise ValueError("IPC message timestamp must be a string")
+        message_data = decoded.get("data", "")
+        if not isinstance(message_data, (str, dict)):
+            raise ValueError("IPC message data must be a string or object")
+
         return cls(
-            type=d["type"],
-            data=d.get("data", ""),
-            seq=d.get("seq", 0),
-            timestamp=d.get("timestamp", ""),
+            type=cast("MessageType", message_type),
+            data=message_data,
+            seq=seq,
+            timestamp=timestamp,
         )
 
 

--- a/gptme/server/ipc_protocol.py
+++ b/gptme/server/ipc_protocol.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 # Big-endian uint32 length prefix
 _HEADER = struct.Struct("!I")
+# Cap the declared payload so a peer cannot force a multi-gigabyte buffer.
+MAX_IPC_PAYLOAD = 1024 * 1024
 
 MessageType = Literal["input", "output", "status", "signal", "error"]
 _MESSAGE_TYPES = frozenset(("input", "output", "status", "signal", "error"))
@@ -39,6 +41,8 @@ class IPCMessage:
                 "timestamp": self.timestamp,
             }
         ).encode()
+        if len(payload) > MAX_IPC_PAYLOAD:
+            raise ValueError(f"IPC payload too large: {len(payload)} bytes")
         return _HEADER.pack(len(payload)) + payload
 
     @classmethod
@@ -86,7 +90,7 @@ def recv_msg(sock: socket.socket, buffer: bytearray | None = None) -> IPCMessage
         header = _recv_exact(sock, _HEADER.size)
         if not header:
             return None
-        (length,) = _HEADER.unpack(header)
+        length = _checked_payload_length(header)
         payload = _recv_exact(sock, length)
         if not payload:
             return None
@@ -99,7 +103,7 @@ def recv_msg(sock: socket.socket, buffer: bytearray | None = None) -> IPCMessage
                 raise ValueError("incomplete IPC message header")
             return None
         buffer.extend(chunk)
-    (length,) = _HEADER.unpack(buffer[: _HEADER.size])
+    length = _checked_payload_length(buffer[: _HEADER.size])
     frame_size = _HEADER.size + length
     while len(buffer) < frame_size:
         chunk = sock.recv(frame_size - len(buffer))
@@ -109,6 +113,13 @@ def recv_msg(sock: socket.socket, buffer: bytearray | None = None) -> IPCMessage
     payload = bytes(buffer[_HEADER.size : frame_size])
     del buffer[:frame_size]
     return IPCMessage.from_bytes(payload)
+
+
+def _checked_payload_length(header: bytes | bytearray) -> int:
+    (length,) = _HEADER.unpack(header)
+    if length > MAX_IPC_PAYLOAD:
+        raise ValueError(f"IPC payload too large: {length} bytes")
+    return length
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes:

--- a/gptme/server/ipc_protocol.py
+++ b/gptme/server/ipc_protocol.py
@@ -1,0 +1,77 @@
+"""IPC message protocol for gptme session daemon.
+
+Wire format: 4-byte big-endian length prefix + UTF-8 JSON payload.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import socket
+
+# Big-endian uint32 length prefix
+_HEADER = struct.Struct("!I")
+
+MessageType = Literal["input", "output", "status", "signal", "error"]
+
+
+@dataclass
+class IPCMessage:
+    type: MessageType
+    data: str | dict = ""
+    seq: int = 0
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def encode(self) -> bytes:
+        payload = json.dumps(
+            {
+                "type": self.type,
+                "data": self.data,
+                "seq": self.seq,
+                "timestamp": self.timestamp,
+            }
+        ).encode()
+        return _HEADER.pack(len(payload)) + payload
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> IPCMessage:
+        d = json.loads(data)
+        return cls(
+            type=d["type"],
+            data=d.get("data", ""),
+            seq=d.get("seq", 0),
+            timestamp=d.get("timestamp", ""),
+        )
+
+
+def send_msg(sock: socket.socket, msg: IPCMessage) -> None:
+    sock.sendall(msg.encode())
+
+
+def recv_msg(sock: socket.socket) -> IPCMessage | None:
+    """Receive one framed message; returns None on EOF."""
+    header = _recv_exact(sock, _HEADER.size)
+    if not header:
+        return None
+    (length,) = _HEADER.unpack(header)
+    payload = _recv_exact(sock, length)
+    if not payload:
+        return None
+    return IPCMessage.from_bytes(payload)
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return b""
+        buf.extend(chunk)
+    return bytes(buf)

--- a/gptme/server/ipc_protocol.py
+++ b/gptme/server/ipc_protocol.py
@@ -75,15 +75,39 @@ def send_msg(sock: socket.socket, msg: IPCMessage) -> None:
     sock.sendall(msg.encode())
 
 
-def recv_msg(sock: socket.socket) -> IPCMessage | None:
-    """Receive one framed message; returns None on EOF."""
-    header = _recv_exact(sock, _HEADER.size)
-    if not header:
-        return None
-    (length,) = _HEADER.unpack(header)
-    payload = _recv_exact(sock, length)
-    if not payload:
-        return None
+def recv_msg(sock: socket.socket, buffer: bytearray | None = None) -> IPCMessage | None:
+    """Receive one framed message; returns None on EOF.
+
+    Pass a persistent ``buffer`` when the socket has a timeout. Bytes received
+    before a timeout then remain available to the next call instead of being
+    mistaken for a new frame header.
+    """
+    if buffer is None:
+        header = _recv_exact(sock, _HEADER.size)
+        if not header:
+            return None
+        (length,) = _HEADER.unpack(header)
+        payload = _recv_exact(sock, length)
+        if not payload:
+            return None
+        return IPCMessage.from_bytes(payload)
+
+    while len(buffer) < _HEADER.size:
+        chunk = sock.recv(_HEADER.size - len(buffer))
+        if not chunk:
+            if buffer:
+                raise ValueError("incomplete IPC message header")
+            return None
+        buffer.extend(chunk)
+    (length,) = _HEADER.unpack(buffer[: _HEADER.size])
+    frame_size = _HEADER.size + length
+    while len(buffer) < frame_size:
+        chunk = sock.recv(frame_size - len(buffer))
+        if not chunk:
+            raise ValueError("incomplete IPC message payload")
+        buffer.extend(chunk)
+    payload = bytes(buffer[_HEADER.size : frame_size])
+    del buffer[:frame_size]
     return IPCMessage.from_bytes(payload)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ gptme-resume = "gptme.cli.cmd_resume:resume"
 gptme-mcp-server = "gptme.cli.cmd_mcp_serve:main"
 gptme-stats = "gptme.cli.cmd_stats:stats"
 gptme-service = "gptme.cli.cmd_service:cli"
+gptme-daemon = "gptme.cli.cmd_daemon:main"
 
 [tool.poetry]
 packages = [

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,357 @@
+"""Tests for gptme session daemon — Phase 1 MVP.
+
+Tests cover:
+- IPC protocol encode/decode roundtrip
+- Daemon socket path helpers
+- start → attach → detach → re-attach session state preservation
+- Daemon survives client SIGHUP (SSH-drop case)
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from gptme.server.daemon import (
+    SessionDaemon,
+    get_pid_path,
+    get_socket_path,
+    list_daemons,
+)
+from gptme.server.ipc_protocol import IPCMessage, recv_msg, send_msg
+
+# ---------------------------------------------------------------------------
+# IPC protocol tests
+# ---------------------------------------------------------------------------
+
+
+class TestIPCProtocol:
+    def test_roundtrip_input(self):
+        """Input message survives encode → decode."""
+        msg = IPCMessage(type="input", data="hello world\n", seq=1)
+        raw = msg.encode()
+        decoded = IPCMessage.from_bytes(raw[4:])  # skip length header
+        assert decoded.type == "input"
+        assert decoded.data == "hello world\n"
+        assert decoded.seq == 1
+
+    def test_roundtrip_output(self):
+        """Output message with unicode survives encode → decode."""
+        msg = IPCMessage(type="output", data="→ done ✓", seq=42)
+        raw = msg.encode()
+        decoded = IPCMessage.from_bytes(raw[4:])
+        assert decoded.type == "output"
+        assert decoded.data == "→ done ✓"
+
+    def test_roundtrip_status(self):
+        """Status message with dict data survives encode → decode."""
+        msg = IPCMessage(type="status", data={"session": "test", "running": True})
+        raw = msg.encode()
+        decoded = IPCMessage.from_bytes(raw[4:])
+        assert decoded.type == "status"
+        assert isinstance(decoded.data, dict)
+        assert decoded.data["session"] == "test"
+        assert decoded.data["running"] is True
+
+    def test_send_recv_over_socket_pair(self):
+        """send_msg / recv_msg work over a real socket pair."""
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sent = IPCMessage(type="input", data="ping", seq=1)
+            send_msg(a, sent)
+            received = recv_msg(b)
+            assert received is not None
+            assert received.type == "input"
+            assert received.data == "ping"
+        finally:
+            a.close()
+            b.close()
+
+    def test_recv_returns_none_on_eof(self):
+        """recv_msg returns None when the other end closes."""
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        b.close()
+        result = recv_msg(a)
+        assert result is None
+        a.close()
+
+    def test_multiple_messages_in_sequence(self):
+        """Multiple framed messages are received in order."""
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            for i in range(5):
+                send_msg(a, IPCMessage(type="input", data=f"msg{i}", seq=i))
+            for i in range(5):
+                msg = recv_msg(b)
+                assert msg is not None
+                assert msg.data == f"msg{i}"
+                assert msg.seq == i
+        finally:
+            a.close()
+            b.close()
+
+
+# ---------------------------------------------------------------------------
+# Daemon path helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonPaths:
+    def test_socket_path_is_under_config_dir(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            sp = get_socket_path("mysession")
+            assert sp == tmp_path / "mysession.socket"
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_pid_path_matches_session(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            pp = get_pid_path("mysession")
+            assert pp == tmp_path / "mysession.pid"
+        finally:
+            _dm.get_daemon_dir = orig
+
+
+# ---------------------------------------------------------------------------
+# SessionDaemon unit tests (no real subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDaemonState:
+    def test_is_running_false_when_no_pid_file(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            d = SessionDaemon("noexist")
+            assert not d.is_running()
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_is_running_false_when_pid_file_stale(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            d = SessionDaemon("stale")
+            # Write a PID that does not exist
+            (tmp_path / "stale.pid").write_text("999999999")
+            assert not d.is_running()
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_is_running_true_with_own_pid(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            d = SessionDaemon("live")
+            (tmp_path / "live.socket").touch()
+            (tmp_path / "live.pid").write_text(str(os.getpid()))
+            assert d.is_running()
+        finally:
+            _dm.get_daemon_dir = orig
+
+
+# ---------------------------------------------------------------------------
+# Integration: echo server simulating daemon I/O
+# ---------------------------------------------------------------------------
+
+
+class _EchoDaemonThread(threading.Thread):
+    """Minimal echo server that speaks the IPC protocol — stand-in for daemon."""
+
+    def __init__(self, sock_path: Path) -> None:
+        super().__init__(daemon=True)
+        self.sock_path = sock_path
+        self.ready = threading.Event()
+        self.received: list[str | dict] = []
+
+    def run(self) -> None:
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(self.sock_path))
+        server.listen(1)
+        self.ready.set()
+        conn, _ = server.accept()
+        try:
+            # Send a welcome message (simulates buffered history)
+            send_msg(conn, IPCMessage(type="output", data="[session output]\n"))
+            # Echo input back as output
+            while True:
+                msg = recv_msg(conn)
+                if msg is None:
+                    break
+                if msg.type == "input":
+                    self.received.append(msg.data)
+                    send_msg(conn, IPCMessage(type="output", data=f"echo: {msg.data}"))
+        except OSError:
+            pass  # client disconnected mid-send; expected in disconnect test
+        finally:
+            conn.close()
+            server.close()
+
+
+class TestAttachProtocol:
+    """Test the attach protocol against a mock daemon (no real gptme subprocess)."""
+
+    def test_attach_receives_history_and_echo(self, tmp_path):
+        sock_path = tmp_path / "test.socket"
+
+        server = _EchoDaemonThread(sock_path)
+        server.start()
+        server.ready.wait(timeout=2)
+
+        # Connect as a client
+        conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        conn.connect(str(sock_path))
+
+        # Receive the welcome message (buffered history)
+        welcome = recv_msg(conn)
+        assert welcome is not None
+        assert welcome.type == "output"
+        assert "session output" in welcome.data
+
+        # Send input
+        send_msg(conn, IPCMessage(type="input", data="test input\n"))
+
+        # Receive echo
+        echo = recv_msg(conn)
+        assert echo is not None
+        assert echo.type == "output"
+        assert "test input" in echo.data
+
+        conn.close()
+        server.join(timeout=1)
+        assert "test input\n" in server.received
+
+    def test_client_disconnect_does_not_crash_server(self, tmp_path):
+        """Daemon (echo server) should survive a client that disconnects abruptly."""
+        sock_path = tmp_path / "crash.socket"
+
+        server = _EchoDaemonThread(sock_path)
+        server.start()
+        server.ready.wait(timeout=2)
+
+        conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        conn.connect(str(sock_path))
+        # Disconnect immediately without sending anything
+        conn.close()
+
+        # Server thread should exit cleanly
+        server.join(timeout=2)
+        assert not server.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# list_daemons
+# ---------------------------------------------------------------------------
+
+
+class TestListDaemons:
+    def test_list_empty(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            assert list_daemons() == []
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_list_with_stale_pid(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            (tmp_path / "old.pid").write_text("999999999")
+            daemons = list_daemons()
+            assert len(daemons) == 1
+            assert daemons[0]["session"] == "old"
+            assert daemons[0]["running"] is False
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_list_with_live_pid(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            (tmp_path / "live.pid").write_text(str(os.getpid()))
+            (tmp_path / "live.socket").touch()
+            daemons = list_daemons()
+            assert len(daemons) == 1
+            assert daemons[0]["running"] is True
+        finally:
+            _dm.get_daemon_dir = orig
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonCLI:
+    def test_list_command_empty(self, tmp_path):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["list"])
+            assert result.exit_code == 0
+            assert "No daemon sessions found" in result.output
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_status_command_not_running(self, tmp_path):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["status", "ghost"])
+            assert result.exit_code == 0
+            assert "stopped" in result.output
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_stop_command_not_running(self, tmp_path):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["stop", "ghost"])
+            assert result.exit_code != 0  # exits 1 when not running
+        finally:
+            _dm.get_daemon_dir = orig

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -9,8 +9,10 @@ Tests cover:
 
 from __future__ import annotations
 
+import fcntl
 import io
 import os
+import signal
 import socket
 import subprocess
 import threading
@@ -239,18 +241,36 @@ class TestSessionDaemonState:
         d.pid_path.write_text(str(os.getpid()))
         d.socket_path.touch()
         signals: list[int] = []
-        real_kill = os.kill
 
-        def record_kill(pid: int, signum: int) -> None:
-            if signum == 0:
-                real_kill(pid, signum)
-            else:
-                signals.append(signum)
-
-        monkeypatch.setattr(os, "kill", record_kill)
+        monkeypatch.setattr(os, "kill", lambda pid, signum: signals.append(signum))
         d.stop()
 
         assert signals == []
+
+    def test_stop_holds_ownership_proof_while_signaling(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("owned-stop")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        observed: list[tuple[int, bool]] = []
+
+        def record_kill(pid: int, signum: int) -> None:
+            probe = owner.pid_path.open()
+            try:
+                with pytest.raises(BlockingIOError):
+                    fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                observed.append((signum, True))
+            finally:
+                probe.close()
+
+        monkeypatch.setattr(os, "kill", record_kill)
+        try:
+            SessionDaemon("owned-stop").stop()
+            assert observed == [(signal.SIGTERM, True)]
+        finally:
+            owner._cleanup()
 
     def test_is_running_true_with_owned_pid_file(self, tmp_path):
         from gptme.server import daemon as _dm
@@ -601,6 +621,31 @@ class TestAttachProtocol:
         try:
             with pytest.raises(ConnectionResetError, match="closed during attach"):
                 attach("stale")
+        finally:
+            thread.join(timeout=1)
+            assert not thread.is_alive()
+
+    def test_attach_receiver_handles_truncated_frame(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        sock_path = tmp_path / "truncated.socket"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+
+        def send_truncated_frame():
+            conn, _ = server.accept()
+            send_msg(conn, IPCMessage(type="status", data={"ready": True}))
+            conn.sendall(IPCMessage(type="output", data="partial").encode()[:6])
+            conn.close()
+            server.close()
+
+        thread = threading.Thread(target=send_truncated_frame)
+        thread.start()
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        try:
+            attach("truncated")
         finally:
             thread.join(timeout=1)
             assert not thread.is_alive()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -267,24 +267,63 @@ class TestSessionDaemonState:
         owner = SessionDaemon("owned-stop")
         owner._acquire_pid_file()
         owner.socket_path.touch()
-        observed: list[tuple[int, bool]] = []
+        observed: list[tuple[int, int]] = []
+        real_close = os.close
 
-        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
-
-        def record_kill(pid: int, signum: int) -> None:
+        def record_send(pidfd: int, signum: int) -> None:
             probe = owner.pid_path.open()
             try:
                 with pytest.raises(BlockingIOError):
                     fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                observed.append((signum, True))
+                observed.append((pidfd, signum))
             finally:
                 probe.close()
 
-        monkeypatch.setattr(os, "kill", record_kill)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: 99)
+        monkeypatch.setattr(_dm, "_pidfd_send_signal", record_send)
+        monkeypatch.setattr(
+            os, "close", lambda fd: None if fd == 99 else real_close(fd)
+        )
+        monkeypatch.setattr(os, "kill", lambda *_args: pytest.fail("unpinned os.kill"))
         try:
             SessionDaemon("owned-stop").stop()
-            assert observed == [(signal.SIGTERM, True)]
+            assert observed == [(99, signal.SIGTERM)]
         finally:
+            owner._cleanup()
+
+    def test_stop_without_pidfd_uses_socket_not_kill(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+        monkeypatch.setattr(os, "kill", lambda *_args: pytest.fail("unpinned os.kill"))
+        owner = SessionDaemon("socket-stop")
+        owner._acquire_pid_file()
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if owner.socket_path.exists():
+            owner.socket_path.unlink()
+        sock.bind(str(owner.socket_path))
+        sock.listen(1)
+        received: list[str] = []
+
+        def accept_stop() -> None:
+            conn, _ = sock.accept()
+            try:
+                send_msg(conn, IPCMessage(type="status", data={"ready": True}))
+                msg = recv_msg(conn)
+                if msg is not None:
+                    received.append(msg.type)
+            finally:
+                conn.close()
+
+        thread = threading.Thread(target=accept_stop)
+        thread.start()
+        try:
+            SessionDaemon("socket-stop").stop()
+            thread.join(timeout=2)
+            assert received == ["signal"]
+        finally:
+            sock.close()
             owner._cleanup()
 
     def test_stop_uses_pidfd_when_available(self, tmp_path, monkeypatch):
@@ -403,6 +442,35 @@ class TestSessionDaemonState:
             assert successor.pid_path.exists()
             assert successor.socket_path.exists()
             assert successor.is_running()
+        finally:
+            successor._cleanup()
+
+    def test_acquire_retries_when_inode_is_unlinked(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("unlinked-inode")
+        owner._acquire_pid_file()
+        successor = SessionDaemon("unlinked-inode")
+        real_flock = fcntl.flock
+
+        def unlink_then_flock(fd, flags):
+            incoming = fd if isinstance(fd, int) else fd.fileno()
+            if (
+                flags & fcntl.LOCK_NB
+                and owner._pid_file is not None
+                and incoming != owner._pid_file.fileno()
+            ):
+                owner._cleanup()
+            real_flock(fd, flags)
+
+        monkeypatch.setattr(fcntl, "flock", unlink_then_flock)
+        successor._acquire_pid_file()
+        try:
+            assert successor.pid_path.exists()
+            assert successor._owns_paths
+            assert successor._pid_file is not None
+            assert _dm._pid_fd_matches_path(successor._pid_file, successor.pid_path)
         finally:
             successor._cleanup()
 
@@ -604,6 +672,38 @@ class TestPersistentTurnLifecycle:
         finally:
             client.close()
             server.close()
+
+    def test_control_connection_stops_occupied_daemon(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+        monkeypatch.setattr(os, "kill", lambda *_args: pytest.fail("unpinned os.kill"))
+        daemon = SessionDaemon("occupied-stop")
+        daemon._acquire_pid_file()
+        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if daemon.socket_path.exists():
+            daemon.socket_path.unlink()
+        server_sock.bind(str(daemon.socket_path))
+        server_sock.listen(2)
+        server_sock.setblocking(False)
+        loop = threading.Thread(target=daemon._accept_loop, args=(server_sock,))
+        loop.start()
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(2)
+        client.connect(str(daemon.socket_path))
+        try:
+            assert recv_msg(client) is not None
+            SessionDaemon("occupied-stop").stop()
+            loop.join(timeout=2)
+            assert daemon._stop_event.is_set()
+            assert not loop.is_alive()
+        finally:
+            client.close()
+            server_sock.close()
+            daemon._stop_event.set()
+            loop.join(timeout=1)
+            daemon._cleanup()
 
     def test_accept_loop_retries_interrupted_select(self, monkeypatch):
         daemon = SessionDaemon("interrupted")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -31,7 +31,7 @@ from gptme.server.daemon import (
     get_socket_path,
     list_daemons,
 )
-from gptme.server.ipc_protocol import IPCMessage, recv_msg, send_msg
+from gptme.server.ipc_protocol import MAX_IPC_PAYLOAD, IPCMessage, recv_msg, send_msg
 
 # ---------------------------------------------------------------------------
 # IPC protocol tests
@@ -143,6 +143,19 @@ class TestIPCProtocol:
     def test_rejects_malformed_messages(self, payload):
         with pytest.raises(ValueError, match="IPC message|message JSON"):
             IPCMessage.from_bytes(payload)
+
+    @pytest.mark.parametrize("use_buffer", [False, True])
+    def test_recv_rejects_oversize_payload(self, use_buffer):
+        import struct
+
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            a.sendall(struct.pack("!I", MAX_IPC_PAYLOAD + 1))
+            with pytest.raises(ValueError, match="too large"):
+                recv_msg(b, bytearray() if use_buffer else None)
+        finally:
+            a.close()
+            b.close()
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +269,8 @@ class TestSessionDaemonState:
         owner.socket_path.touch()
         observed: list[tuple[int, bool]] = []
 
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+
         def record_kill(pid: int, signum: int) -> None:
             probe = owner.pid_path.open()
             try:
@@ -272,6 +287,69 @@ class TestSessionDaemonState:
         finally:
             owner._cleanup()
 
+    def test_stop_uses_pidfd_when_available(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("pidfd-stop")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        sent: list[tuple[int, int]] = []
+        real_close = os.close
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: 99)
+        monkeypatch.setattr(
+            _dm,
+            "_pidfd_send_signal",
+            lambda pidfd, signum: sent.append((pidfd, signum)),
+        )
+        monkeypatch.setattr(
+            os, "close", lambda fd: None if fd == 99 else real_close(fd)
+        )
+        monkeypatch.setattr(
+            os, "kill", lambda pid, signum: pytest.fail("PID kill raced identity")
+        )
+        try:
+            SessionDaemon("pidfd-stop").stop()
+            assert sent == [(99, signal.SIGTERM)]
+        finally:
+            owner._cleanup()
+
+    def test_stop_aborts_if_owner_exits_before_signal(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("exit-before-signal")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        sent: list[int] = []
+
+        def fake_pidfd_open(_pid: int) -> int:
+            # Simulate the owner exiting after the PID is read: the lock is
+            # released and the PID could be reused before the signal.
+            assert owner._pid_file is not None
+            owner._pid_file.close()
+            owner._pid_file = None
+            owner._owns_paths = False
+            return 99
+
+        real_close = os.close
+        monkeypatch.setattr(_dm, "_pidfd_open", fake_pidfd_open)
+        monkeypatch.setattr(
+            _dm, "_pidfd_send_signal", lambda _pidfd, signum: sent.append(signum)
+        )
+        monkeypatch.setattr(os, "kill", lambda _pid, signum: sent.append(signum))
+        monkeypatch.setattr(
+            os, "close", lambda fd: None if fd == 99 else real_close(fd)
+        )
+        try:
+            SessionDaemon("exit-before-signal").stop()
+            assert sent == []
+        finally:
+            if owner._pid_file is not None:
+                owner._cleanup()
+            owner.socket_path.unlink(missing_ok=True)
+            owner.pid_path.unlink(missing_ok=True)
+
     def test_is_running_true_with_owned_pid_file(self, tmp_path):
         from gptme.server import daemon as _dm
 
@@ -285,6 +363,48 @@ class TestSessionDaemonState:
         finally:
             d._cleanup()
             _dm.get_daemon_dir = orig
+
+    def test_cleanup_unlinks_pid_before_releasing_lock(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        daemon = SessionDaemon("cleanup-order")
+        daemon._acquire_pid_file()
+        daemon.socket_path.touch()
+        assert daemon._pid_file is not None
+        original_close = daemon._pid_file.close
+
+        def assert_unlinked_before_close():
+            assert not daemon.pid_path.exists()
+            original_close()
+
+        monkeypatch.setattr(daemon._pid_file, "close", assert_unlinked_before_close)
+        daemon._cleanup()
+
+    def test_cleanup_does_not_unlink_successor_pid(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("handoff")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        assert owner._pid_file is not None
+        original_close = owner._pid_file.close
+        successor = SessionDaemon("handoff")
+
+        def close_after_successor_starts() -> None:
+            successor._acquire_pid_file()
+            successor.socket_path.touch()
+            original_close()
+
+        monkeypatch.setattr(owner._pid_file, "close", close_after_successor_starts)
+        try:
+            owner._cleanup()
+            assert successor.pid_path.exists()
+            assert successor.socket_path.exists()
+            assert successor.is_running()
+        finally:
+            successor._cleanup()
 
     def test_failed_competing_start_does_not_remove_owner_paths(
         self, tmp_path, monkeypatch
@@ -649,6 +769,49 @@ class TestAttachProtocol:
         finally:
             thread.join(timeout=1)
             assert not thread.is_alive()
+
+    def test_attach_returns_when_daemon_exits_without_stdin(
+        self, tmp_path, monkeypatch
+    ):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        sock_path = tmp_path / "hang.socket"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+
+        def send_ready_and_close() -> None:
+            conn, _ = server.accept()
+            send_msg(conn, IPCMessage(type="status", data={"ready": True}))
+            conn.close()
+            server.close()
+
+        read_fd, write_fd = os.pipe()
+        monkeypatch.setattr("sys.stdin", os.fdopen(read_fd))
+        server_thread = threading.Thread(target=send_ready_and_close)
+        server_thread.start()
+        done = threading.Event()
+        errors: list[BaseException] = []
+
+        def run_attach() -> None:
+            try:
+                attach("hang")
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                done.set()
+
+        attach_thread = threading.Thread(target=run_attach)
+        attach_thread.start()
+        try:
+            finished = done.wait(timeout=3)
+            assert finished, "attach hung on stdin after daemon disconnect"
+            assert errors == []
+        finally:
+            os.close(write_fd)
+            attach_thread.join(timeout=1)
+            server_thread.join(timeout=1)
 
     def test_attach_receives_history_and_echo(self, tmp_path):
         sock_path = tmp_path / "test.socket"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -9,16 +9,22 @@ Tests cover:
 
 from __future__ import annotations
 
+import io
 import os
 import socket
+import subprocess
 import threading
+import time
 from typing import TYPE_CHECKING
+
+import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 from gptme.server.daemon import (
     SessionDaemon,
+    attach,
     get_pid_path,
     get_socket_path,
     list_daemons,
@@ -95,6 +101,14 @@ class TestIPCProtocol:
             a.close()
             b.close()
 
+    @pytest.mark.parametrize(
+        "payload",
+        [b"not json", b"[]", b"{}", b'{"type":"bogus"}'],
+    )
+    def test_rejects_malformed_messages(self, payload):
+        with pytest.raises(ValueError, match="IPC message|message JSON"):
+            IPCMessage.from_bytes(payload)
+
 
 # ---------------------------------------------------------------------------
 # Daemon path helpers
@@ -121,6 +135,20 @@ class TestDaemonPaths:
         try:
             pp = get_pid_path("mysession")
             assert pp == tmp_path / "mysession.pid"
+        finally:
+            _dm.get_daemon_dir = orig
+
+    @pytest.mark.parametrize("name", ["../../target", "foo/bar", "..", "."])
+    def test_paths_reject_unsafe_session_names(self, tmp_path, name):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
+        try:
+            with pytest.raises(ValueError, match="single path component"):
+                get_socket_path(name)
+            with pytest.raises(ValueError, match="single path component"):
+                get_pid_path(name)
         finally:
             _dm.get_daemon_dir = orig
 
@@ -160,18 +188,152 @@ class TestSessionDaemonState:
 
         orig = _dm.get_daemon_dir
         _dm.get_daemon_dir = lambda: tmp_path
+        server = _ReadyDaemonThread(tmp_path / "live.socket")
+        server.start()
+        server.ready.wait(timeout=1)
         try:
             d = SessionDaemon("live")
-            (tmp_path / "live.socket").touch()
             (tmp_path / "live.pid").write_text(str(os.getpid()))
             assert d.is_running()
         finally:
+            server.join(timeout=1)
             _dm.get_daemon_dir = orig
+
+
+# ---------------------------------------------------------------------------
+# Persistent turn lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.stdout = io.BytesIO()
+        self.returncode: int | None = None
+        self.terminated = False
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+
+class TestPersistentTurnLifecycle:
+    def test_idle_daemon_waits_for_later_prompts(self, monkeypatch):
+        daemon = SessionDaemon("persistent")
+        calls: list[list[str]] = []
+
+        def fake_run_turn(args, prompts):
+            calls.append(prompts)
+
+        monkeypatch.setattr(daemon, "_run_turn", fake_run_turn)
+        worker = threading.Thread(
+            target=daemon._worker_loop, args=(["--name", "persistent"],)
+        )
+        worker.start()
+        try:
+            time.sleep(0.05)
+            assert worker.is_alive()
+            assert calls == []
+
+            daemon._turn_queue.put(["first prompt"])
+            daemon._turn_queue.join()
+            daemon._turn_queue.put(["follow-up"])
+            daemon._turn_queue.join()
+            assert calls == [["first prompt"], ["follow-up"]]
+            assert worker.is_alive()
+        finally:
+            daemon._stop_event.set()
+            worker.join(timeout=1)
+
+    def test_run_turn_uses_devnull_and_named_conversation(self, monkeypatch):
+        daemon = SessionDaemon("persistent")
+        captured = {}
+        fake_proc = _FakeProcess()
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            captured.update(kwargs)
+            return fake_proc
+
+        monkeypatch.setattr("gptme.server.daemon.subprocess.Popen", fake_popen)
+        daemon._run_turn(["--name", "persistent"], ["hello"])
+
+        assert captured["argv"][-3:] == ["--name", "persistent", "hello"]
+        assert captured["stdin"] is subprocess.DEVNULL
+
+    def test_pump_output_preserves_split_utf8(self, monkeypatch):
+        daemon = SessionDaemon("unicode")
+        read_chunks = iter([b"prefix \xe2", b"\x86\x92 suffix", b""])
+        published: list[tuple[bytes, str | None]] = []
+
+        monkeypatch.setattr(
+            "gptme.server.daemon.os.read", lambda _fd, _n: next(read_chunks)
+        )
+        monkeypatch.setattr(
+            daemon,
+            "_publish_output",
+            lambda chunk, text=None: published.append((chunk, text)),
+        )
+
+        class _Output:
+            def fileno(self) -> int:
+                return 0
+
+        daemon._pump_output(_Output())
+
+        assert "".join(text or "" for _, text in published) == "prefix → suffix"
+        assert "�" not in "".join(text or "" for _, text in published)
+
+    def test_history_is_sent_before_client_is_published(self):
+        daemon = SessionDaemon("ordered")
+        daemon._output_buf.append("history")
+        daemon._output_buf_size = len(b"history")
+        server, client = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            thread = threading.Thread(target=daemon._serve_client, args=(server,))
+            thread.start()
+            ready = recv_msg(client)
+            assert ready is not None
+            assert ready.type == "status"
+            history = recv_msg(client)
+            assert history is not None
+            assert history.data == "history"
+            daemon._publish_output(b"live")
+            live = recv_msg(client)
+            assert live is not None
+            assert live.data == "live"
+        finally:
+            client.close()
+            thread.join(timeout=1)
+            server.close()
 
 
 # ---------------------------------------------------------------------------
 # Integration: echo server simulating daemon I/O
 # ---------------------------------------------------------------------------
+
+
+class _ReadyDaemonThread(threading.Thread):
+    def __init__(self, sock_path: Path) -> None:
+        super().__init__(daemon=True)
+        self.sock_path = sock_path
+        self.ready = threading.Event()
+
+    def run(self) -> None:
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(self.sock_path))
+        server.listen(1)
+        self.ready.set()
+        conn, _ = server.accept()
+        send_msg(conn, IPCMessage(type="status", data={"ready": True}))
+        conn.close()
+        server.close()
 
 
 class _EchoDaemonThread(threading.Thread):
@@ -190,6 +352,7 @@ class _EchoDaemonThread(threading.Thread):
         self.ready.set()
         conn, _ = server.accept()
         try:
+            send_msg(conn, IPCMessage(type="status", data={"ready": True}))
             # Send a welcome message (simulates buffered history)
             send_msg(conn, IPCMessage(type="output", data="[session output]\n"))
             # Echo input back as output
@@ -210,6 +373,29 @@ class _EchoDaemonThread(threading.Thread):
 class TestAttachProtocol:
     """Test the attach protocol against a mock daemon (no real gptme subprocess)."""
 
+    def test_attach_reports_socket_closed_before_handshake(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        sock_path = tmp_path / "stale.socket"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+
+        def close_immediately():
+            conn, _ = server.accept()
+            conn.close()
+            server.close()
+
+        thread = threading.Thread(target=close_immediately)
+        thread.start()
+        try:
+            with pytest.raises(ConnectionResetError, match="closed during attach"):
+                attach("stale")
+        finally:
+            thread.join(timeout=1)
+            assert not thread.is_alive()
+
     def test_attach_receives_history_and_echo(self, tmp_path):
         sock_path = tmp_path / "test.socket"
 
@@ -220,6 +406,10 @@ class TestAttachProtocol:
         # Connect as a client
         conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         conn.connect(str(sock_path))
+
+        ready = recv_msg(conn)
+        assert ready is not None
+        assert ready.type == "status"
 
         # Receive the welcome message (buffered history)
         welcome = recv_msg(conn)
@@ -293,13 +483,16 @@ class TestListDaemons:
 
         orig = _dm.get_daemon_dir
         _dm.get_daemon_dir = lambda: tmp_path
+        server = _ReadyDaemonThread(tmp_path / "live.socket")
+        server.start()
+        server.ready.wait(timeout=1)
         try:
             (tmp_path / "live.pid").write_text(str(os.getpid()))
-            (tmp_path / "live.socket").touch()
             daemons = list_daemons()
             assert len(daemons) == 1
             assert daemons[0]["running"] is True
         finally:
+            server.join(timeout=1)
             _dm.get_daemon_dir = orig
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -309,7 +309,6 @@ class TestSessionDaemonState:
         def accept_stop() -> None:
             conn, _ = sock.accept()
             try:
-                send_msg(conn, IPCMessage(type="status", data={"ready": True}))
                 msg = recv_msg(conn)
                 if msg is not None:
                     received.append(msg.type)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -399,7 +399,9 @@ class TestPersistentTurnLifecycle:
             thread.join(timeout=1)
             server.close()
 
-    def test_client_writes_have_timeout_before_handshake(self, monkeypatch):
+    def test_client_uses_distinct_write_and_read_timeouts(self, monkeypatch):
+        from gptme.server import daemon as daemon_module
+
         daemon = SessionDaemon("bounded-writes")
         server, client = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
         observed_timeouts: list[float | None] = []
@@ -414,10 +416,35 @@ class TestPersistentTurnLifecycle:
             thread = threading.Thread(target=daemon._serve_client, args=(server,))
             thread.start()
             assert recv_msg(client) is not None
-            assert observed_timeouts[0] is not None
+            assert observed_timeouts[0] == daemon_module._CLIENT_WRITE_TIMEOUT
+            assert server.gettimeout() == daemon_module._CLIENT_READ_TIMEOUT
+            daemon._publish_output(b"live")
+            assert recv_msg(client) is not None
+            assert observed_timeouts[-1] == daemon_module._CLIENT_WRITE_TIMEOUT
+            assert server.gettimeout() == daemon_module._CLIENT_READ_TIMEOUT
         finally:
             client.close()
             thread.join(timeout=1)
+            server.close()
+
+    def test_live_write_failure_disconnects_served_client(self, monkeypatch):
+        daemon = SessionDaemon("failed-write")
+        server, client = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        thread = threading.Thread(target=daemon._serve_client, args=(server,))
+        thread.start()
+        assert recv_msg(client) is not None
+
+        def fail_send(_sock, _msg):
+            raise TimeoutError
+
+        monkeypatch.setattr("gptme.server.daemon.send_msg", fail_send)
+        daemon._publish_output(b"blocked")
+        thread.join(timeout=1)
+        try:
+            assert not thread.is_alive()
+            assert daemon._client is None
+        finally:
+            client.close()
             server.close()
 
     def test_accept_loop_retries_interrupted_select(self, monkeypatch):
@@ -521,6 +548,21 @@ class _EchoDaemonThread(threading.Thread):
 
 class TestAttachProtocol:
     """Test the attach protocol against a mock daemon (no real gptme subprocess)."""
+
+    def test_attach_times_out_when_client_slot_is_occupied(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_ATTACH_HANDSHAKE_TIMEOUT", 0.01)
+        sock_path = tmp_path / "occupied.socket"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+        try:
+            with pytest.raises(TimeoutError, match="already has an attached client"):
+                attach("occupied")
+        finally:
+            server.close()
 
     def test_attach_reports_socket_closed_before_handshake(self, tmp_path, monkeypatch):
         from gptme.server import daemon as _dm
@@ -664,6 +706,21 @@ class TestListDaemons:
 
 
 class TestDaemonCLI:
+    @pytest.mark.parametrize("command", ["start", "attach", "stop", "status"])
+    def test_commands_reject_invalid_session_cleanly(self, command):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+
+        args = [command, "foo/bar"]
+        if command == "start":
+            args = [command, "--session", "foo/bar"]
+        result = CliRunner().invoke(cli, args)
+        assert result.exit_code == 2
+        assert "Invalid value" in result.output
+        assert "single path component" in result.output
+        assert "Traceback" not in result.output
+
     def test_attach_can_disable_auto_start(self):
         from click.testing import CliRunner
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -78,6 +78,39 @@ class TestIPCProtocol:
             a.close()
             b.close()
 
+    def test_buffer_preserves_partial_frame_across_timeout(self):
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        b.settimeout(0.01)
+        buffer = bytearray()
+        encoded = IPCMessage(type="input", data="split frame").encode()
+        try:
+            a.sendall(encoded[:6])
+            with pytest.raises(TimeoutError):
+                recv_msg(b, buffer)
+            assert buffer == encoded[:6]
+
+            a.sendall(encoded[6:])
+            received = recv_msg(b, buffer)
+            assert received is not None
+            assert received.data == "split frame"
+            assert buffer == bytearray()
+        finally:
+            a.close()
+            b.close()
+
+    @pytest.mark.parametrize("split_at", [2, 6])
+    def test_buffer_rejects_eof_mid_frame(self, split_at):
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        encoded = IPCMessage(type="input", data="partial").encode()
+        try:
+            a.sendall(encoded[:split_at])
+            a.close()
+            with pytest.raises(ValueError, match="incomplete IPC message"):
+                recv_msg(b, bytearray())
+        finally:
+            a.close()
+            b.close()
+
     def test_recv_returns_none_on_eof(self):
         """recv_msg returns None when the other end closes."""
         a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -258,6 +291,25 @@ class _FakeProcess:
 
 
 class TestPersistentTurnLifecycle:
+    def test_worker_survives_failed_turn(self, monkeypatch):
+        daemon = SessionDaemon("failed-turn")
+        calls = 0
+
+        def fail_once(_args, _prompts):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("spawn failed")
+            daemon._stop_event.set()
+
+        monkeypatch.setattr(daemon, "_run_turn", fail_once)
+        daemon._turn_queue.put(["first"])
+        daemon._turn_queue.put(["second"])
+        daemon._worker_loop([])
+
+        assert calls == 2
+        assert "Turn failed: spawn failed" in "".join(daemon._output_buf)
+
     def test_idle_daemon_waits_for_later_prompts(self, monkeypatch):
         daemon = SessionDaemon("persistent")
         calls: list[list[str]] = []
@@ -298,7 +350,7 @@ class TestPersistentTurnLifecycle:
         monkeypatch.setattr("gptme.server.daemon.subprocess.Popen", fake_popen)
         daemon._run_turn(["--name", "persistent"], ["hello"])
 
-        assert captured["argv"][-3:] == ["--name", "persistent", "hello"]
+        assert captured["argv"][-4:] == ["--name", "persistent", "--", "hello"]
         assert captured["stdin"] is subprocess.DEVNULL
 
     def test_pump_output_preserves_split_utf8(self, monkeypatch):
@@ -387,6 +439,28 @@ class TestPersistentTurnLifecycle:
             assert calls == 2
         finally:
             server.close()
+
+    def test_accept_loop_retries_transient_accept_error(self, monkeypatch):
+        daemon = SessionDaemon("accept-error")
+        select_calls = 0
+
+        class FailingServer:
+            def accept(self):
+                raise OSError
+
+        server = FailingServer()
+
+        def readable_once(*_args):
+            nonlocal select_calls
+            select_calls += 1
+            if select_calls == 1:
+                return [server], [], []
+            daemon._stop_event.set()
+            return [], [], []
+
+        monkeypatch.setattr("gptme.server.daemon.select.select", readable_once)
+        daemon._accept_loop(server)  # type: ignore[arg-type]
+        assert select_calls == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -278,6 +278,7 @@ class TestSessionDaemonState:
                 observed.append((pidfd, signum))
             finally:
                 probe.close()
+            owner._cleanup()
 
         monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: 99)
         monkeypatch.setattr(_dm, "_pidfd_send_signal", record_send)
@@ -315,6 +316,7 @@ class TestSessionDaemonState:
                 send_msg(conn, IPCMessage(type="status", data={"stopping": True}))
             finally:
                 conn.close()
+                owner._cleanup()
 
         thread = threading.Thread(target=accept_stop)
         thread.start()
@@ -323,6 +325,74 @@ class TestSessionDaemonState:
             thread.join(timeout=2)
             assert received == ["signal"]
         finally:
+            sock.close()
+            owner._cleanup()
+
+    def test_stop_waits_for_daemon_teardown(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+        owner = SessionDaemon("slow-stop")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        release = threading.Event()
+
+        def request_stop(_sock_path) -> bool:
+            def teardown() -> None:
+                release.wait()
+                owner._cleanup()
+
+            threading.Thread(target=teardown).start()
+            return True
+
+        monkeypatch.setattr(_dm, "_stop_via_socket", request_stop)
+        stopped = threading.Event()
+
+        def run_stop() -> None:
+            SessionDaemon("slow-stop").stop()
+            stopped.set()
+
+        thread = threading.Thread(target=run_stop)
+        thread.start()
+        try:
+            assert not stopped.wait(timeout=0.1)
+            release.set()
+            assert stopped.wait(timeout=1)
+        finally:
+            release.set()
+            thread.join(timeout=1)
+            owner._cleanup()
+
+    def test_stop_times_out_if_teardown_never_happens(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+        monkeypatch.setattr(_dm, "_STOP_TEARDOWN_TIMEOUT", 0.2)
+        owner = SessionDaemon("stuck-stop")
+        owner._acquire_pid_file()
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if owner.socket_path.exists():
+            owner.socket_path.unlink()
+        sock.bind(str(owner.socket_path))
+        sock.listen(1)
+
+        def accept_stop() -> None:
+            conn, _ = sock.accept()
+            try:
+                recv_msg(conn)
+                send_msg(conn, IPCMessage(type="status", data={"stopping": True}))
+            finally:
+                conn.close()
+
+        thread = threading.Thread(target=accept_stop)
+        thread.start()
+        try:
+            with pytest.raises(TimeoutError, match="did not stop"):
+                SessionDaemon("stuck-stop").stop()
+        finally:
+            thread.join(timeout=1)
             sock.close()
             owner._cleanup()
 
@@ -335,12 +405,13 @@ class TestSessionDaemonState:
         owner.socket_path.touch()
         sent: list[tuple[int, int]] = []
         real_close = os.close
+
+        def record_and_teardown(pidfd: int, signum: int) -> None:
+            sent.append((pidfd, signum))
+            owner._cleanup()
+
         monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: 99)
-        monkeypatch.setattr(
-            _dm,
-            "_pidfd_send_signal",
-            lambda pidfd, signum: sent.append((pidfd, signum)),
-        )
+        monkeypatch.setattr(_dm, "_pidfd_send_signal", record_and_teardown)
         monkeypatch.setattr(
             os, "close", lambda fd: None if fd == 99 else real_close(fd)
         )
@@ -687,7 +758,14 @@ class TestPersistentTurnLifecycle:
         server_sock.bind(str(daemon.socket_path))
         server_sock.listen(2)
         server_sock.setblocking(False)
-        loop = threading.Thread(target=daemon._accept_loop, args=(server_sock,))
+
+        def run_loop() -> None:
+            try:
+                daemon._accept_loop(server_sock)
+            finally:
+                daemon._cleanup()
+
+        loop = threading.Thread(target=run_loop)
         loop.start()
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         client.settimeout(2)
@@ -1102,3 +1180,23 @@ class TestDaemonCLI:
             assert result.exit_code != 0  # exits 1 when not running
         finally:
             _dm.get_daemon_dir = orig
+
+    def test_stop_command_does_not_claim_success_on_teardown_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(SessionDaemon, "is_running", lambda self: True)
+
+        def fail_stop(self) -> None:
+            raise TimeoutError("Daemon did not stop in time")
+
+        monkeypatch.setattr(SessionDaemon, "stop", fail_stop)
+        result = CliRunner().invoke(cli, ["stop", "cli-timeout"])
+        assert result.exit_code != 0
+        assert "Timed out" in result.output
+        assert "Stopped daemon" not in result.output

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -183,20 +183,54 @@ class TestSessionDaemonState:
         finally:
             _dm.get_daemon_dir = orig
 
-    def test_is_running_true_with_own_pid(self, tmp_path):
+    def test_is_running_false_when_stale_pid_was_reused(self, tmp_path):
         from gptme.server import daemon as _dm
 
         orig = _dm.get_daemon_dir
         _dm.get_daemon_dir = lambda: tmp_path
-        server = _ReadyDaemonThread(tmp_path / "live.socket")
-        server.start()
-        server.ready.wait(timeout=1)
+        try:
+            d = SessionDaemon("reused")
+            d.pid_path.write_text(str(os.getpid()))
+            d.socket_path.touch()
+
+            # A live PID and stale socket do not prove that process owns the daemon.
+            assert not d.is_running()
+        finally:
+            _dm.get_daemon_dir = orig
+
+    def test_stop_does_not_signal_reused_pid(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        d = SessionDaemon("reused")
+        d.pid_path.write_text(str(os.getpid()))
+        d.socket_path.touch()
+        signals: list[int] = []
+        real_kill = os.kill
+
+        def record_kill(pid: int, signum: int) -> None:
+            if signum == 0:
+                real_kill(pid, signum)
+            else:
+                signals.append(signum)
+
+        monkeypatch.setattr(os, "kill", record_kill)
+        d.stop()
+
+        assert signals == []
+
+    def test_is_running_true_with_owned_pid_file(self, tmp_path):
+        from gptme.server import daemon as _dm
+
+        orig = _dm.get_daemon_dir
+        _dm.get_daemon_dir = lambda: tmp_path
         try:
             d = SessionDaemon("live")
-            (tmp_path / "live.pid").write_text(str(os.getpid()))
+            d._acquire_pid_file()
+            d.socket_path.touch()
             assert d.is_running()
         finally:
-            server.join(timeout=1)
+            d._cleanup()
             _dm.get_daemon_dir = orig
 
 
@@ -500,12 +534,14 @@ class TestListDaemons:
 
         monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
         daemon = SessionDaemon("occupied")
-        daemon.pid_path.write_text(str(os.getpid()))
+        daemon._acquire_pid_file()
         daemon.socket_path.touch()
-
-        # The single-client MVP cannot accept a status probe while occupied, so
-        # liveness relies on the daemon-owned PID and socket lifecycle markers.
-        assert daemon.is_running()
+        try:
+            # The advisory lock remains held while any client occupies the single
+            # connection slot, so liveness does not depend on a status handshake.
+            assert daemon.is_running()
+        finally:
+            daemon._cleanup()
 
     def test_list_empty(self, tmp_path):
         from gptme.server import daemon as _dm
@@ -536,16 +572,15 @@ class TestListDaemons:
 
         orig = _dm.get_daemon_dir
         _dm.get_daemon_dir = lambda: tmp_path
-        server = _ReadyDaemonThread(tmp_path / "live.socket")
-        server.start()
-        server.ready.wait(timeout=1)
         try:
-            (tmp_path / "live.pid").write_text(str(os.getpid()))
+            daemon = SessionDaemon("live")
+            daemon._acquire_pid_file()
+            daemon.socket_path.touch()
             daemons = list_daemons()
             assert len(daemons) == 1
             assert daemons[0]["running"] is True
         finally:
-            server.join(timeout=1)
+            daemon._cleanup()
             _dm.get_daemon_dir = orig
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -460,6 +460,28 @@ class TestSessionDaemonState:
             owner.socket_path.unlink(missing_ok=True)
             owner.pid_path.unlink(missing_ok=True)
 
+    def test_stop_raises_if_neither_signal_path_succeeds(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(_dm, "_pidfd_open", lambda _pid: None)
+        monkeypatch.setattr(os, "kill", lambda *_args: pytest.fail("unpinned os.kill"))
+        owner = SessionDaemon("no-signal")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        try:
+            with pytest.raises(RuntimeError, match="Failed to signal"):
+                SessionDaemon("no-signal").stop()
+            assert owner._pid_file is not None
+            probe = owner.pid_path.open()
+            try:
+                with pytest.raises(BlockingIOError):
+                    fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            finally:
+                probe.close()
+        finally:
+            owner._cleanup()
+
     def test_is_running_true_with_owned_pid_file(self, tmp_path):
         from gptme.server import daemon as _dm
 
@@ -1199,4 +1221,26 @@ class TestDaemonCLI:
         result = CliRunner().invoke(cli, ["stop", "cli-timeout"])
         assert result.exit_code != 0
         assert "Timed out" in result.output
+        assert "Stopped daemon" not in result.output
+
+    def test_stop_command_does_not_claim_success_when_signal_fails(
+        self, tmp_path, monkeypatch
+    ):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        monkeypatch.setattr(SessionDaemon, "is_running", lambda self: True)
+
+        def fail_stop(self) -> None:
+            raise RuntimeError(
+                "Failed to signal daemon 'cli-unsignaled'; it may still be running"
+            )
+
+        monkeypatch.setattr(SessionDaemon, "stop", fail_stop)
+        result = CliRunner().invoke(cli, ["stop", "cli-unsignaled"])
+        assert result.exit_code != 0
+        assert "Failed to signal" in result.output
         assert "Stopped daemon" not in result.output

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -266,6 +266,24 @@ class TestSessionDaemonState:
             d._cleanup()
             _dm.get_daemon_dir = orig
 
+    def test_failed_competing_start_does_not_remove_owner_paths(
+        self, tmp_path, monkeypatch
+    ):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        owner = SessionDaemon("racing")
+        contender = SessionDaemon("racing")
+        owner._acquire_pid_file()
+        owner.socket_path.touch()
+        try:
+            contender.start([], daemonize=False)
+            assert owner.pid_path.exists()
+            assert owner.socket_path.exists()
+            assert owner.is_running()
+        finally:
+            owner._cleanup()
+
 
 # ---------------------------------------------------------------------------
 # Persistent turn lifecycle

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -313,6 +313,47 @@ class TestPersistentTurnLifecycle:
             thread.join(timeout=1)
             server.close()
 
+    def test_client_writes_have_timeout_before_handshake(self, monkeypatch):
+        daemon = SessionDaemon("bounded-writes")
+        server, client = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        observed_timeouts: list[float | None] = []
+        original_send_msg = send_msg
+
+        def capture_timeout(sock, msg):
+            observed_timeouts.append(sock.gettimeout())
+            original_send_msg(sock, msg)
+
+        monkeypatch.setattr("gptme.server.daemon.send_msg", capture_timeout)
+        try:
+            thread = threading.Thread(target=daemon._serve_client, args=(server,))
+            thread.start()
+            assert recv_msg(client) is not None
+            assert observed_timeouts[0] is not None
+        finally:
+            client.close()
+            thread.join(timeout=1)
+            server.close()
+
+    def test_accept_loop_retries_interrupted_select(self, monkeypatch):
+        daemon = SessionDaemon("interrupted")
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        calls = 0
+
+        def interrupted_once(*_args):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise InterruptedError
+            daemon._stop_event.set()
+            return [], [], []
+
+        monkeypatch.setattr("gptme.server.daemon.select.select", interrupted_once)
+        try:
+            daemon._accept_loop(server)
+            assert calls == 2
+        finally:
+            server.close()
+
 
 # ---------------------------------------------------------------------------
 # Integration: echo server simulating daemon I/O
@@ -454,6 +495,18 @@ class TestAttachProtocol:
 
 
 class TestListDaemons:
+    def test_is_running_while_primary_client_is_attached(self, tmp_path, monkeypatch):
+        from gptme.server import daemon as _dm
+
+        monkeypatch.setattr(_dm, "get_daemon_dir", lambda: tmp_path)
+        daemon = SessionDaemon("occupied")
+        daemon.pid_path.write_text(str(os.getpid()))
+        daemon.socket_path.touch()
+
+        # The single-client MVP cannot accept a status probe while occupied, so
+        # liveness relies on the daemon-owned PID and socket lifecycle markers.
+        assert daemon.is_running()
+
     def test_list_empty(self, tmp_path):
         from gptme.server import daemon as _dm
 
@@ -502,6 +555,15 @@ class TestListDaemons:
 
 
 class TestDaemonCLI:
+    def test_attach_can_disable_auto_start(self):
+        from click.testing import CliRunner
+
+        from gptme.cli.cmd_daemon import cli
+
+        result = CliRunner().invoke(cli, ["attach", "--help"])
+        assert result.exit_code == 0
+        assert "--no-start-if-missing" in result.output
+
     def test_list_command_empty(self, tmp_path):
         from click.testing import CliRunner
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -312,6 +312,7 @@ class TestSessionDaemonState:
                 msg = recv_msg(conn)
                 if msg is not None:
                     received.append(msg.type)
+                send_msg(conn, IPCMessage(type="status", data={"stopping": True}))
             finally:
                 conn.close()
 


### PR DESCRIPTION
## Summary

- Adds `gptme daemon` command group for managing persistent background sessions
- Sessions survive terminal close, SSH drops, and laptop sleep via Unix domain socket IPC
- Implements tmux-style attach/detach UX: `gptme daemon start`, `gptme daemon attach`

## Design

**Architecture**: Unix domain socket + 4-byte length-prefixed JSON protocol. Chosen over HTTP for lower latency, simpler implementation, and `mode 0600` user-isolation.

**New files**:
- `gptme/server/ipc_protocol.py` — wire format codec (`IPCMessage`, `send_msg`, `recv_msg`)
- `gptme/server/daemon.py` — `SessionDaemon` class (double-fork daemonize, I/O pump, accept loop, 64KB ring-buffer history replay)
- `gptme/cli/cmd_daemon.py` — Click subcommands: `start`, `attach`, `list`, `stop`, `status`
- `tests/test_daemon.py` — 19 tests covering protocol roundtrip, path helpers, daemon state, attach protocol, CLI smoke

**Design decisions** (resolved, from architecture doc `knowledge/technical-designs/gptme-session-daemon-architecture.md`):
- Auto-start on attach (Option A — better UX, matches tmux)
- Socket at `~/.config/gptme/daemon/<name>.socket` via `get_config_dir()` (survives `/tmp` cleanup)  
- Single-client MVP — multi-client observe-only fan-out is Phase 3
- In-flight recovery is Phase 2; MVP reuses existing JSONL persistence

## Usage

```bash
# Start a background session
gptme daemon start --session mywork "Implement feature X"

# Re-attach from any terminal (auto-starts if not running)
gptme daemon attach mywork

# List and manage
gptme daemon list
gptme daemon status mywork
gptme daemon stop mywork

# Also available as standalone binary
gptme-daemon start --session mywork
```

## Test plan

- [x] `pytest tests/test_daemon.py` — 19/19 pass
- [x] ruff clean (TC003, B904, F401 violations fixed)
- [x] mypy clean on daemon files (pre-existing acp errors unrelated)
- [ ] Manual smoke test: `gptme daemon start --session test "say hello" && gptme daemon attach test`