### PR TITLE
fix(cli): support stdin dash in slop check

### DIFF
--- a/gptme/cli/cmd_slop.py
+++ b/gptme/cli/cmd_slop.py
@@ -20,7 +20,7 @@ def slop() -> None:
 @click.argument(
     "file",
     required=False,
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=click.Path(exists=True, dir_okay=False, path_type=Path, allow_dash=True),
 )
 @click.option(
     "--text", "inline_text", default=None, help="Inline text to scan instead of a file."
@@ -86,7 +86,7 @@ def check(
 
     if inline_text is not None:
         text = inline_text
-    elif file is not None:
+    elif file is not None and str(file) != "-":
         text = file.read_text(encoding="utf-8", errors="replace")
     else:
         if sys.stdin.isatty():

--- a/tests/test_anti_slop.py
+++ b/tests/test_anti_slop.py
@@ -247,3 +247,10 @@ def test_cli_check_stdin():
     runner = CliRunner()
     result = runner.invoke(anti_slop, ["check"], input=_CLEAN_20W + "\n")
     assert result.exit_code == 0
+
+
+def test_cli_check_stdin_dash():
+    runner = CliRunner()
+    result = runner.invoke(anti_slop, ["check", "-"], input=_CLEAN_20W + "\n")
+    assert result.exit_code == 0
+    assert "PASS" in result.output


### PR DESCRIPTION
## Summary

- accept `-` as the conventional stdin path for `gptme-util slop check`
- route both an omitted file and explicit `-` through stdin
- add regression coverage for the explicit dash form

## Verification

- `env -u VIRTUAL_ENV .venv/bin/python -m pytest tests/test_anti_slop.py -q` (27 passed)
- `uv run ruff check gptme/cli/cmd_slop.py tests/test_anti_slop.py`
- `uv run ruff format --check gptme/cli/cmd_slop.py tests/test_anti_slop.py`
- manual pipe smoke test through `.venv/bin/gptme-util slop check -`

The help already documents stdin and the no-argument pipe form works; this makes the explicit Unix `-` spelling work too, matching `gptme-util tokens count --file -`.
