### PR TITLE
fix(status): serialize list/dict provider values as JSON in table format

### DIFF
--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -137,8 +137,19 @@ def _disk_usage(path: Path | None = None) -> str:
 
 
 def _markdown_table_cell(value: object) -> str:
-    """Escape dynamic values for a single markdown table cell."""
-    text = " ".join(str(value).splitlines()).strip()
+    """Escape dynamic values for a single markdown table cell.
+
+    Lists and dicts are serialised as compact JSON so the cell content is
+    machine-parseable rather than a raw Python repr.
+    """
+    if isinstance(value, (list, dict)):
+        try:
+            text = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError):
+            text = str(value)
+    else:
+        text = str(value)
+    text = " ".join(text.splitlines()).strip()
     if not text:
         return "none"
     return text.replace("|", r"\|")

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -146,12 +146,24 @@ def _markdown_table_cell(value: object) -> str:
     if structured:
         try:
             text = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+            # U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are not
+            # escaped by json.dumps(ensure_ascii=False), but they act as
+            # newlines in every line-oriented parser — including markdown table
+            # renderers and str.splitlines().  Replace them with their JSON
+            # \uXXXX escape forms so that the cell is safe for all consumers
+            # while still round-tripping correctly through json.loads.
+            text = text.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
         except (TypeError, ValueError):
             text = str(value)
             structured = False
     else:
         text = str(value)
-    text = " ".join(text.splitlines()).strip()
+    # Collapse newlines in plain-text values.  Skip for structured output:
+    # JSON is compact and single-line after the U+2028/U+2029 escaping above.
+    if not structured:
+        text = " ".join(text.splitlines()).strip()
+    else:
+        text = text.strip()
     if not text:
         return "none"
     # Markdown's ``\|`` escape is invalid inside JSON strings.  A JSON unicode

--- a/gptme/cli/cmd_status.py
+++ b/gptme/cli/cmd_status.py
@@ -142,17 +142,22 @@ def _markdown_table_cell(value: object) -> str:
     Lists and dicts are serialised as compact JSON so the cell content is
     machine-parseable rather than a raw Python repr.
     """
-    if isinstance(value, (list, dict)):
+    structured = isinstance(value, (list, dict))
+    if structured:
         try:
             text = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
         except (TypeError, ValueError):
             text = str(value)
+            structured = False
     else:
         text = str(value)
     text = " ".join(text.splitlines()).strip()
     if not text:
         return "none"
-    return text.replace("|", r"\|")
+    # Markdown's ``\|`` escape is invalid inside JSON strings.  A JSON unicode
+    # escape hides the delimiter from the Markdown parser while preserving the
+    # value when a consumer decodes the cell.
+    return text.replace("|", r"\u007c" if structured else r"\|")
 
 
 def _strip_markdown(doc: str) -> str:

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -939,3 +939,47 @@ def test_build_table_document_provider_list_dict_values_are_compact_json():
     assert json.loads(rows["items"]) == [{"id": "task-1", "title": "Some | task"}]
     assert json.loads(rows["counts"]) == {"done": 3, "pending": 1}
     assert rows["items"] == ('[{"id":"task-1","title":"Some \\u007c task"}]')
+
+
+def test_build_table_document_unicode_line_separators_preserved_in_json():
+    """U+2028/U+2029 inside nested JSON values must survive the table cell renderer.
+
+    json.dumps(ensure_ascii=False) emits U+2028/U+2029 literally inside JSON
+    string values.  Before the fix, str.splitlines() (which splits on those
+    Unicode line-separator characters) was applied to the JSON output, silently
+    corrupting any structured (dict/list) cell whose strings contained them.
+
+    Plain string values intentionally go through splitlines() for newline
+    collapsing — this test uses a dict value so the bug is exercised.
+    """
+
+    class _LineSepProvider:
+        name = "linesep"
+
+        def collect(self) -> dict:
+            # "meta" is a dict, so _markdown_table_cell calls json.dumps.
+            # U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) appear
+            # inside the nested strings; json.dumps(ensure_ascii=False) emits
+            # them literally.  Without the fix splitlines() splits on them.
+            return {
+                "meta": {
+                    "a": "before after",
+                    "b": "x y",
+                }
+            }
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_LineSepProvider()])
+    rows = {
+        cells[1].strip(): cells[2].strip()
+        for line in doc.splitlines()
+        if line.startswith("|")
+        for cells in [line.split("|")]
+        if len(cells) == 4
+    }
+    parsed = json.loads(rows["meta"])
+    # Characters must survive round-trip — splitlines() would have turned them to spaces.
+    assert parsed["a"] == "before after", f"U+2028 corrupted: {parsed['a']!r}"
+    assert parsed["b"] == "x y", f"U+2029 corrupted: {parsed['b']!r}"

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -910,3 +910,32 @@ def test_build_table_document_provider_non_string_key_skipped():
     # The valid string key still appears.
     assert "| string_key |" in doc
     assert "kept" in doc
+
+
+def test_build_table_document_provider_list_dict_values_are_compact_json():
+    """Provider list/dict values must appear as compact JSON in table format, not Python repr.
+
+    Without the fix, str([{"id": "x"}]) produces "[{'id': 'x'}]" — Python repr
+    with single-quoted strings that is not valid JSON.  The cell must instead
+    contain compact JSON produced by json.dumps().
+    """
+
+    class _ComplexProvider:
+        name = "complex"
+
+        def collect(self) -> dict:
+            return {
+                "items": [{"id": "task-1", "title": "Some task"}],
+                "counts": {"done": 3, "pending": 1},
+            }
+
+        def narrative_sections(self) -> list:
+            return []
+
+    doc = build_table_document(providers=[_ComplexProvider()])
+    # Python repr must NOT appear (single-quoted keys are the tell)
+    assert "[{'id'" not in doc, "Python repr list detected in table output"
+    assert "{'done'" not in doc, "Python repr dict detected in table output"
+    # Compact JSON must be present for both list and dict values
+    assert '"task-1"' in doc, "list value not serialized as JSON"
+    assert '"done"' in doc, "dict value not serialized as JSON"

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -913,19 +913,14 @@ def test_build_table_document_provider_non_string_key_skipped():
 
 
 def test_build_table_document_provider_list_dict_values_are_compact_json():
-    """Provider list/dict values must appear as compact JSON in table format, not Python repr.
-
-    Without the fix, str([{"id": "x"}]) produces "[{'id': 'x'}]" — Python repr
-    with single-quoted strings that is not valid JSON.  The cell must instead
-    contain compact JSON produced by json.dumps().
-    """
+    """Provider list/dict values must remain valid JSON inside table cells."""
 
     class _ComplexProvider:
         name = "complex"
 
         def collect(self) -> dict:
             return {
-                "items": [{"id": "task-1", "title": "Some task"}],
+                "items": [{"id": "task-1", "title": "Some | task"}],
                 "counts": {"done": 3, "pending": 1},
             }
 
@@ -933,9 +928,14 @@ def test_build_table_document_provider_list_dict_values_are_compact_json():
             return []
 
     doc = build_table_document(providers=[_ComplexProvider()])
-    # Python repr must NOT appear (single-quoted keys are the tell)
-    assert "[{'id'" not in doc, "Python repr list detected in table output"
-    assert "{'done'" not in doc, "Python repr dict detected in table output"
-    # Compact JSON must be present for both list and dict values
-    assert '"task-1"' in doc, "list value not serialized as JSON"
-    assert '"done"' in doc, "dict value not serialized as JSON"
+    rows = {
+        cells[1].strip(): cells[2].strip()
+        for line in doc.splitlines()
+        if line.startswith("|")
+        for cells in [line.split("|")]
+        if len(cells) == 4
+    }
+
+    assert json.loads(rows["items"]) == [{"id": "task-1", "title": "Some | task"}]
+    assert json.loads(rows["counts"]) == {"done": 3, "pending": 1}
+    assert rows["items"] == ('[{"id":"task-1","title":"Some \\u007c task"}]')


### PR DESCRIPTION
## Summary

`gptme-util status --format table` was rendering provider values that are lists or dicts as Python `repr` strings (e.g. `[{'id': 'task-1', 'title': '...'}]`) rather than valid JSON. Any consumer expecting compact JSON from the table output (including the `gptme-bob-status` plugin's `bob_active_tasks`, `bob_services`, etc.) would receive unparseable content.

**Root cause**: `_markdown_table_cell()` called `str(value)` unconditionally, and `str()` on list/dict produces Python repr.

**Fix**: detect `list`/`dict` types and use `json.dumps(value, ensure_ascii=False, separators=(",", ":"))`. Scalar values continue to use `str()` unchanged. Falls back to `str()` if `json.dumps` raises.

- Added regression test `test_build_table_document_provider_list_dict_values_are_compact_json` that asserts Python repr syntax is absent and compact JSON is present.

## Test plan

- [x] New test `test_build_table_document_provider_list_dict_values_are_compact_json` verifies list/dict → compact JSON
- [x] All 43 existing `tests/test_cli_status.py` tests still pass
- [x] Pre-commit hooks pass