### PR TITLE
feat(ci): use config-driven root structure validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,37 +18,9 @@ repos:
     additional_dependencies: [types-tabulate, types-docutils, tomli, tomli_w, opentelemetry-api, opentelemetry-sdk, prometheus-client, prompt_toolkit, click, pytest, openai==1.101.0, rich, tomlkit, dspy, textual]
     args: [--ignore-missing-imports, --check-untyped-defs]
 - repo: https://github.com/gptme/gptme-contrib
-  rev: 74c946c792c87eccd8632dbf26cbc390dd5c26bd  # post-#1479: shareable hook + git-ls-files impl
+  rev: 13d63e63b35705bc16646ed4b0964dcfa176bc43  # gptme/gptme-contrib#1520
   hooks:
-  - id: check-root-structure
-    args:
-      # Files
-      - --allow=.dockerignore
-      - --allow=.env.example
-      - --allow=.github
-      - --allow=.gitignore
-      - --allow=.pre-commit-config.yaml
-      - --allow=AGENTS.md
-      - --allow=LICENSE
-      - --allow=Makefile
-      - --allow=README.md
-      - --allow=SECURITY.md
-      - --allow=docker-compose.yml
-      - --allow=gptme.toml
-      - --allow=mypy.ini
-      - --allow=poetry.lock
-      - --allow=pyproject.toml
-      # Directories
-      - --allow=docs
-      - --allow=gptme
-      - --allow=gptme-extension
-      - --allow=media
-      - --allow=packages
-      - --allow=scripts
-      - --allow=site
-      - --allow=tauri
-      - --allow=tests
-      - --allow=webui
+  - id: validate-root-structure
 - repo: local
   hooks:
   - id: check-rst-formatting

--- a/root-structure-allowlist.yaml
+++ b/root-structure-allowlist.yaml
@@ -1,0 +1,34 @@
+---
+# Allowed top-level entries in the gptme repository.
+# Update this list deliberately when adding a new root file or directory.
+
+allowed_entries:
+  # Files and configuration
+  - .dockerignore
+  - .env.example
+  - .github
+  - .gitignore
+  - .pre-commit-config.yaml
+  - AGENTS.md
+  - LICENSE
+  - Makefile
+  - README.md
+  - SECURITY.md
+  - docker-compose.yml
+  - gptme.toml
+  - mypy.ini
+  - poetry.lock
+  - pyproject.toml
+  - root-structure-allowlist.yaml
+
+  # Directories
+  - docs
+  - gptme
+  - gptme-extension
+  - media
+  - packages
+  - scripts
+  - site
+  - tauri
+  - tests
+  - webui


### PR DESCRIPTION
## Summary

Swap gptme's hardcoded `check-root-structure --allow …` hook for the shared config-driven `validate-root-structure` hook, with the allowlist owned in-repo as `root-structure-allowlist.yaml`.

This is Phase 2.4 of the root-structure validator propagation (local task `root-structure-validator-propagation`). The shared implementation now lives in gptme-contrib; consuming repos should own a data file, not a copy of the checker.

Pinned to the durable [gptme/gptme-contrib#1520](https://github.com/gptme/gptme-contrib/pull/1520) merge commit (`13d63e63`), **not** the earlier #1505 merge. #1520 is what makes the remote Python hook installable (`validate-root-structure` console script + `[build-system]` + runtime PyYAML).

## Changes

- Add `root-structure-allowlist.yaml` with the same entries previously passed as `--allow` args, plus the allowlist file itself.
- Replace hook id `check-root-structure` with `validate-root-structure` and drop the arg list.
- Pin `rev` to `13d63e63b35705bc16646ed4b0964dcfa176bc43` (gptme/gptme-contrib#1520).

`mypy.ini` stays on the allowlist even though it is not currently in the tree — it was already permitted by the old hook.

## Test plan

- [x] `pre-commit run validate-root-structure --all-files` against the GitHub-pinned rev — passed
- [x] `pre-commit try-repo` at `13d63e63` — passed
- [x] Negative path: a forbidden root file fails the hook
- [ ] CI pre-commit job on this PR

## Related

- gptme/gptme-contrib#1520 (installable remote hook)
- gptme/gptme-contrib#1505 (shared validator)
- gptme/gptme-contrib#1445 (origin)
- Sibling: gptme-cloud Phase 2.5 (opened in parallel)
- Still open: gptme/gptme-agent-template#88 (Phase 2.3 still vendors a local copy)