### PR TITLE
feat(eval): route fable-5 and haiku-4.5 to tool format by default

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -29,7 +29,7 @@ from ..tools import ToolFormat
 from ..util.git_cmd import GIT_CMD
 from .run import run_evals
 from .suites import suites, tests_default, tests_default_ids, tests_map
-from .types import CaseResult, EvalResult, EvalSpec, ModelConfig
+from .types import CaseResult, EvalResult, EvalSpec, ModelConfig, get_effective_format
 
 # Configure logging, including fully-qualified module names
 logging.basicConfig(
@@ -681,8 +681,15 @@ def main(
             if tool_format
             else ["markdown", "xml", "tool"]
         )
+        # Apply model-aware format routing: some models (fable-5, haiku-4.5) have
+        # high failure rates on markdown format and are routed to tool format instead.
+        # Explicit model@format specs bypass this to allow intentional format testing.
         model_configs.extend(
-            ModelConfig(model=model_spec, tool_format=fmt) for fmt in formats
+            ModelConfig(
+                model=model_spec,
+                tool_format=get_effective_format(model_spec, fmt),
+            )
+            for fmt in formats
         )
 
     results_files = []

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -685,11 +685,13 @@ def main(
         # high failure rates on markdown format and are routed to tool format instead.
         # Explicit model@format specs bypass this to allow intentional format testing.
         model_configs.extend(
-            ModelConfig(
-                model=model_spec,
-                tool_format=get_effective_format(model_spec, fmt),
+            dict.fromkeys(
+                ModelConfig(
+                    model=model_spec,
+                    tool_format=get_effective_format(model_spec, fmt),
+                )
+                for fmt in formats
             )
-            for fmt in formats
         )
 
     results_files = []

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -685,18 +685,20 @@ def main(
         # Explicit model@format specs and --tool-format bypass this so callers can
         # intentionally test the failing markdown format.
         model_configs.extend(
-            dict.fromkeys(
-                ModelConfig(
-                    model=model_spec,
-                    tool_format=(
-                        fmt
-                        if tool_format is not None
-                        else get_effective_format(model_spec, fmt)
-                    ),
-                )
-                for fmt in formats
+            ModelConfig(
+                model=model_spec,
+                tool_format=(
+                    fmt
+                    if tool_format is not None
+                    else get_effective_format(model_spec, fmt)
+                ),
             )
+            for fmt in formats
         )
+
+    # Routing may collapse formats, and repeated/mixed model specs may resolve to
+    # the same paid run. Keep only the first occurrence across the full CLI input.
+    model_configs = list(dict.fromkeys(model_configs))
 
     results_files = []
     for f in eval_names_or_result_files:

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -681,14 +681,18 @@ def main(
             if tool_format
             else ["markdown", "xml", "tool"]
         )
-        # Apply model-aware format routing: some models (fable-5, haiku-4.5) have
-        # high failure rates on markdown format and are routed to tool format instead.
-        # Explicit model@format specs bypass this to allow intentional format testing.
+        # Apply model-aware format routing only during automatic format expansion.
+        # Explicit model@format specs and --tool-format bypass this so callers can
+        # intentionally test the failing markdown format.
         model_configs.extend(
             dict.fromkeys(
                 ModelConfig(
                     model=model_spec,
-                    tool_format=get_effective_format(model_spec, fmt),
+                    tool_format=(
+                        fmt
+                        if tool_format is not None
+                        else get_effective_format(model_spec, fmt)
+                    ),
                 )
                 for fmt in formats
             )

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -27,8 +27,9 @@ Status = Literal["success", "error", "timeout"]
 DEFAULT_TOOL_FORMAT_MODELS: frozenset[str] = frozenset(
     {
         "claude-fable-5",
-        # Match both the accepted undated alias and dated model IDs.
+        # Providers use both dash- and dot-form Haiku 4.5 identifiers.
         "claude-haiku-4-5",
+        "claude-haiku-4.5",
     }
 )
 

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -27,7 +27,8 @@ Status = Literal["success", "error", "timeout"]
 DEFAULT_TOOL_FORMAT_MODELS: frozenset[str] = frozenset(
     {
         "claude-fable-5",
-        "claude-haiku-4-5-20251001",
+        # Match both the accepted undated alias and dated model IDs.
+        "claude-haiku-4-5",
     }
 )
 

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -14,6 +14,37 @@ from ..tools import ToolFormat
 Files = dict[str, str | bytes]
 Status = Literal["success", "error", "timeout"]
 
+# Models where markdown format produces systematic continuation failures.
+# These are routed to "tool" format when no explicit format is requested.
+#
+# Failure modes (annotated from 2026-08-23/24 eval runs):
+#   fable-5:    ~83% failure — continuation_post_tool: model stops after last
+#               tool call, emitting an empty final message (evaluator can't verify)
+#   haiku-4.5:  ~75% failure — continuation_pre_tool: model writes prose code
+#               blocks instead of executing save/shell tool calls; workspace unchanged
+#
+# Sonnet-4.6 on tool format has high pass rate with no systematic failure.
+DEFAULT_TOOL_FORMAT_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-fable-5",
+        "claude-haiku-4-5-20251001",
+    }
+)
+
+
+def get_effective_format(model: str, requested_format: "ToolFormat") -> "ToolFormat":
+    """Return the effective tool format, routing markdown→tool for affected models.
+
+    Applied during auto-expansion of formats (when no explicit ``@format`` was
+    given). Explicit ``model@markdown`` specs bypass this routing intentionally
+    so callers can still test the failing format if needed.
+    """
+    if requested_format == "markdown" and any(
+        m in model for m in DEFAULT_TOOL_FORMAT_MODELS
+    ):
+        return cast(ToolFormat, "tool")
+    return requested_format
+
 
 @dataclass(frozen=True)
 class ModelConfig:

--- a/tests/test_eval_format_routing.py
+++ b/tests/test_eval_format_routing.py
@@ -6,8 +6,13 @@ no explicit format is specified, while other models and explicit @format
 specs are unaffected.
 """
 
-import pytest
+import importlib
+from unittest.mock import patch
 
+import pytest
+from click.testing import CliRunner
+
+from gptme.eval.main import main
 from gptme.eval.types import (
     DEFAULT_TOOL_FORMAT_MODELS,
     ModelConfig,
@@ -41,13 +46,16 @@ class TestGetEffectiveFormat:
         result = get_effective_format("claude-sonnet-4-6", fmt)  # type: ignore[arg-type]
         assert result == fmt
 
-    def test_partial_model_name_match(self):
-        """Routing uses substring match — a model ID that contains a listed name is routed."""
-        # e.g. openrouter/anthropic/claude-haiku-4-5-20251001
-        result = get_effective_format(
-            "openrouter/anthropic/claude-haiku-4-5-20251001", "markdown"
-        )
-        assert result == "tool"
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-haiku-4-5",
+            "openrouter/anthropic/claude-haiku-4-5-20251001",
+        ],
+    )
+    def test_partial_model_name_match(self, model: str):
+        """Routing handles both undated aliases and provider-prefixed dated IDs."""
+        assert get_effective_format(model, "markdown") == "tool"
 
     def test_unrelated_model_with_markdown(self):
         """A model whose name contains no affected substring keeps markdown."""
@@ -70,10 +78,31 @@ class TestModelConfigExpansion:
             for fmt in formats
         ]
         tool_formats = [c.tool_format for c in configs]
-        # markdown → tool; xml stays xml; tool stays tool
+        # Routing itself maps markdown → tool; the CLI deduplicates this expansion.
         assert tool_formats == ["tool", "xml", "tool"]
-        # Dedup: the caller may want to deduplicate, but routing itself creates duplicates
-        assert len(set(tool_formats)) == 2  # "tool" and "xml"
+
+    def test_affected_model_cli_expansion_has_no_duplicate_paid_runs(self):
+        """The CLI sends each routed model/format combination to run_evals once."""
+        eval_main = importlib.import_module("gptme.eval.main")
+        captured_configs: list[ModelConfig] = []
+
+        def fake_run_evals(_evals, model_configs, *_args, **_kwargs):
+            captured_configs.extend(model_configs)
+            return {}
+
+        with (
+            patch.object(eval_main, "run_evals", side_effect=fake_run_evals),
+            patch.object(eval_main, "print_model_results", return_value=None),
+            patch.object(eval_main, "print_model_results_table", return_value=None),
+            patch.object(eval_main, "write_results", return_value=None),
+        ):
+            result = CliRunner().invoke(main, ["hello", "--model", "claude-fable-5"])
+
+        assert result.exit_code == 0, result.output
+        assert captured_configs == [
+            ModelConfig("claude-fable-5", "tool"),
+            ModelConfig("claude-fable-5", "xml"),
+        ]
 
     def test_explicit_at_format_spec_bypasses_routing(self):
         """Explicit model@format spec is NOT routed (handled before expansion)."""
@@ -103,7 +132,7 @@ class TestDefaultToolFormatModels:
 
     def test_known_models_present(self):
         assert "claude-fable-5" in DEFAULT_TOOL_FORMAT_MODELS
-        assert "claude-haiku-4-5-20251001" in DEFAULT_TOOL_FORMAT_MODELS
+        assert "claude-haiku-4-5" in DEFAULT_TOOL_FORMAT_MODELS
 
     def test_sonnet_not_in_set(self):
         # Sonnet has high pass rate on tool format but no systematic markdown failure

--- a/tests/test_eval_format_routing.py
+++ b/tests/test_eval_format_routing.py
@@ -112,6 +112,21 @@ class TestModelConfigExpansion:
             ModelConfig("claude-fable-5", "xml"),
         ]
 
+    def test_repeated_and_explicit_specs_have_no_duplicate_paid_runs(self):
+        """Deduplication applies across all model specifications."""
+        result, captured_configs = self.invoke_cli(
+            "--model",
+            "claude-fable-5",
+            "--model",
+            "claude-fable-5@tool",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured_configs == [
+            ModelConfig("claude-fable-5", "tool"),
+            ModelConfig("claude-fable-5", "xml"),
+        ]
+
     def test_explicit_tool_format_flag_bypasses_routing(self):
         """An explicit --tool-format value is never rewritten."""
         result, captured_configs = self.invoke_cli(

--- a/tests/test_eval_format_routing.py
+++ b/tests/test_eval_format_routing.py
@@ -10,7 +10,7 @@ import importlib
 from unittest.mock import patch
 
 import pytest
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 from gptme.eval.main import main
 from gptme.eval.types import (
@@ -81,8 +81,9 @@ class TestModelConfigExpansion:
         # Routing itself maps markdown → tool; the CLI deduplicates this expansion.
         assert tool_formats == ["tool", "xml", "tool"]
 
-    def test_affected_model_cli_expansion_has_no_duplicate_paid_runs(self):
-        """The CLI sends each routed model/format combination to run_evals once."""
+    @staticmethod
+    def invoke_cli(*args: str) -> tuple[Result, list[ModelConfig]]:
+        """Invoke the eval CLI without executing paid model calls."""
         eval_main = importlib.import_module("gptme.eval.main")
         captured_configs: list[ModelConfig] = []
 
@@ -96,13 +97,31 @@ class TestModelConfigExpansion:
             patch.object(eval_main, "print_model_results_table", return_value=None),
             patch.object(eval_main, "write_results", return_value=None),
         ):
-            result = CliRunner().invoke(main, ["hello", "--model", "claude-fable-5"])
+            result = CliRunner().invoke(main, ["hello", *args])
+
+        return result, captured_configs
+
+    def test_affected_model_cli_expansion_has_no_duplicate_paid_runs(self):
+        """The CLI sends each routed model/format combination to run_evals once."""
+        result, captured_configs = self.invoke_cli("--model", "claude-fable-5")
 
         assert result.exit_code == 0, result.output
         assert captured_configs == [
             ModelConfig("claude-fable-5", "tool"),
             ModelConfig("claude-fable-5", "xml"),
         ]
+
+    def test_explicit_tool_format_flag_bypasses_routing(self):
+        """An explicit --tool-format value is never rewritten."""
+        result, captured_configs = self.invoke_cli(
+            "--model",
+            "claude-fable-5",
+            "--tool-format",
+            "markdown",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured_configs == [ModelConfig("claude-fable-5", "markdown")]
 
     def test_explicit_at_format_spec_bypasses_routing(self):
         """Explicit model@format spec is NOT routed (handled before expansion)."""

--- a/tests/test_eval_format_routing.py
+++ b/tests/test_eval_format_routing.py
@@ -1,0 +1,110 @@
+"""
+Tests for model-aware eval format routing.
+
+Verifies that fable-5 and haiku-4.5 are routed from markdown→tool when
+no explicit format is specified, while other models and explicit @format
+specs are unaffected.
+"""
+
+import pytest
+
+from gptme.eval.types import (
+    DEFAULT_TOOL_FORMAT_MODELS,
+    ModelConfig,
+    get_effective_format,
+)
+
+
+class TestGetEffectiveFormat:
+    """Unit tests for get_effective_format()."""
+
+    @pytest.mark.parametrize("model", sorted(DEFAULT_TOOL_FORMAT_MODELS))
+    def test_markdown_routed_to_tool_for_affected_models(self, model: str):
+        """Affected models get markdown→tool routing."""
+        result = get_effective_format(model, "markdown")
+        assert result == "tool", (
+            f"{model} should be routed to 'tool' but got '{result}'"
+        )
+
+    @pytest.mark.parametrize("model", sorted(DEFAULT_TOOL_FORMAT_MODELS))
+    @pytest.mark.parametrize("fmt", ["tool", "xml"])
+    def test_non_markdown_formats_unchanged_for_affected_models(
+        self, model: str, fmt: str
+    ):
+        """Non-markdown formats are never overridden, even for affected models."""
+        result = get_effective_format(model, fmt)  # type: ignore[arg-type]
+        assert result == fmt
+
+    @pytest.mark.parametrize("fmt", ["markdown", "tool", "xml"])
+    def test_unaffected_model_unchanged(self, fmt: str):
+        """Models not in DEFAULT_TOOL_FORMAT_MODELS are always passed through."""
+        result = get_effective_format("claude-sonnet-4-6", fmt)  # type: ignore[arg-type]
+        assert result == fmt
+
+    def test_partial_model_name_match(self):
+        """Routing uses substring match — a model ID that contains a listed name is routed."""
+        # e.g. openrouter/anthropic/claude-haiku-4-5-20251001
+        result = get_effective_format(
+            "openrouter/anthropic/claude-haiku-4-5-20251001", "markdown"
+        )
+        assert result == "tool"
+
+    def test_unrelated_model_with_markdown(self):
+        """A model whose name contains no affected substring keeps markdown."""
+        result = get_effective_format("gpt-5.6-sol", "markdown")
+        assert result == "markdown"
+
+
+class TestModelConfigExpansion:
+    """Integration tests: verify ModelConfig objects created in the expansion path."""
+
+    def test_affected_model_no_explicit_format_gets_tool(self):
+        """Simulate what main.py does in the auto-expansion path."""
+        formats = ["markdown", "xml", "tool"]
+        model = "claude-fable-5"
+        configs = [
+            ModelConfig(
+                model=model,
+                tool_format=get_effective_format(model, fmt),  # type: ignore[arg-type]
+            )
+            for fmt in formats
+        ]
+        tool_formats = [c.tool_format for c in configs]
+        # markdown → tool; xml stays xml; tool stays tool
+        assert tool_formats == ["tool", "xml", "tool"]
+        # Dedup: the caller may want to deduplicate, but routing itself creates duplicates
+        assert len(set(tool_formats)) == 2  # "tool" and "xml"
+
+    def test_explicit_at_format_spec_bypasses_routing(self):
+        """Explicit model@format spec is NOT routed (handled before expansion)."""
+        # This tests the design contract: from_spec with explicit @markdown must
+        # NOT apply routing (routing only happens in the expansion path in main.py).
+        mc = ModelConfig.from_spec("claude-fable-5@markdown")
+        assert mc.model == "claude-fable-5"
+        assert mc.tool_format == "markdown"  # explicit → no routing
+
+    def test_unaffected_model_unchanged_in_expansion(self):
+        """Unaffected model keeps all three formats in expansion."""
+        formats = ["markdown", "xml", "tool"]
+        model = "claude-sonnet-4-6"
+        configs = [
+            ModelConfig(
+                model=model,
+                tool_format=get_effective_format(model, fmt),  # type: ignore[arg-type]
+            )
+            for fmt in formats
+        ]
+        tool_formats = [c.tool_format for c in configs]
+        assert tool_formats == ["markdown", "xml", "tool"]
+
+
+class TestDefaultToolFormatModels:
+    """Verify the constant itself is sane."""
+
+    def test_known_models_present(self):
+        assert "claude-fable-5" in DEFAULT_TOOL_FORMAT_MODELS
+        assert "claude-haiku-4-5-20251001" in DEFAULT_TOOL_FORMAT_MODELS
+
+    def test_sonnet_not_in_set(self):
+        # Sonnet has high pass rate on tool format but no systematic markdown failure
+        assert "claude-sonnet-4-6" not in DEFAULT_TOOL_FORMAT_MODELS

--- a/tests/test_eval_format_routing.py
+++ b/tests/test_eval_format_routing.py
@@ -51,10 +51,11 @@ class TestGetEffectiveFormat:
         [
             "anthropic/claude-haiku-4-5",
             "openrouter/anthropic/claude-haiku-4-5-20251001",
+            "openrouter/anthropic/claude-haiku-4.5",
         ],
     )
     def test_partial_model_name_match(self, model: str):
-        """Routing handles both undated aliases and provider-prefixed dated IDs."""
+        """Routing handles provider prefixes, dated IDs, and punctuation variants."""
         assert get_effective_format(model, "markdown") == "tool"
 
     def test_unrelated_model_with_markdown(self):
@@ -152,6 +153,7 @@ class TestDefaultToolFormatModels:
     def test_known_models_present(self):
         assert "claude-fable-5" in DEFAULT_TOOL_FORMAT_MODELS
         assert "claude-haiku-4-5" in DEFAULT_TOOL_FORMAT_MODELS
+        assert "claude-haiku-4.5" in DEFAULT_TOOL_FORMAT_MODELS
 
     def test_sonnet_not_in_set(self):
         # Sonnet has high pass rate on tool format but no systematic markdown failure


### PR DESCRIPTION
## What

Adds model-aware format routing so that `claude-fable-5` and `claude-haiku-4-5-20251001` default to `tool` format instead of `markdown` during auto-expansion. Explicit `model@markdown` specs bypass routing (for intentional format testing).

## Why

Annotated failure analysis from 2026-08-23/24 eval runs (issue #3653):

**Fable-5 / markdown**: ~83% failure rate — `continuation_post_tool`: model stops after last tool call, emitting an empty final message; evaluator can't verify output

**Haiku-4.5 / markdown**: ~75% failure rate — `continuation_pre_tool`: model writes prose code blocks instead of executing `save`/`shell` tool calls; workspace unchanged

Both are model-format mismatches mechanically distinguishable in the conversation log. Sonnet-4.6 on tool format has high pass rate.

## Changes

- `gptme/eval/types.py`: Add `DEFAULT_TOOL_FORMAT_MODELS` (frozenset) and `get_effective_format(model, requested_format)` with docstring explaining the routing logic
- `gptme/eval/main.py`: Import and apply routing during format auto-expansion; explicit `@format` specs are unchanged
- `tests/test_eval_format_routing.py`: 16 tests covering all routing cases

## Design

Routing only applies in the format auto-expansion path (when no `@format` is given). If a caller explicitly specifies `claude-fable-5@markdown`, they get markdown — this is intentional, to allow testing the failure mode.

Closes #3653