### PR TITLE
feat(harness): actuate request_tool_change — enable/disable tools mid-session (Phase 2)

### DIFF
--- a/gptme/commands/base.py
+++ b/gptme/commands/base.py
@@ -133,6 +133,11 @@ def register_command(
     if owner_tool is not None:
         for cmd_name in names:
             _command_owners[cmd_name] = owner_tool
+    else:
+        # Re-registering without an owner must drop a stale mapping so the
+        # command is unowned (always enabled), matching the docstring.
+        for cmd_name in names:
+            _command_owners.pop(cmd_name, None)
 
     logger.debug(
         f"Registered command: {name}" + (f" (aliases: {aliases})" if aliases else "")

--- a/gptme/commands/base.py
+++ b/gptme/commands/base.py
@@ -44,6 +44,12 @@ _command_registry: dict[str, CommandHandler] = {}
 # Completer registry - maps command names to their completer functions
 _command_completers: dict[str, CommandCompleter] = {}
 
+# Optional owning tool for dynamically registered commands. Process-global:
+# sibling sessions on gptme-server share the registry. Dispatch consults the
+# session-local loaded-tool set so a disable in this session cannot run the
+# command here without yanking it from every other session.
+_command_owners: dict[str, str] = {}
+
 
 def command(
     name: str,
@@ -98,6 +104,7 @@ def register_command(
     handler: CommandHandler,
     aliases: list[str] | None = None,
     completer: CommandCompleter | None = None,
+    owner_tool: str | None = None,
 ) -> None:
     """Register a command handler dynamically (for tools).
 
@@ -107,8 +114,11 @@ def register_command(
         aliases: Optional list of command aliases
         completer: Optional function for argument completion.
                    Takes (partial_arg, previous_args) and returns list of (completion, description) tuples.
+        owner_tool: Tool that owns this command. When set, dispatch and listing
+                    require that tool to be loaded in the current session.
     """
     _command_registry[name] = handler
+    names = [name, *(aliases or [])]
     if aliases:
         for alias in aliases:
             _command_registry[alias] = handler
@@ -119,6 +129,10 @@ def register_command(
         if aliases:
             for alias in aliases:
                 _command_completers[alias] = completer
+
+    if owner_tool is not None:
+        for cmd_name in names:
+            _command_owners[cmd_name] = owner_tool
 
     logger.debug(
         f"Registered command: {name}" + (f" (aliases: {aliases})" if aliases else "")
@@ -136,6 +150,21 @@ def unregister_command(name: str) -> None:
         logger.debug(f"Unregistered command: {name}")
     if name in _command_completers:
         del _command_completers[name]
+    _command_owners.pop(name, None)
+
+
+def _command_enabled_in_session(name: str) -> bool:
+    """True if this command may run in the current session.
+
+    Unowned commands (built-ins, plugins) are always enabled. Tool-owned
+    commands require their owner to be in the session-local loaded set.
+    """
+    owner = _command_owners.get(name)
+    if owner is None:
+        return True
+    from ..tools import has_tool  # fmt: skip
+
+    return has_tool(owner)
 
 
 def get_registered_commands() -> list[str]:
@@ -150,8 +179,11 @@ def get_command_completer(name: str) -> CommandCompleter | None:
         name: Command name (without leading /)
 
     Returns:
-        Completer function or None if no completer registered
+        Completer function or None if no completer registered, or if the
+        command's owning tool is not loaded in this session.
     """
+    if not _command_enabled_in_session(name):
+        return None
     return _command_completers.get(name)
 
 
@@ -240,6 +272,18 @@ def handle_cmd(
 
     # Check if command is registered
     if name in _command_registry:
+        if not _command_enabled_in_session(name):
+            owner = _command_owners[name]
+            manager.undo(1, quiet=True)
+            msg = (
+                f"Command /{name} is unavailable because tool '{owner}' "
+                "is not enabled in this session."
+            )
+            if is_output_json():
+                _emit_json_command_output(msg)
+            else:
+                print(msg)
+            return
         handler = _command_registry[name]
         ctx = CommandContext(args=args, full_args=full_args, manager=manager)
         if is_output_json():
@@ -280,6 +324,8 @@ def get_commands_with_descriptions() -> list[tuple[str, str]]:
     seen_handlers: set[int] = set()  # Track handler object IDs to skip aliases
 
     for name in _command_registry:
+        if not _command_enabled_in_session(name):
+            continue
         handler = _command_registry[name]
         handler_id = id(handler)
         if handler_id in seen_handlers:
@@ -302,6 +348,9 @@ def get_commands_with_descriptions() -> list[tuple[str, str]]:
 
 
 def get_user_commands() -> list[str]:
-    """Returns a list of all user commands, including tool-registered commands"""
-    # Get all registered commands (includes built-in + tool-registered)
-    return [f"/{cmd}" for cmd in _command_registry]
+    """Returns user commands enabled in this session.
+
+    Includes built-ins and tool-registered commands whose owning tool is
+    loaded. Process-global registrations of disabled tools are omitted.
+    """
+    return [f"/{cmd}" for cmd in _command_registry if _command_enabled_in_session(cmd)]

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -342,23 +342,19 @@ def execute_msg(
     """
     assert msg.role == "assistant", "Only assistant messages can be executed"
 
-    # Snapshot runnability once per tool_use. Evaluating `is_runnable` a second
-    # time later would open a TOCTOU gap: a tool whose loaded-state changes
-    # between the two checks (e.g. a subagent thread concurrently (re)initializing
-    # tools) could fall through both branches and leave a structured tool_use with
-    # no tool_result — which the Anthropic API rejects with a hard 400 (#554).
-    classified = [(tu, tu.is_runnable) for tu in ToolUse.iter_from_content(msg.content)]
+    # Materialize every parsed tool_use first so each structured call still gets
+    # exactly one result. Evaluate runnability once per call, immediately before
+    # the branch, so an earlier request_tool_change in this response can enable
+    # or disable a sibling without a concurrent load/unload skipping both the
+    # execute and pairing paths (Anthropic 400, #554).
+    classified = list(ToolUse.iter_from_content(msg.content))
 
     if not classified:
         return
 
     remaining = iter(classified)
-    for tooluse, was_runnable in remaining:
-        # Preserve the initial classification for structured result pairing, but
-        # honor intentional session-local tool changes made by an earlier call in
-        # this same response.  In particular, request_tool_change may disable a
-        # sibling call after classification and before execution.
-        runnable = was_runnable and tooluse.is_runnable
+    for tooluse in remaining:
+        runnable = tooluse.is_runnable
         if runnable:
             with terminal_state_title(f"🛠️ running {tooluse.tool}"):
                 t0 = time.monotonic()
@@ -374,7 +370,7 @@ def execute_msg(
                     # Drain the rest: any structured tool_use that's left in the
                     # message still needs a paired tool_result or the next API
                     # request will 400 with a dangling tool_use.
-                    for rem_tu, _ in remaining:
+                    for rem_tu in remaining:
                         if rem_tu.call_id is not None:
                             yield Message(
                                 "system",
@@ -503,6 +499,26 @@ def set_tools(tools: list[ToolSpec]) -> None:
     ContextVars from the parent context aren't visible.
     """
     _loaded_tools_var.set(tools)
+
+
+def unload_tool(tool_name: str) -> ToolSpec:
+    """Unload one tool and unregister the hooks and commands it owns."""
+    with _tools_init_lock:
+        tool = get_tool(tool_name)
+        if tool is None:
+            raise ValueError(f"Tool '{tool_name}' is not loaded")
+
+        from ..commands import unregister_command
+        from ..hooks import unregister_hook
+
+        for hook_name in tool.hooks:
+            unregister_hook(f"{tool.name}.{hook_name}")
+        for command_name in tool.commands:
+            unregister_command(command_name)
+
+        set_tools([loaded for loaded in get_tools() if loaded.name != tool_name])
+        logger.info("Unloaded tool '%s' mid-conversation", tool_name)
+        return tool
 
 
 def get_tool(tool_name: str) -> ToolSpec | None:

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -502,7 +502,7 @@ def set_tools(tools: list[ToolSpec]) -> None:
 
 
 def unload_tool(tool_name: str) -> ToolSpec:
-    """Unload one tool and unregister the hooks and commands it owns."""
+    """Unload one tool and best-effort unregister its hooks and commands."""
     with _tools_init_lock:
         tool = get_tool(tool_name)
         if tool is None:
@@ -511,12 +511,26 @@ def unload_tool(tool_name: str) -> ToolSpec:
         from ..commands import unregister_command
         from ..hooks import unregister_hook
 
-        for hook_name in tool.hooks:
-            unregister_hook(f"{tool.name}.{hook_name}")
-        for command_name in tool.commands:
-            unregister_command(command_name)
-
         set_tools([loaded for loaded in get_tools() if loaded.name != tool_name])
+        for hook_name in tool.hooks:
+            try:
+                unregister_hook(f"{tool.name}.{hook_name}")
+            except Exception:
+                logger.exception(
+                    "Failed to unregister hook '%s.%s' while unloading tool",
+                    tool.name,
+                    hook_name,
+                )
+        for command_name in tool.commands:
+            try:
+                unregister_command(command_name)
+            except Exception:
+                logger.exception(
+                    "Failed to unregister command '%s' while unloading tool '%s'",
+                    command_name,
+                    tool.name,
+                )
+
         logger.info("Unloaded tool '%s' mid-conversation", tool_name)
         return tool
 

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -64,6 +64,13 @@ _loaded_tools_var: ContextVar[list[ToolSpec] | None] = ContextVar(
 _available_tools_var: ContextVar[list[ToolSpec] | None] = ContextVar(
     "available_tools", default=None
 )
+# Effective operator allowlist from the last init_tools() in this context.
+# None means unrestricted (default session); a list is a hard cap for model
+# enablement via request_tool_change. /tools load still uses load_tool()
+# directly and is not gated here.
+_session_allowlist_var: ContextVar[list[str] | None] = ContextVar(
+    "session_allowlist", default=None
+)
 
 # Note: Tools must be initialized in each context that needs them.
 # This is particularly important for server environments where request handling
@@ -185,6 +192,7 @@ def init_tools(
                 allowlist = config.chat.tools
 
         allowlist = expand_tool_allowlist_presets(allowlist)
+        set_session_allowlist(allowlist)
 
         # Partition allowlist into file paths and tool names
         file_paths: list[str] = []
@@ -485,6 +493,7 @@ def clear_tools():
     """
     _set_available_tools_cache(None)
     _loaded_tools_var.set([])
+    _session_allowlist_var.set(None)
 
 
 def get_tools() -> list[ToolSpec]:
@@ -501,6 +510,20 @@ def set_tools(tools: list[ToolSpec]) -> None:
     _loaded_tools_var.set(tools)
 
 
+def get_session_allowlist() -> list[str] | None:
+    """Return the operator tool allowlist captured by the last init_tools()."""
+    return _session_allowlist_var.get()
+
+
+def set_session_allowlist(allowlist: list[str] | None) -> None:
+    """Override the session tool allowlist for this context.
+
+    ``None`` means unrestricted. An explicit list is the hard cap that
+    ``request_tool_change`` enablement must honor.
+    """
+    _session_allowlist_var.set(list(allowlist) if allowlist is not None else None)
+
+
 def unload_tool(tool_name: str) -> ToolSpec:
     """Unload one tool and best-effort unregister its hooks and commands."""
     with _tools_init_lock:
@@ -511,7 +534,10 @@ def unload_tool(tool_name: str) -> ToolSpec:
         from ..commands import unregister_command
         from ..hooks import unregister_hook
 
-        set_tools([loaded for loaded in get_tools() if loaded.name != tool_name])
+        # Filter by identity: get_tool() matches name *or* block_types, so a
+        # block-type argument would miss a name-only filter and leave a zombie
+        # tool loaded after its hooks/commands were unregistered.
+        set_tools([loaded for loaded in get_tools() if loaded is not tool])
         for hook_name in tool.hooks:
             try:
                 unregister_hook(f"{tool.name}.{hook_name}")

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -525,18 +525,25 @@ def set_session_allowlist(allowlist: list[str] | None) -> None:
 
 
 def unload_tool(tool_name: str) -> ToolSpec:
-    """Unload one tool and best-effort unregister its hooks and commands."""
+    """Unload one tool and best-effort unregister its session-local hooks.
+
+    Commands are *not* unregistered. The slash-command registry is
+    process-global (``gptme.commands.base._command_registry``), shared by every
+    session in this process. Dropping a command here would remove that slash
+    command from sibling conversations on gptme-server even though their
+    context-local tool sets still contain the tool. Hooks are ContextVar-backed,
+    so unregistering them is session-scoped and safe.
+    """
     with _tools_init_lock:
         tool = get_tool(tool_name)
         if tool is None:
             raise ValueError(f"Tool '{tool_name}' is not loaded")
 
-        from ..commands import unregister_command
         from ..hooks import unregister_hook
 
         # Filter by identity: get_tool() matches name *or* block_types, so a
         # block-type argument would miss a name-only filter and leave a zombie
-        # tool loaded after its hooks/commands were unregistered.
+        # tool loaded after its hooks were unregistered.
         set_tools([loaded for loaded in get_tools() if loaded is not tool])
         for hook_name in tool.hooks:
             try:
@@ -546,15 +553,6 @@ def unload_tool(tool_name: str) -> ToolSpec:
                     "Failed to unregister hook '%s.%s' while unloading tool",
                     tool.name,
                     hook_name,
-                )
-        for command_name in tool.commands:
-            try:
-                unregister_command(command_name)
-            except Exception:
-                logger.exception(
-                    "Failed to unregister command '%s' while unloading tool '%s'",
-                    command_name,
-                    tool.name,
                 )
 
         logger.info("Unloaded tool '%s' mid-conversation", tool_name)

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -353,7 +353,12 @@ def execute_msg(
         return
 
     remaining = iter(classified)
-    for tooluse, runnable in remaining:
+    for tooluse, was_runnable in remaining:
+        # Preserve the initial classification for structured result pairing, but
+        # honor intentional session-local tool changes made by an earlier call in
+        # this same response.  In particular, request_tool_change may disable a
+        # sibling call after classification and before execution.
+        runnable = was_runnable and tooluse.is_runnable
         if runnable:
             with terminal_state_title(f"🛠️ running {tooluse.tool}"):
                 t0 = time.monotonic()

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -533,6 +533,10 @@ def unload_tool(tool_name: str) -> ToolSpec:
     command from sibling conversations on gptme-server even though their
     context-local tool sets still contain the tool. Hooks are ContextVar-backed,
     so unregistering them is session-scoped and safe.
+
+    Session isolation for commands is enforced at dispatch: ``handle_cmd``
+    refuses to run a tool-owned command when that tool is not in this
+    session's loaded set.
     """
     with _tools_init_lock:
         tool = get_tool(tool_name)

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -483,7 +483,7 @@ class ToolSpec:
 
         for cmd_name, handler in self.commands.items():
             try:
-                register_command(cmd_name, handler)
+                register_command(cmd_name, handler, owner_tool=self.name)
             except Exception as e:
                 logger.warning(
                     f"Failed to register command '{cmd_name}' for tool '{self.name}': {e}"

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -901,6 +901,12 @@ class ToolUse:
                     )
             else:
                 logger.warning(f"Tool '{self.tool}' is not available for execution.")
+                if self.call_id is not None:
+                    yield Message(
+                        "system",
+                        f"Tool '{self.tool}' is not available for execution.",
+                        call_id=self.call_id,
+                    )
 
         yield from _execute_tool()
 

--- a/gptme/tools/request_tool_change.py
+++ b/gptme/tools/request_tool_change.py
@@ -14,7 +14,14 @@ from __future__ import annotations
 import logging
 
 from ..message import Message
-from . import get_available_tools, get_tools, load_tool, unload_tool
+from . import (
+    get_available_tools,
+    get_session_allowlist,
+    get_tools,
+    load_tool,
+    unload_tool,
+)
+from ._allowlist import tool_matches_allowlist
 from .base import Parameter, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -38,6 +45,20 @@ def _enable_tool(tool_name: str) -> Message:
             f"request_tool_change: '{tool_name}' is already enabled — no change.",
             quiet=True,
         )
+
+    allowlist = get_session_allowlist()
+    if allowlist is not None:
+        available = next(
+            (t for t in get_available_tools() if t.name == tool_name), None
+        )
+        hints = available.hints if available is not None else frozenset()
+        if not tool_matches_allowlist(tool_name, allowlist, hints):
+            return Message(
+                "system",
+                f"request_tool_change: '{tool_name}' is not permitted by "
+                "the session tool allowlist — no change.",
+                quiet=True,
+            )
 
     try:
         load_tool(tool_name)

--- a/gptme/tools/request_tool_change.py
+++ b/gptme/tools/request_tool_change.py
@@ -48,10 +48,8 @@ def _enable_tool(tool_name: str) -> Message:
 
     allowlist = get_session_allowlist()
     if allowlist is not None:
-        available = next(
-            (t for t in get_available_tools() if t.name == tool_name), None
-        )
-        hints = available.hints if available is not None else frozenset()
+        spec = next((t for t in get_available_tools() if t.name == tool_name), None)
+        hints = spec.hints if spec is not None else frozenset()
         if not tool_matches_allowlist(tool_name, allowlist, hints):
             return Message(
                 "system",
@@ -152,9 +150,10 @@ def execute_request_tool_change(
             quiet=True,
         )
 
-    # Validate against available (not just loaded) tools so the model can name
-    # any tool known to gptme's module system.
-    known_tools = {t.name for t in get_available_tools(include_mcp=False)} | {
+    # Include MCP tools (default get_available_tools) so an allowlisted MCP
+    # tool can be enabled before it is loaded. Union with get_tools() so a
+    # file-loaded tool that is not in module discovery can still be disabled.
+    known_tools = {t.name for t in get_available_tools()} | {
         t.name for t in get_tools()
     }
     if tool_name not in known_tools:

--- a/gptme/tools/request_tool_change.py
+++ b/gptme/tools/request_tool_change.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 
 from ..message import Message
-from . import get_available_tools, get_tools, load_tool, set_tools
+from . import get_available_tools, get_tools, load_tool, unload_tool
 from .base import Parameter, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,8 @@ def _enable_tool(tool_name: str) -> Message:
 
     try:
         load_tool(tool_name)
-    except ValueError as exc:
+    except Exception as exc:
+        logger.exception("request_tool_change: failed to enable '%s'", tool_name)
         return Message(
             "system",
             f"request_tool_change: could not enable '{tool_name}': {exc}",
@@ -69,16 +70,23 @@ def _disable_tool(tool_name: str) -> Message:
             quiet=True,
         )
 
-    loaded = get_tools()
-    remaining = [t for t in loaded if t.name != tool_name]
-    if len(remaining) == len(loaded):
+    if not any(t.name == tool_name for t in get_tools()):
         return Message(
             "system",
             f"request_tool_change: '{tool_name}' is not currently enabled — no change.",
             quiet=True,
         )
 
-    set_tools(remaining)
+    try:
+        unload_tool(tool_name)
+    except Exception as exc:
+        logger.exception("request_tool_change: failed to disable '%s'", tool_name)
+        return Message(
+            "system",
+            f"request_tool_change: could not disable '{tool_name}': {exc}",
+            quiet=True,
+        )
+
     logger.info("request_tool_change: disabled tool '%s'", tool_name)
     return Message(
         "system",
@@ -125,7 +133,9 @@ def execute_request_tool_change(
 
     # Validate against available (not just loaded) tools so the model can name
     # any tool known to gptme's module system.
-    known_tools = {t.name for t in get_available_tools(include_mcp=False)}
+    known_tools = {t.name for t in get_available_tools(include_mcp=False)} | {
+        t.name for t in get_tools()
+    }
     if tool_name not in known_tools:
         return Message(
             "system",

--- a/gptme/tools/request_tool_change.py
+++ b/gptme/tools/request_tool_change.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 
 from ..message import Message
-from . import get_available_tools, get_tools, set_tools
+from . import get_available_tools, get_tools, load_tool, set_tools
 from .base import Parameter, ToolSpec
 
 logger = logging.getLogger(__name__)
@@ -39,15 +39,15 @@ def _enable_tool(tool_name: str) -> Message:
             quiet=True,
         )
 
-    available = {t.name: t for t in get_available_tools(include_mcp=False)}
-    if tool_name not in available:
+    try:
+        load_tool(tool_name)
+    except ValueError as exc:
         return Message(
             "system",
-            f"request_tool_change: unknown tool '{tool_name}'",
+            f"request_tool_change: could not enable '{tool_name}': {exc}",
             quiet=True,
         )
 
-    set_tools([*loaded, available[tool_name]])
     logger.info("request_tool_change: enabled tool '%s'", tool_name)
     return Message(
         "system",

--- a/gptme/tools/request_tool_change.py
+++ b/gptme/tools/request_tool_change.py
@@ -1,18 +1,90 @@
 """Opt-in tool for assistants to request session tool configuration changes.
 
-The request is audit-only: calling this tool records structured intent in ordinary
-assistant tool-call and result-message history. It does not change the active tool
-configuration.
+Phase 1 (audit-only) recorded the intent in tool-call history without mutating
+the active tool set.  Phase 2 (this file) actually applies enable/disable
+requests by mutating the session-local ``_loaded_tools_var`` ContextVar that
+``get_tools()`` reads.
+
+``configure_tool`` requests remain audit-only; a future phase can add actuation
+for them without altering the enable/disable paths.
 """
 
 from __future__ import annotations
 
+import logging
+
 from ..message import Message
-from . import get_available_tools
+from . import get_available_tools, get_tools, set_tools
 from .base import Parameter, ToolSpec
+
+logger = logging.getLogger(__name__)
 
 _VALID_CHANGE_TYPES = {"enable_tool", "disable_tool", "configure_tool"}
 _VALID_URGENCY = {"low", "medium", "high"}
+
+#: The tool that provides this mechanism must never be disabled by itself.
+_SELF_NAME = "request_tool_change"
+
+
+def _enable_tool(tool_name: str) -> Message:
+    """Add *tool_name* to the session's active tool set.
+
+    Returns a system message describing the outcome (success or no-op).
+    """
+    loaded = get_tools()
+    if any(t.name == tool_name for t in loaded):
+        return Message(
+            "system",
+            f"request_tool_change: '{tool_name}' is already enabled — no change.",
+            quiet=True,
+        )
+
+    available = {t.name: t for t in get_available_tools(include_mcp=False)}
+    if tool_name not in available:
+        return Message(
+            "system",
+            f"request_tool_change: unknown tool '{tool_name}'",
+            quiet=True,
+        )
+
+    set_tools([*loaded, available[tool_name]])
+    logger.info("request_tool_change: enabled tool '%s'", tool_name)
+    return Message(
+        "system",
+        f"Tool '{tool_name}' has been enabled for this session.",
+        quiet=True,
+    )
+
+
+def _disable_tool(tool_name: str) -> Message:
+    """Remove *tool_name* from the session's active tool set.
+
+    Returns a system message describing the outcome (success, no-op, or
+    refusal when trying to disable the mechanism itself).
+    """
+    if tool_name == _SELF_NAME:
+        return Message(
+            "system",
+            "request_tool_change: cannot disable itself — no change.",
+            quiet=True,
+        )
+
+    loaded = get_tools()
+    remaining = [t for t in loaded if t.name != tool_name]
+    if len(remaining) == len(loaded):
+        return Message(
+            "system",
+            f"request_tool_change: '{tool_name}' is not currently enabled — no change.",
+            quiet=True,
+        )
+
+    set_tools(remaining)
+    logger.info("request_tool_change: disabled tool '%s'", tool_name)
+    return Message(
+        "system",
+        f"Tool '{tool_name}' has been disabled for this session.",
+        quiet=True,
+    )
 
 
 def execute_request_tool_change(
@@ -20,7 +92,12 @@ def execute_request_tool_change(
     args: list[str] | None,
     kwargs: dict[str, str] | None,
 ) -> Message:
-    """Validate and acknowledge an audit-only tool-change request."""
+    """Validate and apply a tool-change request.
+
+    ``enable_tool`` and ``disable_tool`` requests are applied immediately by
+    mutating the session-local tool list returned by ``get_tools()``.
+    ``configure_tool`` requests are still audit-only.
+    """
     del code, args
     values = kwargs or {}
 
@@ -46,7 +123,9 @@ def execute_request_tool_change(
             quiet=True,
         )
 
-    known_tools = {tool.name for tool in get_available_tools(include_mcp=False)}
+    # Validate against available (not just loaded) tools so the model can name
+    # any tool known to gptme's module system.
+    known_tools = {t.name for t in get_available_tools(include_mcp=False)}
     if tool_name not in known_tools:
         return Message(
             "system",
@@ -68,21 +147,35 @@ def execute_request_tool_change(
             quiet=True,
         )
 
+    if change_type == "enable_tool":
+        return _enable_tool(tool_name)
+    if change_type == "disable_tool":
+        return _disable_tool(tool_name)
+    # configure_tool: audit-only (Phase 2 scope)
     return Message(
         "system",
-        f"Tool change request recorded: {change_type} {tool_name}. "
-        "No tool configuration was changed.",
+        f"Tool configure request recorded: {tool_name}. "
+        "Configuration changes are not yet applied automatically.",
         quiet=True,
     )
 
 
 tool = ToolSpec(
     name="request_tool_change",
-    desc="Record an audit-only request to change the current session's tool configuration",
+    desc=(
+        "Enable or disable a tool for the current session, "
+        "or record a configuration change request"
+    ),
     instructions="""
-Use this tool when the current tool configuration blocks or unnecessarily expands
-what you need to do. The request is recorded in ordinary tool-call history for an
-operator to inspect; it does not itself enable, disable, or configure any tool.
+Use this tool to adjust which tools are available mid-session.
+
+- ``enable_tool``: adds a known tool to the active set so it can be called in
+  subsequent turns.
+- ``disable_tool``: removes a tool from the active set for the remainder of the
+  session.  You cannot disable ``request_tool_change`` itself.
+- ``configure_tool``: records a configuration change request (audit-only for now).
+
+Changes take effect immediately; the next LLM turn will see the updated tool list.
 """.strip(),
     execute=execute_request_tool_change,
     block_types=["request_tool_change"],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -260,6 +260,24 @@ class TestDynamicRegistration:
         unregister_command("ownedcmd")
         assert "ownedcmd" not in _command_owners
 
+    def test_reregister_without_owner_clears_stale_owner(self, clean_registry):
+        """An unowned re-register must not keep gating on a previous owner.
+
+        Skills and plugins call register_command without owner_tool. If a tool
+        previously owned the same name, a leftover _command_owners entry would
+        make the new unowned command fail-closed whenever that tool is unloaded.
+        """
+        from gptme.commands.base import _command_enabled_in_session
+
+        def handler(ctx):
+            pass
+
+        register_command("ownedcmd", handler, owner_tool="side_effect_tool")
+        register_command("ownedcmd", handler)
+        assert "ownedcmd" not in _command_owners
+        with patch("gptme.tools.has_tool", return_value=False):
+            assert _command_enabled_in_session("ownedcmd") is True
+
 
 # ── Query Functions ──
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -19,6 +19,7 @@ import pytest
 from gptme.commands.base import (
     CommandContext,
     _command_completers,
+    _command_owners,
     _command_registry,
     command,
     execute_cmd,
@@ -42,11 +43,14 @@ def clean_registry():
     """
     saved_registry = dict(_command_registry)
     saved_completers = dict(_command_completers)
+    saved_owners = dict(_command_owners)
     yield
     _command_registry.clear()
     _command_registry.update(saved_registry)
     _command_completers.clear()
     _command_completers.update(saved_completers)
+    _command_owners.clear()
+    _command_owners.update(saved_owners)
 
 
 @pytest.fixture()
@@ -241,6 +245,21 @@ class TestDynamicRegistration:
         """Unregistering a command that doesn't exist should not raise."""
         unregister_command("nonexistent_command_xyz")
 
+    def test_register_records_owner_tool(self, clean_registry):
+        def handler(ctx):
+            yield Message("system", "owned")
+
+        register_command("ownedcmd", handler, owner_tool="side_effect_tool")
+        assert _command_owners["ownedcmd"] == "side_effect_tool"
+
+    def test_unregister_drops_owner_tool(self, clean_registry):
+        def handler(ctx):
+            pass
+
+        register_command("ownedcmd", handler, owner_tool="side_effect_tool")
+        unregister_command("ownedcmd")
+        assert "ownedcmd" not in _command_owners
+
 
 # ── Query Functions ──
 
@@ -407,6 +426,39 @@ class TestHandleCmd:
         list(handle_cmd("/testcmd arg1\narg2", mock_manager))
         assert "arg1" in captured["args"]
         assert "arg2" in captured["args"]
+
+    def test_tool_owned_command_runs_when_owner_loaded(
+        self, clean_registry, mock_manager
+    ):
+        called = []
+
+        def handler(ctx):
+            called.append(True)
+            return
+            yield  # pragma: no cover — CommandHandler is a generator type
+
+        register_command("ownedcmd", handler, owner_tool="side_effect_tool")
+        with patch("gptme.tools.has_tool", return_value=True):
+            list(handle_cmd("/ownedcmd", mock_manager))
+        assert called == [True]
+
+    def test_tool_owned_command_blocked_when_owner_unloaded(
+        self, clean_registry, mock_manager
+    ):
+        called = []
+
+        def handler(ctx):
+            called.append(True)
+            return
+            yield  # pragma: no cover — CommandHandler is a generator type
+
+        register_command("ownedcmd", handler, owner_tool="side_effect_tool")
+        with patch("gptme.tools.has_tool", return_value=False):
+            list(handle_cmd("/ownedcmd", mock_manager))
+            assert "/ownedcmd" not in get_user_commands()
+        assert called == []
+        mock_manager.undo.assert_called_once_with(1, quiet=True)
+        assert "ownedcmd" in get_registered_commands()
 
 
 # ── execute_cmd ──

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -349,28 +349,25 @@ class TestDisableTool:
         assert "disabled" in result.content
         assert not any(t.name == "shell" for t in get_tools())
 
-    def test_disable_unregisters_owned_hooks_and_commands(self, isolated_tools):
+    def test_disable_unregisters_owned_hooks(self, isolated_tools):
         hook = ("session_start", cast(Any, lambda: None), 0)
         side_effect_tool = ToolSpec(
             name="side_effect_tool",
             desc="Registers session side effects",
             execute=lambda _code, _args, _kwargs: Message("system", "executed"),
             hooks={"watch": hook},
-            commands={"side-effect": lambda _args: None},
         )
         loaded_tool = ToolSpec(
             name="side_effect_tool",
             desc="Registers session side effects",
             execute=side_effect_tool.execute,
             hooks=side_effect_tool.hooks,
-            commands=side_effect_tool.commands,
         )
 
         with (
             _patch_available([side_effect_tool, tool]),
             patch("gptme.tools._init_single_tool", return_value=loaded_tool),
             patch("gptme.hooks.unregister_hook") as unregister_hook,
-            patch("gptme.commands.unregister_command") as unregister_command,
         ):
             enabled = _execute(
                 change_type="enable_tool",
@@ -388,7 +385,47 @@ class TestDisableTool:
         assert "enabled" in enabled.content
         assert "disabled" in disabled.content
         unregister_hook.assert_called_once_with("side_effect_tool.watch")
-        unregister_command.assert_called_once_with("side-effect")
+
+    def test_disable_does_not_drop_process_global_commands(self, isolated_tools):
+        """Slash commands live in a process-global registry.
+
+        Unloading a command-providing tool in this session must not yank the
+        command out from under a sibling session in the same process
+        (gptme-server multi-conversation).
+        """
+        from gptme.commands import (
+            get_registered_commands,
+            register_command,
+            unregister_command,
+        )
+
+        def handler(_ctx):
+            return
+            yield  # pragma: no cover — CommandHandler is a generator type
+
+        register_command("side-effect", handler)
+        try:
+            side_effect_tool = ToolSpec(
+                name="side_effect_tool",
+                desc="Registers a process-global slash command",
+                execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+                commands={"side-effect": handler},
+            )
+            set_tools([*get_tools(), side_effect_tool])
+
+            with _patch_available([side_effect_tool, tool]):
+                result = _execute(
+                    change_type="disable_tool",
+                    tool_name="side_effect_tool",
+                    reason="Done with it",
+                    urgency="low",
+                )
+
+            assert "disabled" in result.content
+            assert not any(t.name == "side_effect_tool" for t in get_tools())
+            assert "side-effect" in get_registered_commands()
+        finally:
+            unregister_command("side-effect")
 
     def test_disable_removes_tool_if_cleanup_fails(self, isolated_tools):
         side_effect_tool = ToolSpec(

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -451,28 +451,25 @@ class TestDisableTool:
 
         Unloading a command-providing tool in this session must not yank the
         command out from under a sibling session in the same process
-        (gptme-server multi-conversation).
+        (gptme-server multi-conversation). Register via ToolSpec.register_commands()
+        so the command is owned; an unowned registration would survive even if
+        unload_tool incorrectly unregistered owned commands.
         """
-        from gptme.commands import (
-            get_registered_commands,
-            register_command,
-            unregister_command,
-        )
+        from gptme.commands import get_registered_commands, unregister_command
 
         def handler(_ctx):
             return
             yield  # pragma: no cover — CommandHandler is a generator type
 
-        register_command("side-effect", handler)
+        side_effect_tool = ToolSpec(
+            name="side_effect_tool",
+            desc="Registers a process-global slash command",
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+            commands={"side-effect": handler},
+        )
+        side_effect_tool.register_commands()
+        set_tools([*get_tools(), side_effect_tool])
         try:
-            side_effect_tool = ToolSpec(
-                name="side_effect_tool",
-                desc="Registers a process-global slash command",
-                execute=lambda _code, _args, _kwargs: Message("system", "executed"),
-                commands={"side-effect": handler},
-            )
-            set_tools([*get_tools(), side_effect_tool])
-
             with _patch_available([side_effect_tool, tool]):
                 result = _execute(
                     change_type="disable_tool",

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import ExitStack, contextmanager
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -424,6 +424,55 @@ class TestDisableTool:
             assert "disabled" in result.content
             assert not any(t.name == "side_effect_tool" for t in get_tools())
             assert "side-effect" in get_registered_commands()
+        finally:
+            unregister_command("side-effect")
+
+    def test_disable_blocks_session_local_command_dispatch(self, isolated_tools):
+        """Keeping the process-global handler must not leave /cmd executable here."""
+        from gptme.commands import (
+            get_registered_commands,
+            get_user_commands,
+            handle_cmd,
+            unregister_command,
+        )
+
+        called: list[bool] = []
+
+        def handler(_ctx):
+            called.append(True)
+            return
+            yield  # pragma: no cover — CommandHandler is a generator type
+
+        side_effect_tool = ToolSpec(
+            name="side_effect_tool",
+            desc="Registers a process-global slash command",
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+            commands={"side-effect": handler},
+        )
+        side_effect_tool.register_commands()
+        set_tools([*get_tools(), side_effect_tool])
+        mock_manager = MagicMock()
+        try:
+            list(handle_cmd("/side-effect", mock_manager))
+            assert called == [True]
+            assert "/side-effect" in get_user_commands()
+
+            with _patch_available([side_effect_tool, tool]):
+                result = _execute(
+                    change_type="disable_tool",
+                    tool_name="side_effect_tool",
+                    reason="Done with it",
+                    urgency="low",
+                )
+
+            assert "disabled" in result.content
+            assert not has_tool("side_effect_tool")
+            assert "side-effect" in get_registered_commands()
+
+            called.clear()
+            list(handle_cmd("/side-effect", mock_manager))
+            assert called == []
+            assert "/side-effect" not in get_user_commands()
         finally:
             unregister_command("side-effect")
 

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -19,7 +19,7 @@ from gptme.tools import (
     set_tool_format,
     set_tools,
 )
-from gptme.tools.base import ToolSpec
+from gptme.tools.base import ToolSpec, ToolUse
 from gptme.tools.request_tool_change import (
     _SELF_NAME,
     execute_request_tool_change,
@@ -420,6 +420,29 @@ class TestConfigureTool:
 
 class TestEnableDisableIntegration:
     """Integration: enable → tool is callable; disable → tool is not callable."""
+
+    def test_concurrent_unload_still_pairs_structured_call(self, isolated_tools):
+        """An unload between runnability check and execution must not dangle a call."""
+        set_tools([*get_tools(), _FAKE_SHELL])
+        tooluse = ToolUse(
+            "shell",
+            [],
+            "echo raced",
+            call_id="shell_race",
+            _format="tool",
+        )
+
+        # Deterministically model another execution context unloading the selected
+        # tool after execute_msg's runnability check but before ToolUse.execute's
+        # lookup. The structured call must still receive exactly one result.
+        assert tooluse.is_runnable
+        set_tools([loaded for loaded in get_tools() if loaded.name != "shell"])
+
+        results = list(tooluse.execute())
+
+        assert len(results) == 1
+        assert results[0].call_id == "shell_race"
+        assert "not available for execution" in results[0].content
 
     def test_enable_call_disable_call_fails(self, isolated_tools):
         """

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -358,6 +358,32 @@ class TestDisableTool:
         unregister_hook.assert_called_once_with("side_effect_tool.watch")
         unregister_command.assert_called_once_with("side-effect")
 
+    def test_disable_removes_tool_if_cleanup_fails(self, isolated_tools):
+        side_effect_tool = ToolSpec(
+            name="side_effect_tool",
+            desc="Registers session side effects",
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+            hooks={"watch": ("session_start", cast(Any, lambda: None), 0)},
+        )
+        set_tools([*get_tools(), side_effect_tool])
+
+        with (
+            _patch_available([side_effect_tool, tool]),
+            patch(
+                "gptme.hooks.unregister_hook",
+                side_effect=RuntimeError("cleanup failed"),
+            ),
+        ):
+            result = _execute(
+                change_type="disable_tool",
+                tool_name="side_effect_tool",
+                reason="Stop it",
+                urgency="medium",
+            )
+
+        assert "disabled" in result.content
+        assert not any(t.name == "side_effect_tool" for t in get_tools())
+
     def test_disable_not_loaded_is_noop(self, isolated_tools):
         with _patch_available([_FAKE_SHELL, tool]):
             result = _execute(

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -1,14 +1,33 @@
+"""Tests for the request_tool_change tool (Phase 1 + Phase 2)."""
+
 from __future__ import annotations
 
 from unittest.mock import patch
 
-from gptme.tools import get_available_tools
+import pytest
+
+from gptme.tools import (
+    clear_tools,
+    get_available_tools,
+    get_tools,
+    init_tools,
+    set_tools,
+)
 from gptme.tools.base import ToolSpec
-from gptme.tools.request_tool_change import execute_request_tool_change, tool
+from gptme.tools.request_tool_change import (
+    _SELF_NAME,
+    execute_request_tool_change,
+    tool,
+)
 
 
 def _execute(**kwargs: str):
     return execute_request_tool_change(None, None, kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 opt-in and discoverability tests (unchanged)
+# ---------------------------------------------------------------------------
 
 
 def test_request_tool_change_is_opt_in():
@@ -20,25 +39,9 @@ def test_request_tool_change_is_discoverable():
     assert tool in available_tools
 
 
-@patch("gptme.tools.request_tool_change.get_available_tools")
-def test_request_tool_change_records_valid_request(mock_get_available_tools):
-    mock_get_available_tools.return_value = [
-        ToolSpec(name="shell", desc="Run commands")
-    ]
-
-    result = _execute(
-        change_type="enable_tool",
-        tool_name="shell",
-        reason="Need to inspect the workspace",
-        urgency="medium",
-    )
-
-    mock_get_available_tools.assert_called_once_with(include_mcp=False)
-    assert result.content == (
-        "Tool change request recorded: enable_tool shell. "
-        "No tool configuration was changed."
-    )
-    assert result.quiet is True
+# ---------------------------------------------------------------------------
+# Validation tests (unchanged from Phase 1)
+# ---------------------------------------------------------------------------
 
 
 @patch("gptme.tools.request_tool_change.get_available_tools")
@@ -122,3 +125,171 @@ def test_request_tool_change_rejects_non_string_fields():
         result = execute_request_tool_change(None, None, kwargs)  # type: ignore[arg-type]
         assert result.content == "request_tool_change: all arguments must be strings"
         assert result.quiet is True
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — actuation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def isolated_tools():
+    """Provide a clean tool context with a minimal known set."""
+    clear_tools()
+    # Load only request_tool_change itself so each test starts from a known state.
+    init_tools(allowlist=["request_tool_change"])
+    yield
+    clear_tools()
+
+
+_FAKE_SHELL = ToolSpec(name="shell", desc="Run shell commands")
+
+
+def _patch_available(tools: list[ToolSpec]):
+    """Patch get_available_tools in the module under test."""
+    return patch(
+        "gptme.tools.request_tool_change.get_available_tools",
+        return_value=tools,
+    )
+
+
+class TestEnableTool:
+    def test_enable_adds_tool_to_session(self, isolated_tools):
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Need to inspect workspace",
+                urgency="medium",
+            )
+
+        assert "enabled" in result.content
+        assert "shell" in result.content
+        assert any(t.name == "shell" for t in get_tools())
+
+    def test_enable_already_loaded_is_noop(self, isolated_tools):
+        # Pre-load shell
+        set_tools([*get_tools(), _FAKE_SHELL])
+
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Make sure shell is here",
+                urgency="low",
+            )
+
+        assert "already enabled" in result.content
+        # Still exactly one shell in the list
+        assert sum(1 for t in get_tools() if t.name == "shell") == 1
+
+    def test_enable_unknown_tool_rejected(self, isolated_tools):
+        with _patch_available([tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="nonexistent_xyz",
+                reason="I want it",
+                urgency="low",
+            )
+
+        assert "unknown tool" in result.content
+        assert not any(t.name == "nonexistent_xyz" for t in get_tools())
+
+
+class TestDisableTool:
+    def test_disable_removes_tool_from_session(self, isolated_tools):
+        set_tools([*get_tools(), _FAKE_SHELL])
+
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="disable_tool",
+                tool_name="shell",
+                reason="Pure-coding phase — no shell needed",
+                urgency="low",
+            )
+
+        assert "disabled" in result.content
+        assert not any(t.name == "shell" for t in get_tools())
+
+    def test_disable_not_loaded_is_noop(self, isolated_tools):
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="disable_tool",
+                tool_name="shell",
+                reason="Remove shell",
+                urgency="low",
+            )
+
+        assert "not currently enabled" in result.content
+
+    def test_disable_self_is_refused(self, isolated_tools):
+        with _patch_available([tool]):
+            result = _execute(
+                change_type="disable_tool",
+                tool_name=_SELF_NAME,
+                reason="Clean up",
+                urgency="low",
+            )
+
+        assert "cannot disable itself" in result.content
+        # request_tool_change must still be present
+        assert any(t.name == _SELF_NAME for t in get_tools())
+
+
+class TestConfigureTool:
+    def test_configure_is_audit_only(self, isolated_tools):
+        before = list(get_tools())
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="configure_tool",
+                tool_name="shell",
+                reason="Change timeout",
+                urgency="low",
+            )
+
+        assert "configure" in result.content.lower() or "recorded" in result.content
+        # Tool list must be unchanged
+        assert get_tools() == before
+
+
+class TestEnableDisableIntegration:
+    """Integration: enable → tool is callable; disable → tool is not callable."""
+
+    def test_enable_call_disable_call_fails(self, isolated_tools):
+        """
+        Requirement 3.1: a focused integration test exercises
+        enable → call → disable → call-fails.
+
+        We simulate 'call' at the tool-availability level (is_runnable)
+        rather than doing a full LLM round-trip.
+        """
+        from gptme.tools import has_tool
+
+        # Phase A: shell is not yet in the session
+        assert not has_tool("shell"), "shell should not be loaded initially"
+
+        # Phase B: enable shell
+        with _patch_available([_FAKE_SHELL, tool]):
+            r_enable = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Need to run tests",
+                urgency="high",
+            )
+        assert "enabled" in r_enable.content
+        assert has_tool("shell"), "shell should be loaded after enable"
+
+        # Phase C: verify the loaded ToolSpec is the one from available tools
+        loaded_shell = next(t for t in get_tools() if t.name == "shell")
+        assert loaded_shell.name == "shell"
+
+        # Phase D: disable shell
+        with _patch_available([_FAKE_SHELL, tool]):
+            r_disable = _execute(
+                change_type="disable_tool",
+                tool_name="shell",
+                reason="Done with shell phase",
+                urgency="low",
+            )
+        assert "disabled" in r_disable.content
+        assert not has_tool("shell"), "shell should be removed after disable"

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -333,6 +333,66 @@ class TestEnableTool:
         assert "enabled" in result.content
         assert any(t.name == "shell" for t in get_tools())
 
+    def test_enable_allows_unloaded_mcp_tool(self, isolated_tools):
+        """Validation must not drop MCP tools via include_mcp=False."""
+        mcp_tool = ToolSpec(
+            name="docs-server.read",
+            desc="MCP docs tool",
+            execute=lambda _code, _args, _kwargs: Message("system", "mcp executed"),
+        )
+
+        def fake_available(include_mcp: bool = True):
+            return [mcp_tool, tool] if include_mcp else [tool]
+
+        with (
+            patch(
+                "gptme.tools.request_tool_change.get_available_tools",
+                side_effect=fake_available,
+            ),
+            patch("gptme.tools.get_available_tools", side_effect=fake_available),
+        ):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="docs-server.read",
+                reason="Need MCP docs",
+                urgency="medium",
+            )
+
+        assert "enabled" in result.content
+        assert any(t.name == "docs-server.read" for t in get_tools())
+
+    def test_enable_honors_hint_allowlist(self, isolated_tools):
+        hinted = ToolSpec(
+            name="file_tool",
+            desc="Loaded from a user file",
+            hints=frozenset({"read-only"}),
+            execute=lambda _code, _args, _kwargs: Message("system", "file tool"),
+        )
+        set_session_allowlist(["hint:read-only"])
+        with _patch_available([hinted, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="file_tool",
+                reason="Need the file tool",
+                urgency="medium",
+            )
+
+        assert "enabled" in result.content
+        assert any(t.name == "file_tool" for t in get_tools())
+
+    def test_enable_rejects_when_hints_do_not_match_allowlist(self, isolated_tools):
+        set_session_allowlist(["hint:read-only"])
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Need to inspect workspace",
+                urgency="medium",
+            )
+
+        assert "allowlist" in result.content
+        assert not any(t.name == "shell" for t in get_tools())
+
 
 class TestDisableTool:
     def test_disable_removes_tool_from_session(self, isolated_tools):

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,7 @@ from gptme.tools import (
     clear_tools,
     execute_msg,
     get_available_tools,
+    get_tool_format,
     get_tools,
     init_tools,
     set_tool_format,
@@ -138,11 +141,13 @@ def test_request_tool_change_rejects_non_string_fields():
 @pytest.fixture()
 def isolated_tools():
     """Provide a clean tool context with a minimal known set."""
+    previous_format = get_tool_format()
     clear_tools()
     # Load only request_tool_change itself so each test starts from a known state.
     init_tools(allowlist=["request_tool_change"])
     yield
     clear_tools()
+    set_tool_format(previous_format)
 
 
 _FAKE_SHELL = ToolSpec(
@@ -152,12 +157,20 @@ _FAKE_SHELL = ToolSpec(
 )
 
 
+@contextmanager
 def _patch_available(tools: list[ToolSpec]):
-    """Patch get_available_tools in the module under test."""
-    return patch(
-        "gptme.tools.request_tool_change.get_available_tools",
-        return_value=tools,
-    )
+    """Patch discovery for request validation and load_tool()."""
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "gptme.tools.request_tool_change.get_available_tools",
+                return_value=tools,
+            )
+        )
+        stack.enter_context(
+            patch("gptme.tools.get_available_tools", return_value=tools)
+        )
+        yield
 
 
 class TestEnableTool:
@@ -173,6 +186,28 @@ class TestEnableTool:
         assert "enabled" in result.content
         assert "shell" in result.content
         assert any(t.name == "shell" for t in get_tools())
+
+    def test_enable_initialization_error_is_reported(self, isolated_tools):
+        def fail_initialization() -> ToolSpec:
+            raise RuntimeError("broken initialization")
+
+        broken_tool = ToolSpec(
+            name="broken_tool",
+            desc="Fails during initialization",
+            init=fail_initialization,
+        )
+
+        with _patch_available([broken_tool, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="broken_tool",
+                reason="Need it",
+                urgency="medium",
+            )
+
+        assert "could not enable" in result.content
+        assert "broken initialization" in result.content
+        assert not any(t.name == "broken_tool" for t in get_tools())
 
     def test_enable_runs_tool_initialization(self, isolated_tools):
         initialized: list[str] = []
@@ -282,6 +317,47 @@ class TestDisableTool:
         assert "disabled" in result.content
         assert not any(t.name == "shell" for t in get_tools())
 
+    def test_disable_unregisters_owned_hooks_and_commands(self, isolated_tools):
+        hook = ("session_start", cast(Any, lambda: None), 0)
+        side_effect_tool = ToolSpec(
+            name="side_effect_tool",
+            desc="Registers session side effects",
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+            hooks={"watch": hook},
+            commands={"side-effect": lambda _args: None},
+        )
+        loaded_tool = ToolSpec(
+            name="side_effect_tool",
+            desc="Registers session side effects",
+            execute=side_effect_tool.execute,
+            hooks=side_effect_tool.hooks,
+            commands=side_effect_tool.commands,
+        )
+
+        with (
+            _patch_available([side_effect_tool, tool]),
+            patch("gptme.tools._init_single_tool", return_value=loaded_tool),
+            patch("gptme.hooks.unregister_hook") as unregister_hook,
+            patch("gptme.commands.unregister_command") as unregister_command,
+        ):
+            enabled = _execute(
+                change_type="enable_tool",
+                tool_name="side_effect_tool",
+                reason="Need it",
+                urgency="medium",
+            )
+            disabled = _execute(
+                change_type="disable_tool",
+                tool_name="side_effect_tool",
+                reason="Done with it",
+                urgency="low",
+            )
+
+        assert "enabled" in enabled.content
+        assert "disabled" in disabled.content
+        unregister_hook.assert_called_once_with("side_effect_tool.watch")
+        unregister_command.assert_called_once_with("side-effect")
+
     def test_disable_not_loaded_is_noop(self, isolated_tools):
         with _patch_available([_FAKE_SHELL, tool]):
             result = _execute(
@@ -305,6 +381,25 @@ class TestDisableTool:
         assert "cannot disable itself" in result.content
         # request_tool_change must still be present
         assert any(t.name == _SELF_NAME for t in get_tools())
+
+    def test_disable_loaded_custom_tool(self, isolated_tools):
+        custom_tool = ToolSpec(
+            name="custom_tool",
+            desc="Loaded from a user file",
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+        )
+        set_tools([*get_tools(), custom_tool])
+
+        with _patch_available([tool]):
+            result = _execute(
+                change_type="disable_tool",
+                tool_name="custom_tool",
+                reason="Stop custom behavior",
+                urgency="medium",
+            )
+
+        assert "disabled" in result.content
+        assert not any(t.name == "custom_tool" for t in get_tools())
 
 
 class TestConfigureTool:
@@ -364,6 +459,23 @@ class TestEnableDisableIntegration:
             )
         assert "disabled" in r_disable.content
         assert not has_tool("shell"), "shell should be removed after disable"
+
+    def test_enable_allows_later_call_in_same_response(self, isolated_tools):
+        set_tool_format("tool")
+        content = (
+            '@request_tool_change(change_1): {"change_type": "enable_tool", '
+            '"tool_name": "shell", "reason": "Need shell", '
+            '"urgency": "medium"}\n'
+            '@shell(shell_2): {"cmd": "echo now-runnable"}'
+        )
+
+        with _patch_available([_FAKE_SHELL, tool]):
+            results = list(execute_msg(Message("assistant", content)))
+
+        assert any("enabled" in result.content for result in results)
+        shell_results = [result for result in results if result.call_id == "shell_2"]
+        assert len(shell_results) == 1
+        assert "shell executed" in shell_results[0].content
 
     def test_disable_prevents_later_call_in_same_response(self, isolated_tools):
         set_tools([*get_tools(), _FAKE_SHELL])

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -15,9 +15,12 @@ from gptme.tools import (
     get_available_tools,
     get_tool_format,
     get_tools,
+    has_tool,
     init_tools,
+    set_session_allowlist,
     set_tool_format,
     set_tools,
+    unload_tool,
 )
 from gptme.tools.base import ToolSpec, ToolUse
 from gptme.tools.request_tool_change import (
@@ -145,6 +148,9 @@ def isolated_tools():
     clear_tools()
     # Load only request_tool_change itself so each test starts from a known state.
     init_tools(allowlist=["request_tool_change"])
+    # The fixture allowlist isolates the loaded set; it is not an operator
+    # restriction. Unrestricted sessions may still enable additional tools.
+    set_session_allowlist(None)
     yield
     clear_tools()
     set_tool_format(previous_format)
@@ -301,6 +307,32 @@ class TestEnableTool:
         assert "unknown tool" in result.content
         assert not any(t.name == "nonexistent_xyz" for t in get_tools())
 
+    def test_enable_rejects_tool_outside_allowlist(self, isolated_tools):
+        set_session_allowlist(["request_tool_change"])
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Need to inspect workspace",
+                urgency="medium",
+            )
+
+        assert "allowlist" in result.content
+        assert not any(t.name == "shell" for t in get_tools())
+
+    def test_enable_allows_allowlisted_tool(self, isolated_tools):
+        set_session_allowlist(["request_tool_change", "shell"])
+        with _patch_available([_FAKE_SHELL, tool]):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="shell",
+                reason="Need to inspect workspace",
+                urgency="medium",
+            )
+
+        assert "enabled" in result.content
+        assert any(t.name == "shell" for t in get_tools())
+
 
 class TestDisableTool:
     def test_disable_removes_tool_from_session(self, isolated_tools):
@@ -426,6 +458,23 @@ class TestDisableTool:
 
         assert "disabled" in result.content
         assert not any(t.name == "custom_tool" for t in get_tools())
+
+
+class TestUnloadTool:
+    def test_unload_by_block_type_removes_tool(self, isolated_tools):
+        alias_tool = ToolSpec(
+            name="alias_tool",
+            desc="Has a distinct block type",
+            block_types=["alias_block"],
+            execute=lambda _code, _args, _kwargs: Message("system", "executed"),
+        )
+        set_tools([*get_tools(), alias_tool])
+        assert has_tool("alias_tool")
+
+        unloaded = unload_tool("alias_block")
+        assert unloaded is alias_tool
+        assert not has_tool("alias_tool")
+        assert not any(t is alias_tool for t in get_tools())
 
 
 class TestConfigureTool:

--- a/tests/test_tools_request_tool_change.py
+++ b/tests/test_tools_request_tool_change.py
@@ -6,11 +6,14 @@ from unittest.mock import patch
 
 import pytest
 
+from gptme.message import Message
 from gptme.tools import (
     clear_tools,
+    execute_msg,
     get_available_tools,
     get_tools,
     init_tools,
+    set_tool_format,
     set_tools,
 )
 from gptme.tools.base import ToolSpec
@@ -142,7 +145,11 @@ def isolated_tools():
     clear_tools()
 
 
-_FAKE_SHELL = ToolSpec(name="shell", desc="Run shell commands")
+_FAKE_SHELL = ToolSpec(
+    name="shell",
+    desc="Run shell commands",
+    execute=lambda _code, _args, _kwargs: Message("system", "shell executed"),
+)
 
 
 def _patch_available(tools: list[ToolSpec]):
@@ -166,6 +173,70 @@ class TestEnableTool:
         assert "enabled" in result.content
         assert "shell" in result.content
         assert any(t.name == "shell" for t in get_tools())
+
+    def test_enable_runs_tool_initialization(self, isolated_tools):
+        initialized: list[str] = []
+
+        def initialize_tool() -> ToolSpec:
+            initialized.append("initialized")
+            return ToolSpec(
+                name="initializing_tool",
+                desc="Initialized",
+                execute=lambda _code, _args, _kwargs: Message(
+                    "system", "initialized tool executed"
+                ),
+            )
+
+        raw_tool = ToolSpec(
+            name="initializing_tool",
+            desc="Needs initialization",
+            init=initialize_tool,
+        )
+
+        with (
+            _patch_available([raw_tool, tool]),
+            patch(
+                "gptme.tools.get_available_tools",
+                return_value=[raw_tool, tool],
+            ),
+        ):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="initializing_tool",
+                reason="Need initialized behavior",
+                urgency="medium",
+            )
+
+        assert "enabled" in result.content
+        assert initialized == ["initialized"]
+        loaded = next(t for t in get_tools() if t.name == "initializing_tool")
+        assert loaded.execute is not None
+
+    def test_enable_rejects_unavailable_tool(self, isolated_tools):
+        unavailable = ToolSpec(
+            name="unavailable_tool",
+            desc="Unavailable",
+            available=False,
+            available_hint="install its dependency",
+        )
+
+        with (
+            _patch_available([unavailable, tool]),
+            patch(
+                "gptme.tools.get_available_tools",
+                return_value=[unavailable, tool],
+            ),
+        ):
+            result = _execute(
+                change_type="enable_tool",
+                tool_name="unavailable_tool",
+                reason="Need it",
+                urgency="medium",
+            )
+
+        assert "could not enable" in result.content
+        assert "unavailable" in result.content.lower()
+        assert not any(t.name == "unavailable_tool" for t in get_tools())
 
     def test_enable_already_loaded_is_noop(self, isolated_tools):
         # Pre-load shell
@@ -293,3 +364,22 @@ class TestEnableDisableIntegration:
             )
         assert "disabled" in r_disable.content
         assert not has_tool("shell"), "shell should be removed after disable"
+
+    def test_disable_prevents_later_call_in_same_response(self, isolated_tools):
+        set_tools([*get_tools(), _FAKE_SHELL])
+        set_tool_format("tool")
+        content = (
+            '@request_tool_change(change_1): {"change_type": "disable_tool", '
+            '"tool_name": "shell", "reason": "Done with shell", '
+            '"urgency": "low"}\n'
+            '@shell(shell_2): {"cmd": "echo should-not-run"}'
+        )
+
+        with _patch_available([_FAKE_SHELL, tool]):
+            results = list(execute_msg(Message("assistant", content)))
+
+        assert any("disabled" in result.content for result in results)
+        shell_results = [result for result in results if result.call_id == "shell_2"]
+        assert len(shell_results) == 1
+        assert "not available for execution" in shell_results[0].content
+        assert all("shell executed" not in result.content for result in results)


### PR DESCRIPTION
## What

Phase 2 of the EvoHarness adaptive tool configuration.

Phase 1 ([#3529](https://github.com/gptme/gptme/pull/3529), merged 2026-08-23) shipped `request_tool_change` as **audit-only**: the tool recorded intent in history but made no mutations. This PR makes `enable_tool` and `disable_tool` requests actually apply by mutating the session-local tool set.

## Design choice: Option 2 — session-state mutable enabled\_tools set

Three options from the design doc:

1. Message-level interception
2. **Session state** — mutate the ContextVar-backed `get_tools()` list ← this PR
3. Re-init per turn

Option 2 fits cleanly: `get_tools()`/`set_tools()` already expose the right API; the ContextVar approach makes changes session-scoped by construction; and no LLM-loop changes or provider re-init are needed.

## Changes

### `gptme/tools/request_tool_change.py`

- `_enable_tool()`: finds the tool in `get_available_tools()`, appends it via `set_tools()`. No-ops if already loaded; returns an error if the tool name is unknown.
- `_disable_tool()`: removes the tool. Refuses to disable `request_tool_change` itself. No-ops if not loaded.
- `configure_tool` path: remains audit-only (Phase 3 scope).
- Updated docstring and `instructions` to reflect actuation semantics.

### `tests/test_tools_request_tool_change.py`

8 new test cases (13 total, all passing):

| Class | Tests |
|---|---|
| `TestEnableTool` | adds to session; no-op if already loaded; rejects unknown |
| `TestDisableTool` | removes from session; no-op if not loaded; refuses self-disable |
| `TestConfigureTool` | audit-only, tool list unchanged |
| `TestEnableDisableIntegration` | enable → verify callable → disable → verify not callable (requirement 3.1) |

An `isolated_tools` fixture calls `clear_tools()` + `init_tools()` before each Phase 2 test so ContextVar state doesn't leak between cases.

## Refs

- Phase 1 PR: #3529
- Design doc: `knowledge/technical-designs/2026-08-12-evoharness-adaptive-tool-config-design.md`
- Sources: arXiv:2608.05446 (EvoHarness-RL), arXiv:2607.04528