### PR TITLE
feat(tools): expose convert as auto-discovered structured tool

### DIFF
--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -25,6 +25,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar
 
+from ..message import Message
+from .base import Parameter, ToolSpec
+
 logger = logging.getLogger(__name__)
 
 
@@ -818,6 +821,92 @@ def convert_file(
             error=f"Could not create output directory {dest.parent}: {e}",
         )
     return conv.convert(src, dest, quality=quality, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Structured tool surface (auto-discovered ToolSpec)
+# ---------------------------------------------------------------------------
+
+
+def _execute_convert(
+    code: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Message:
+    """Execute a file conversion from a structured tool call.
+
+    Accepts keyword arguments ``input_path`` (required) and ``output_path``
+    (required; extension selects the target format). Optional ``quality``
+    (low/medium/high) and ``dry_run``.
+    """
+    kwargs = kwargs or {}
+    src_raw = kwargs.get("input_path")
+    dest_raw = kwargs.get("output_path")
+    if not src_raw or not dest_raw:
+        return Message(
+            "system",
+            "Error: both `input_path` and `output_path` are required.",
+        )
+
+    src = Path(src_raw)
+    dest = Path(dest_raw)
+    if not src.exists():
+        return Message("system", f"Error: input file not found: {src}")
+
+    quality = kwargs.get("quality", "medium")
+    dry_run = kwargs.get("dry_run", "false").lower() in ("true", "1", "yes")
+
+    result = convert_file(src, dest, quality=quality, dry_run=dry_run)
+    return Message("system", result.summary())
+
+
+tool = ToolSpec(
+    name="convert",
+    desc="Convert a file to another format using offline system tools",
+    instructions=(
+        "Convert files between formats using offline system tools (FFmpeg, "
+        "ImageMagick, Poppler, python-docx, pypdf) with graceful fallback when "
+        "a specific converter is unavailable. Useful for format bridges in "
+        "air-gapped or offline workflows: PDF→PNG/JPEG for visual inspection, "
+        "document→text for summarization, video→thumbnail for metadata, and "
+        "image↔image reformatting.\n\n"
+        "Set `output_path` with the desired target extension (e.g. `.png`) to "
+        "select the destination format. Pass `quality` = low/medium/high and "
+        "`dry_run` = true to show the converter plan without writing output.\n\n"
+        "Run the `convert` tool with `dry_run` first to confirm the converter "
+        "chain, then execute for real."
+    ),
+    execute=_execute_convert,
+    parameters=[
+        Parameter(
+            name="input_path",
+            type="string",
+            description="Path to the source file to convert",
+            required=True,
+        ),
+        Parameter(
+            name="output_path",
+            type="string",
+            description=(
+                "Path of the output file; its extension selects the target "
+                "format (e.g. .png, .jpg, .txt, .md)"
+            ),
+            required=True,
+        ),
+        Parameter(
+            name="quality",
+            type="string",
+            enum=["low", "medium", "high"],
+            description="Conversion quality (default: medium)",
+        ),
+        Parameter(
+            name="dry_run",
+            type="string",
+            enum=["true", "false"],
+            description="If true, show the converter plan without executing",
+        ),
+    ],
+)
 
 
 # ---------------------------------------------------------------------------

--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -165,6 +165,11 @@ class ConversionResult:
     def summary(self) -> str:
         if not self.success:
             return f"Conversion failed ({self.converter_used}): {self.error}"
+        if self.metadata.get("dry_run"):
+            return (
+                f"Dry-run: would convert via {self.converter_used} → "
+                f"{self.output_path} (no file written)"
+            )
         parts = [f"Converted via {self.converter_used} → {self.output_path}"]
         if self.lossy:
             parts.append("(lossy)")

--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -854,7 +854,8 @@ def _execute_convert(
         return Message("system", f"Error: input file not found: {src}")
 
     quality = kwargs.get("quality", "medium")
-    dry_run = kwargs.get("dry_run", "false").lower() in ("true", "1", "yes")
+    # `dry_run` may arrive as a JSON boolean or a string; normalize defensively.
+    dry_run = str(kwargs.get("dry_run", "false")).lower() in ("true", "1", "yes")
 
     result = convert_file(src, dest, quality=quality, dry_run=dry_run)
     return Message("system", result.summary())
@@ -864,17 +865,16 @@ tool = ToolSpec(
     name="convert",
     desc="Convert a file to another format using offline system tools",
     instructions=(
-        "Convert files between formats using offline system tools (FFmpeg, "
-        "ImageMagick, Poppler, python-docx, pypdf) with graceful fallback when "
-        "a specific converter is unavailable. Useful for format bridges in "
-        "air-gapped or offline workflows: PDF→PNG/JPEG for visual inspection, "
-        "document→text for summarization, video→thumbnail for metadata, and "
-        "image↔image reformatting.\n\n"
-        "Set `output_path` with the desired target extension (e.g. `.png`) to "
-        "select the destination format. Pass `quality` = low/medium/high and "
-        "`dry_run` = true to show the converter plan without writing output.\n\n"
-        "Run the `convert` tool with `dry_run` first to confirm the converter "
-        "chain, then execute for real."
+        "Use this tool when a workflow needs a file in a different format: "
+        "render a PDF to images for visual inspection, extract text from a "
+        "document for summarization, make a video thumbnail, or reformat an "
+        "image. It runs fully offline, falling back gracefully when a specific "
+        "converter is unavailable.\n\n"
+        "Choose the destination format by the `output_path` extension (e.g. "
+        "`.png`, `.jpg`, `.txt`, `.md`). Set `quality` to low/medium/high "
+        "when the conversion supports it, and pass `dry_run` = true to see "
+        "the converter plan first. For a new conversion, dry-run before "
+        "executing to confirm the chain is available."
     ),
     execute=_execute_convert,
     parameters=[

--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -855,9 +855,16 @@ def _execute_convert(
 
     quality = kwargs.get("quality", "medium")
     # `dry_run` may arrive as a JSON boolean or a string; normalize defensively.
-    dry_run = str(kwargs.get("dry_run", "false")).lower() in ("true", "1", "yes")
+    dry_run = str(kwargs.get("dry_run", "false")).strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
 
-    result = convert_file(src, dest, quality=quality, dry_run=dry_run)
+    try:
+        result = convert_file(src, dest, quality=quality, dry_run=dry_run)
+    except OSError as exc:
+        return Message("system", f"Conversion error: {exc}")
     return Message("system", result.summary())
 
 

--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -801,6 +801,15 @@ def convert_file(
         )
 
     if dry_run:
+        # Match the concrete converters: a directory destination cannot succeed.
+        # Dry-run used to skip this check and report a possible conversion.
+        if dest.is_dir():
+            return ConversionResult(
+                success=False,
+                output_path=dest,
+                converter_used=conv.name,
+                error=f"Destination is an existing directory: {dest}",
+            )
         return ConversionResult(
             success=True,
             output_path=dest,
@@ -914,8 +923,12 @@ tool = ToolSpec(
         Parameter(
             name="dry_run",
             type="string",
-            enum=["true", "false"],
-            description="If true, show the converter plan without executing",
+            # Keep in sync with the truthy set in `_execute_convert`.
+            enum=["true", "false", "1", "yes"],
+            description=(
+                "If true, show the converter plan without executing. "
+                "Accepts true/false/1/yes (JSON booleans also work)."
+            ),
         ),
     ],
 )

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -13,6 +13,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+from gptme.tools.base import ToolSpec
 from gptme.tools.convert import (
     ConversionResult,
     DocumentToTextConverter,
@@ -994,3 +995,87 @@ def test_doc_to_text_specific_error_when_only_python_docx_installed(tmp_path):
     assert "libreoffice" in result.error.lower() or "LibreOffice" in result.error
     # Must NOT say the generic "nothing available" message — python-docx IS there
     assert "No document" not in result.error
+
+
+# ---------------------------------------------------------------------------
+# Structured tool surface (ToolSpec)
+# ---------------------------------------------------------------------------
+
+
+def test_convert_tool_exported_and_discoverable():
+    """The convert module exposes an auto-discoverable ToolSpec named `convert`."""
+    from gptme.tools import convert
+    from gptme.tools.base import _iter_tool_specs
+
+    assert isinstance(convert.tool, ToolSpec)
+    assert convert.tool.name == "convert"
+    # Auto-discovery collects it from the module.
+    specs = list(_iter_tool_specs(convert))
+    assert any(s.name == "convert" for s in specs)
+
+
+def test_convert_tool_parameters():
+    """The convert tool exposes input_path/output_path/quality/dry_run parameters."""
+    from gptme.tools import convert
+
+    names = [p.name for p in convert.tool.parameters]
+    assert names == ["input_path", "output_path", "quality", "dry_run"]
+    by_name = {p.name: p for p in convert.tool.parameters}
+    assert by_name["input_path"].required
+    assert by_name["output_path"].required
+    assert by_name["quality"].enum == ["low", "medium", "high"]
+
+
+def test_execute_convert_success(tmp_path):
+    """_execute_convert forwards args to convert_file and returns a summary Message."""
+    from gptme.tools import convert
+
+    src = tmp_path / "in.png"
+    src.write_bytes(b"\x89PNG\r\n\x1a\n")
+    dest = tmp_path / "out.jpg"
+
+    with patch(
+        "gptme.tools.convert.convert_file",
+        return_value=ConversionResult(
+            success=True,
+            output_path=dest,
+            converter_used="image",
+            lossy=True,
+        ),
+    ) as mock_convert:
+        result = convert._execute_convert(
+            None, None, {"input_path": str(src), "output_path": str(dest)}
+        )
+
+    assert result.role == "system"
+    assert "Converted" in result.content
+    assert "out.jpg" in result.content
+    assert "lossy" in result.content
+    mock_convert.assert_called_once()
+    call_args, call_kwargs = mock_convert.call_args
+    assert str(call_args[0]) == str(src)
+    assert str(call_args[1]) == str(dest)
+    assert call_kwargs.get("quality") == "medium"
+    assert call_kwargs.get("dry_run") is False
+
+
+def test_execute_convert_missing_args():
+    """_execute_convert reports an error when required args are missing."""
+    from gptme.tools import convert
+
+    result = convert._execute_convert(None, None, {"input_path": "/tmp/x.png"})
+    assert result.role == "system"
+    assert "Error" in result.content
+
+
+def test_execute_convert_missing_input():
+    """_execute_convert reports a clear error for a nonexistent input."""
+    from gptme.tools import convert
+
+    result = convert._execute_convert(
+        None,
+        None,
+        {"input_path": "/nonexistent/nope.png", "output_path": "/tmp/out.png"},
+    )
+    assert result.role == "system"
+    assert "input file not found" in result.content

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -564,6 +564,25 @@ def test_convert_file_dry_run(avail_all, tmp_path):
     assert "no file written" in summary
 
 
+def test_convert_file_dry_run_rejects_directory_destination(avail_all, tmp_path):
+    """Dry-run must fail when dest is an existing directory, matching real conversion."""
+    src = tmp_path / "doc.pdf"
+    src.write_bytes(b"%PDF-1.4")
+    dest = tmp_path / "out.png"
+    dest.mkdir()
+    with (
+        patch("gptme.tools.convert.get_availability", return_value=avail_all),
+        patch("gptme.tools.convert._detect_mime", return_value="application/pdf"),
+    ):
+        result = convert_file(src, dest, dry_run=True)
+    assert not result.success
+    assert result.error is not None
+    assert "directory" in result.error.lower()
+    summary = result.summary()
+    assert "failed" in summary.lower()
+    assert "Dry-run:" not in summary
+
+
 def test_convert_file_no_converter(avail_none, tmp_path):
     src = tmp_path / "mystery.xyz"
     src.write_bytes(b"garbage")
@@ -1043,6 +1062,7 @@ def test_convert_tool_parameters():
     assert by_name["input_path"].required
     assert by_name["output_path"].required
     assert by_name["quality"].enum == ["low", "medium", "high"]
+    assert by_name["dry_run"].enum == ["true", "false", "1", "yes"]
 
 
 def test_execute_convert_success(tmp_path):
@@ -1137,8 +1157,9 @@ def test_execute_convert_dry_run_boolean(tmp_path):
     assert "no file written" in result.content
 
 
-def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
-    """A whitespace-padded true value must not execute a real conversion."""
+@pytest.mark.parametrize("value", ["true", "1", "yes", "TRUE", " Yes ", " true "])
+def test_execute_convert_dry_run_truthy_values(tmp_path, value):
+    """Schema truthy values (and padded/cased variants) must dry-run, not convert."""
     from gptme.tools import convert
 
     src = tmp_path / "in.png"
@@ -1160,7 +1181,7 @@ def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
             {
                 "input_path": str(src),
                 "output_path": str(dest),
-                "dry_run": " true ",
+                "dry_run": value,
             },
         )
 

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -1079,3 +1079,34 @@ def test_execute_convert_missing_input():
     )
     assert result.role == "system"
     assert "input file not found" in result.content
+
+
+def test_execute_convert_dry_run_boolean(tmp_path):
+    """_execute_convert tolerates `dry_run` arriving as a JSON boolean (True)."""
+    from typing import cast
+
+    from gptme.tools import convert
+
+    src = tmp_path / "in.png"
+    src.write_bytes(b"\x89PNG\r\n\x1a\n")
+    dest = tmp_path / "out.jpg"
+
+    # Provider-native calls can deliver a real boolean despite the str annotation.
+    kwargs = cast(
+        "dict[str, str]",
+        {
+            "input_path": str(src),
+            "output_path": str(dest),
+            "dry_run": True,
+        },
+    )
+
+    with patch(
+        "gptme.tools.convert.convert_file",
+        return_value=ConversionResult(
+            success=True, output_path=dest, converter_used="image"
+        ),
+    ) as mock_convert:
+        convert._execute_convert(None, None, kwargs)
+
+    assert mock_convert.call_args.kwargs["dry_run"] is True

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -558,6 +558,10 @@ def test_convert_file_dry_run(avail_all, tmp_path):
     assert result.success
     assert result.metadata.get("dry_run") is True
     assert not dest.exists()  # dry_run should NOT create the file
+    summary = result.summary()
+    assert "Dry-run" in summary
+    assert "Converted via" not in summary
+    assert "no file written" in summary
 
 
 def test_convert_file_no_converter(avail_none, tmp_path):
@@ -602,6 +606,21 @@ def test_conversion_result_summary_failure():
     summary = result.summary()
     assert "failed" in summary.lower()
     assert "Exit code 1" in summary
+
+
+def test_conversion_result_summary_dry_run():
+    """Dry-run summaries must not claim a conversion completed."""
+    result = ConversionResult(
+        success=True,
+        output_path=Path("/tmp/out.png"),
+        converter_used="pdftoppm",
+        metadata={"dry_run": True, "src_mime": "application/pdf", "dest_ext": "png"},
+    )
+    summary = result.summary()
+    assert summary.startswith("Dry-run:")
+    assert "pdftoppm" in summary
+    assert "no file written" in summary
+    assert "Converted via" not in summary
 
 
 def test_convert_file_same_path_rejected(avail_all, tmp_path):
@@ -1104,12 +1123,18 @@ def test_execute_convert_dry_run_boolean(tmp_path):
     with patch(
         "gptme.tools.convert.convert_file",
         return_value=ConversionResult(
-            success=True, output_path=dest, converter_used="image"
+            success=True,
+            output_path=dest,
+            converter_used="image",
+            metadata={"dry_run": True},
         ),
     ) as mock_convert:
-        convert._execute_convert(None, None, kwargs)
+        result = convert._execute_convert(None, None, kwargs)
 
     assert mock_convert.call_args.kwargs["dry_run"] is True
+    assert "Dry-run" in result.content
+    assert "Converted via" not in result.content
+    assert "no file written" in result.content
 
 
 def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
@@ -1123,10 +1148,13 @@ def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
     with patch(
         "gptme.tools.convert.convert_file",
         return_value=ConversionResult(
-            success=True, output_path=dest, converter_used="image"
+            success=True,
+            output_path=dest,
+            converter_used="image",
+            metadata={"dry_run": True},
         ),
     ) as mock_convert:
-        convert._execute_convert(
+        result = convert._execute_convert(
             None,
             None,
             {
@@ -1137,6 +1165,8 @@ def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
         )
 
     assert mock_convert.call_args.kwargs["dry_run"] is True
+    assert "Dry-run" in result.content
+    assert "Converted via" not in result.content
 
 
 def test_execute_convert_reports_os_error(tmp_path):

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -1110,3 +1110,52 @@ def test_execute_convert_dry_run_boolean(tmp_path):
         convert._execute_convert(None, None, kwargs)
 
     assert mock_convert.call_args.kwargs["dry_run"] is True
+
+
+def test_execute_convert_dry_run_string_strips_whitespace(tmp_path):
+    """A whitespace-padded true value must not execute a real conversion."""
+    from gptme.tools import convert
+
+    src = tmp_path / "in.png"
+    src.write_bytes(b"\x89PNG\r\n\x1a\n")
+    dest = tmp_path / "out.jpg"
+
+    with patch(
+        "gptme.tools.convert.convert_file",
+        return_value=ConversionResult(
+            success=True, output_path=dest, converter_used="image"
+        ),
+    ) as mock_convert:
+        convert._execute_convert(
+            None,
+            None,
+            {
+                "input_path": str(src),
+                "output_path": str(dest),
+                "dry_run": " true ",
+            },
+        )
+
+    assert mock_convert.call_args.kwargs["dry_run"] is True
+
+
+def test_execute_convert_reports_os_error(tmp_path):
+    """OS failures from converter execution are returned as tool output."""
+    from gptme.tools import convert
+
+    src = tmp_path / "in.png"
+    src.write_bytes(b"\x89PNG\r\n\x1a\n")
+    dest = tmp_path / "out.jpg"
+
+    with patch(
+        "gptme.tools.convert.convert_file",
+        side_effect=PermissionError("output directory is read-only"),
+    ):
+        result = convert._execute_convert(
+            None,
+            None,
+            {"input_path": str(src), "output_path": str(dest)},
+        )
+
+    assert result.role == "system"
+    assert result.content == "Conversion error: output directory is read-only"


### PR DESCRIPTION
## Summary

Phase 1.6 of the file-format-conversion tool (task `gptme-file-format-conversion-tool`): wires the Phase 1 `convert_file` CLI into an **auto-discovered structured ToolSpec** so agents can invoke conversions as a tool call rather than via the shell CLI.

The Phase 1 merge (PR #3595, `b04893049`) shipped the converter core + argparse CLI but no ToolSpec — the module was invisible to `_iter_tool_specs`. This closes that gap.

## Changes

- **`gptme/tools/convert.py`**:
  - `_execute_convert`: maps structured tool kwargs (`input_path`, `output_path`, `quality`, `dry_run`) onto `convert_file` and returns a summary `Message`
  - module-level `tool = ToolSpec(name="convert", ...)` with parameters matching the Phase 0 design's MCP surface (`input_path`, `output_path` required; `quality` low/medium/high; `dry_run` true/false)
- **`tests/test_tools_convert.py`**: 5 new tests — auto-discovery via `_iter_tool_specs`, parameter schema, success path (with mock `convert_file`), missing-arg error, missing-input error

## Verification

- `pytest tests/test_tools_convert.py`: **70 passed** (65 existing + 5 new)
- `ruff check` + `ruff format`: clean
- `mypy gptme/tools/convert.py`: 0 errors (pre-existing `acp/` errors on master are unrelated)

## Closes

Implements Phase 1.6 of task `gptme-file-format-conversion-tool` (Phase 0 design: `knowledge/technical-designs/gptme-file-format-conversion-tool-phase0.md`).
