### PR TITLE
fix(tests): stop pytest-retry × tmp_path teardown KeyError failing green runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 import pytest
 import requests
+
+# Hook implementation lives in its own module so the regression test can load
+# the exact shipped code via `-p retry_compat` instead of a copy.
+from retry_compat import pytest_runtest_teardown  # noqa: F401
 from thread_leak import (
     diff_threads,
     format_leaks,

--- a/tests/retry_compat.py
+++ b/tests/retry_compat.py
@@ -1,0 +1,36 @@
+"""Compatibility shims for pytest-retry interacting with pytest internals.
+
+Loaded as a plugin by ``tests/conftest.py`` (and directly, via ``-p
+retry_compat``, by the regression tests that guard it).
+"""
+
+import pytest
+from _pytest.tmpdir import tmppath_result_key
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Re-seed pytest's ``tmp_path`` bookkeeping so retried tests can tear down.
+
+    pytest's ``tmp_path`` finalizer reads ``node.stash[tmppath_result_key]`` and
+    then ``del``etes it (``_pytest/tmpdir.py``). That key is only (re)populated
+    by tmpdir's ``pytest_runtest_makereport`` hook.
+
+    pytest-retry runs a preliminary teardown before each retry -- consuming and
+    deleting the key -- then re-runs setup/call by invoking the hooks directly
+    and building the report with ``TestReport.from_item_and_call``, which
+    bypasses ``pytest_runtest_makereport`` entirely. The key is therefore never
+    restored, so the *final* teardown of any retried test that used ``tmp_path``
+    raises ``KeyError: <_pytest.stash.StashKey ...>``.
+
+    That turns a test which *passed on retry* into a job-failing ERROR, which
+    defeats the point of ``--retries``. Seeding an empty dict restores the
+    pre-retry behaviour. The value is only consulted under
+    ``tmp_path_retention_policy = "failed"``; we use the default ("all"), where
+    the dict is fetched but never read.
+
+    Observed on pytest 9.1 x pytest-retry 1.7.0. Remove once pytest-retry
+    restores the stash or routes retry attempts through the makereport hook.
+    """
+    item.stash.setdefault(tmppath_result_key, {})
+    yield

--- a/tests/test_pytest_retry_tmp_path_interaction.py
+++ b/tests/test_pytest_retry_tmp_path_interaction.py
@@ -1,0 +1,90 @@
+"""Regression guard for the pytest-retry x ``tmp_path`` teardown interaction.
+
+pytest's ``tmp_path`` finalizer reads ``node.stash[tmppath_result_key]`` and
+deletes it; only tmpdir's ``pytest_runtest_makereport`` hook puts it back.
+pytest-retry tears down before each retry (consuming the key) and then re-runs
+setup/call through the hooks directly, bypassing ``makereport``. The final
+teardown of any retried test using ``tmp_path`` therefore raises
+``KeyError: <_pytest.stash.StashKey ...>``.
+
+The damage: a test that *passed on retry* still fails the job, which is exactly
+what ``--retries`` exists to prevent. ``tests/retry_compat.py`` re-seeds the key.
+
+Sibling guard for the other retry-machinery bug: see
+``tests/test_pytest_timeout_retry_interaction.py``.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent
+
+# Fails on the first attempt, passes on the second, and uses tmp_path -- the
+# exact shape that trips the stash bug.
+FLAKY_TMP_PATH_TEST = textwrap.dedent(
+    """
+    _attempts = {"n": 0}
+
+
+    def test_flaky_using_tmp_path(tmp_path):
+        (tmp_path / "artifact.txt").write_text("hello")
+        _attempts["n"] += 1
+        assert _attempts["n"] > 1, "fails on first attempt only"
+    """
+)
+
+
+def _run_isolated_pytest(
+    tmp_path: Path, *plugin_args: str
+) -> subprocess.CompletedProcess:
+    (tmp_path / "test_flake.py").write_text(FLAKY_TMP_PATH_TEST)
+    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_flake.py",
+            "-p",
+            "no:cacheprovider",
+            *plugin_args,
+            "-q",
+            "--retries",
+            "1",
+            "--retry-delay",
+            "0",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env={**os.environ, "PYTHONPATH": str(TESTS_DIR)},
+    )
+
+
+def test_retried_tmp_path_test_tears_down_cleanly(tmp_path):
+    """With retry_compat loaded, a retried tmp_path test reports a clean pass."""
+    result = _run_isolated_pytest(tmp_path, "-p", "retry_compat")
+    output = result.stdout + result.stderr
+
+    assert "StashKey" not in output, output
+    assert " error" not in output, output
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{output}"
+
+
+def test_without_shim_the_stash_keyerror_still_reproduces(tmp_path):
+    """Falsifies the guard above.
+
+    If pytest-retry (or pytest) fixes this upstream, this test starts failing --
+    that is the signal to delete ``tests/retry_compat.py`` and this file.
+    """
+    result = _run_isolated_pytest(tmp_path)
+    output = result.stdout + result.stderr
+
+    assert "StashKey" in output, (
+        "upstream appears fixed; drop tests/retry_compat.py and this guard\n" + output
+    )


### PR DESCRIPTION
## Problem

A test that **passes on retry** can still fail the whole CI job:

```
ERROR tests/test_subagent_unit.py::TestSubagentCancel::test_thread_completion_skips_notify_when_cancel_wins_race
  - KeyError: <_pytest.stash.StashKey object at 0x7ffac78a5c00>
...
= 11579 passed, 42 skipped, 2 xfailed, 2 xpassed, 1 error, 2 retried in 822.09s =
make: *** [Makefile:59: test] Error 1
```

That was the *only* red check on #3658 — an unrelated flake that had already
passed on attempt 2. `--retries` is supposed to absorb exactly this.

## Root cause

1. pytest's `tmp_path` finalizer reads `node.stash[tmppath_result_key]` and then
   **deletes** it (`_pytest/tmpdir.py:305-312`).
2. That key is only (re)populated by tmpdir's `pytest_runtest_makereport` hook
   (`_pytest/tmpdir.py:350`).
3. pytest-retry runs a **preliminary teardown** before each retry
   (`retry_plugin.py:210`) — consuming and deleting the key — then re-runs
   setup/call by invoking the hooks directly and building the report with
   `TestReport.from_item_and_call` (`retry_plugin.py:236-238`), which **bypasses
   `pytest_runtest_makereport` entirely**.

So the key is never restored, and the final teardown of *any* retried test that
used `tmp_path` raises `KeyError`. This is a generic pytest-retry × pytest
incompatibility, not a bug in the test that happens to show red.

Reproduces in 0.07s with a 5-line test — pytest 9.1.1 × pytest-retry 1.7.0,
both inside gptme's pinned ranges (`pytest = "^9.1"`, `pytest-retry = "^1.7.0"`).

## Fix

`tests/retry_compat.py` re-seeds the key in a `tryfirst` `pytest_runtest_teardown`
wrapper. The seeded value is only consulted under
`tmp_path_retention_policy = "failed"`; we use the default (`"all"`), where the
dict is fetched but never read — so the seeded content is inert here.

It's a plugin module rather than inline conftest code so the regression test can
load **the shipped code** via `-p retry_compat` instead of a copy.

## Why this and not `@pytest.mark.no_retry`

`no_retry` (used for `test_multi_tool_per_message`, #3171) suppresses the
symptom per-test by making the test *not retry* — which turns a genuine flake
into a hard failure, and needs re-applying every time a new `tmp_path` test
flakes. This fixes the machinery once, for every test.

## Tests

- `test_retried_tmp_path_test_tears_down_cleanly` — with the shim, a retried
  `tmp_path` test exits 0 with no error.
- `test_without_shim_the_stash_keyerror_still_reproduces` — **falsifies** the
  guard above. When pytest-retry fixes this upstream, this test fails, which is
  the signal to delete `tests/retry_compat.py` and this file.

Verified: both pass against pytest 9.1.1 / pytest-retry 1.7.0. Also verified the
conftest re-export actually registers the hook (`1 passed, 1 retried`, exit 0 —
previously `1 passed, 1 error`), rather than being a silent no-op.

## Related

- Sibling guard for the other retry-machinery bug: `tests/test_pytest_timeout_retry_interaction.py` (#3634)
- Prior instance-level workaround: #3171