### PR TITLE
fix(tests): give subagent thread-join guard a real liveness budget

### DIFF
--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -7,12 +7,22 @@ import pytest
 from gptme.tools.subagent import SubtaskDef, _subagents, subagent
 
 
-def _wait_for_new_subagent_threads(initial_count: int, timeout: float = 1.0) -> None:
-    """Join spawned threads before a thread-mocking patch context can unwind."""
+def _wait_for_new_subagent_threads(initial_count: int, timeout: float = 30.0) -> None:
+    """Join spawned threads before a thread-mocking patch context can unwind.
+
+    The timeout is a liveness bound, not a latency assertion: a healthy thread
+    joins as soon as it exits, so a generous budget costs nothing. It must stay
+    generous because the thread has to be *scheduled* first, and run_subagent
+    then acquires the global slot semaphore before its (mocked) body runs. Under
+    a loaded parallel CI run that startup can take seconds, which made a 1s
+    budget fail as `assert not True` with no diagnostic.
+    """
     for sa in _subagents[initial_count:]:
         if sa.thread is not None:
             sa.thread.join(timeout=timeout)
-            assert not sa.thread.is_alive()
+            assert not sa.thread.is_alive(), (
+                f"subagent {sa.agent_id!r} thread still alive after {timeout}s join"
+            )
 
 
 def _new_subagents(initial_count: int):


### PR DESCRIPTION
## Problem

`Test` on `master` went red in [run 33134265411](https://github.com/gptme/gptme/actions/runs/33134265411) with a single failure:

```
FAILED tests/test_tools_subagent.py::test_role_explicit_profile_overrides_role_profile
  - AssertionError: assert not True
  +  where True = is_alive()
  +    where is_alive = <Thread(Thread-27 (run_subagent), started daemon ...)>.is_alive
```

The test helper joined each spawned thread with a **1.0s** timeout and then hard-asserted `not is_alive()`:

```python
def _wait_for_new_subagent_threads(initial_count: int, timeout: float = 1.0) -> None:
    for sa in _subagents[initial_count:]:
        if sa.thread is not None:
            sa.thread.join(timeout=timeout)
            assert not sa.thread.is_alive()
```

That turns a *scheduling* budget into a *correctness* assertion. Even with `_create_subagent_thread` mocked, the thread has to be scheduled first, and `run_subagent` then acquires the global slot semaphore (`get_slot_sem().acquire()`, default `min(8, cpu_count)`) before its mocked body runs. On a loaded parallel CI run that startup can exceed a second, and the test fails with no diagnostic beyond `assert not True`.

Corroborating: 1.0s is the tightest budget in the file by a wide margin — every sibling `thread.join()` here already uses 5s or 10s.

## Fix

Keep the guard, fix its budget.

The guard is not incidental: it came from #3257 to close the mock-revert race where a `@patch` context unwinds while the spawned thread is still pre-lookup, letting the real function run unmocked. It should stay.

But the timeout is a **liveness bound, not a latency assertion** — a healthy thread joins the moment it exits, so a generous budget costs nothing in the passing case while still catching a genuinely stuck thread. Raised to 30s.

Also adds the subagent id to the assertion message, so a real hang reports *which* agent hung instead of `assert not True`.

## Verification

- `tests/test_tools_subagent.py` — **123 passed** locally.
- `ruff format` + `ruff check` clean; pre-commit passed.

Test-only change; no production code touched.

Note on honesty: this is a mechanism fix argued from the failure signature and the semaphore-acquire path, not a reproduced flake — the race is timing-dependent and I did not reproduce it deterministically.