### PR TITLE
fix(browser): harden lynx URL validation

### DIFF
--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -6,24 +6,40 @@ import logging
 import os
 import subprocess
 import tempfile
+from pathlib import Path
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+_MAX_INPUT_LENGTH = 2048
 
 
 def _validate_url_scheme(url: str) -> None:
-    """Validate that URL uses a safe scheme (http/https only).
+    """Validate that a URL is safe to pass to lynx.
 
     Security: Prevents file:// protocol from reading local files.
     See: https://github.com/gptme/gptme/issues/1021
     """
-    parsed = urlparse(url)
+    if not url or len(url) > _MAX_INPUT_LENGTH:
+        raise ValueError(
+            f"URL must be non-empty and no longer than {_MAX_INPUT_LENGTH} characters."
+        )
+
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+    except ValueError as exc:
+        raise ValueError("Invalid URL") from exc
+
     allowed_schemes = {"http", "https"}
     if parsed.scheme.lower() not in allowed_schemes:
         raise ValueError(
             f"URL scheme '{parsed.scheme}' not allowed. "
             f"Only {allowed_schemes} are permitted for security reasons."
         )
+    if not hostname:
+        raise ValueError("URL must include a hostname.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("URL must not include embedded credentials.")
 
 
 def read_url(url: str, cookies: dict | None = None) -> str:
@@ -37,16 +53,28 @@ def read_url(url: str, cookies: dict | None = None) -> str:
     if cookies:
         # Create Netscape-format cookie file for lynx
         parsed = urlparse(url)
-        domain = parsed.hostname or ""
+        domain = parsed.hostname
+        assert domain is not None  # Guaranteed by _validate_url_scheme().
+        for name, value in cookies.items():
+            if (
+                not isinstance(name, str)
+                or not isinstance(value, str)
+                or not name
+                or any(char in name + value for char in "\r\n\t")
+            ):
+                raise ValueError(
+                    "Cookie names and values must not be empty or contain tabs/newlines."
+                )
         fd, cookie_file = tempfile.mkstemp(suffix=".txt", prefix="lynx_cookies_")
         try:
+            Path(cookie_file).chmod(0o600)
             with os.fdopen(fd, "w") as f:
                 f.write("# Netscape HTTP Cookie File\n")
                 for name, value in cookies.items():
                     # Format: domain, tail-match, path, secure, expiry, name, value
                     f.write(f".{domain}\tTRUE\t/\tFALSE\t0\t{name}\t{value}\n")
         except Exception:
-            os.unlink(cookie_file)
+            Path(cookie_file).unlink(missing_ok=True)
             cookie_file = None
             raise
         cmd.extend([f"-cookie_file={cookie_file}", "-accept_all_cookies"])
@@ -64,11 +92,18 @@ def read_url(url: str, cookies: dict | None = None) -> str:
         )
         return p.stdout
     finally:
-        if cookie_file and os.path.exists(cookie_file):
-            os.unlink(cookie_file)
+        if cookie_file:
+            Path(cookie_file).unlink(missing_ok=True)
 
 
 def search(query: str, engine: str = "duckduckgo") -> str:
+    if engine not in {"google", "duckduckgo"}:
+        raise ValueError(f"Unknown search engine: {engine}")
+    if not query.strip() or len(query) > _MAX_INPUT_LENGTH:
+        raise ValueError(
+            f"Search query must be non-empty and no longer than {_MAX_INPUT_LENGTH} characters."
+        )
+
     if engine == "google":
         # Use SOCS cookie (newer Google consent format) to bypass GDPR banner,
         # and gl=us to avoid region-specific consent redirects.

--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -66,14 +66,18 @@ def read_url(url: str, cookies: dict | None = None) -> str:
                     "Cookie names and values must not be empty or contain tabs/newlines."
                 )
         fd, cookie_file = tempfile.mkstemp(suffix=".txt", prefix="lynx_cookies_")
+        fd_open = True
         try:
             Path(cookie_file).chmod(0o600)
             with os.fdopen(fd, "w") as f:
+                fd_open = False
                 f.write("# Netscape HTTP Cookie File\n")
                 for name, value in cookies.items():
                     # Format: domain, tail-match, path, secure, expiry, name, value
                     f.write(f".{domain}\tTRUE\t/\tFALSE\t0\t{name}\t{value}\n")
         except Exception:
+            if fd_open:
+                os.close(fd)
             Path(cookie_file).unlink(missing_ok=True)
             cookie_file = None
             raise
@@ -99,21 +103,29 @@ def read_url(url: str, cookies: dict | None = None) -> str:
 def search(query: str, engine: str = "duckduckgo") -> str:
     if engine not in {"google", "duckduckgo"}:
         raise ValueError(f"Unknown search engine: {engine}")
-    if not query.strip() or len(query) > _MAX_INPUT_LENGTH:
-        raise ValueError(
-            f"Search query must be non-empty and no longer than {_MAX_INPUT_LENGTH} characters."
-        )
+    if not query.strip():
+        raise ValueError("Search query must be non-empty.")
 
     if engine == "google":
         # Use SOCS cookie (newer Google consent format) to bypass GDPR banner,
         # and gl=us to avoid region-specific consent redirects.
+        url = f"https://www.google.com/search?q={query}&hl=en&gl=us"
+        if len(url) > _MAX_INPUT_LENGTH:
+            raise ValueError(
+                f"Search query URL must be no longer than {_MAX_INPUT_LENGTH} characters."
+            )
         return read_url(
-            f"https://www.google.com/search?q={query}&hl=en&gl=us",
+            url,
             cookies={
                 "SOCS": "CAISHAgBEhJnd3NfMjAyMzA4MTAtMF9SQzIaAmVuIAEaBgiA_LyaBg",
                 "CONSENT": "PENDING+987",
             },
         )
     if engine == "duckduckgo":
-        return read_url(f"https://lite.duckduckgo.com/lite/?q={query}")
+        url = f"https://lite.duckduckgo.com/lite/?q={query}"
+        if len(url) > _MAX_INPUT_LENGTH:
+            raise ValueError(
+                f"Search query URL must be no longer than {_MAX_INPUT_LENGTH} characters."
+            )
+        return read_url(url)
     raise ValueError(f"Unknown search engine: {engine}")

--- a/tests/test_browser_lynx.py
+++ b/tests/test_browser_lynx.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import stat
 import sys
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -82,6 +83,28 @@ def test_read_url_cookie_file_is_private():
         assert observed_mode == 0o600
 
 
+def test_read_url_closes_cookie_descriptor_when_chmod_fails():
+    fd, cookie_path = tempfile.mkstemp()
+    try:
+        with (
+            patch(
+                "gptme.tools._browser_lynx.tempfile.mkstemp",
+                return_value=(fd, cookie_path),
+            ),
+            patch("gptme.tools._browser_lynx.Path.chmod", side_effect=PermissionError),
+            pytest.raises(PermissionError),
+        ):
+            read_url("https://example.com", cookies={"CONSENT": "YES"})
+
+        with pytest.raises(OSError, match="WinError 6|Bad file descriptor"):
+            os.fstat(fd)
+        assert not os.path.exists(cookie_path)
+    finally:
+        if os.path.exists(cookie_path):
+            os.close(fd)
+            os.unlink(cookie_path)
+
+
 def test_search_rejects_invalid_input():
     with pytest.raises(ValueError, match="non-empty"):
         search("   ")
@@ -91,6 +114,31 @@ def test_search_rejects_invalid_input():
 
     with pytest.raises(ValueError, match="Unknown search engine"):
         search("query", "bing")
+
+
+@pytest.mark.parametrize(
+    ("engine", "url_template"),
+    [
+        ("google", "https://www.google.com/search?q={query}&hl=en&gl=us"),
+        ("duckduckgo", "https://lite.duckduckgo.com/lite/?q={query}"),
+    ],
+)
+def test_search_accepts_query_that_fits_final_url_limit(
+    monkeypatch, engine, url_template
+):
+    captured_url = None
+
+    def mock_read_url(url, cookies=None):
+        nonlocal captured_url
+        captured_url = url
+        return "search results"
+
+    monkeypatch.setattr("gptme.tools._browser_lynx.read_url", mock_read_url)
+    query = "a" * (2048 - len(url_template.format(query="")))
+
+    assert search(query, engine) == "search results"
+    assert captured_url is not None
+    assert len(captured_url) <= 2048
 
 
 @pytest.mark.slow

--- a/tests/test_browser_lynx.py
+++ b/tests/test_browser_lynx.py
@@ -1,6 +1,9 @@
 """Tests for lynx browser backend."""
 
+import os
 import shutil
+import stat
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +29,68 @@ def test_url_scheme_validation():
 
     with pytest.raises(ValueError, match="not allowed"):
         _validate_url_scheme("javascript:alert(1)")
+
+
+def test_url_validation_rejects_missing_host_and_credentials():
+    with pytest.raises(ValueError, match="hostname"):
+        _validate_url_scheme("https://")
+
+    with pytest.raises(ValueError, match="hostname"):
+        _validate_url_scheme("https:///etc/passwd")
+
+    with pytest.raises(ValueError, match="credentials"):
+        _validate_url_scheme("https://user:password@example.com")
+
+
+def test_url_validation_enforces_input_length():
+    prefix = "https://example.com/"
+    _validate_url_scheme(prefix + "a" * (2048 - len(prefix)))
+
+    with pytest.raises(ValueError, match="2048"):
+        _validate_url_scheme(prefix + "a" * (2049 - len(prefix)))
+
+
+@pytest.mark.parametrize("cookies", [{"bad\nname": "value"}, {"name": "bad\tvalue"}])
+def test_read_url_rejects_cookie_line_injection(cookies):
+    with pytest.raises(ValueError, match="tabs/newlines"):
+        read_url("https://example.com", cookies=cookies)
+
+
+def test_read_url_cookie_file_is_private():
+    observed_mode = None
+    cookie_path = None
+
+    def mock_run(cmd, **kwargs):
+        nonlocal cookie_path, observed_mode
+        cookie_path = next(
+            arg.split("=", 1)[1] for arg in cmd if arg.startswith("-cookie_file=")
+        )
+        observed_mode = stat.S_IMODE(os.stat(cookie_path).st_mode)
+
+        from unittest.mock import MagicMock
+
+        result = MagicMock()
+        result.stdout = "mock page content"
+        return result
+
+    with patch("gptme.tools._browser_lynx.subprocess.run", side_effect=mock_run):
+        read_url("https://example.com", cookies={"CONSENT": "YES"})
+
+    assert cookie_path is not None
+    assert not os.path.exists(cookie_path)
+    if sys.platform != "win32":
+        assert observed_mode == 0o600
+
+
+def test_search_rejects_invalid_input():
+    with pytest.raises(ValueError, match="non-empty"):
+        search("   ")
+
+    with pytest.raises(ValueError, match="2048"):
+        search("a" * 2049)
+
+    with pytest.raises(ValueError, match="Unknown search engine"):
+        search("query", "bing")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fixes #3643

`_validate_url_scheme` now rejects empty or oversized URLs, missing hostnames, malformed URLs, and embedded credentials while preserving HTTP(S)-only behavior. Cookie names and values are validated before writing Netscape cookie files; files are explicitly private and cleaned up with `Path.unlink(missing_ok=True)`, including when permission setup fails. Search queries and engines are validated before provider URLs are constructed, and the final provider URL stays within the same limit.

Tests:
- `python -m pytest -q tests/test_browser_lynx.py` — 13 passed, 2 skipped (lynx unavailable)
- `ruff check gptme/tools/_browser_lynx.py tests/test_browser_lynx.py`
- `ruff format --check gptme/tools/_browser_lynx.py tests/test_browser_lynx.py`
- `mypy --follow-imports=skip gptme/tools/_browser_lynx.py`
- `git diff --check`

The full direct pytest collection is currently blocked by a missing `multiprocessing_logging` dependency in the local environment; repository `make` commands are unavailable on this Windows host.