### PR TITLE
feat(service-init): add optional local health probe

### DIFF
--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -333,6 +333,97 @@ Append-only logs in `journal/YYYY-MM-DD/`.
 Never modify historical entries.
 """
 
+HEALTH_CHECK_TEMPLATE = '''\
+#!/usr/bin/env python3
+"""Generated local health probe for the {name} systemd user service."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+
+
+def check_service_status(service_name: str) -> dict[str, str]:
+    """Return a JSON-serializable summary of a systemd user service."""
+    try:
+        result = subprocess.run(
+            [
+                "systemctl",
+                "--user",
+                "show",
+                service_name,
+                "--property=LoadState",
+                "--property=ActiveState",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {{
+            "service": service_name,
+            "status": "error",
+            "error": str(exc),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }}
+
+    properties = dict(
+        line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+    )
+    load_state = properties.get("LoadState", "unknown")
+    active_state = properties.get("ActiveState", "unknown")
+    status = (
+        "healthy"
+        if result.returncode == 0 and active_state == "active"
+        else "unhealthy"
+    )
+    return {{
+        "service": service_name,
+        "load_state": load_state,
+        "active_state": active_state,
+        "status": status,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }}
+
+
+def main() -> int:
+    health = check_service_status("{name}.service")
+    print(json.dumps(health, indent=2))
+    return 0 if health["status"] == "healthy" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+HEALTH_README_TEMPLATE = """\
+# {name} health probe
+
+`health-check.py` is a local command-line probe for the generated Linux systemd
+user service. It does **not** start an HTTP server.
+
+```bash
+./health-check.py
+```
+
+The command prints JSON and exits 0 only while `{name}.service` is active. It
+exits 1 for inactive, failed, missing, timed-out, or unreachable user managers,
+which makes it suitable for local monitoring and cron checks.
+
+Useful companion commands:
+
+```bash
+systemctl --user status {name}.service
+journalctl --user -u {name}.service -n 50
+systemctl --user start {name}.service
+```
+
+The probe is generated only for `--platform linux`. launchd users can inspect
+`launchctl print gui/$(id -u)/com.gptme.{name}` instead.
+"""
+
 
 def _resolve_work_dir(work_dir: str) -> Path:
     """Resolve the agent work directory path (does not create it)."""
@@ -465,6 +556,11 @@ def cli() -> None:
     is_flag=True,
     help="Overwrite existing generated files.",
 )
+@click.option(
+    "--enable-health-check",
+    is_flag=True,
+    help="Generate a local JSON health probe (Linux/systemd only).",
+)
 def init(
     name: str,
     model: str,
@@ -473,12 +569,14 @@ def init(
     timer_schedule: str,
     platform_choice: str,
     force: bool,
+    enable_health_check: bool,
 ) -> None:
     """Scaffold a persistent service for a headless gptme agent.
 
     Generates, in the agent work directory:
 
-        gptme.toml, AGENTS.md, gptme-agent-run.sh
+        gptme.toml, AGENTS.md, prompt.md, gptme-agent-run.sh
+        health-check.py, HEALTH.md       # Linux with --enable-health-check
 
     and, in the service output directory:
 
@@ -494,6 +592,7 @@ def init(
         \b
         # Linux (systemd)
         gptme service init --name myagent --model gpt-4o-mini --work-dir ~/gptme-agent
+        gptme service init --name myagent --enable-health-check
         systemctl --user daemon-reload
         systemctl --user enable --now myagent.timer
 
@@ -515,17 +614,22 @@ def init(
     # Resolve platform (auto-detect if needed)
     if platform_choice == "auto":
         platform_choice = _detect_platform()
-        if platform_choice == "macos" and output_dir is None:
-            # Inform users explicitly: on macOS we now default to launchd
-            # instead of the old systemd default, so anyone with scripts
-            # expecting ~/.config/systemd/user gets a clear heads-up.
-            click.echo(
-                "Note: macOS detected — generating a launchd plist in "
-                "~/Library/LaunchAgents instead of a systemd unit. "
-                "Pass --platform linux to generate systemd units for a "
-                "Linux target.",
-                err=True,
-            )
+    if enable_health_check and platform_choice == "macos":
+        raise click.UsageError(
+            "--enable-health-check supports Linux systemd services only. "
+            "Use 'launchctl print' to inspect a macOS launchd agent."
+        )
+    if platform_choice == "macos" and output_dir is None:
+        # Inform users explicitly: on macOS we now default to launchd
+        # instead of the old systemd default, so anyone with scripts
+        # expecting ~/.config/systemd/user gets a clear heads-up.
+        click.echo(
+            "Note: macOS detected — generating a launchd plist in "
+            "~/Library/LaunchAgents instead of a systemd unit. "
+            "Pass --platform linux to generate systemd units for a "
+            "Linux target.",
+            err=True,
+        )
 
     # Set default output directory based on platform
     if output_dir is None:
@@ -711,6 +815,20 @@ def init(
         force=force,
     )
     startup.chmod(0o755)
+
+    if enable_health_check:
+        health_script = work / "health-check.py"
+        if _write_file(
+            health_script,
+            HEALTH_CHECK_TEMPLATE.format(name=name),
+            force=force,
+        ):
+            health_script.chmod(0o755)
+        _write_file(
+            work / "HEALTH.md",
+            HEALTH_README_TEMPLATE.format(name=name),
+            force=force,
+        )
 
     click.echo()
     click.echo(f"✅ Initialized headless agent '{name}'")

--- a/gptme/cli/cmd_service.py
+++ b/gptme/cli/cmd_service.py
@@ -364,6 +364,8 @@ def check_service_status(service_name: str) -> dict[str, str]:
     except (OSError, subprocess.TimeoutExpired) as exc:
         return {{
             "service": service_name,
+            "load_state": "unknown",
+            "active_state": "unknown",
             "status": "error",
             "error": str(exc),
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -612,14 +614,15 @@ def init(
         )
 
     # Resolve platform (auto-detect if needed)
-    if platform_choice == "auto":
+    platform_was_auto = platform_choice == "auto"
+    if platform_was_auto:
         platform_choice = _detect_platform()
     if enable_health_check and platform_choice == "macos":
         raise click.UsageError(
             "--enable-health-check supports Linux systemd services only. "
             "Use 'launchctl print' to inspect a macOS launchd agent."
         )
-    if platform_choice == "macos" and output_dir is None:
+    if platform_was_auto and platform_choice == "macos" and output_dir is None:
         # Inform users explicitly: on macOS we now default to launchd
         # instead of the old systemd default, so anyone with scripts
         # expecting ~/.config/systemd/user gets a clear heads-up.

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -107,6 +107,29 @@ def test_health_check_reports_state_and_preserves_failure_exit_code(
     } == json.loads(proc.stdout)
 
 
+def test_health_check_error_uses_stable_json_schema(tmp_path: Path) -> None:
+    _run_init(tmp_path, "--platform", "linux", "--enable-health-check")
+    health_check = tmp_path / "health-check.py"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    env = {**os.environ, "PATH": str(fake_bin)}
+
+    proc = subprocess.run(
+        ["/usr/bin/python3", str(health_check)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert payload["load_state"] == "unknown"
+    assert payload["active_state"] == "unknown"
+    assert payload["status"] == "error"
+    assert "error" in payload
+
+
 def test_health_check_does_not_chmod_skipped_file(tmp_path: Path) -> None:
     health_check = tmp_path / "health-check.py"
     health_check.write_text("user-owned\n")
@@ -637,6 +660,26 @@ def test_macos_autodetect_emits_warning(tmp_path: Path) -> None:
     assert "launchd plist" in result.output.lower(), (
         "expected the launchd-plist note in output (fires only when output_dir is None)"
     )
+
+
+def test_explicit_macos_platform_does_not_claim_autodetection(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "agent",
+            "--work-dir",
+            str(tmp_path),
+            "--platform",
+            "macos",
+        ],
+        env={"HOME": str(tmp_path)},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "macOS detected" not in result.output
 
 
 def test_help_references_launchd_and_full_template() -> None:

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -6,6 +6,7 @@ parse), and the on-demand (no-timer) path.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -74,6 +75,47 @@ def test_health_check_generates_executable_local_probe(tmp_path: Path) -> None:
     assert "datetime.now(timezone.utc)" in script
     assert "does **not** start an HTTP server" in docs
     assert "curl" not in docs
+
+
+def test_health_check_reports_state_and_preserves_failure_exit_code(
+    tmp_path: Path,
+) -> None:
+    _run_init(tmp_path, "--platform", "linux", "--enable-health-check")
+    health_check = tmp_path / "health-check.py"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    systemctl = fake_bin / "systemctl"
+    systemctl.write_text(
+        "#!/bin/sh\nprintf 'LoadState=loaded\\nActiveState=inactive\\n'\nexit 0\n"
+    )
+    systemctl.chmod(0o755)
+    env = {**os.environ, "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}"}
+
+    proc = subprocess.run(
+        [str(health_check)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert proc.returncode == 1
+    assert json.loads(proc.stdout) | {
+        "load_state": "loaded",
+        "active_state": "inactive",
+        "status": "unhealthy",
+    } == json.loads(proc.stdout)
+
+
+def test_health_check_does_not_chmod_skipped_file(tmp_path: Path) -> None:
+    health_check = tmp_path / "health-check.py"
+    health_check.write_text("user-owned\n")
+    health_check.chmod(0o600)
+
+    _run_init(tmp_path, "--platform", "linux", "--enable-health-check")
+
+    assert health_check.read_text() == "user-owned\n"
+    assert health_check.stat().st_mode & 0o777 == 0o600
 
 
 def test_health_check_rejects_macos(tmp_path: Path) -> None:

--- a/tests/test_cmd_service.py
+++ b/tests/test_cmd_service.py
@@ -52,6 +52,53 @@ def test_generates_service_and_timer(tmp_path: Path) -> None:
     assert (work / "gptme-agent-run.sh").exists()
 
 
+def test_health_check_is_opt_in(tmp_path: Path) -> None:
+    _run_init(tmp_path)
+    assert not (tmp_path / "health-check.py").exists()
+    assert not (tmp_path / "HEALTH.md").exists()
+
+
+def test_health_check_generates_executable_local_probe(tmp_path: Path) -> None:
+    _run_init(tmp_path, "--platform", "linux", "--enable-health-check")
+
+    health_check = tmp_path / "health-check.py"
+    health_docs = tmp_path / "HEALTH.md"
+    assert health_check.stat().st_mode & 0o111
+    assert health_docs.exists()
+
+    script = health_check.read_text()
+    docs = health_docs.read_text()
+    assert '"testagent.service"' in script
+    assert '"--property=ActiveState"' in script
+    assert 'properties.get("ActiveState"' in script
+    assert "datetime.now(timezone.utc)" in script
+    assert "does **not** start an HTTP server" in docs
+    assert "curl" not in docs
+
+
+def test_health_check_rejects_macos(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            "--name",
+            "testagent",
+            "--work-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path / "launchd"),
+            "--platform",
+            "macos",
+            "--enable-health-check",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "supports Linux systemd services only" in result.output
+    assert not tmp_path.exists() or not any(tmp_path.iterdir())
+
+
 def test_agents_md_references_template_and_multiple_service_managers(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- add `--enable-health-check` to `gptme service init`
- generate an executable `health-check.py` that reports the Linux systemd user unit state as JSON
- generate `HEALTH.md` with accurate local-probe usage and troubleshooting commands
- keep the feature opt-in and reject it for launchd, where the systemd probe cannot work

## Scope

This is a **local command-line probe**, not an HTTP endpoint. It exits 0 only when the generated service is active and exits 1 for inactive, failed, missing, timed-out, or unreachable user managers. macOS users should inspect their launchd agent with `launchctl print`.

## Verification

- `57 passed` — `tests/test_cmd_service.py`
- scoped pre-commit: ruff, ruff-format, mypy, root-structure checks all pass
- manual clean-directory generation verified executable modes and JSON output for a missing unit (`status=unhealthy`, exit 1)

Supersedes the stale pre-PR branch commit with a clean implementation on current master.
