### PR TITLE
fix(llm): stop double-retrying and survive 429s in interactive mode

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -356,6 +356,7 @@ Besides the configuration files, gptme supports several environment variables to
 .. rubric:: API Configuration
 
 - ``LLM_API_TIMEOUT`` - Set the timeout in seconds for LLM API requests (default: 600). Must be a valid numeric string (e.g., "600", "1800"). Useful for local LLMs that may take longer to respond.
+- ``GPTME_LLM_MAX_RETRIES`` - Number of attempts (including the first) for a failing LLM request (default: 11). Retries use exponential backoff capped at 60s per wait, giving a ~5 minute window so a brief upstream rate-limit or outage does not end a long session. Provider SDK-level retries are disabled so this is the only retry loop.
 - ``GPTME_ANTHROPIC_FAST_MODE`` - Enable Anthropic fast mode for the Anthropic provider (default: false). When enabled, requests set ``speed: "fast"`` for up to ~2.5x higher output tokens/sec at premium pricing — a research preview available on Claude Opus 4.8+. Requires an org with fast-mode access; otherwise the API returns an error. Off by default, so it never affects standard usage. Useful for latency-sensitive callers (e.g. gptme-voice).
 
 .. rubric:: Browser Configuration

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -18,7 +18,7 @@ from .constants import (
 )
 from .hooks import HookType, trigger_hook
 from .init import init
-from .llm import is_provider_error, mark_llm_reply_origin, reply
+from .llm import is_provider_error, reply
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
@@ -367,8 +367,8 @@ def _run_chat_loop(
             # A failing provider call (rate limit, upstream outage, network
             # error) must not kill an interactive session: report it and hand
             # control back to the user, who can retry or switch model.
-            # Only errors tagged at the LLM `reply()` call qualify — tool
-            # httpx failures must not be swallowed as "LLM request failed".
+            # Only errors tagged at the provider call inside `reply()` qualify
+            # — tool/hook httpx or SDK failures must not be swallowed.
             # Non-interactive runs still fail loudly so the exit code carries
             # the error class. See https://github.com/gptme/gptme/issues/3668
             if not interactive or not is_provider_error(e):
@@ -630,23 +630,19 @@ def step(
         if tool_format == "tool":
             tools = [t for t in get_tools() if t.is_runnable]
 
-        # generate response — isolate this call so tool/hook httpx errors are
-        # not tagged as recoverable LLM failures.
-        try:
-            with terminal_state_title("🤔 generating"):
-                msg_response = reply(
-                    msgs,
-                    get_model(model).full,
-                    stream,
-                    tools,
-                    workspace,
-                    output_schema,
-                    on_token=on_token,
-                    on_thinking=on_thinking,
-                )
-        except Exception as e:
-            mark_llm_reply_origin(e)
-            raise
+        # generate response — `reply()` tags only the provider call, after
+        # GENERATION_PRE hooks, so tool/hook failures still propagate.
+        with terminal_state_title("🤔 generating"):
+            msg_response = reply(
+                msgs,
+                get_model(model).full,
+                stream,
+                tools,
+                workspace,
+                output_schema,
+                on_token=on_token,
+                on_thinking=on_thinking,
+            )
         if get_config().get_env_bool("GPTME_COSTS"):
             log_costs(msgs + [msg_response])
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -536,15 +536,18 @@ def _should_prompt_for_input(log: Log) -> bool:
     last_msg = log[-1] if log else None
 
     # Check if there's an interrupt, decline, or provider-error message after
-    # the last assistant message. These all mean "hand control back to the
-    # user" rather than auto-generating. Hooks (like cost_awareness) may
-    # append after the marker, so scan until the last assistant message.
+    # the last assistant *and* last user message. These mean "hand control
+    # back to the user" rather than auto-generating. A newer user turn
+    # supersedes the marker (crash recovery / queued follow-up). Hooks
+    # (like cost_awareness) may append system messages after the marker, so
+    # skip those — but stop at user or assistant.
     has_recent_return_to_prompt = False
     for msg in reversed(log):
-        if msg.role == "assistant":
+        if msg.role in ("assistant", "user"):
             break
-        if msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT) or (
-            msg.content.startswith(LLM_REQUEST_FAILED_PREFIX)
+        if msg.role == "system" and (
+            msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT)
+            or msg.content.startswith(LLM_REQUEST_FAILED_PREFIX)
         ):
             has_recent_return_to_prompt = True
             break

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -545,9 +545,13 @@ def _should_prompt_for_input(log: Log) -> bool:
     for msg in reversed(log):
         if msg.role in ("assistant", "user"):
             break
-        if msg.role == "system" and (
-            msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT)
-            or msg.content.startswith(LLM_REQUEST_FAILED_PREFIX)
+        if (
+            msg.role == "system"
+            and not msg.call_id
+            and (
+                msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT)
+                or msg.content.startswith(LLM_REQUEST_FAILED_PREFIX)
+            )
         ):
             has_recent_return_to_prompt = True
             break

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -18,7 +18,7 @@ from .constants import (
 )
 from .hooks import HookType, trigger_hook
 from .init import init
-from .llm import is_provider_error, reply
+from .llm import is_provider_error, mark_llm_reply_origin, reply
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
@@ -367,6 +367,8 @@ def _run_chat_loop(
             # A failing provider call (rate limit, upstream outage, network
             # error) must not kill an interactive session: report it and hand
             # control back to the user, who can retry or switch model.
+            # Only errors tagged at the LLM `reply()` call qualify — tool
+            # httpx failures must not be swallowed as "LLM request failed".
             # Non-interactive runs still fail loudly so the exit code carries
             # the error class. See https://github.com/gptme/gptme/issues/3668
             if not interactive or not is_provider_error(e):
@@ -628,20 +630,25 @@ def step(
         if tool_format == "tool":
             tools = [t for t in get_tools() if t.is_runnable]
 
-        # generate response
-        with terminal_state_title("🤔 generating"):
-            msg_response = reply(
-                msgs,
-                get_model(model).full,
-                stream,
-                tools,
-                workspace,
-                output_schema,
-                on_token=on_token,
-                on_thinking=on_thinking,
-            )
-            if get_config().get_env_bool("GPTME_COSTS"):
-                log_costs(msgs + [msg_response])
+        # generate response — isolate this call so tool/hook httpx errors are
+        # not tagged as recoverable LLM failures.
+        try:
+            with terminal_state_title("🤔 generating"):
+                msg_response = reply(
+                    msgs,
+                    get_model(model).full,
+                    stream,
+                    tools,
+                    workspace,
+                    output_schema,
+                    on_token=on_token,
+                    on_thinking=on_thinking,
+                )
+        except Exception as e:
+            mark_llm_reply_origin(e)
+            raise
+        if get_config().get_env_bool("GPTME_COSTS"):
+            log_costs(msgs + [msg_response])
 
         # Trigger generation post hooks (e.g., TTS)
         if generation_post_msgs := trigger_hook(

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -18,7 +18,7 @@ from .constants import (
 )
 from .hooks import HookType, trigger_hook
 from .init import init
-from .llm import reply
+from .llm import is_provider_error, reply
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
@@ -361,6 +361,21 @@ def _run_chat_loop(
                 console.log("Interrupted.")
             manager.append(Message("system", INTERRUPT_CONTENT))
             # Clear any remaining prompts to avoid confusion
+            prompt_queue.clear()
+            continue
+        except Exception as e:
+            # A failing provider call (rate limit, upstream outage, network
+            # error) must not kill an interactive session: report it and hand
+            # control back to the user, who can retry or switch model.
+            # Non-interactive runs still fail loudly so the exit code carries
+            # the error class. See https://github.com/gptme/gptme/issues/3668
+            if not interactive or not is_provider_error(e):
+                raise
+            logger.error("LLM request failed: %s", e)
+            if not is_output_json() and not is_output_quiet():
+                console.log(f"[red]LLM request failed:[/red] {e}")
+            manager.append(Message("system", f"LLM request failed: {e}"))
+            # Drop queued prompts — they were meant for the failed turn.
             prompt_queue.clear()
             continue
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -10,6 +10,7 @@ from .config import ChatConfig, get_config, require_workspace_exists
 from .constants import (
     DECLINED_CONTENT,
     INTERRUPT_CONTENT,
+    LLM_REQUEST_FAILED_PREFIX,
     MAX_MESSAGE_LENGTH,
     MAX_PROMPT_QUEUE_SIZE,
 )
@@ -373,10 +374,10 @@ def _run_chat_loop(
             # the error class. See https://github.com/gptme/gptme/issues/3668
             if not interactive or not is_provider_error(e):
                 raise
-            logger.error("LLM request failed: %s", e)
+            logger.error("%s %s", LLM_REQUEST_FAILED_PREFIX, e)
             if not is_output_json() and not is_output_quiet():
-                console.log(f"[red]LLM request failed:[/red] {e}")
-            manager.append(Message("system", f"LLM request failed: {e}"))
+                console.log(f"[red]{LLM_REQUEST_FAILED_PREFIX}[/red] {e}")
+            manager.append(Message("system", f"{LLM_REQUEST_FAILED_PREFIX} {e}"))
             # Drop queued prompts — they were meant for the failed turn.
             prompt_queue.clear()
             continue
@@ -534,26 +535,30 @@ def _should_prompt_for_input(log: Log) -> bool:
     """
     last_msg = log[-1] if log else None
 
-    # Check if there's an interrupt or decline message after the last assistant message
-    # This handles cases where hooks (like cost_awareness) add messages after the interrupt/decline
-    has_recent_interrupt_or_decline = False
+    # Check if there's an interrupt, decline, or provider-error message after
+    # the last assistant message. These all mean "hand control back to the
+    # user" rather than auto-generating. Hooks (like cost_awareness) may
+    # append after the marker, so scan until the last assistant message.
+    has_recent_return_to_prompt = False
     for msg in reversed(log):
         if msg.role == "assistant":
             break
-        if msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT):
-            has_recent_interrupt_or_decline = True
+        if msg.content in (INTERRUPT_CONTENT, DECLINED_CONTENT) or (
+            msg.content.startswith(LLM_REQUEST_FAILED_PREFIX)
+        ):
+            has_recent_return_to_prompt = True
             break
 
     # Ask for input when:
     # - No messages at all
     # - Last message was from assistant (normal flow)
-    # - There was an interrupt or decline after the last assistant message
+    # - There was an interrupt, decline, or provider error after the last assistant
     # - Last message was pinned
     # - No user messages exist in the entire log
     return (
         not last_msg
         or last_msg.role == "assistant"
-        or has_recent_interrupt_or_decline
+        or has_recent_return_to_prompt
         or last_msg.pinned
         or not any(role == "user" for role in [m.role for m in log])
     )

--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -54,6 +54,12 @@ INTERRUPT_CONTENT = "Interrupted by user"
 # Content for when user declines execution (behaves like interrupt - returns to prompt)
 DECLINED_CONTENT = "Execution declined by user"
 
+# Prefix of the system message written when an interactive session recovers from
+# an exhausted LLM provider error. `_should_prompt_for_input` treats this like
+# interrupt/decline so the loop returns control to the user instead of
+# auto-generating (which would hammer a still-down provider).
+LLM_REQUEST_FAILED_PREFIX = "LLM request failed:"
+
 # Maximum length for user message content (characters)
 # This prevents unbounded memory usage and context window overflow
 # 100k characters ≈ 25k tokens for typical English text

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -275,34 +275,33 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
     return model_meta.max_output or 4096
 
 
-# SDK exception types always mean "the provider call failed". httpx is also
-# used by tools (browser, HTTP requests), so a transport error only counts as
-# a provider failure when it originated at the LLM `reply()` call — tagged
-# there so the interactive recovery handler cannot swallow a tool outage as
-# "LLM request failed". See https://github.com/gptme/gptme/issues/3668
-_PROVIDER_SDK_MODULES = frozenset({"openai", "anthropic"})
-_PROVIDER_TRANSPORT_MODULES = frozenset({"httpx"})
+# SDK and httpx exceptions are also raised by tools and GENERATION_PRE hooks
+# (browser, embeddings, context fetchers). Interactive recovery only kicks in
+# when the exception was tagged at the actual provider call inside `reply()`,
+# after those hooks have already run. See https://github.com/gptme/gptme/issues/3668
+_PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx"})
 _LLM_REPLY_ORIGIN_ATTR = "_gptme_from_llm_reply"
 
 
 def mark_llm_reply_origin(exc: BaseException) -> None:
-    """Mark an exception as raised from the LLM `reply()` call in `chat.step`."""
+    """Mark an exception as raised from the provider call inside `reply()`.
+
+    Applied after GENERATION_PRE hooks so a hook/tool failure is not treated
+    as a recoverable LLM outage.
+    """
     setattr(exc, _LLM_REPLY_ORIGIN_ATTR, True)
 
 
 def is_provider_error(e: BaseException) -> bool:
-    """Whether an exception came from an LLM provider SDK or its HTTP transport.
+    """Whether an exception is a recoverable LLM provider/transport failure.
 
-    Used to decide whether an interactive session can recover by returning
-    control to the user instead of crashing.
-    See https://github.com/gptme/gptme/issues/3668
+    Requires the ``_gptme_from_llm_reply`` tag so untagged openai/anthropic/httpx
+    errors from tools or hooks still propagate. See gptme/gptme#3668.
     """
+    if not getattr(e, _LLM_REPLY_ORIGIN_ATTR, False):
+        return False
     modules = {(cls.__module__ or "").split(".", 1)[0] for cls in type(e).__mro__}
-    if modules & _PROVIDER_SDK_MODULES:
-        return True
-    if modules & _PROVIDER_TRANSPORT_MODULES:
-        return getattr(e, _LLM_REPLY_ORIGIN_ATTR, False)
-    return False
+    return bool(modules & _PROVIDER_ERROR_MODULES)
 
 
 @trace_function(name="llm.reply", attributes={"component": "llm"})
@@ -339,6 +338,38 @@ def reply(
     if context_msgs:
         generation_msgs.extend(context_msgs)
 
+    # Tag only the provider call, not GENERATION_PRE hook failures above.
+    try:
+        return _reply_after_hooks(
+            generation_msgs,
+            model,
+            stream,
+            tools,
+            output_schema,
+            on_token,
+            on_thinking,
+            max_tokens,
+            temperature,
+            top_p,
+        )
+    except Exception as e:
+        mark_llm_reply_origin(e)
+        raise
+
+
+def _reply_after_hooks(
+    generation_msgs: list[Message],
+    model: str,
+    stream: bool,
+    tools: list[ToolSpec] | None,
+    output_schema: type | None,
+    on_token: Callable[[str], None] | None,
+    on_thinking: Callable[[bool], None] | None,
+    max_tokens: int | None,
+    temperature: float | None,
+    top_p: float | None,
+) -> Message:
+    """Provider call portion of `reply()`, after GENERATION_PRE hooks."""
     init_llm(get_provider_from_model(model))
     config = get_config()
     agent_name = _get_agent_name(config)

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -275,10 +275,19 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
     return model_meta.max_output or 4096
 
 
-# Top-level modules whose exceptions mean "the provider call failed", as opposed
-# to a bug in gptme. Matched by defining module rather than by a hardcoded list
-# of exception classes, so new SDK error types are covered automatically.
-_PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx"})
+# SDK exception types always mean "the provider call failed". httpx is also
+# used by tools (browser, HTTP requests), so a transport error only counts as
+# a provider failure when it originated at the LLM `reply()` call — tagged
+# there so the interactive recovery handler cannot swallow a tool outage as
+# "LLM request failed". See https://github.com/gptme/gptme/issues/3668
+_PROVIDER_SDK_MODULES = frozenset({"openai", "anthropic"})
+_PROVIDER_TRANSPORT_MODULES = frozenset({"httpx"})
+_LLM_REPLY_ORIGIN_ATTR = "_gptme_from_llm_reply"
+
+
+def mark_llm_reply_origin(exc: BaseException) -> None:
+    """Mark an exception as raised from the LLM `reply()` call in `chat.step`."""
+    setattr(exc, _LLM_REPLY_ORIGIN_ATTR, True)
 
 
 def is_provider_error(e: BaseException) -> bool:
@@ -288,10 +297,12 @@ def is_provider_error(e: BaseException) -> bool:
     control to the user instead of crashing.
     See https://github.com/gptme/gptme/issues/3668
     """
-    return any(
-        (cls.__module__ or "").split(".")[0] in _PROVIDER_ERROR_MODULES
-        for cls in type(e).__mro__
-    )
+    modules = {(cls.__module__ or "").split(".", 1)[0] for cls in type(e).__mro__}
+    if modules & _PROVIDER_SDK_MODULES:
+        return True
+    if modules & _PROVIDER_TRANSPORT_MODULES:
+        return getattr(e, _LLM_REPLY_ORIGIN_ATTR, False)
+    return False
 
 
 @trace_function(name="llm.reply", attributes={"component": "llm"})

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -275,6 +275,25 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
     return model_meta.max_output or 4096
 
 
+# Top-level modules whose exceptions mean "the provider call failed", as opposed
+# to a bug in gptme. Matched by defining module rather than by a hardcoded list
+# of exception classes, so new SDK error types are covered automatically.
+_PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx"})
+
+
+def is_provider_error(e: BaseException) -> bool:
+    """Whether an exception came from an LLM provider SDK or its HTTP transport.
+
+    Used to decide whether an interactive session can recover by returning
+    control to the user instead of crashing.
+    See https://github.com/gptme/gptme/issues/3668
+    """
+    return any(
+        (cls.__module__ or "").split(".")[0] in _PROVIDER_ERROR_MODULES
+        for cls in type(e).__mro__
+    )
+
+
 @trace_function(name="llm.reply", attributes={"component": "llm"})
 def reply(
     messages: list[Message],

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -279,7 +279,7 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
 # (browser, embeddings, context fetchers). Interactive recovery only kicks in
 # when the exception was tagged at the actual provider call inside `reply()`,
 # after those hooks have already run. See https://github.com/gptme/gptme/issues/3668
-_PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx"})
+_PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx", "requests"})
 _LLM_REPLY_ORIGIN_ATTR = "_gptme_from_llm_reply"
 
 
@@ -295,8 +295,10 @@ def mark_llm_reply_origin(exc: BaseException) -> None:
 def is_provider_error(e: BaseException) -> bool:
     """Whether an exception is a recoverable LLM provider/transport failure.
 
-    Requires the ``_gptme_from_llm_reply`` tag so untagged openai/anthropic/httpx
+    Requires the ``_gptme_from_llm_reply`` tag so untagged openai/anthropic/httpx/requests
     errors from tools or hooks still propagate. See gptme/gptme#3668.
+    ``requests`` covers openai-subscription (and similar HTTP backends) which do
+    not raise SDK types.
     """
     if not getattr(e, _LLM_REPLY_ORIGIN_ATTR, False):
         return False

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -21,6 +21,12 @@ from ..tools.base import ToolSpec
 from .constants import _MIN_RESPONSE_TOKENS
 from .models import ModelMeta, get_model
 from .retry_abort import backoff_wait, current_generation
+from .retry_policy import (
+    DEFAULT_BASE_DELAY,
+    SDK_MAX_RETRIES,
+    get_max_retries,
+    retry_delay,
+)
 from .utils import (
     apply_cache_control,
     extract_tool_uses_from_assistant_message,
@@ -445,7 +451,7 @@ def _handle_anthropic_transient_error(
     if not should_retry or attempt == max_retries - 1:
         raise e
 
-    delay = base_delay * (2**attempt)
+    delay = retry_delay(attempt, base_delay)
     status_code = getattr(e, "status_code", "unknown")
     logger.warning(
         f"Anthropic API transient error (status {status_code}), "
@@ -458,7 +464,9 @@ def _handle_anthropic_transient_error(
         raise e
 
 
-def retry_on_overloaded(max_retries: int = 5, base_delay: float = 1.0):
+def retry_on_overloaded(
+    max_retries: int | None = None, base_delay: float = DEFAULT_BASE_DELAY
+):
     """Decorator to retry functions on Anthropic API transient errors with exponential backoff.
 
     Handles 5xx server errors, rate limits, and other transient API issues.
@@ -471,12 +479,13 @@ def retry_on_overloaded(max_retries: int = 5, base_delay: float = 1.0):
             # interrupts pending retries after this point, every backoff wait
             # for this call aborts immediately (even attempts started later).
             generation = current_generation()
-            for attempt in range(max_retries):
+            attempts = max_retries if max_retries is not None else get_max_retries()
+            for attempt in range(attempts):
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
                     _handle_anthropic_transient_error(
-                        e, attempt, max_retries, base_delay, generation=generation
+                        e, attempt, attempts, base_delay, generation=generation
                     )
             # _handle_anthropic_transient_error raises on last attempt,
             # but guard against silent None return if logic changes
@@ -487,7 +496,9 @@ def retry_on_overloaded(max_retries: int = 5, base_delay: float = 1.0):
     return decorator
 
 
-def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0):
+def retry_generator_on_overloaded(
+    max_retries: int | None = None, base_delay: float = DEFAULT_BASE_DELAY
+):
     """Decorator to retry generator functions on Anthropic API transient errors with exponential backoff.
 
     Handles 5xx server errors, rate limits, and other transient API issues.
@@ -501,7 +512,8 @@ def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0)
         def wrapper(*args, **kwargs):
             # Capture the retry generation once per call (see retry_abort.py).
             generation = current_generation()
-            for attempt in range(max_retries):
+            attempts = max_retries if max_retries is not None else get_max_retries()
+            for attempt in range(attempts):
                 has_yielded = False
                 try:
                     gen = func(*args, **kwargs)
@@ -520,7 +532,7 @@ def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0)
                         # Can't retry after streaming has started - would cause duplicates
                         raise
                     _handle_anthropic_transient_error(
-                        e, attempt, max_retries, base_delay, generation=generation
+                        e, attempt, attempts, base_delay, generation=generation
                     )
             # _handle_anthropic_transient_error raises on last attempt,
             # but guard against silent None return if logic changes
@@ -598,7 +610,8 @@ def _init_anthropic(
 
     _anthropic = Anthropic(
         api_key=api_key,
-        max_retries=5,
+        # gptme's retry decorators own retries; see retry_policy
+        max_retries=SDK_MAX_RETRIES,
         base_url=proxy_url or None,
         timeout=timeout,
     )
@@ -647,7 +660,7 @@ def _get_gptme_client() -> "Anthropic":
 
         _anthropic_gptme = Anthropic(
             api_key=api_key,
-            max_retries=5,
+            max_retries=SDK_MAX_RETRIES,
             base_url=get_base_url(config),
             timeout=timeout,
         )

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -99,6 +99,7 @@ def _lazy_client_factory(cls_name: str):
     """Return an ``OpenAI``/``AzureOpenAI``-like constructor that defers SDK import."""
 
     def factory(**kwargs: Any) -> OpenAI:
+        kwargs.setdefault("max_retries", SDK_MAX_RETRIES)
         return cast("OpenAI", _LazyClient(cls_name, kwargs))
 
     return factory
@@ -646,12 +647,7 @@ def get_client(provider: Provider) -> OpenAI:
     """Get client for specific provider, initializing if needed."""
     if provider not in clients:
         init(provider, get_config())
-    client = clients[provider]
-    # gptme's retry decorators own the retry policy; leaving the SDK's own
-    # retries enabled multiplies attempts (sdk_retries * max_retries) and makes
-    # the effective backoff schedule unpredictable. See retry_policy.
-    client.max_retries = SDK_MAX_RETRIES
-    return client
+    return clients[provider]
 
 
 def has_client(provider: Provider) -> bool:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -36,6 +36,12 @@ from .openai_responses import (
     _tool_spec_to_responses_tool,
 )
 from .retry_abort import backoff_wait, current_generation
+from .retry_policy import (
+    DEFAULT_BASE_DELAY,
+    SDK_MAX_RETRIES,
+    get_max_retries,
+    retry_delay,
+)
 from .utils import (
     apply_cache_control,
     extract_tool_uses_from_assistant_message,
@@ -640,7 +646,12 @@ def get_client(provider: Provider) -> OpenAI:
     """Get client for specific provider, initializing if needed."""
     if provider not in clients:
         init(provider, get_config())
-    return clients[provider]
+    client = clients[provider]
+    # gptme's retry decorators own the retry policy; leaving the SDK's own
+    # retries enabled multiplies attempts (sdk_retries * max_retries) and makes
+    # the effective backoff schedule unpredictable. See retry_policy.
+    client.max_retries = SDK_MAX_RETRIES
+    return client
 
 
 def has_client(provider: Provider) -> bool:
@@ -823,7 +834,7 @@ def _handle_openai_transient_error(
     if not should_retry or attempt == max_retries - 1:
         raise e
 
-    delay = base_delay * (2**attempt)
+    delay = retry_delay(attempt, base_delay)
     status_code = getattr(e, "status_code", "unknown")
     logger.warning(
         f"OpenAI API transient error (status {status_code}), "
@@ -834,7 +845,9 @@ def _handle_openai_transient_error(
         raise e
 
 
-def retry_on_openai_error(max_retries: int = 5, base_delay: float = 1.0):
+def retry_on_openai_error(
+    max_retries: int | None = None, base_delay: float = DEFAULT_BASE_DELAY
+):
     """Decorator to retry functions on OpenAI API transient errors with exponential backoff.
 
     Handles 5xx server errors, rate limits, and other transient API issues.
@@ -843,16 +856,17 @@ def retry_on_openai_error(max_retries: int = 5, base_delay: float = 1.0):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            attempts = max_retries if max_retries is not None else get_max_retries()
             # Capture the retry generation once per call: if test teardown
             # interrupts pending retries after this point, every backoff wait
             # for this call aborts immediately (even attempts started later).
             generation = current_generation()
-            for attempt in range(max_retries):
+            for attempt in range(attempts):
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
                     _handle_openai_transient_error(
-                        e, attempt, max_retries, base_delay, generation=generation
+                        e, attempt, attempts, base_delay, generation=generation
                     )
             # _handle_openai_transient_error raises on last attempt,
             # but guard against silent None return if logic changes
@@ -863,7 +877,9 @@ def retry_on_openai_error(max_retries: int = 5, base_delay: float = 1.0):
     return decorator
 
 
-def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.0):
+def retry_generator_on_openai_error(
+    max_retries: int | None = None, base_delay: float = DEFAULT_BASE_DELAY
+):
     """Decorator to retry generator functions on OpenAI API transient errors with exponential backoff.
 
     Handles 5xx server errors, rate limits, and other transient API issues.
@@ -875,9 +891,10 @@ def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            attempts = max_retries if max_retries is not None else get_max_retries()
             # Capture the retry generation once per call (see retry_abort.py).
             generation = current_generation()
-            for attempt in range(max_retries):
+            for attempt in range(attempts):
                 has_yielded = False
                 try:
                     gen = func(*args, **kwargs)
@@ -896,7 +913,7 @@ def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.
                         # Can't retry after streaming has started - would cause duplicates
                         raise
                     _handle_openai_transient_error(
-                        e, attempt, max_retries, base_delay, generation=generation
+                        e, attempt, attempts, base_delay, generation=generation
                     )
             # _handle_openai_transient_error raises on last attempt,
             # but guard against silent None return if logic changes

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -481,11 +481,11 @@ def init(provider: Provider, config: Config):
     """Initialize OpenAI client for a given provider.
 
     Missing API keys raise here (fail fast at startup); the SDK client itself
-    is constructed lazily on first use (see _LazyClient).
+    is constructed lazily on first use (see _LazyClient). Every provider is
+    registered through ``_init_openai_client``, which injects
+    ``max_retries=SDK_MAX_RETRIES`` via the lazy factory so SDK retries cannot
+    stack on gptme's retry loop.
     """
-    OpenAI = _lazy_client_factory("OpenAI")
-    AzureOpenAI = _lazy_client_factory("AzureOpenAI")
-
     proxy_key = config.get_env("LLM_PROXY_API_KEY")
     proxy_url = config.get_env("LLM_PROXY_URL")
 
@@ -514,17 +514,15 @@ def init(provider: Provider, config: Config):
     elif provider == "azure":
         api_key = config.get_env_required("AZURE_OPENAI_API_KEY")
         azure_endpoint = config.get_env_required("AZURE_OPENAI_ENDPOINT")
-        clients[provider] = AzureOpenAI(
-            api_key=api_key,
-            api_version="2023-07-01-preview",
-            azure_endpoint=azure_endpoint,
-            timeout=timeout,
+        _init_openai_client(
+            provider, api_key=api_key, base_url=azure_endpoint, timeout=timeout
         )
     elif provider == "openrouter":
         api_key = proxy_key or _get_provider_api_key(
             config, provider, "OPENROUTER_API_KEY"
         )
-        clients[provider] = OpenAI(
+        _init_openai_client(
+            provider,
             api_key=api_key,
             base_url=proxy_url or "https://openrouter.ai/api/v1",
             timeout=timeout,
@@ -533,7 +531,8 @@ def init(provider: Provider, config: Config):
         api_key = proxy_key or _get_provider_api_key(
             config, provider, "REQUESTY_API_KEY"
         )
-        clients[provider] = OpenAI(
+        _init_openai_client(
+            provider,
             api_key=api_key,
             base_url=proxy_url or "https://router.requesty.ai/v1",
             timeout=timeout,
@@ -543,22 +542,21 @@ def init(provider: Provider, config: Config):
 
         api_key = proxy_key or get_api_key(config)
         base_url = proxy_url or get_base_url(config)
-        clients[provider] = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            timeout=timeout,
+        _init_openai_client(
+            provider, api_key=api_key, base_url=base_url, timeout=timeout
         )
     elif provider == "gemini":
         api_key = _get_provider_api_key(config, provider, "GEMINI_API_KEY")
-        clients[provider] = OpenAI(
+        _init_openai_client(
+            provider,
             api_key=api_key,
             base_url="https://generativelanguage.googleapis.com/v1beta",
             timeout=timeout,
         )
     elif provider == "xai":
         api_key = _get_provider_api_key(config, provider, "XAI_API_KEY")
-        clients[provider] = OpenAI(
-            api_key=api_key, base_url="https://api.x.ai/v1", timeout=timeout
+        _init_openai_client(
+            provider, api_key=api_key, base_url="https://api.x.ai/v1", timeout=timeout
         )
     elif provider == "grok-subscription":
         # SuperGrok subscription: OAuth token from grok CLI or gptme auth flow.
@@ -578,24 +576,32 @@ def init(provider: Provider, config: Config):
         return  # _init_openai_client already assigned clients[provider]
     elif provider == "groq":
         api_key = _get_provider_api_key(config, provider, "GROQ_API_KEY")
-        clients[provider] = OpenAI(
-            api_key=api_key, base_url="https://api.groq.com/openai/v1", timeout=timeout
+        _init_openai_client(
+            provider,
+            api_key=api_key,
+            base_url="https://api.groq.com/openai/v1",
+            timeout=timeout,
         )
     elif provider == "deepseek":
         api_key = _get_provider_api_key(config, provider, "DEEPSEEK_API_KEY")
-        clients[provider] = OpenAI(
-            api_key=api_key, base_url="https://api.deepseek.com/v1", timeout=timeout
+        _init_openai_client(
+            provider,
+            api_key=api_key,
+            base_url="https://api.deepseek.com/v1",
+            timeout=timeout,
         )
     elif provider == "moonshot":
         api_key = _get_provider_api_key(config, provider, "MOONSHOT_API_KEY")
-        clients[provider] = OpenAI(
+        _init_openai_client(
+            provider,
             api_key=api_key,
             base_url="https://api.moonshot.ai/v1",
             timeout=timeout,
         )
     elif provider == "nvidia":
         api_key = _get_provider_api_key(config, provider, "NVIDIA_API_KEY")
-        clients[provider] = OpenAI(
+        _init_openai_client(
+            provider,
             api_key=api_key,
             base_url="https://integrate.api.nvidia.com/v1",
             timeout=timeout,
@@ -607,7 +613,9 @@ def init(provider: Provider, config: Config):
         if not api_base:
             raise KeyError("Missing environment variable OPENAI_BASE_URL")
         api_key = config.get_env("OPENAI_API_KEY") or "ollama"
-        clients[provider] = OpenAI(api_key=api_key, base_url=api_base, timeout=timeout)
+        _init_openai_client(
+            provider, api_key=api_key, base_url=api_base, timeout=timeout
+        )
     else:
         # Check if this is a custom provider (config-file based)
         custom_provider = next(
@@ -615,7 +623,8 @@ def init(provider: Provider, config: Config):
         )
         if custom_provider:
             api_key = custom_provider.get_api_key(config)
-            clients[provider] = OpenAI(
+            _init_openai_client(
+                provider,
                 api_key=api_key,
                 base_url=custom_provider.base_url,
                 timeout=timeout,
@@ -632,7 +641,8 @@ def init(provider: Provider, config: Config):
                         f"Missing environment variable {plugin.api_key_env} "
                         f"required by provider plugin {plugin.name!r}"
                     )
-                clients[provider] = OpenAI(
+                _init_openai_client(
+                    provider,
                     api_key=api_key,
                     base_url=plugin.base_url,
                     timeout=timeout,

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -585,7 +585,16 @@ def stream(
         )
         if resp.status_code != 200:
             error_text = resp.text[:500]
-            raise ValueError(f"Codex API error {resp.status_code}: {error_text}")
+            # HTTPError (module `requests`) is a recoverable provider error
+            # for interactive recovery. ValueError is not — it looks like a
+            # gptme bug and crashes the chat loop. Keep the message format
+            # `_classify_fatal_error` already matches for 429/401/503.
+            err = requests.HTTPError(
+                f"Codex API error {resp.status_code}: {error_text}",
+                response=resp,
+            )
+            resp.close()
+            raise err
         return resp
 
     def _sse_events():

--- a/gptme/llm/retry_policy.py
+++ b/gptme/llm/retry_policy.py
@@ -6,9 +6,12 @@ gptme's own retry loop: a single 429 turned into ``sdk_retries * max_retries``
 requests, all inside a backoff window too short to outlast a rate-limit blip
 (see https://github.com/gptme/gptme/issues/3668).
 
-So: SDK-level retries are disabled (``SDK_MAX_RETRIES = 0``) and this module is
-the single place that decides how many attempts gptme makes and how long it
-waits between them.
+So: SDK-level retries are disabled (``SDK_MAX_RETRIES = 0``) for every client
+constructed through ``llm_openai`` / ``llm_anthropic`` (including OpenAI-compatible
+providers and grok-subscription). ``openai-subscription`` talks to ChatGPT's
+backend with ``requests`` and has its own stream-retry loop — it does not use
+an OpenAI SDK client. This module is the single place that decides how many
+attempts gptme makes and how long it waits between them.
 
 The default budget is ~5 minutes of cumulative backoff (1, 2, 4, 8, 16, 32,
 then 60s per attempt), so a short upstream outage does not kill a long

--- a/gptme/llm/retry_policy.py
+++ b/gptme/llm/retry_policy.py
@@ -1,0 +1,60 @@
+"""Shared retry policy for LLM provider calls.
+
+gptme owns the retry/backoff policy for LLM requests. The provider SDKs
+(openai, anthropic) also retry internally by default, which multiplies with
+gptme's own retry loop: a single 429 turned into ``sdk_retries * max_retries``
+requests, all inside a backoff window too short to outlast a rate-limit blip
+(see https://github.com/gptme/gptme/issues/3668).
+
+So: SDK-level retries are disabled (``SDK_MAX_RETRIES = 0``) and this module is
+the single place that decides how many attempts gptme makes and how long it
+waits between them.
+
+The default budget is ~5 minutes of cumulative backoff (1, 2, 4, 8, 16, 32,
+then 60s per attempt), so a short upstream outage does not kill a long
+autonomous session. Override with ``GPTME_LLM_MAX_RETRIES``.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Provider SDKs must not retry — gptme's retry decorators own the policy.
+SDK_MAX_RETRIES = 0
+
+# Attempts (including the first, non-retry attempt) made by gptme's decorators.
+# 11 attempts with the delays below is ~303s (~5 min) of cumulative backoff.
+DEFAULT_MAX_RETRIES = 11
+
+# Exponential backoff: base_delay * 2**attempt, capped at MAX_RETRY_DELAY.
+DEFAULT_BASE_DELAY = 1.0
+MAX_RETRY_DELAY = 60.0
+
+
+def get_max_retries(default: int = DEFAULT_MAX_RETRIES) -> int:
+    """Number of attempts for LLM calls, overridable via GPTME_LLM_MAX_RETRIES."""
+    from ..config import get_config  # fmt: skip
+
+    raw = get_config().get_env("GPTME_LLM_MAX_RETRIES")
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid GPTME_LLM_MAX_RETRIES value: %r. Must be an integer, using %d.",
+            raw,
+            default,
+        )
+        return default
+    if value < 1:
+        logger.warning(
+            "GPTME_LLM_MAX_RETRIES must be >= 1, got %d, using %d.", value, default
+        )
+        return default
+    return value
+
+
+def retry_delay(attempt: int, base_delay: float = DEFAULT_BASE_DELAY) -> float:
+    """Capped exponential backoff delay for a zero-indexed attempt."""
+    return min(base_delay * (2**attempt), MAX_RETRY_DELAY)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -853,3 +853,133 @@ def test_complete_hook_fires_in_current_turn():
     # complete_hook MUST raise — complete was called in the current turn.
     with pytest.raises(SessionCompleteException):
         list(complete_hook(messages))
+
+
+def _rate_limit_error():
+    """An openai RateLimitError like the one in issue #3668."""
+    from openai import RateLimitError
+
+    response = MagicMock()
+    response.status_code = 429
+    return RateLimitError("upstream rate-limited", response=response, body=None)
+
+
+def test_interactive_survives_provider_error():
+    """A 429 (or any provider error) returns control to the user, not a crash.
+
+    Regression test for https://github.com/gptme/gptme/issues/3668
+    """
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    # See test_chained_prompts_continue_after_complete for why we use sys.modules.
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+    appended: list[Message] = []
+    manager.append.side_effect = appended.append
+
+    prompt_queue = [Message("user", "hello")]
+
+    with (
+        patch.object(
+            _chat_mod,
+            "_process_message_conversation",
+            side_effect=_rate_limit_error(),
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+        # After the failure the loop asks the user for input; simulate exit
+        patch.object(_chat_mod, "_get_user_input", return_value=None),
+        patch.object(_chat_mod, "_should_prompt_for_input", return_value=True),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=prompt_queue,
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=True,
+        )
+
+    assert any(
+        msg.role == "system" and "LLM request failed" in msg.content for msg in appended
+    ), f"expected an error message in the log, got: {appended}"
+
+
+def test_non_interactive_still_raises_provider_error():
+    """Non-interactive runs must keep failing loudly so exit codes stay useful."""
+    import sys
+
+    from openai import RateLimitError
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+
+    with (
+        patch.object(
+            _chat_mod,
+            "_process_message_conversation",
+            side_effect=_rate_limit_error(),
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+        pytest.raises(RateLimitError),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "hello")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=False,
+        )
+
+
+def test_interactive_still_raises_non_provider_errors():
+    """Bugs in gptme itself must not be swallowed as recoverable API errors."""
+    import sys
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+
+    with (
+        patch.object(
+            _chat_mod,
+            "_process_message_conversation",
+            side_effect=ValueError("bug in gptme"),
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+        pytest.raises(ValueError, match="bug in gptme"),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "hello")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=True,
+        )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -983,3 +983,79 @@ def test_interactive_still_raises_non_provider_errors():
             model=None,
             interactive=True,
         )
+
+
+def _httpx_connect_error():
+    import httpx
+
+    return httpx.ConnectError("tool network failed")
+
+
+def test_interactive_does_not_swallow_tool_httpx_errors():
+    """httpx errors from tools/hooks must not be recovered as LLM failures."""
+    import sys
+
+    import httpx
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+
+    with (
+        patch.object(
+            _chat_mod,
+            "_process_message_conversation",
+            side_effect=_httpx_connect_error(),
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+        pytest.raises(httpx.ConnectError, match="tool network failed"),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "hello")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=True,
+        )
+
+
+def test_step_marks_httpx_from_reply_as_provider_error():
+    """httpx raised by reply() is recoverable; the same type from tools is not."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import is_provider_error, mark_llm_reply_origin
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+
+    with (
+        patch.object(chat_module, "reply", side_effect=httpx.ConnectError("upstream")),
+        pytest.raises(httpx.ConnectError) as ei,
+    ):
+        list(
+            chat_module.step(
+                [Message("user", "hello")],
+                stream=False,
+                model="openai/gpt-4",
+            )
+        )
+
+    assert is_provider_error(ei.value)
+    # Untagged twin of the same exception class is a tool failure.
+    tool_err = httpx.ConnectError("browser failed")
+    assert not is_provider_error(tool_err)
+    mark_llm_reply_origin(tool_err)
+    assert is_provider_error(tool_err)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -873,53 +873,91 @@ def _rate_limit_error(*, tagged: bool = True):
     return err
 
 
-def test_interactive_survives_provider_error():
-    """A 429 (or any provider error) returns control to the user, not a crash.
+def test_should_prompt_after_provider_error_system_message():
+    """A trailing LLM-failure system message must return control to the user.
 
-    Regression test for https://github.com/gptme/gptme/issues/3668
+    Crash recovery still auto-continues on a trailing *user* message. The
+    provider-error path must not take that branch — otherwise the loop
+    immediately re-calls the provider and hammers a still-down API.
+    """
+    from gptme.chat import _should_prompt_for_input
+    from gptme.constants import LLM_REQUEST_FAILED_PREFIX
+    from gptme.logmanager import Log
+    from gptme.message import Message
+
+    failed = Log(
+        [
+            Message("user", "hello"),
+            Message("system", f"{LLM_REQUEST_FAILED_PREFIX} RateLimitError"),
+        ]
+    )
+    assert _should_prompt_for_input(failed) is True
+
+    # Existing crash-recovery path: trailing user message auto-generates.
+    assert _should_prompt_for_input(Log([Message("user", "hello")])) is False
+
+
+def test_interactive_survives_provider_error(tmp_path):
+    """A 429 returns control to the user, not a crash or retry loop.
+
+    Must not patch ``_should_prompt_for_input``: the previous version of this
+    test did, which hid an infinite retry when the last message is the
+    LLM-failure system message. Regression for gptme/gptme#3668 and
+    AI-review P1 0cb85cacfd0f.
     """
     import sys
 
     from gptme.chat import _run_chat_loop
+    from gptme.logmanager import Log
     from gptme.message import Message
 
     # See test_chained_prompts_continue_after_complete for why we use sys.modules.
     _chat_mod = sys.modules["gptme.chat"]
 
     manager = MagicMock()
-    manager.log = MagicMock()
-    manager.workspace = Path("/tmp")
-    manager.logdir = Path("/tmp/logdir")
-    appended: list[Message] = []
-    manager.append.side_effect = appended.append
+    manager.log = Log()
+    manager.workspace = tmp_path
+    manager.logdir = tmp_path
 
-    prompt_queue = [Message("user", "hello")]
+    def _append(msg: Message) -> None:
+        manager.log = manager.log.append(msg)
+
+    manager.append.side_effect = _append
+
+    process_calls = 0
+
+    def _process(*args, **kwargs):
+        nonlocal process_calls
+        process_calls += 1
+        if process_calls > 3:
+            raise RuntimeError("provider-error recovery re-entered the LLM call")
+        raise _rate_limit_error()
 
     with (
-        patch.object(
-            _chat_mod,
-            "_process_message_conversation",
-            side_effect=_rate_limit_error(),
-        ),
+        patch.object(_chat_mod, "_process_message_conversation", side_effect=_process),
         patch.object(_chat_mod, "trigger_hook", return_value=[]),
         patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
         patch.object(_chat_mod, "execute_cmd", return_value=False),
-        # After the failure the loop asks the user for input; simulate exit
+        # After the failure the loop asks the user for input; simulate exit.
+        # Do NOT patch _should_prompt_for_input — that was masking the retry loop.
         patch.object(_chat_mod, "_get_user_input", return_value=None),
-        patch.object(_chat_mod, "_should_prompt_for_input", return_value=True),
     ):
         _run_chat_loop(
             manager=manager,
-            prompt_queue=prompt_queue,
+            prompt_queue=[Message("user", "hello")],
             stream=False,
             tool_format="markdown",
             model=None,
             interactive=True,
         )
 
+    assert process_calls == 1, (
+        f"expected one LLM call then a user prompt, got {process_calls}"
+    )
     assert any(
-        msg.role == "system" and "LLM request failed" in msg.content for msg in appended
-    ), f"expected an error message in the log, got: {appended}"
+        msg.role == "system" and "LLM request failed" in msg.content
+        for msg in manager.log
+    ), f"expected an error message in the log, got: {list(manager.log)}"
 
 
 def test_non_interactive_still_raises_provider_error():

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -881,7 +881,7 @@ def test_should_prompt_after_provider_error_system_message():
     immediately re-calls the provider and hammers a still-down API.
     """
     from gptme.chat import _should_prompt_for_input
-    from gptme.constants import LLM_REQUEST_FAILED_PREFIX
+    from gptme.constants import INTERRUPT_CONTENT, LLM_REQUEST_FAILED_PREFIX
     from gptme.logmanager import Log
     from gptme.message import Message
 
@@ -895,6 +895,36 @@ def test_should_prompt_after_provider_error_system_message():
 
     # Existing crash-recovery path: trailing user message auto-generates.
     assert _should_prompt_for_input(Log([Message("user", "hello")])) is False
+
+    # A newer user turn supersedes the failure marker. Scanning past it
+    # would stall crash-recovery / queued follow-ups (P2 6fc9a6d00154).
+    recovered = Log(
+        [
+            Message("user", "hello"),
+            Message("system", f"{LLM_REQUEST_FAILED_PREFIX} RateLimitError"),
+            Message("user", "try again"),
+        ]
+    )
+    assert _should_prompt_for_input(recovered) is False
+
+    # Hook system messages after the marker must still return to the user.
+    hooked = Log(
+        [
+            Message("user", "hello"),
+            Message("system", f"{LLM_REQUEST_FAILED_PREFIX} RateLimitError"),
+            Message("system", "cost: $0.01"),
+        ]
+    )
+    assert _should_prompt_for_input(hooked) is True
+    interrupted_then_user = Log(
+        [
+            Message("user", "hello"),
+            Message("assistant", "hi"),
+            Message("system", INTERRUPT_CONTENT),
+            Message("user", "continue"),
+        ]
+    )
+    assert _should_prompt_for_input(interrupted_then_user) is False
 
 
 def test_interactive_survives_provider_error(tmp_path):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -926,6 +926,21 @@ def test_should_prompt_after_provider_error_system_message():
     )
     assert _should_prompt_for_input(interrupted_then_user) is False
 
+    # Tool results are also system messages. A tool whose output happens to
+    # start with the failure prefix must not steal control from the turn.
+    tool_result = Log(
+        [
+            Message("user", "hello"),
+            Message("assistant", "calling tool"),
+            Message(
+                "system",
+                f"{LLM_REQUEST_FAILED_PREFIX} fake tool output",
+                call_id="call_1",
+            ),
+        ]
+    )
+    assert _should_prompt_for_input(tool_result) is False
+
 
 def test_interactive_survives_provider_error(tmp_path):
     """A 429 returns control to the user, not a crash or retry loop.

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -855,13 +855,22 @@ def test_complete_hook_fires_in_current_turn():
         list(complete_hook(messages))
 
 
-def _rate_limit_error():
-    """An openai RateLimitError like the one in issue #3668."""
+def _rate_limit_error(*, tagged: bool = True):
+    """An openai RateLimitError like the one in issue #3668.
+
+    Tagged errors simulate the provider call inside ``reply()``; untagged
+    errors simulate a tool or hook using the OpenAI SDK.
+    """
     from openai import RateLimitError
+
+    from gptme.llm import mark_llm_reply_origin
 
     response = MagicMock()
     response.status_code = 429
-    return RateLimitError("upstream rate-limited", response=response, body=None)
+    err = RateLimitError("upstream rate-limited", response=response, body=None)
+    if tagged:
+        mark_llm_reply_origin(err)
+    return err
 
 
 def test_interactive_survives_provider_error():
@@ -991,6 +1000,43 @@ def _httpx_connect_error():
     return httpx.ConnectError("tool network failed")
 
 
+def test_interactive_does_not_swallow_untagged_sdk_errors():
+    """OpenAI SDK errors from tools/hooks must not recover as LLM failures."""
+    import sys
+
+    from openai import RateLimitError
+
+    from gptme.chat import _run_chat_loop
+    from gptme.message import Message
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    manager = MagicMock()
+    manager.log = MagicMock()
+    manager.workspace = Path("/tmp")
+    manager.logdir = Path("/tmp/logdir")
+
+    with (
+        patch.object(
+            _chat_mod,
+            "_process_message_conversation",
+            side_effect=_rate_limit_error(tagged=False),
+        ),
+        patch.object(_chat_mod, "trigger_hook", return_value=[]),
+        patch.object(_chat_mod, "include_paths", side_effect=lambda msg, ws: msg),
+        patch.object(_chat_mod, "execute_cmd", return_value=False),
+        pytest.raises(RateLimitError, match="upstream rate-limited"),
+    ):
+        _run_chat_loop(
+            manager=manager,
+            prompt_queue=[Message("user", "hello")],
+            stream=False,
+            tool_format="markdown",
+            model=None,
+            interactive=True,
+        )
+
+
 def test_interactive_does_not_swallow_tool_httpx_errors():
     """httpx errors from tools/hooks must not be recovered as LLM failures."""
     import sys
@@ -1029,7 +1075,7 @@ def test_interactive_does_not_swallow_tool_httpx_errors():
 
 
 def test_step_marks_httpx_from_reply_as_provider_error():
-    """httpx raised by reply() is recoverable; the same type from tools is not."""
+    """httpx raised by the provider call inside reply() is recoverable."""
     import importlib
 
     import httpx
@@ -1040,9 +1086,14 @@ def test_step_marks_httpx_from_reply_as_provider_error():
 
     init_tools(allowlist=["shell"])
     chat_module = importlib.import_module("gptme.chat")
+    llm_module = importlib.import_module("gptme.llm")
 
     with (
-        patch.object(chat_module, "reply", side_effect=httpx.ConnectError("upstream")),
+        patch.object(llm_module, "init_llm", return_value=None),
+        patch("gptme.hooks.trigger_hook", return_value=iter([])),
+        patch.object(
+            llm_module, "_chat_complete", side_effect=httpx.ConnectError("upstream")
+        ),
         pytest.raises(httpx.ConnectError) as ei,
     ):
         list(

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -450,6 +450,44 @@ def test_stream_retries_exhausted_reraises(monkeypatch):
     assert mock_post.call_count == 3  # initial + 2 retries
 
 
+class _Non200Response:
+    def __init__(self, status_code: int, body: str) -> None:
+        self.status_code = status_code
+        self.text = body
+        self.closed = False
+
+    def iter_lines(self) -> Iterator[bytes]:
+        raise AssertionError("iter_lines should not run on a non-200 response")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_stream_non_200_raises_http_error():
+    """A Codex 429 must surface as requests.HTTPError, not ValueError.
+
+    Interactive recovery matches provider errors by defining module
+    (openai/anthropic/httpx/requests). Raising ValueError hid subscription
+    rate-limits from that path. See gptme/gptme#3668 / AI-review P1 e7ff9bb47622.
+    """
+    auth = _make_auth()
+    resp = _Non200Response(429, "usage_limit_reached")
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch("gptme.llm.llm_openai_subscription.requests.post", return_value=resp),
+        pytest.raises(requests.HTTPError, match="Codex API error 429") as ei,
+    ):
+        list(
+            llm_openai_subscription.stream(
+                [Message(role="user", content="hello")], "gpt-5.6-sol"
+            )
+        )
+
+    assert ei.value.response is resp
+    assert resp.closed
+
+
 def _drain_stream(events: list[dict[str, Any]]) -> tuple[str, Any]:
     """Drain the stream generator, returning (content, return_value)."""
     auth = _make_auth()

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -1,0 +1,74 @@
+"""Tests for the shared LLM retry policy.
+
+Regression tests for https://github.com/gptme/gptme/issues/3668:
+provider SDKs retried on their own on top of gptme's retry loop (so one 429
+became sdk_retries * max_retries requests), and the backoff window was too
+short to outlast a brief upstream rate-limit.
+"""
+
+import pytest
+
+from gptme.llm.retry_policy import (
+    DEFAULT_BASE_DELAY,
+    DEFAULT_MAX_RETRIES,
+    MAX_RETRY_DELAY,
+    SDK_MAX_RETRIES,
+    get_max_retries,
+    retry_delay,
+)
+
+
+def test_backoff_is_exponential_then_capped():
+    assert retry_delay(0) == DEFAULT_BASE_DELAY
+    assert retry_delay(1) == 2 * DEFAULT_BASE_DELAY
+    assert retry_delay(2) == 4 * DEFAULT_BASE_DELAY
+    # Without a cap, attempt 10 would sleep for over 17 minutes
+    assert retry_delay(10) == MAX_RETRY_DELAY
+
+
+def test_default_retry_window_is_about_five_minutes():
+    """A <1min upstream blip must not kill a long autonomous session."""
+    total = sum(retry_delay(a) for a in range(DEFAULT_MAX_RETRIES - 1))
+    assert 280 <= total <= 360, f"retry window is {total}s, expected ~5min"
+
+
+def test_sdk_retries_are_disabled():
+    """gptme owns retries; SDK-level retries would multiply the attempts."""
+    assert SDK_MAX_RETRIES == 0
+
+
+def test_max_retries_env_override(monkeypatch):
+    monkeypatch.setenv("GPTME_LLM_MAX_RETRIES", "3")
+    assert get_max_retries() == 3
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "0", "-1"])
+def test_invalid_max_retries_falls_back_to_default(monkeypatch, value):
+    monkeypatch.setenv("GPTME_LLM_MAX_RETRIES", value)
+    assert get_max_retries() == DEFAULT_MAX_RETRIES
+
+
+def test_openai_client_has_sdk_retries_disabled(monkeypatch):
+    """get_client() must hand back a client that does not retry on its own."""
+    from openai import OpenAI
+
+    from gptme.llm import llm_openai
+
+    # A client built the naive way retries twice per request by default
+    naive = OpenAI(api_key="test-key")
+    assert naive.max_retries > 0
+
+    monkeypatch.setitem(llm_openai.clients, "openai", OpenAI(api_key="test-key"))
+    client = llm_openai.get_client("openai")
+    assert client.max_retries == SDK_MAX_RETRIES
+
+
+def test_anthropic_clients_have_sdk_retries_disabled():
+    """The Anthropic clients are constructed with SDK retries disabled."""
+    import inspect
+
+    from gptme.llm import llm_anthropic
+
+    source = inspect.getsource(llm_anthropic)
+    assert "max_retries=SDK_MAX_RETRIES" in source
+    assert "max_retries=5" not in source

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -100,8 +100,8 @@ def test_openai_compat_providers_disable_sdk_retries(
     assert client._kwargs["max_retries"] == SDK_MAX_RETRIES
 
 
-def test_is_provider_error_distinguishes_sdk_from_tool_httpx():
-    """SDK errors recover; untagged httpx (tools) does not; tagged httpx does."""
+def test_is_provider_error_requires_reply_origin_tag():
+    """Untagged SDK/httpx errors (tools, hooks) do not recover; tagged ones do."""
     from unittest.mock import MagicMock
 
     import httpx
@@ -112,6 +112,8 @@ def test_is_provider_error_distinguishes_sdk_from_tool_httpx():
     response = MagicMock()
     response.status_code = 429
     sdk_err = RateLimitError("upstream", response=response, body=None)
+    assert not is_provider_error(sdk_err)
+    mark_llm_reply_origin(sdk_err)
     assert is_provider_error(sdk_err)
 
     tool_err = httpx.ConnectError("browser failed")
@@ -119,7 +121,46 @@ def test_is_provider_error_distinguishes_sdk_from_tool_httpx():
     mark_llm_reply_origin(tool_err)
     assert is_provider_error(tool_err)
 
-    assert not is_provider_error(ValueError("bug in gptme"))
+    bug = ValueError("bug in gptme")
+    mark_llm_reply_origin(bug)
+    assert not is_provider_error(bug)
+
+
+def test_reply_does_not_tag_generation_pre_hook_errors(monkeypatch):
+    """httpx from GENERATION_PRE must not look like a recoverable LLM failure."""
+    import httpx
+
+    from gptme.llm import is_provider_error, reply
+    from gptme.message import Message
+
+    def boom(*_args, **_kwargs):
+        raise httpx.ConnectError("hook fetch failed")
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", boom)
+
+    with pytest.raises(httpx.ConnectError, match="hook fetch failed") as ei:
+        reply([Message("user", "hi")], "openai/gpt-4")
+    assert not is_provider_error(ei.value)
+
+
+def test_reply_tags_provider_call_errors(monkeypatch):
+    """httpx/SDK errors from the provider call after hooks are recoverable."""
+    import httpx
+
+    from gptme.llm import is_provider_error, reply
+    from gptme.message import Message
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *_a, **_k: iter([]))
+    monkeypatch.setattr("gptme.llm.init_llm", lambda *_a, **_k: None)
+
+    def fail_complete(*_args, **_kwargs):
+        raise httpx.ConnectError("upstream")
+
+    monkeypatch.setattr("gptme.llm._chat_complete", fail_complete)
+
+    with pytest.raises(httpx.ConnectError, match="upstream") as ei:
+        reply([Message("user", "hi")], "openai/gpt-4", stream=False)
+    assert is_provider_error(ei.value)
 
 
 def test_anthropic_clients_have_sdk_retries_disabled():

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -125,6 +125,20 @@ def test_is_provider_error_requires_reply_origin_tag():
     mark_llm_reply_origin(bug)
     assert not is_provider_error(bug)
 
+    # openai-subscription / grok-subscription talk HTTP via `requests`, not the
+    # OpenAI SDK. Tagged requests errors must recover; untagged ones must not
+    # (a tool using `requests` is still a tool bug).
+    import requests
+
+    tagged_http = requests.HTTPError("Codex API error 429: usage_limit_reached")
+    assert not is_provider_error(tagged_http)
+    mark_llm_reply_origin(tagged_http)
+    assert is_provider_error(tagged_http)
+
+    tagged_timeout = requests.exceptions.Timeout("read timeout")
+    mark_llm_reply_origin(tagged_timeout)
+    assert is_provider_error(tagged_timeout)
+
 
 def test_reply_does_not_tag_generation_pre_hook_errors(monkeypatch):
     """httpx from GENERATION_PRE must not look like a recoverable LLM failure."""

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -48,19 +48,19 @@ def test_invalid_max_retries_falls_back_to_default(monkeypatch, value):
     assert get_max_retries() == DEFAULT_MAX_RETRIES
 
 
-def test_openai_client_has_sdk_retries_disabled(monkeypatch):
-    """get_client() must hand back a client that does not retry on its own."""
-    from openai import OpenAI
-
+def test_openai_lazy_client_materializes_with_sdk_retries_disabled(monkeypatch):
+    """The production lazy-client path must disable retries before construction."""
+    from gptme.config import Config
     from gptme.llm import llm_openai
 
-    # A client built the naive way retries twice per request by default
-    naive = OpenAI(api_key="test-key")
-    assert naive.max_retries > 0
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delitem(llm_openai.clients, "openai", raising=False)
+    llm_openai.init("openai", Config())
 
-    monkeypatch.setitem(llm_openai.clients, "openai", OpenAI(api_key="test-key"))
     client = llm_openai.get_client("openai")
-    assert client.max_retries == SDK_MAX_RETRIES
+    assert isinstance(client, llm_openai._LazyClient)
+    assert client._kwargs["max_retries"] == SDK_MAX_RETRIES
+    assert client._materialize().max_retries == SDK_MAX_RETRIES
 
 
 def test_anthropic_clients_have_sdk_retries_disabled():

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -63,6 +63,65 @@ def test_openai_lazy_client_materializes_with_sdk_retries_disabled(monkeypatch):
     assert client._materialize().max_retries == SDK_MAX_RETRIES
 
 
+@pytest.mark.parametrize(
+    ("provider", "env_var", "extra_env"),
+    [
+        ("openai", "OPENAI_API_KEY", {}),
+        ("openrouter", "OPENROUTER_API_KEY", {}),
+        ("groq", "GROQ_API_KEY", {}),
+        ("deepseek", "DEEPSEEK_API_KEY", {}),
+        ("xai", "XAI_API_KEY", {}),
+        ("gemini", "GEMINI_API_KEY", {}),
+        ("moonshot", "MOONSHOT_API_KEY", {}),
+        ("nvidia", "NVIDIA_API_KEY", {}),
+        (
+            "azure",
+            "AZURE_OPENAI_API_KEY",
+            {"AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com"},
+        ),
+        ("local", "OPENAI_API_KEY", {"OPENAI_BASE_URL": "http://localhost:11434/v1"}),
+    ],
+)
+def test_openai_compat_providers_disable_sdk_retries(
+    monkeypatch, provider, env_var, extra_env
+):
+    """Every OpenAI-compatible init path must disable SDK retries, not just openai."""
+    from gptme.config import Config
+    from gptme.llm import llm_openai
+
+    monkeypatch.setenv(env_var, "test-key")
+    for key, value in extra_env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delitem(llm_openai.clients, provider, raising=False)
+    llm_openai.init(provider, Config())
+
+    client = llm_openai.get_client(provider)
+    assert isinstance(client, llm_openai._LazyClient)
+    assert client._kwargs["max_retries"] == SDK_MAX_RETRIES
+
+
+def test_is_provider_error_distinguishes_sdk_from_tool_httpx():
+    """SDK errors recover; untagged httpx (tools) does not; tagged httpx does."""
+    from unittest.mock import MagicMock
+
+    import httpx
+    from openai import RateLimitError
+
+    from gptme.llm import is_provider_error, mark_llm_reply_origin
+
+    response = MagicMock()
+    response.status_code = 429
+    sdk_err = RateLimitError("upstream", response=response, body=None)
+    assert is_provider_error(sdk_err)
+
+    tool_err = httpx.ConnectError("browser failed")
+    assert not is_provider_error(tool_err)
+    mark_llm_reply_origin(tool_err)
+    assert is_provider_error(tool_err)
+
+    assert not is_provider_error(ValueError("bug in gptme"))
+
+
 def test_anthropic_clients_have_sdk_retries_disabled():
     """The Anthropic clients are constructed with SDK retries disabled."""
     import inspect


### PR DESCRIPTION
Fixes gptme/gptme#3668.

The reported 429 exposed three separate defects. Each is fixed here.

### 1. Retries were doubled

The provider SDKs retry internally — `openai` defaults to `max_retries=2`, and our Anthropic clients passed `max_retries=5` explicitly — *on top of* gptme's own retry decorators. That is the `2*5` pattern in the issue's log: one transient error became up to 15 (openai) or 25 (anthropic) requests hammering an already rate-limited endpoint, with an effective backoff schedule nobody designed.

SDK-level retries are now disabled (`max_retries=0`). gptme's decorators are the only retry loop.

### 2. The backoff window was far too short

5 attempts × uncapped `1.0 * 2**n` gave up after ~15s of waiting, so a sub-minute upstream blip could kill an entire session.

Default is now 11 attempts with each wait capped at 60s → **~5 minutes** of cumulative backoff (1, 2, 4, 8, 16, 32, 60, 60, 60, 60). Tunable via `GPTME_LLM_MAX_RETRIES`.

### 3. It crashed instead of returning control

An exhausted retry propagated out of the chat loop and terminated gptme, even interactively — the worst part of the report.

The loop now catches provider errors (anything from `openai`, `anthropic`, or `httpx`), logs them, appends a system message to the log, and returns to the prompt so you can retry or switch model. Deliberately narrow:

- **non-interactive uses the same 11-attempt / ~5-minute retry policy, then raises if all attempts fail** — `_classify_fatal_error` exit codes (75 rate-limit, etc.) are unchanged, which automation depends on
- **non-provider exceptions still raise in both modes** — a bug in gptme must not be swallowed as a recoverable API error

Errors are matched by defining module rather than a hardcoded list of exception classes, so new SDK error types are covered without maintenance.

### Shape

The policy now lives in one place, `gptme/llm/retry_policy.py`, instead of being duplicated across `llm_openai.py` and `llm_anthropic.py`.

### Verification

- New `tests/test_llm_retry_policy.py` (9 tests): backoff cap, ~5min window, env override + invalid values, SDK retries off for both providers
- New chat-loop tests: interactive recovers from a `RateLimitError`; non-interactive still raises it; a `ValueError` still raises interactively
- Confirmed the interactive-recovery test **fails on master** and passes here
- `269 passed` across `test_llm_openai.py`, `test_llm_anthropic.py`, `test_chat.py`, `test_llm_retry_abort.py`, `test_llm_retry_policy.py`; ruff clean
