### PR TITLE
fix(cli): suppress all shortcut dispatch after double dash

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -868,7 +868,7 @@ def main(
 
     # gptme-util subcommand mirroring: `gptme chats [...]` → `gptme-util chats [...]`
     # Any top-level gptme-util subcommand can be invoked without typing 'gptme-util'.
-    # Suppressed when '--' was used (parse_args sets util_dispatch_suppressed).
+    # Suppressed when '--' was used (parse_args sets shortcut_dispatch_suppressed).
     if prompts and not show_version:
         from .util import UTIL_SUBCOMMANDS  # cheap: just a sorted list constant
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -122,8 +122,8 @@ class _DynamicHelpCommand(click.Command):
             if a == "--":
                 # '--' is the POSIX end-of-options sentinel: the user wants
                 # everything after it treated as literal prompts, not as a
-                # utility shortcut.  Signal main() to skip util dispatch.
-                ctx.meta["util_dispatch_suppressed"] = True
+                # utility shortcut. Signal main() to suppress all shortcut dispatch.
+                ctx.meta["shortcut_dispatch_suppressed"] = True
                 break
             if a == "-":
                 # '-' is gptme's MULTIPROMPT_SEPARATOR, not an option prefix.
@@ -843,9 +843,17 @@ def main(
 ):
     """Main entrypoint for the CLI."""
     show_version = version or version_json
+    dispatch_suppressed = click.get_current_context().meta.get(
+        "shortcut_dispatch_suppressed", False
+    )
 
     # Dispatch: `gptme search QUERY` → chats search (discoverability alias)
-    if prompts and prompts[0] == "search" and not show_version:
+    if (
+        prompts
+        and prompts[0] == "search"
+        and not show_version
+        and not dispatch_suppressed
+    ):
         from ..tools.chats import search_chats  # fmt: skip
 
         query = " ".join(prompts[1:]).strip()
@@ -864,10 +872,7 @@ def main(
     if prompts and not show_version:
         from .util import UTIL_SUBCOMMANDS  # cheap: just a sorted list constant
 
-        _ctx = click.get_current_context()
-        if prompts[0] in UTIL_SUBCOMMANDS and not _ctx.meta.get(
-            "util_dispatch_suppressed", False
-        ):
+        if prompts[0] in UTIL_SUBCOMMANDS and not dispatch_suppressed:
             if util_exec := shutil.which("gptme-util"):
                 sys.exit(subprocess.call([util_exec, *prompts]))
             else:
@@ -881,11 +886,7 @@ def main(
     # Plugin dispatch: `gptme CMD [args...]` → `gptme-CMD [args...]` if installed
     # Enables extensibility: `gptme sessions` works if gptme-sessions is in PATH.
     # Suppressed after '--' for the same literal-prompt semantics as util dispatch.
-    if (
-        prompts
-        and not show_version
-        and not _ctx.meta.get("util_dispatch_suppressed", False)
-    ):
+    if prompts and not show_version and not dispatch_suppressed:
         plugin = f"gptme-{prompts[0]}"
         if plugin_path := shutil.which(plugin):
             sys.exit(subprocess.call([plugin_path, *prompts[1:]]))

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -80,6 +80,17 @@ class TestSearchAlias:
         mock_search.assert_not_called()
         assert "{" in result.output or "version" in result.output.lower()
 
+    def test_search_suppressed_after_double_dash(self, runner: CliRunner):
+        """gptme -- search treats search as a prompt, not the search alias."""
+        with (
+            patch("gptme.tools.chats.search_chats") as mock_search,
+            patch("gptme.cli.main.shutil.which", return_value=None),
+            patch.object(importlib.import_module("gptme.chat"), "chat"),
+        ):
+            result = runner.invoke(main, ["--", "search"])
+        assert result.exit_code == 0
+        mock_search.assert_not_called()
+
 
 class TestPluginDispatch:
     def test_plugin_found_in_path_is_executed(self, runner: CliRunner):
@@ -277,20 +288,15 @@ class TestUtilSubcommandMirroring:
             ["/usr/local/bin/gptme-util", "chats", "list", "--help"]
         )
 
-    def test_util_subcmd_after_double_dash_suppresses_dispatch(self, runner: CliRunner):
-        """gptme -- chats list sets util_dispatch_suppressed in ctx.meta.
+    def test_util_subcmd_after_double_dash_suppresses_dispatch(self):
+        """The '--' sentinel suppresses utility dispatch.
 
-        '--' is the POSIX end-of-options sentinel: everything after it is treated
-        as a literal prompt, not as a utility shortcut (same intuition as '-' for
-        multi-prompt chaining).  parse_args sets util_dispatch_suppressed so
-        main() skips the UTIL_SUBCOMMANDS check.
-
-        We test parse_args via make_context (which runs parse_args but NOT the
+        We test parse_args via make_context (which runs parse_args but not the
         main() body) to avoid triggering LLM initialisation in the test.
         """
         with patch("gptme.cli.main.shutil.which", return_value=None):
             ctx = main.make_context("gptme", ["--", "chats", "list"])
-        assert ctx.meta.get("util_dispatch_suppressed", False)
+        assert ctx.meta.get("shortcut_dispatch_suppressed", False)
 
     def test_util_subcmd_after_unknown_option_does_not_dispatch(
         self, runner: CliRunner
@@ -302,7 +308,10 @@ class TestUtilSubcommandMirroring:
         enabling util dispatch, so allow_interspersed_args stays True and
         --help fires as an eager option showing gptme's top-level help.
         """
-        with patch("gptme.cli.main.subprocess.call") as mock_call:
+        with (
+            patch("gptme.cli.main.shutil.which", return_value=None),
+            patch("gptme.cli.main.subprocess.call") as mock_call,
+        ):
             result = runner.invoke(main, ["--bogus", "chats", "list", "--help"])
         assert "Usage:" in result.output
         assert result.exit_code == 0
@@ -312,7 +321,10 @@ class TestUtilSubcommandMirroring:
         self, runner: CliRunner
     ):
         """gptme -x chats list --help shows gptme help, not gptme-util."""
-        with patch("gptme.cli.main.subprocess.call") as mock_call:
+        with (
+            patch("gptme.cli.main.shutil.which", return_value=None),
+            patch("gptme.cli.main.subprocess.call") as mock_call,
+        ):
             result = runner.invoke(main, ["-x", "chats", "list", "--help"])
         assert "Usage:" in result.output
         assert result.exit_code == 0

--- a/tests/test_search_alias.py
+++ b/tests/test_search_alias.py
@@ -85,11 +85,13 @@ class TestSearchAlias:
         with (
             patch("gptme.tools.chats.search_chats") as mock_search,
             patch("gptme.cli.main.shutil.which", return_value=None),
-            patch.object(importlib.import_module("gptme.chat"), "chat"),
+            patch.object(importlib.import_module("gptme.chat"), "chat") as mock_chat,
         ):
             result = runner.invoke(main, ["--", "search"])
         assert result.exit_code == 0
         mock_search.assert_not_called()
+        prompt_msgs = mock_chat.call_args.args[0]
+        assert [msg.content for msg in prompt_msgs] == ["search"]
 
 
 class TestPluginDispatch:


### PR DESCRIPTION
## Problem

The merged shortcut-dispatch fix in gptme/gptme#3630 left two real edge cases from its final AI review:

- `gptme -- search` still invoked the built-in search alias, even though `--` is the literal-prompt sentinel and already suppressed utility/plugin shortcuts.
- The unknown-option regression tests depended on the host `PATH`; an installed `gptme--bogus` or `gptme-x` binary could make them fail.

The review's other claimed runtime bug (`--model -- chats list`) is not a bug: Click consumes `--` as the value of `--model`, so it is not an end-of-options sentinel in that command.

## Fix

- Rename the parse metadata to `shortcut_dispatch_suppressed` and apply it consistently to the built-in search alias, utility shortcuts, and plugin shortcuts.
- Add coverage proving `gptme -- search` reaches normal prompt handling.
- Patch `shutil.which` in the two unknown-option tests so they are independent of the machine's installed plugins.

## Verification

- `pytest tests/test_search_alias.py`: 29 passed
- Ruff check and format: clean
- pre-commit: clean

Follow-up to gptme/gptme#3630.
