### PR TITLE
docs: point the free on-ramp at live OpenRouter models

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,9 @@ This stack is simple and composable: selectors improve work choice, lessons stee
 
 - Python 3.10 or newer
 - Credentials for at least one LLM provider:
-  - OpenRouter can be configured interactively with `/account setup openrouter`
-    inside gptme, using browser OAuth onboarding.
+  - Fastest no-credit-card path: `/account setup openrouter` inside gptme
+    (browser OAuth), then `gptme "hello" -m openrouter/openrouter/free`.
+    See [Getting Started][docs-getting-started].
   - Subscriptions work too: sign in with your ChatGPT Plus/Pro or SuperGrok plan
     via `gptme-auth openai-subscription` or `gptme-auth grok-subscription`,
     no API key needed (see [providers docs][docs-providers]).

--- a/README.md
+++ b/README.md
@@ -438,9 +438,11 @@ This stack is simple and composable: selectors improve work choice, lessons stee
 
 - Python 3.10 or newer
 - Credentials for at least one LLM provider:
-  - Fastest no-credit-card path: `/account setup openrouter` inside gptme
-    (browser OAuth), then `gptme "hello" -m openrouter/openrouter/free`.
-    See [Getting Started][docs-getting-started].
+  - Fastest no-credit-card path: start `gptme`, choose **OpenRouter** in the
+    startup provider setup (browser OAuth), then run
+    `gptme "hello" -m openrouter/openrouter/free`. On an existing setup, use
+    `/account setup openrouter` inside a session. See
+    [Getting Started][docs-getting-started].
   - Subscriptions work too: sign in with your ChatGPT Plus/Pro or SuperGrok plan
     via `gptme-auth openai-subscription` or `gptme-auth grok-subscription`,
     no API key needed (see [providers docs][docs-providers]).

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -135,12 +135,18 @@ OpenRouter aggregates free model tiers behind one API key. The ``:free`` catalog
 **rotates** — last month's model id is often gone. Prefer the free router, and
 pin a specific ``:free`` model only after you have confirmed it is still listed.
 
+Start gptme, then run the setup command inside the session (a fresh install
+cannot dispatch it from the shell before a model is configured):
+
+.. code-block:: text
+
+    /account setup openrouter
+
+Then use the default free router:
+
 .. code-block:: bash
 
-    # Sign in with browser — no credit card required
-    gptme '/account setup openrouter'
-
-    # Default free router (OpenRouter model id is openrouter/free)
+    # OpenRouter model id is openrouter/free
     gptme "hello" -m openrouter/openrouter/free
 
     # Pin a currently listed free model (catalog rotates)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -180,14 +180,6 @@ inference. Current catalog: https://openrouter.ai/models?max_price=0
     export GROQ_API_KEY="your-key"
     gptme "hello" -m groq/llama-3.3-70b-versatile
 
-.. note::
-
-   There is no public ``OPENAI_API_KEY=free`` endpoint at ``freellmapi.com``
-   (parked domain; POST ``/v1/chat/completions`` returns HTTP 405).
-   `FreeLLMAPI <https://github.com/tashfeenahmed/freellmapi>`_ is a
-   **self-hosted** OpenAI-compatible router that needs your own provider keys.
-   See :doc:`providers-custom`.
-
 .. tip::
 
    Free cloud tiers give better results than local small models for most tasks, while still

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -135,12 +135,10 @@ OpenRouter aggregates free model tiers behind one API key. The ``:free`` catalog
 **rotates** — last month's model id is often gone. Prefer the free router, and
 pin a specific ``:free`` model only after you have confirmed it is still listed.
 
-Start gptme, then run the setup command inside the session (a fresh install
-cannot dispatch it from the shell before a model is configured):
-
-.. code-block:: text
-
-    /account setup openrouter
+On a fresh install, start ``gptme`` and choose **OpenRouter** in the startup
+provider setup. gptme opens the browser OAuth flow before entering the chat.
+On an already configured installation, you can instead run
+``/account setup openrouter`` inside a session.
 
 Then use the default free router:
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -127,23 +127,38 @@ for Ollama, vLLM, and custom server setup.
 Free Cloud Providers (No Credit Card Required)
 ----------------------------------------------
 
-Several cloud providers offer free tiers that work with gptme out of the box:
+Several cloud providers offer free tiers that work with gptme out of the box.
 
-**OpenRouter** (recommended: largest free model catalog)
+**OpenRouter** (recommended: one browser sign-in, no credit card)
 
-OpenRouter aggregates free model tiers from Google, Meta, Mistral, and others behind one API key:
+OpenRouter aggregates free model tiers behind one API key. The ``:free`` catalog
+**rotates** — last month's model id is often gone. Prefer the free router, and
+pin a specific ``:free`` model only after you have confirmed it is still listed.
 
 .. code-block:: bash
 
     # Sign in with browser — no credit card required
     gptme '/account setup openrouter'
 
-    # Then use any :free-tagged model
-    gptme "hello" -m openrouter/google/gemini-2.5-flash:free
-    gptme "hello" -m openrouter/meta-llama/llama-3.3-70b-instruct:free
+    # Default free router (OpenRouter model id is openrouter/free)
+    gptme "hello" -m openrouter/openrouter/free
 
-Free OpenRouter models are rate-limited but sufficient for personal use. The ``:free`` suffix selects
-the free tier; omitting it routes to paid inference.
+    # Pin a currently listed free model (catalog rotates)
+    gptme "hello" -m openrouter/cohere/north-mini-code:free
+
+The doubled ``openrouter/openrouter/free`` is intentional: gptme's
+``<provider>/<model>`` split plus OpenRouter's own ``openrouter/free`` model id.
+``-m openrouter/free`` sends ``model=free`` and 404s.
+
+Verified 2026-08-28 (chat + gptme ``shell`` tool, shared free pool):
+
+- ``openrouter/openrouter/free`` — 200k ctx, tools work. Recommended default.
+- ``openrouter/cohere/north-mini-code:free`` — 256k ctx, tools work.
+
+Shared-pool ``:free`` endpoints 429 often (Gemma 4 and GLM-5.2 did during the
+same probe). Retry, pick another listed model, or add your own provider key at
+https://openrouter.ai/settings/integrations. Omitting ``:free`` routes to paid
+inference. Current catalog: https://openrouter.ai/models?max_price=0
 
 **Google Gemini** (generous free quota, 1 M token context)
 
@@ -160,6 +175,14 @@ the free tier; omitting it routes to paid inference.
     # Get a free API key at https://console.groq.com (no credit card)
     export GROQ_API_KEY="your-key"
     gptme "hello" -m groq/llama-3.3-70b-versatile
+
+.. note::
+
+   There is no public ``OPENAI_API_KEY=free`` endpoint at ``freellmapi.com``
+   (parked domain; POST ``/v1/chat/completions`` returns HTTP 405).
+   `FreeLLMAPI <https://github.com/tashfeenahmed/freellmapi>`_ is a
+   **self-hosted** OpenAI-compatible router that needs your own provider keys.
+   See :doc:`providers-custom`.
 
 .. tip::
 

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -187,6 +187,31 @@ named ``[[providers]]`` entry.
     VLLM_API_KEY="none"   # vLLM often needs no auth
     gptme 'hello' -m vllm/meta-llama/Llama-3.1-8B-Instruct
 
+**Example (FreeLLMAPI, self-hosted aggregator):**
+
+`FreeLLMAPI <https://github.com/tashfeenahmed/freellmapi>`_ routes across the
+free tiers of providers whose keys you add locally. It is **not** a hosted
+no-key API — ``https://freellmapi.com/v1`` is a parked domain.
+
+After the local server is running (default ``http://127.0.0.1:3001``) and you
+have copied the unified key from its dashboard:
+
+.. code-block:: toml
+
+    [[providers]]
+    name = "freellmapi"
+    base_url = "http://127.0.0.1:3001/v1"
+    api_key_env = "FREELLMAPI_API_KEY"
+    default_model = "auto"
+
+.. code-block:: sh
+
+    export FREELLMAPI_API_KEY="freellmapi-your-unified-key"
+    gptme 'hello' -m freellmapi/auto
+
+For a zero-setup free cloud path (no self-hosting), use OpenRouter instead —
+see :doc:`getting-started`.
+
 **Tokenizer in airgapped environments**
 
 gptme may fetch the OpenAI ``cl100k_base`` tokenizer to count tokens. Offline, that

--- a/docs/providers-custom.rst
+++ b/docs/providers-custom.rst
@@ -187,31 +187,6 @@ named ``[[providers]]`` entry.
     VLLM_API_KEY="none"   # vLLM often needs no auth
     gptme 'hello' -m vllm/meta-llama/Llama-3.1-8B-Instruct
 
-**Example (FreeLLMAPI, self-hosted aggregator):**
-
-`FreeLLMAPI <https://github.com/tashfeenahmed/freellmapi>`_ routes across the
-free tiers of providers whose keys you add locally. It is **not** a hosted
-no-key API — ``https://freellmapi.com/v1`` is a parked domain.
-
-After the local server is running (default ``http://127.0.0.1:3001``) and you
-have copied the unified key from its dashboard:
-
-.. code-block:: toml
-
-    [[providers]]
-    name = "freellmapi"
-    base_url = "http://127.0.0.1:3001/v1"
-    api_key_env = "FREELLMAPI_API_KEY"
-    default_model = "auto"
-
-.. code-block:: sh
-
-    export FREELLMAPI_API_KEY="freellmapi-your-unified-key"
-    gptme 'hello' -m freellmapi/auto
-
-For a zero-setup free cloud path (no self-hosting), use OpenRouter instead —
-see :doc:`getting-started`.
-
 **Tokenizer in airgapped environments**
 
 gptme may fetch the OpenAI ``cl100k_base`` tokenizer to count tokens. Offline, that


### PR DESCRIPTION
## Summary

Follow-up to #3631. The getting-started **Free Cloud Providers** examples
(`openrouter/google/gemini-2.5-flash:free` and
`openrouter/meta-llama/llama-3.3-70b-instruct:free`) are no longer in
OpenRouter's free catalog — they 404.

This PR:

- Points the no-credit-card on-ramp at `openrouter/openrouter/free` (OpenRouter's
  free router) and a currently listed pin (`cohere/north-mini-code:free`)
- Warns that the `:free` catalog rotates and the shared pool 429s
- Documents why `-m openrouter/free` 404s (gptme splits on the first `/`)
- Adds the no-credit-card command to the README Getting Started prerequisites

README overlap with #3664 is a different section (MCP vs Prerequisites).
No conflict.

## Probe (2026-08-28)

| Model | Chat | gptme `shell` tool | Notes |
|---|---|---|---|
| `openrouter/openrouter/free` | yes | yes | Recommended. Routed to `nvidia/nemotron-3-super-120b-a12b:free` |
| `openrouter/cohere/north-mini-code:free` | yes | yes | 256k ctx pin |
| `openrouter/free` | 404 | — | gptme sends `model=free` |
| `google/gemini-2.5-flash:free` | missing | — | Not in catalog |
| `meta-llama/llama-3.3-70b-instruct:free` | missing | — | Not in catalog |
| Gemma 4 `:free` / `z-ai/glm-5.2:free` | 429 | — | Shared-pool rate limit |
| `openrouter/minimax/minimax-m3:free` | yes | crash | gptme `list index out of range` |

## Test plan

- [x] Live OpenRouter catalog check (`GET /api/v1/models`)
- [x] `gptme -n --tools none` chat probe
- [x] `gptme -n -t shell` tool probe (`echo YEAR_OK`)
- [ ] `make docs` / Sphinx link check in CI
