### PR TITLE
fix: match Claude Code's cwd→project-dir encoding (CC memory + agent hook)

### DIFF
--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import struct
 import subprocess
 from pathlib import Path
 
@@ -168,15 +169,67 @@ def get_profile_memory_dir(profile_name: str) -> Path:
     return path
 
 
+def _claude_project_dirname(path: str) -> str:
+    """Replicate Claude Code's cwd → project-directory-name encoding.
+
+    Mirrors CC's own implementation (``cli.js``, verified against v2.1.239)::
+
+        sanitize(e) = e.replace(/[^a-zA-Z0-9]/g, "-")
+        dirname(e)  = sanitize(e).length <= 200
+                          ? sanitize(e)
+                          : sanitize(e).slice(0, 200) + "-" + hash(e)
+        hash(e)     = |djb2_xor32(e)| in base36
+
+    Every non-alphanumeric character (``/``, ``\\``, ``:``, ``_``, ``.``,
+    spaces, non-ASCII, ...) becomes a dash, with no collapsing of runs — so
+    ``C:\\`` → ``C--``. Overlong names are truncated and disambiguated with a
+    hash of the *original* path.
+
+    CC runs on JS, where strings, ``.length``, ``.charCodeAt()`` and the regex
+    all operate on UTF-16 code units. We iterate the same units so that paths
+    with astral characters (emoji, ...) — two units each, ``"--"`` when
+    sanitized — encode identically.
+    """
+    n_units = len(path.encode("utf-16-le")) // 2
+    units = struct.unpack(f"<{n_units}H", path.encode("utf-16-le"))
+
+    def _is_alnum_unit(u: int) -> bool:
+        return 48 <= u <= 57 or 65 <= u <= 90 or 97 <= u <= 122
+
+    sanitized = "".join(chr(u) if _is_alnum_unit(u) else "-" for u in units)
+    if len(sanitized) <= 200:
+        return sanitized
+
+    # 32-bit signed djb2-style hash: t = (t << 5) - t + codeUnit, wrapped to
+    # int32 after each step (JS `| 0`), then Math.abs(...).toString(36).
+    h = 0
+    for u in units:
+        h = (h * 31 + u) & 0xFFFFFFFF
+        if h >= 0x80000000:
+            h -= 0x100000000
+    n = abs(h)
+    if n == 0:
+        suffix = "0"
+    else:
+        digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+        chars = []
+        while n:
+            n, r = divmod(n, 36)
+            chars.append(digits[r])
+        suffix = "".join(reversed(chars))
+    return sanitized[:200] + "-" + suffix
+
+
 def get_cc_memory_dir(workspace: Path) -> Path:
     """Get the Claude Code memory directory for a given workspace.
 
     Claude Code stores per-project memories at:
         ~/.claude/projects/<workspace-hash>/memory/
 
-    where the hash is the absolute workspace path with slashes, backslashes, and
-    colons replaced by dashes, e.g. ``/home/user/myproject`` → ``-home-user-myproject``
-    and ``C:\\Users\\user\\project`` → ``C--Users-user-project``.
+    where ``<workspace-hash>`` is the absolute workspace path encoded via
+    :func:`_claude_project_dirname` (every non-alphanumeric character replaced
+    by a dash), e.g. ``/home/user/my_project`` → ``-home-user-my-project`` and
+    ``C:\\Users\\user\\project`` → ``C--Users-user-project``.
 
     This allows gptme sessions to read memories written by CC sessions (and vice
     versa when the memory tool writes to this location).
@@ -188,16 +241,14 @@ def get_cc_memory_dir(workspace: Path) -> Path:
         Path to the CC memory directory (may not exist)
 
     Note:
-        The slash-to-dash encoding is non-injective: paths that differ only by a
-        dash versus a path separator (e.g. ``/a/b`` and ``/a-b``) map to the
-        same identifier. This is CC's own encoding scheme; gptme replicates it
-        faithfully so it reads the correct memory directory. The collision risk is
-        inherited from CC's design and cannot be resolved without diverging from
-        CC's path formula.
+        The encoding is non-injective: paths that differ only by a dash versus
+        any other non-alphanumeric character (e.g. ``/a/b``, ``/a-b`` and
+        ``/a_b``) map to the same identifier. This is CC's own encoding scheme;
+        gptme replicates it faithfully so it reads the correct memory directory.
+        The collision risk is inherited from CC's design and cannot be resolved
+        without diverging from CC's path formula.
     """
-    workspace_hash = (
-        str(workspace.resolve()).replace("\\", "-").replace("/", "-").replace(":", "-")
-    )
+    workspace_hash = _claude_project_dirname(str(workspace.resolve()))
     return Path.home() / ".claude" / "projects" / workspace_hash / "memory"
 
 

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -196,7 +196,7 @@ def _claude_project_dirname(path: str) -> str:
     # 16-bit code units of the string, matching JS string/charCodeAt semantics.
     # An empty path yields no units (struct.unpack("<0H", b"") -> ()) and an
     # empty dirname, same as JS.
-    utf16 = path.encode("utf-16-le")
+    utf16 = path.encode("utf-16-le", errors="surrogatepass")
     units = struct.unpack(f"<{len(utf16) // 2}H", utf16)
 
     def _is_alnum_unit(u: int) -> bool:

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -172,13 +172,16 @@ def get_profile_memory_dir(profile_name: str) -> Path:
 def _claude_project_dirname(path: str) -> str:
     """Replicate Claude Code's cwd → project-directory-name encoding.
 
-    Mirrors CC's own implementation (``cli.js``, verified against v2.1.239)::
+    Mirrors CC's own implementation (bundle functions ``wv`` / ``pL`` / ``y9t``
+    in ``cli.js`` — also in the VS Code extension's ``extension.js`` — verified
+    against v2.1.239)::
 
         sanitize(e) = e.replace(/[^a-zA-Z0-9]/g, "-")
         dirname(e)  = sanitize(e).length <= 200
                           ? sanitize(e)
                           : sanitize(e).slice(0, 200) + "-" + hash(e)
-        hash(e)     = |djb2_xor32(e)| in base36
+        hash(e)     = Math.abs(e.split("").reduce(
+                          (t, c) => (t * 31 + c.charCodeAt(0)) | 0, 0)).toString(36)
 
     Every non-alphanumeric character (``/``, ``\\``, ``:``, ``_``, ``.``,
     spaces, non-ASCII, ...) becomes a dash, with no collapsing of runs — so
@@ -190,8 +193,11 @@ def _claude_project_dirname(path: str) -> str:
     with astral characters (emoji, ...) — two units each, ``"--"`` when
     sanitized — encode identically.
     """
-    n_units = len(path.encode("utf-16-le")) // 2
-    units = struct.unpack(f"<{n_units}H", path.encode("utf-16-le"))
+    # 16-bit code units of the string, matching JS string/charCodeAt semantics.
+    # An empty path yields no units (struct.unpack("<0H", b"") -> ()) and an
+    # empty dirname, same as JS.
+    utf16 = path.encode("utf-16-le")
+    units = struct.unpack(f"<{len(utf16) // 2}H", utf16)
 
     def _is_alnum_unit(u: int) -> bool:
         return 48 <= u <= 57 or 65 <= u <= 90 or 97 <= u <= 122
@@ -200,8 +206,9 @@ def _claude_project_dirname(path: str) -> str:
     if len(sanitized) <= 200:
         return sanitized
 
-    # 32-bit signed djb2-style hash: t = (t << 5) - t + codeUnit, wrapped to
-    # int32 after each step (JS `| 0`), then Math.abs(...).toString(36).
+    # CC's y9t(): t = (t * 31 + codeUnit), coerced to a signed int32 after each
+    # step (JS `| 0`), then Math.abs(...).toString(36). Not canonical djb2
+    # (which multiplies by 33) — this is the 31-multiplier variant CC ships.
     h = 0
     for u in units:
         h = (h * 31 + u) & 0xFFFFFFFF

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -146,6 +146,26 @@ class TestRuntimeParsers:
         assert info.mode == "interactive"
         assert info.cmdline_summary == "hello bob, bootstrap please"
 
+    def test_claude_parser_finds_project_dir_via_cc_encoding(
+        self, tmp_path: Path
+    ) -> None:
+        """``log_dir`` must be located with Claude Code's real cwd→project-dir
+        encoding (every non-alphanumeric char → "-"), not a naive "/"→"-"
+        replace that leaves "_", ".", ":" untouched and is a no-op on Windows
+        paths like ``C:\\Users\\me\\proj``.
+        """
+        from gptme.hooks.workspace_agents import _parse_claude_code
+
+        cwd = "/home/user/my_project.v2"
+        encoded = "-home-user-my-project-v2"
+        project_dir = tmp_path / ".claude" / "projects" / encoded
+        project_dir.mkdir(parents=True)
+
+        with patch("gptme.hooks.workspace_agents.Path.home", return_value=tmp_path):
+            info = _parse_claude_code(101, ["claude", "hi"], cwd)
+
+        assert info.log_dir == str(project_dir)
+
     def test_codex_exec_is_autonomous(self) -> None:
         from gptme.hooks.workspace_agents import _parse_codex
 

--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -29,6 +29,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from ..dirs import _claude_project_dirname
 from ..hooks import HookType, StopPropagation, register_hook
 from ..message import Message
 from ..util.git_cmd import GIT_CMD
@@ -1063,7 +1064,11 @@ def _parse_claude_code(pid: int, cmdline: list[str], cwd: str) -> AgentInfo:
     mode = "autonomous" if is_pipe else "interactive"
 
     log_dir = None
-    project_hash = cwd.replace("/", "-")
+    # Claude Code derives its per-project dir name from cwd by replacing *every*
+    # non-alphanumeric char with "-" (plus a hash for overlong paths); replicate
+    # that exactly instead of a naive "/" → "-" that drops "_", ".", ":" and is
+    # a no-op on Windows paths. See gptme.dirs._claude_project_dirname.
+    project_hash = _claude_project_dirname(cwd)
     project_dir = Path.home() / ".claude" / "projects" / project_hash
     if project_dir.is_dir():
         log_dir = str(project_dir)

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -1,9 +1,67 @@
 """Tests for Claude Code memory integration in gptme workspace context."""
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
-from gptme.dirs import get_cc_memory_dir, get_cc_memory_file
+from gptme.dirs import _claude_project_dirname, get_cc_memory_dir, get_cc_memory_file
+
+
+class TestClaudeProjectDirname:
+    """Tests for _claude_project_dirname (CC's cwd → project-dir encoding).
+
+    Expected values cross-checked against Claude Code's own implementation
+    (cli.js, v2.1.239): sanitize = s.replace(/[^a-zA-Z0-9]/g, "-"), with a
+    truncate-to-200 + base36-hash fallback for overlong names.
+    """
+
+    def test_posix_path(self):
+        assert _claude_project_dirname("/home/user/myproject") == "-home-user-myproject"
+
+    def test_windows_path(self):
+        assert (
+            _claude_project_dirname("C:\\Users\\user\\project")
+            == "C--Users-user-project"
+        )
+
+    def test_underscores_dots_spaces(self):
+        assert (
+            _claude_project_dirname("/home/user/my_project.v2 backup")
+            == "-home-user-my-project-v2-backup"
+        )
+
+    def test_runs_not_collapsed(self):
+        # C:\ -> "C" + ":" + "\" -> "C--"
+        assert _claude_project_dirname("C:\\").startswith("C--")
+        assert _claude_project_dirname("/a/./b") == "-a---b"
+
+    def test_non_ascii_becomes_dashes(self):
+        # BMP non-alphanumeric -> one dash per code unit
+        assert _claude_project_dirname("/tmp/café") == "-tmp-caf-"
+
+    def test_astral_char_is_two_dashes(self):
+        # CC runs on JS: an astral char is two UTF-16 code units, so it
+        # sanitizes to "--" and counts as length 2. Node reference:
+        # "/home/user/\U0001F600/proj" -> "-home-user----proj"
+        assert (
+            _claude_project_dirname("/home/user/\U0001f600/proj")
+            == "-home-user----proj"
+        )
+
+    def test_overlong_path_truncated_and_hashed(self):
+        path = "/" + "a_very/deep.path " * 30 + "end"
+        result = _claude_project_dirname(path)
+        # CC: slice(0, 200) + "-" + hash; node reference gives hash "xs0et0"
+        assert len(result) == 207
+        assert result.endswith("-xs0et0")
+        assert result[:200] == re.sub(r"[^a-zA-Z0-9]", "-", path)[:200]
+
+    def test_overlong_path_with_astral_char(self):
+        # Node reference: "/a/🚀🚀/b" + "y"*210 -> hash "jga4eu"
+        path = "/a/\U0001f680\U0001f680/b" + "y" * 210
+        result = _claude_project_dirname(path)
+        assert result.endswith("-jga4eu")
+        assert result[:200].startswith("-a------b")
 
 
 class TestGetCcMemoryDir:
@@ -17,6 +75,23 @@ class TestGetCcMemoryDir:
             cc_dir
             == Path.home() / ".claude" / "projects" / "-home-user-myproject" / "memory"
         )
+
+    def test_non_alphanumeric_replaced(self):
+        """Every non-alphanumeric char is replaced by a dash, matching CC's encoding.
+
+        CC encodes the cwd as ``cwd.replace(/[^a-zA-Z0-9]/g, '-')``, so
+        underscores, dots and spaces must map to dashes too — not just path
+        separators. e.g. ``/home/user/my_project`` → ``-home-user-my-project``.
+        Patched resolve() keeps this independent of the host OS.
+        """
+
+        class _Resolved:
+            def __str__(self):
+                return "/home/user/my_project.v2 backup"
+
+        with patch.object(Path, "resolve", return_value=_Resolved()):
+            hash_part = get_cc_memory_dir(Path("/irrelevant")).parent.name
+        assert hash_part == "-home-user-my-project-v2-backup"
 
     def test_nested_workspace(self, tmp_path):
         """Deeper workspace paths produce correct hash."""
@@ -61,12 +136,15 @@ class TestGetCcMemoryDir:
     def test_path_collision_documented(self):
         """Paths differing only by dash-vs-separator produce the same hash (CC's design).
 
-        e.g. /a/b and /a-b both map to '-a-b'. This is an inherent property of
-        CC's own slash-to-dash encoding; gptme replicates it faithfully.
+        e.g. /a/b, /a-b and /a_b all map to '-a-b'. This is an inherent property
+        of CC's own encoding (every non-alphanumeric char → dash); gptme
+        replicates it faithfully.
         """
         ws_slash = Path("/home/user/a/b")
         ws_dash = Path("/home/user/a-b")
+        ws_underscore = Path("/home/user/a_b")
         assert get_cc_memory_dir(ws_slash) == get_cc_memory_dir(ws_dash)
+        assert get_cc_memory_dir(ws_slash) == get_cc_memory_dir(ws_underscore)
 
 
 class TestGetCcMemoryFile:

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -13,10 +13,23 @@ class TestClaudeProjectDirname:
     Expected values cross-checked against Claude Code's own implementation
     (cli.js, v2.1.239): sanitize = s.replace(/[^a-zA-Z0-9]/g, "-"), with a
     truncate-to-200 + base36-hash fallback for overlong names.
+
+    The hash suffixes below were produced by running CC's own functions in
+    Node; regenerate with (charCodeAt is per UTF-16 unit, like CC)::
+
+        node -e 'const wv=e=>e.replace(/[^a-zA-Z0-9]/g,"-");
+          const y9t=e=>{let t=0;for(let r=0;r<e.length;r++)t=(t<<5)-t+e.charCodeAt(r)|0;
+            return Math.abs(t).toString(36)};
+          const pL=e=>{const t=wv(e);return t.length<=200?t:t.slice(0,200)+"-"+y9t(e)};
+          console.log(pL(process.argv[1]))' "<path>"
     """
 
     def test_posix_path(self):
         assert _claude_project_dirname("/home/user/myproject") == "-home-user-myproject"
+
+    def test_empty_path(self):
+        # struct.unpack("<0H", b"") -> (); no units -> empty dirname (matches JS)
+        assert _claude_project_dirname("") == ""
 
     def test_windows_path(self):
         assert (


### PR DESCRIPTION
## Problem

`get_cc_memory_dir()` computes the Claude Code project-directory name as:

```python
str(workspace.resolve()).replace("\\", "-").replace("/", "-").replace(":", "-")
```

But Claude Code sanitizes the cwd with `replace(/[^a-zA-Z0-9]/g, "-")` — **every**
non-alphanumeric character becomes a dash, including `_`, `.` and spaces (verified
against `cli.js`, v2.1.239).

So for any workspace whose path contains one of those (very common — `my_project`,
`repo.v2`, dotted dirs), gptme computes the wrong hash and:

- silently fails to load CC's `MEMORY.md` into workspace context (the read side, #3626)
- the `memory` write tool (#3638, open) would write to a directory CC can't read

The same ad-hoc encoding has a second, blunter copy in
`gptme/hooks/workspace_agents.py` — see [Second call site](#second-call-site) below.

### Reproduced

For a workspace at `/home/user/my_project`:

| | value | on disk |
|---|---|---|
| current formula | `-home-user-my_project` | ❌ does not exist |
| Claude Code | `-home-user-my-project` | ✅ exists |

## Fix

Add `_claude_project_dirname()` that replicates CC's encoding faithfully
(`cli.js`, v2.1.239):

```js
sanitize(e) = e.replace(/[^a-zA-Z0-9]/g, "-")           // no run-collapsing: "C:\" -> "C--"
dirname(e)  = sanitize(e).length <= 200
                  ? sanitize(e)
                  : sanitize(e).slice(0, 200) + "-" + hash(e)   // djb2-ish int32, base36
```

- The `> 200` branch (overlong paths) was also unhandled before — now replicated.
- CC runs on JS, where the regex / `.length` / `.charCodeAt()` all work on **UTF-16 code
  units**, so the helper iterates code units too. Astral characters (emoji, …) are two
  units → `"--"` when sanitized, exactly as JS produces them.

Expected values in the new tests were cross-checked with a Node reference run.

### Second call site

`_parse_claude_code()` in the parallel-agent hook located CC's session log dir with
`cwd.replace("/", "-")` — even blunter (only `/`), and a complete no-op on Windows
`C:\…` paths. When it misses, `log_dir` stays `None` and `_resolve_claude_conversation_id`
is never called, so the hook silently drops the CC conversation link. Now routed through
the same `_claude_project_dirname` helper.

## Tests

- New `TestClaudeProjectDirname` (posix/windows paths, `_`/`.`/space, no run-collapsing,
  BMP non-ASCII, astral char, overlong → truncate+hash, overlong + astral).
- New `test_claude_parser_finds_project_dir_via_cc_encoding` for the hook call site.
- Extended `test_non_alphanumeric_replaced` and `test_path_collision_documented`.
- All pre-existing `test_cc_memory.py` / `test_workspace_agents.py` assertions unchanged
  and passing.

Note: 3 tests in `TestGetCcMemoryDir` (`test_path_formula`, `test_nested_workspace`,
`test_resolves_workspace`) fail on Windows both before and after this change — they
hardcode POSIX paths / need symlink privilege. Left as-is (out of scope).
