### PR TITLE
feat(shell): improve background job control

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -65,6 +65,7 @@ from .shell_background import (
     execute_jobs_command,
     execute_kill_command,
     execute_output_command,
+    execute_wait_command,
     get_background_job,
 )
 from .shell_background import (
@@ -92,6 +93,48 @@ _is_windows = os.name == "nt"
 
 # ANSI escape sequence pattern for stripping terminal formatting
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+def _redirect_background_stdin(command: str) -> str:
+    """Redirect stdin before unquoted ``&`` operators in a shell command.
+
+    Appending ``< /dev/null`` to a command ending in ``&`` creates a separate
+    null command after the background operator. The background process keeps
+    the persistent shell's stdin and can consume subsequent tool commands.
+    """
+    import bashlex
+
+    try:
+        nodes = bashlex.parse(command)
+    except Exception:
+        # split_commands handles unsupported and invalid syntax separately.
+        # Avoid rewriting syntax we cannot classify confidently here.
+        return command
+
+    positions: list[int] = []
+
+    def _collect_operators(value: object) -> None:
+        if isinstance(value, list):
+            for item in value:
+                _collect_operators(item)
+            return
+        if not hasattr(value, "kind"):
+            return
+        position = getattr(value, "pos", None)
+        if (
+            getattr(value, "kind", None) == "operator"
+            and getattr(value, "op", None) == "&"
+            and isinstance(position, tuple)
+        ):
+            positions.append(position[0])
+        for child in vars(value).values():
+            _collect_operators(child)
+
+    _collect_operators(nodes)
+
+    for position in reversed(positions):
+        command = command[:position].rstrip() + " < /dev/null " + command[position:]
+    return command
 
 
 def strip_ansi_codes(text: str) -> str:
@@ -169,6 +212,8 @@ For long-running commands (dev servers, builds, etc.), use background jobs:
 - `bg <command>` - Start command in background, returns job ID
 - `jobs` - List all background jobs with status
 - `output <id>` - Show accumulated output from a job
+- `output <id> --new` - Show only output added since the last incremental read
+- `wait <id> [timeout]` - Wait for a job to finish, optionally with a timeout
 - `kill <id>` - Terminate a background job
 
 This prevents blocking on commands like `npm run dev` that run indefinitely.
@@ -242,6 +287,7 @@ def examples(tool_format):
 > Use these commands to manage it:
 > - `jobs` - List all background jobs
 > - `output 1` - Show output from job #1
+> - `wait 1 60s` - Wait up to 60 seconds for job #1
 > - `kill 1` - Terminate job #1
 
 > User: check the server output
@@ -551,8 +597,12 @@ class ShellSession:
                     # Fallback to raw command if parsing fails
                     logger.warning(f"Failed to parse pipe in command '{command}': {e}")
             elif not has_stdin_redirect and "|" not in command_parts:
-                # No pipe and no stdin redirection - add /dev/null
-                command += " < /dev/null"
+                # Redirect background commands before ``&`` so they cannot
+                # consume future input sent to the persistent shell.
+                redirected = _redirect_background_stdin(command)
+                command = (
+                    redirected if redirected != command else command + " < /dev/null"
+                )
         except ValueError as e:
             logger.warning(f"Failed shlex parsing command, using raw command: {e}")
 
@@ -1872,6 +1922,15 @@ def execute_shell(
         # Show output from job: output <id>
         job_id_str = cmd_parts[1] if len(cmd_parts) > 1 else ""
         yield from execute_output_command(job_id_str)
+        return
+
+    if cmd_lower.startswith("wait "):
+        wait_parts = cmd_stripped.split()
+        if len(wait_parts) not in (2, 3):
+            yield Message("system", "Usage: `wait <job-id> [timeout]`")
+            return
+        timeout_str = wait_parts[2] if len(wait_parts) == 3 else None
+        yield from execute_wait_command(wait_parts[1], timeout_str)
         return
 
     if cmd_lower.startswith("kill ") and len(cmd_parts) == 2:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -100,7 +100,9 @@ def _redirect_background_stdin(command: str) -> str:
 
     Appending ``< /dev/null`` to a command ending in ``&`` creates a separate
     null command after the background operator. The background process keeps
-    the persistent shell's stdin and can consume subsequent tool commands.
+    the persistent shell's stdin and can consume subsequent tool commands. If
+    the asynchronous list has a trailing foreground command, redirect that
+    command as well.
     """
     import bashlex
 
@@ -134,6 +136,8 @@ def _redirect_background_stdin(command: str) -> str:
 
     for position in reversed(positions):
         command = command[:position].rstrip() + " < /dev/null " + command[position:]
+    if positions and not command.rstrip().endswith("&"):
+        command += " < /dev/null"
     return command
 
 
@@ -212,8 +216,9 @@ For long-running commands (dev servers, builds, etc.), use background jobs:
 - `bg <command>` - Start command in background, returns job ID
 - `jobs` - List all background jobs with status
 - `output <id>` - Show accumulated output from a job
-- `output <id> --new` - Show only output added since the last incremental read
-- `wait <id> [timeout]` - Wait for a job to finish, optionally with a timeout
+- `output <id> --new` - Poll a running job without repeating output already seen
+- `wait <id> [timeout]` - Wait when the next step depends on completion; a
+  timeout leaves the job running so it can be polled or waited on again
 - `kill <id>` - Terminate a background job
 
 This prevents blocking on commands like `npm run dev` that run indefinitely.

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -206,22 +206,20 @@ These programs are available, among others:
 
 ### When to use the shell
 
-Use the shell when you need to inspect the workspace, search or examine files,
-check git state, or run existing commands and tests. Prefer the shell over
-answering from memory when the repo can tell you the answer directly.
+Use the shell to inspect the workspace, search files, check git state, or run
+existing commands and tests. Prefer the repo over answering from memory.
 
 ### Background Jobs
 
-For long-running commands (dev servers, builds, etc.), use background jobs:
-- `bg <command>` - Start command in background, returns job ID
-- `jobs` - List all background jobs with status
-- `output <id>` - Show accumulated output from a job
-- `output <id> --new` - Poll a running job without repeating output already seen
-- `wait <id> [timeout]` - Wait when the next step depends on completion; a
-  timeout leaves the job running so it can be polled or waited on again
-- `kill <id>` - Terminate a background job
+For long-running commands (dev servers, builds):
+- `bg <command>` - start, returns job ID
+- `jobs` - list jobs
+- `output <id>` - accumulated output
+- `output <id> --new` - unread output only; poll while waiting for a log line
+- `wait <id> [timeout]` - wait for completion; timeout leaves the job running
+- `kill <id>` - terminate
 
-This prevents blocking on commands like `npm run dev` that run indefinitely.
+Avoids blocking on commands like `npm run dev` that run indefinitely.
 """.strip()
 
 instructions_format: dict[str, str] = {}

--- a/gptme/tools/shell_background.py
+++ b/gptme/tools/shell_background.py
@@ -10,6 +10,7 @@ import atexit
 import importlib
 import logging
 import os
+import re
 import subprocess
 import threading
 import time
@@ -45,6 +46,10 @@ class BackgroundJob:
     start_time: float
     stdout_buffer: list[str] = field(default_factory=list)
     stderr_buffer: list[str] = field(default_factory=list)
+    _stdout_buffer_start: int = field(default=0, repr=False)
+    _stderr_buffer_start: int = field(default=0, repr=False)
+    _stdout_read_offset: int = field(default=0, repr=False)
+    _stderr_read_offset: int = field(default=0, repr=False)
     _reader_thread: threading.Thread | None = field(default=None, repr=False)
     _stop_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _buffer_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -74,9 +79,13 @@ class BackgroundJob:
                         if data:
                             with self._buffer_lock:
                                 if fd == stdout_fd:
-                                    self._append_to_buffer(self.stdout_buffer, data)
+                                    self._stdout_buffer_start += self._append_to_buffer(
+                                        self.stdout_buffer, data
+                                    )
                                 else:
-                                    self._append_to_buffer(self.stderr_buffer, data)
+                                    self._stderr_buffer_start += self._append_to_buffer(
+                                        self.stderr_buffer, data
+                                    )
                     except BlockingIOError:
                         pass
                     except (OSError, ValueError):
@@ -92,9 +101,13 @@ class BackgroundJob:
                         if data:
                             with self._buffer_lock:
                                 if fd == stdout_fd:
-                                    self._append_to_buffer(self.stdout_buffer, data)
+                                    self._stdout_buffer_start += self._append_to_buffer(
+                                        self.stdout_buffer, data
+                                    )
                                 else:
-                                    self._append_to_buffer(self.stderr_buffer, data)
+                                    self._stderr_buffer_start += self._append_to_buffer(
+                                        self.stderr_buffer, data
+                                    )
                 except (OSError, ValueError):
                     break
 
@@ -104,7 +117,7 @@ class BackgroundJob:
                 remaining = self.process.stdout.read()
                 if remaining:
                     with self._buffer_lock:
-                        self._append_to_buffer(
+                        self._stdout_buffer_start += self._append_to_buffer(
                             self.stdout_buffer,
                             remaining.decode("utf-8", errors="replace"),
                         )
@@ -115,26 +128,40 @@ class BackgroundJob:
                 remaining = self.process.stderr.read()
                 if remaining:
                     with self._buffer_lock:
-                        self._append_to_buffer(
+                        self._stderr_buffer_start += self._append_to_buffer(
                             self.stderr_buffer,
                             remaining.decode("utf-8", errors="replace"),
                         )
             except (OSError, ValueError):
                 pass
 
-    def _append_to_buffer(self, buffer: list[str], data: str) -> None:
+    def _append_to_buffer(self, buffer: list[str], data: str) -> int:
         """Append data to buffer, enforcing size limit."""
         buffer.append(data)
         # Check total size and truncate from front if needed
         total_size = sum(len(s) for s in buffer)
+        removed_size = 0
         while total_size > _MAX_BUFFER_SIZE and len(buffer) > 1:
             removed = buffer.pop(0)
             total_size -= len(removed)
+            removed_size += len(removed)
+        return removed_size
 
-    def get_output(self) -> tuple[str, str]:
-        """Get accumulated stdout and stderr."""
+    def get_output(self, *, incremental: bool = False) -> tuple[str, str]:
+        """Get accumulated stdout and stderr, optionally since the last read."""
         with self._buffer_lock:
-            return "".join(self.stdout_buffer), "".join(self.stderr_buffer)
+            stdout = "".join(self.stdout_buffer)
+            stderr = "".join(self.stderr_buffer)
+            if not incremental:
+                return stdout, stderr
+
+            stdout_start = max(self._stdout_read_offset - self._stdout_buffer_start, 0)
+            stderr_start = max(self._stderr_read_offset - self._stderr_buffer_start, 0)
+            new_stdout = stdout[stdout_start:]
+            new_stderr = stderr[stderr_start:]
+            self._stdout_read_offset = self._stdout_buffer_start + len(stdout)
+            self._stderr_read_offset = self._stderr_buffer_start + len(stderr)
+            return new_stdout, new_stderr
 
     def is_running(self) -> bool:
         """Check if process is still running."""
@@ -278,6 +305,7 @@ def execute_bg_command(
         f"Use these commands to manage it:\n"
         f"- `jobs` - List all background jobs\n"
         f"- `output {job.id}` - Show output from job #{job.id}\n"
+        f"- `wait {job.id}` - Wait for job #{job.id} to finish\n"
         f"- `kill {job.id}` - Terminate job #{job.id}",
     )
 
@@ -306,8 +334,16 @@ def execute_jobs_command() -> Generator[Message, None, None]:
 
 def execute_output_command(job_id_str: str) -> Generator[Message, None, None]:
     """Show output from a background job."""
+    parts = job_id_str.split()
+    incremental = False
+    if len(parts) == 2 and parts[1] == "--new":
+        incremental = True
+    elif len(parts) != 1:
+        yield Message("system", "Usage: `output <job-id> [--new]`")
+        return
+
     try:
-        job_id = int(job_id_str)
+        job_id = int(parts[0])
     except ValueError:
         yield Message(
             "system", f"Invalid job ID: `{job_id_str}`. Use `jobs` to list active jobs."
@@ -321,7 +357,7 @@ def execute_output_command(job_id_str: str) -> Generator[Message, None, None]:
         )
         return
 
-    stdout, stderr = job.get_output()
+    stdout, stderr = job.get_output(incremental=incremental)
     status = (
         "Running"
         if job.is_running()
@@ -346,9 +382,56 @@ def execute_output_command(job_id_str: str) -> Generator[Message, None, None]:
         else:
             msg += md_codeblock("stderr", stderr) + "\n\n"
     if not stdout and not stderr:
-        msg += "No output yet.\n"
+        msg += "No new output.\n" if incremental else "No output yet.\n"
 
     yield Message("system", msg)
+
+
+def execute_wait_command(
+    job_id_str: str, timeout_str: str | None = None
+) -> Generator[Message, None, None]:
+    """Wait for a background job to finish, up to an optional timeout."""
+    try:
+        job_id = int(job_id_str)
+    except ValueError:
+        yield Message(
+            "system", f"Invalid job ID: `{job_id_str}`. Use `jobs` to list active jobs."
+        )
+        return
+
+    timeout: float | None = None
+    if timeout_str is not None:
+        match = re.fullmatch(r"(\d+(?:\.\d+)?)([smh]?)", timeout_str.lower())
+        if not match:
+            yield Message(
+                "system",
+                "Invalid timeout. Use seconds or a suffix such as `30s`, `2m`, or `1h`.",
+            )
+            return
+        value = float(match.group(1))
+        multiplier = {"": 1, "s": 1, "m": 60, "h": 3600}[match.group(2)]
+        timeout = value * multiplier
+
+    job = get_background_job(job_id)
+    if not job:
+        yield Message(
+            "system", f"No job with ID #{job_id}. Use `jobs` to list active jobs."
+        )
+        return
+
+    try:
+        job.process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        yield Message(
+            "system",
+            f"Job #{job_id} is still running after {timeout_str}. "
+            f"Use `wait {job_id}` to keep waiting or `output {job_id} --new` to poll output.",
+        )
+        return
+
+    if job._reader_thread and job._reader_thread.is_alive():
+        job._reader_thread.join(timeout=1.0)
+    yield from execute_output_command(str(job_id))
 
 
 def execute_kill_command(job_id_str: str) -> Generator[Message, None, None]:

--- a/gptme/tools/shell_background.py
+++ b/gptme/tools/shell_background.py
@@ -167,6 +167,10 @@ class BackgroundJob:
         """Check if process is still running."""
         return self.process.poll() is None
 
+    def is_output_complete(self) -> bool:
+        """Check whether the reader has drained all inherited output pipes."""
+        return self._reader_thread is None or not self._reader_thread.is_alive()
+
     def elapsed_time(self) -> float:
         """Get elapsed time in seconds."""
         return time.time() - self.start_time
@@ -255,7 +259,9 @@ def cleanup_finished_jobs() -> None:
     """Remove finished jobs from tracking (thread-safe)."""
     with _job_lock:
         finished = [
-            job_id for job_id, job in _background_jobs.items() if not job.is_running()
+            job_id
+            for job_id, job in _background_jobs.items()
+            if not job.is_running() and job.is_output_complete()
         ]
         for job_id in finished:
             del _background_jobs[job_id]
@@ -358,15 +364,24 @@ def execute_output_command(job_id_str: str) -> Generator[Message, None, None]:
         return
 
     stdout, stderr = job.get_output(incremental=incremental)
-    status = (
-        "Running"
-        if job.is_running()
-        else f"Finished (exit code: {job.process.returncode})"
-    )
+    if job.is_running():
+        status = "Running"
+    elif not job.is_output_complete():
+        status = (
+            f"Finished (exit code: {job.process.returncode}; output still draining)"
+        )
+    else:
+        status = f"Finished (exit code: {job.process.returncode})"
     elapsed = job.elapsed_time()
 
     msg = f"**Job #{job_id}** - {status} ({elapsed:.1f}s)\n"
     msg += f"Command: `{job.command}`\n\n"
+    if not job.is_running() and not job.is_output_complete():
+        msg += (
+            "The command exited, but a descendant still holds an output pipe. "
+            f"Use `wait {job_id}` again or `output {job_id} --new` to collect "
+            "the remaining output.\n\n"
+        )
 
     if stdout:
         # Truncate if too long

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -135,7 +135,10 @@ def test_redirect_background_stdin_before_ampersand():
 
     assert _redirect_background_stdin("sleep 1 &") == "sleep 1 < /dev/null &"
     assert _redirect_background_stdin("sleep 1 & echo done") == (
-        "sleep 1 < /dev/null & echo done"
+        "sleep 1 < /dev/null & echo done < /dev/null"
+    )
+    assert _redirect_background_stdin("sleep 1 & cat") == (
+        "sleep 1 < /dev/null & cat < /dev/null"
     )
     assert _redirect_background_stdin("echo '&' && echo ok") == "echo '&' && echo ok"
     assert _redirect_background_stdin("echo ok 2>&1") == "echo ok 2>&1"

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -130,6 +130,21 @@ multiline command"
     assert len(commands) == 1
 
 
+def test_redirect_background_stdin_before_ampersand():
+    from gptme.tools.shell import _redirect_background_stdin
+
+    assert _redirect_background_stdin("sleep 1 &") == "sleep 1 < /dev/null &"
+    assert _redirect_background_stdin("sleep 1 & echo done") == (
+        "sleep 1 < /dev/null & echo done"
+    )
+    assert _redirect_background_stdin("echo '&' && echo ok") == "echo '&' && echo ok"
+    assert _redirect_background_stdin("echo ok 2>&1") == "echo ok 2>&1"
+    assert _redirect_background_stdin("echo ok &> output") == "echo ok &> output"
+    assert _redirect_background_stdin("cat <<'EOF'\na & b\nEOF") == (
+        "cat <<'EOF'\na & b\nEOF"
+    )
+
+
 def test_heredoc_complex(shell):
     # Test nested heredocs
     ret, out, err = shell.run(
@@ -1747,6 +1762,20 @@ def test_bg_command_executes_remaining_commands():
 
     execute.assert_called_once()
     assert execute.call_args.args[0] == "printf remaining"
+
+
+def test_wait_command_dispatches_timeout():
+    """The shell control command passes job ID and timeout to the wait handler."""
+    from unittest.mock import patch
+
+    from gptme.tools.shell import execute_shell
+
+    with patch(
+        "gptme.tools.shell.execute_wait_command", return_value=iter([])
+    ) as execute_wait:
+        list(execute_shell("wait 7 2m", [], None))
+
+    execute_wait.assert_called_once_with("7", "2m")
 
 
 def test_execute_bg_command():

--- a/tests/test_tools_shell_background.py
+++ b/tests/test_tools_shell_background.py
@@ -27,6 +27,7 @@ from gptme.tools.shell_background import (
     execute_jobs_command,
     execute_kill_command,
     execute_output_command,
+    execute_wait_command,
     get_background_job,
     list_background_jobs,
     reset_background_jobs,
@@ -104,6 +105,16 @@ class TestBackgroundJobOutput:
         stdout, stderr = job.get_output()
         assert stdout == "hello world"
         assert stderr == "warn"
+
+    def test_get_output_incrementally(self):
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.poll.return_value = None
+        job = BackgroundJob(id=1, command="echo hi", process=proc, start_time=0)
+        job.stdout_buffer = ["first"]
+        assert job.get_output(incremental=True) == ("first", "")
+        job.stdout_buffer.append(" second")
+        assert job.get_output(incremental=True) == (" second", "")
+        assert job.get_output(incremental=True) == ("", "")
 
     def test_append_to_buffer_within_limit(self):
         proc = MagicMock(spec=subprocess.Popen)
@@ -487,6 +498,19 @@ class TestExecuteOutputCommand:
         assert "No output yet" in msgs[0].content
         job.kill()
 
+    def test_shows_only_new_output(self):
+        job = start_background_job("sleep 10")
+        with job._buffer_lock:
+            job.stdout_buffer = ["first"]
+        first = _collect(execute_output_command(f"{job.id} --new"))[0].content
+        with job._buffer_lock:
+            job.stdout_buffer.append(" second")
+        second = _collect(execute_output_command(f"{job.id} --new"))[0].content
+        assert "first" in first
+        assert "first" not in second
+        assert "second" in second
+        job.kill()
+
     def test_truncates_long_stdout(self):
         job = start_background_job("echo hello_from_bg")
         job.process.wait(timeout=5)
@@ -508,6 +532,29 @@ class TestExecuteOutputCommand:
         msgs = _collect(execute_output_command(str(job.id)))
         content = msgs[0].content
         assert "truncated" in content
+
+
+class TestExecuteWaitCommand:
+    """Test execute_wait_command."""
+
+    def test_waits_for_job_and_returns_output(self):
+        job = start_background_job("sleep 0.1 && echo done")
+        content = _collect(execute_wait_command(str(job.id), "2s"))[0].content
+        assert "Finished" in content
+        assert "done" in content
+
+    def test_timeout_leaves_job_running(self):
+        job = start_background_job("sleep 10")
+        content = _collect(execute_wait_command(str(job.id), "0.01s"))[0].content
+        assert "still running" in content
+        assert job.is_running()
+        job.kill()
+
+    def test_rejects_invalid_timeout(self):
+        job = start_background_job("sleep 10")
+        content = _collect(execute_wait_command(str(job.id), "later"))[0].content
+        assert "Invalid timeout" in content
+        job.kill()
 
 
 class TestExecuteKillCommand:

--- a/tests/test_tools_shell_background.py
+++ b/tests/test_tools_shell_background.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gptme.tools import shell_background
 from gptme.tools.shell_background import (
     _MAX_BUFFER_SIZE,
     BackgroundJob,
@@ -346,6 +347,19 @@ class TestCleanupFinishedJobs:
         assert get_background_job(job.id) is not None
         job.kill()
 
+    def test_keeps_finished_job_while_output_is_draining(self):
+        process = MagicMock(spec=subprocess.Popen)
+        process.poll.return_value = 0
+        job = BackgroundJob(id=1, command="true", process=process, start_time=0)
+        reader = MagicMock(spec=threading.Thread)
+        reader.is_alive.return_value = True
+        job._reader_thread = reader
+        shell_background._background_jobs[job.id] = job
+
+        cleanup_finished_jobs()
+
+        assert get_background_job(job.id) is job
+
 
 class TestResetBackgroundJobs:
     """Test reset_background_jobs."""
@@ -555,6 +569,23 @@ class TestExecuteWaitCommand:
         content = _collect(execute_wait_command(str(job.id), "later"))[0].content
         assert "Invalid timeout" in content
         job.kill()
+
+    def test_reports_when_finished_job_output_is_still_draining(self):
+        process = MagicMock(spec=subprocess.Popen)
+        process.poll.return_value = 0
+        process.returncode = 0
+        job = BackgroundJob(id=1, command="true", process=process, start_time=0)
+        reader = MagicMock(spec=threading.Thread)
+        reader.is_alive.return_value = True
+        job._reader_thread = reader
+        shell_background._background_jobs[job.id] = job
+
+        content = _collect(execute_wait_command(str(job.id), "2s"))[0].content
+
+        reader.join.assert_called_once_with(timeout=1.0)
+        assert "output still draining" in content
+        assert f"wait {job.id}" in content
+        assert f"output {job.id} --new" in content
 
 
 class TestExecuteKillCommand:


### PR DESCRIPTION
Closes #3667.

## Summary

- place the shell's `/dev/null` redirect before parsed background `&` operators so background processes cannot consume later commands sent to the persistent shell
- redirect a trailing foreground command in a compound asynchronous list as well, so commands such as `sleep 1 & cat` cannot retain the persistent shell's stdin
- add `wait <job-id> [timeout]` with seconds, minutes, and hours suffix support
- add `output <job-id> --new` for incremental polling without discarding accumulated output
- keep finished jobs available until their output reader has drained inherited pipes, and report when output is still draining
- document the new background-job controls in the shell tool prompt

## Testing

- `ruff format` and `ruff check` on the four changed files
- focused pytest cases covering ampersand parsing, wait dispatch/timeouts, incremental output, and output-reader draining
- 70 background-job tests passed on Windows; 2 platform-specific cases were deselected (`getpgid` is unavailable and the local WSL bash bridge does not preserve the loop variable)

`mypy` reports 12 existing Windows-only errors for POSIX `os.getpgid`, `os.killpg`, and `signal.SIGKILL` references; the changed code introduces no additional mypy errors.
