### PR TITLE
fix(security): route git subprocesses through GIT_CMD in review-pr and 3-way merge

### DIFF
--- a/gptme/cli/cmd_review_pr.py
+++ b/gptme/cli/cmd_review_pr.py
@@ -79,6 +79,7 @@ import click
 
 from ..tools._allowlist import READ_ONLY_TOOL_PRESET
 from ..util.gh import infer_owner_repo, run_gh_json
+from ..util.git_cmd import GIT_CMD
 from ..util.review import (
     FindingSeverity,
     FindingStatus,
@@ -481,7 +482,7 @@ def _git_output(args: list[str]) -> str | None:
     """Run a read-only git command in the working directory; None on failure."""
     try:
         result = subprocess.run(
-            ["git", *args],
+            [GIT_CMD, *args],
             capture_output=True,
             text=True,
             timeout=15,
@@ -623,7 +624,7 @@ def _materialize_review_tree(cwd: str) -> tempfile.TemporaryDirectory[str]:
     export = tempfile.TemporaryDirectory(prefix="gptme-review-")
     try:
         archive = subprocess.run(
-            ["git", "archive", "--format=tar", "HEAD"],
+            [GIT_CMD, "archive", "--format=tar", "HEAD"],
             cwd=cwd,
             capture_output=True,
             check=False,

--- a/gptme/tools/hashline_edit.py
+++ b/gptme/tools/hashline_edit.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ..message import Message
+from ..util.git_cmd import GIT_CMD
 from ._hashline_snapshot import lookup_snapshot, store_snapshot
 from .base import Parameter, ToolSpec, ToolUse
 
@@ -735,7 +736,7 @@ def _try_3way_merge(
         # count.  Codes > 127 (e.g. 128/255) indicate git operational errors.
         result = subprocess.run(
             [
-                "git",
+                GIT_CMD,
                 "merge-file",
                 "-p",
                 "-L",

--- a/tests/test_tools_hashline_edit.py
+++ b/tests/test_tools_hashline_edit.py
@@ -1173,6 +1173,36 @@ class TestMergeRecovery:
 
         assert new_tag == compute_tag(new_content)
 
+    def test_merge_invokes_git_via_resolved_path(self, tmp_path: Path):
+        """merge-file must run git through GIT_CMD, not a bare "git" that
+        CreateProcess would resolve against the (workspace) CWD on Windows.
+        """
+        import subprocess
+        from unittest.mock import patch
+
+        from gptme.util.git_cmd import GIT_CMD
+
+        f = tmp_path / "f.txt"
+        original = "alpha\nbeta\n"
+        f.write_text(original)
+        tag = store_snapshot(str(f.resolve()), original)
+        f.write_text("alpha\nbeta\nextra\n")
+        block = f"[{f.resolve()}#{tag}]\nPUT 1.=1:\n+ALPHA\n"
+
+        real_run = subprocess.run
+        seen = []
+
+        def spy(cmd, *args, **kwargs):
+            seen.append(cmd)
+            return real_run(cmd, *args, **kwargs)
+
+        with patch("subprocess.run", side_effect=spy):
+            _msgs(execute_hashline_edit(block, [str(f)], None))
+
+        merge_cmds = [c for c in seen if len(c) > 1 and c[1] == "merge-file"]
+        assert merge_cmds, seen
+        assert merge_cmds[0][0] == GIT_CMD
+
     def test_operational_merge_failure_high_exit_code(self, tmp_path: Path):
         """git merge-file returning exit > 127 is reported as an operational error."""
         from subprocess import CompletedProcess

--- a/tests/test_util_review.py
+++ b/tests/test_util_review.py
@@ -2366,12 +2366,13 @@ def test_materialize_review_tree_excludes_untracked_files_and_git_metadata(
 
 def test_materialize_review_tree_captures_archive_before_extracting(monkeypatch):
     from gptme.cli import cmd_review_pr
+    from gptme.util.git_cmd import GIT_CMD
 
     calls = []
 
     def fake_run(args, **kwargs):
         calls.append((args, kwargs))
-        if args[:2] == ["git", "archive"]:
+        if args[:2] == [GIT_CMD, "archive"]:
             assert kwargs["capture_output"] is True
             return subprocess.CompletedProcess(args, 0, stdout=b"archive", stderr=b"")
         assert args[:2] == ["tar", "-xf"]


### PR DESCRIPTION
Follow-up to #3267.

## Problem

#3267 ("extend GIT_CMD hardening to **all** remaining bare git subprocess call
sites") replaced every `["git", ...]` subprocess with `[GIT_CMD, ...]`, where
`GIT_CMD` is an absolute path resolved with the process CWD stripped from the
search path. The point is Windows `CreateProcess`, which resolves a bare `git`
against the current directory before PATH — so a `git.exe` / `git.bat` sitting
in the working directory gets run instead of the real git.

Three git call sites added **after** that audit reintroduced the bare-`"git"`
pattern:

| Site | Added | Context |
|---|---|---|
| `gptme/tools/hashline_edit.py` — `git merge-file` | #3520 (Aug 12) | 3-way merge recovery; runs with the process CWD, which for CLI sessions is the workspace |
| `gptme/cli/cmd_review_pr.py` — `_git_output()` helper | #3512 (Aug 10) | review provenance checks |
| `gptme/cli/cmd_review_pr.py` — `git archive` in `_materialize_review_tree()` | #3512 | runs against a checkout of **attacker-authored PR content** by design (see that function's docstring) |

The `review-pr` `git archive` case is the sharpest: the reviewer is explicitly
built to handle hostile PR content, and a PR can commit a `git.bat` to the repo
root.

## Fix

Route all three through `GIT_CMD`, exactly as #3267 did for the sites it covered.
No behaviour change on POSIX (`GIT_CMD` is just `shutil.which("git")` there).

`gh` invocations in `cmd_review_pr.py` have the same CWD-hijack shape but there
is no `GH_CMD` equivalent yet — left out of scope.

## Tests

- New `test_merge_invokes_git_via_resolved_path` — asserts `merge-file` is
  invoked with `GIT_CMD` as argv[0].
- `test_materialize_review_tree_captures_archive_before_extracting` updated to
  assert `GIT_CMD` (mirrors the assertion updates #3267 made in
  `test_tools_autocommit.py`).
- Full `test_tools_hashline_edit.py` + `test_util_review.py` pass (283 tests).
