### PR TITLE
fix(server): return 400, not 500, for non-dict JSON bodies on tools QUERY and steer

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1194,7 +1194,12 @@ def api_steer_external_session(external_session_id: str):
         body = {}
     elif not isinstance(body, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
-    message = (body.get("message") or "").strip()
+    raw_message = body.get("message")
+    if raw_message is None:
+        return flask.jsonify({"error": "message is required"}), 400
+    if not isinstance(raw_message, str):
+        return flask.jsonify({"error": "message must be a string"}), 400
+    message = raw_message.strip()
     if not message:
         return flask.jsonify({"error": "message is required"}), 400
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1190,6 +1190,8 @@ def api_steer_external_session(external_session_id: str):
     steer implementation (gptme-sessions steer) is not available.
     """
     body = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object"}), 400
     message = (body.get("message") or "").strip()
     if not message:
         return flask.jsonify({"error": "message is required"}), 400

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1189,8 +1189,10 @@ def api_steer_external_session(external_session_id: str):
     Returns 422 if the session does not support steering, 501 if the server-side
     steer implementation (gptme-sessions steer) is not available.
     """
-    body = request.get_json(silent=True) or {}
-    if not isinstance(body, dict):
+    body = request.get_json(silent=True)
+    if body is None:
+        body = {}
+    elif not isinstance(body, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
     message = (body.get("message") or "").strip()
     if not message:

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -325,8 +325,10 @@ def query_tools():
           "fields": ["name", "block_types"]
         }
     """
-    body = flask.request.get_json(silent=True) or {}
-    if not isinstance(body, dict):
+    body = flask.request.get_json(silent=True)
+    if body is None:
+        body = {}
+    elif not isinstance(body, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
     try:
         query = ToolQueryRequest(**body)

--- a/gptme/server/tools_api.py
+++ b/gptme/server/tools_api.py
@@ -326,6 +326,8 @@ def query_tools():
         }
     """
     body = flask.request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object"}), 400
     try:
         query = ToolQueryRequest(**body)
     except ValidationError as e:

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -255,13 +255,18 @@ def test_query_invalid_regex_pattern_returns_400(client: FlaskClient):
     assert "Invalid regex" in data["error"]
 
 
-@pytest.mark.parametrize("body", [[1, 2, 3], "just-a-string", 42, True])
+@pytest.mark.parametrize(
+    "body",
+    [[1, 2, 3], [], "just-a-string", "", 42, 0, True, False],
+)
 def test_query_non_dict_body_returns_400(client: FlaskClient, body):
-    """A non-dict JSON body (list/str/int/bool) must 400, not 500.
+    """A non-dict JSON body must 400, not 500.
 
     Regression: ``ToolQueryRequest(**body)`` raised ``TypeError`` on a
     non-mapping body, which escaped the ``ValidationError`` handler and
-    surfaced as a Flask 500.
+    surfaced as a Flask 500. A follow-up (``or {}`` before the type
+    check) also let falsy non-dicts (``[]``, ``""``, ``0``, ``false``)
+    through as an empty object.
     """
     resp = client.open(
         "/api/v2/tools",

--- a/tests/test_server_tools_query.py
+++ b/tests/test_server_tools_query.py
@@ -253,3 +253,23 @@ def test_query_invalid_regex_pattern_returns_400(client: FlaskClient):
     data = resp.get_json()
     assert "error" in data
     assert "Invalid regex" in data["error"]
+
+
+@pytest.mark.parametrize("body", [[1, 2, 3], "just-a-string", 42, True])
+def test_query_non_dict_body_returns_400(client: FlaskClient, body):
+    """A non-dict JSON body (list/str/int/bool) must 400, not 500.
+
+    Regression: ``ToolQueryRequest(**body)`` raised ``TypeError`` on a
+    non-mapping body, which escaped the ``ValidationError`` handler and
+    surfaced as a Flask 500.
+    """
+    resp = client.open(
+        "/api/v2/tools",
+        method="QUERY",
+        content_type="application/json",
+        data=json.dumps(body),
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert data["error"] == "Request body must be a JSON object"

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1264,6 +1264,28 @@ def test_v2_steer_external_session_non_dict_body_returns_400(client: FlaskClient
     assert data["error"] == "Request body must be a JSON object"
 
 
+@pytest.mark.parametrize(
+    "message",
+    [123, True, [1, 2], {"nested": "obj"}],
+)
+def test_v2_steer_external_session_non_string_message_returns_400(
+    client: FlaskClient, message
+):
+    """A dict body with a non-string message must 400, not 500.
+
+    Regression: after the non-dict guard, ``(body.get("message") or "").strip()``
+    still raised ``AttributeError`` on truthy non-strings (int/bool/list/dict).
+    """
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        json={"message": message},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert data["error"] == "message must be a string"
+
+
 def test_v2_steer_external_session_not_found(
     client: FlaskClient, fake_steerable_provider
 ):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1241,12 +1241,17 @@ def test_v2_steer_external_session_missing_message(
     assert response2.status_code == 400
 
 
-@pytest.mark.parametrize("body", [[1, 2, 3], "just-a-string", 42, True])
+@pytest.mark.parametrize(
+    "body",
+    [[1, 2, 3], [], "just-a-string", "", 42, 0, True, False],
+)
 def test_v2_steer_external_session_non_dict_body_returns_400(client: FlaskClient, body):
     """A non-dict JSON body must 400, not 500.
 
     Regression: ``body.get("message")`` raised ``AttributeError`` on a
-    non-mapping body, which surfaced as a Flask 500.
+    non-mapping body, which surfaced as a Flask 500. A follow-up
+    (``or {}`` before the type check) also let falsy non-dicts
+    (``[]``, ``""``, ``0``, ``false``) through as an empty object.
     """
     response = client.post(
         "/api/v2/external-sessions/abc123/steer",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1241,6 +1241,24 @@ def test_v2_steer_external_session_missing_message(
     assert response2.status_code == 400
 
 
+@pytest.mark.parametrize("body", [[1, 2, 3], "just-a-string", 42, True])
+def test_v2_steer_external_session_non_dict_body_returns_400(client: FlaskClient, body):
+    """A non-dict JSON body must 400, not 500.
+
+    Regression: ``body.get("message")`` raised ``AttributeError`` on a
+    non-mapping body, which surfaced as a Flask 500.
+    """
+    response = client.post(
+        "/api/v2/external-sessions/abc123/steer",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert data["error"] == "Request body must be a JSON object"
+
+
 def test_v2_steer_external_session_not_found(
     client: FlaskClient, fake_steerable_provider
 ):


### PR DESCRIPTION
## Problem

Two server v2 endpoints 500 (Flask default error page) instead of returning a clean 400 when the request body is a JSON value that is not an object:

- `QUERY /api/v2/tools`
- `POST /api/v2/external-sessions/<id>/steer`

Both did `body = request.get_json(silent=True) or {}` and then used the result as a mapping (`ToolQueryRequest(**body)` / `body.get("message")`). A truthy non-dict body — list, string, number, or `true` — escapes the `ValidationError` handler as a `TypeError`/`AttributeError` and surfaces as a **500**.

Repro (live server, any of these):

```
QUERY /api/v2/tools
[1,2,3]          # -> 500  (was)  / 400 (now)

POST /api/v2/external-sessions/<id>/steer
"str"          # -> 500  (was)  / 400 (now)
```

`null` and no-body already behaved (falsy -> `{}`), which is why this only bites on truthy non-objects.

## Fix

Guard with an `isinstance(body, dict)` check that returns a clean 400, matching the pattern the `tasks` and `favorites` endpoints already use ("Request body must be a JSON object" / "JSON body must be an object").

## Tests

- `tests/test_server_tools_query.py::test_query_non_dict_body_returns_400` (parametrized over list/str/int/bool)
- `tests/test_server_v2.py::test_v2_steer_external_session_non_dict_body_returns_400` (same)

Full suites green: `test_server_tools_query.py`, `test_server_bad_input.py`, `test_server_fresh_bad_input.py` (57 passed) and `test_server_v2.py` (240 passed, 5 skipped). ruff + pre-commit clean; mypy clean on both changed files (remaining mypy notes are pre-existing in transitive imports).

Found by dogfooding the server API surface with edge inputs.