### PR TITLE
fix(convert): handle non-UTF-8 converter stderr without crashing

### DIFF
--- a/gptme/tools/convert.py
+++ b/gptme/tools/convert.py
@@ -308,7 +308,9 @@ class PDFToImageConverter(Converter):
                             lossy=dest_ext in ("jpg", "jpeg"),
                         )
                 # tmpdir cleanup handles any partial page files automatically
-            logger.warning("pdftoppm failed: %s", result.stderr.decode())
+            logger.warning(
+                "pdftoppm failed: %s", result.stderr.decode(errors="replace")
+            )
             warnings.append("pdftoppm failed; falling back to ImageMagick")
 
         if avail.imagemagick:
@@ -334,7 +336,7 @@ class PDFToImageConverter(Converter):
                 success=False,
                 output_path=None,
                 converter_used="imagemagick",
-                error=result.stderr.decode()[:300],
+                error=result.stderr.decode(errors="replace")[:300],
                 warnings=warnings,
             )
 
@@ -418,7 +420,8 @@ class ImageConverter(Converter):
                     lossy=lossy,
                 )
             logger.warning(
-                "ffmpeg image convert failed: %s", result.stderr.decode()[-200:]
+                "ffmpeg image convert failed: %s",
+                result.stderr.decode(errors="replace")[-200:],
             )
 
         if avail.imagemagick:
@@ -438,7 +441,7 @@ class ImageConverter(Converter):
                 success=False,
                 output_path=None,
                 converter_used="imagemagick",
-                error=result.stderr.decode()[:300],
+                error=result.stderr.decode(errors="replace")[:300],
             )
 
         return ConversionResult(
@@ -523,7 +526,7 @@ class PDFToTextConverter(Converter):
                 success=False,
                 output_path=None,
                 converter_used="pdftotext",
-                error=result.stderr.decode()[:300],
+                error=result.stderr.decode(errors="replace")[:300],
                 warnings=warnings,
             )
 
@@ -638,7 +641,9 @@ class DocumentToTextConverter(Converter):
                             converter_used="libreoffice",
                             warnings=warnings,
                         )
-                warnings.append(f"libreoffice failed: {result.stderr.decode()[:200]}")
+                warnings.append(
+                    f"libreoffice failed: {result.stderr.decode(errors='replace')[:200]}"
+                )
 
         if (
             avail.python_docx
@@ -726,7 +731,7 @@ class VideoThumbnailConverter(Converter):
             success=False,
             output_path=None,
             converter_used="ffmpeg",
-            error=result.stderr.decode()[-300:],
+            error=result.stderr.decode(errors="replace")[-300:],
         )
 
 

--- a/tests/test_tools_convert.py
+++ b/tests/test_tools_convert.py
@@ -306,6 +306,40 @@ class TestPDFToImageConverter:
         assert result.error is not None
         assert "directory" in result.error.lower()
 
+    def test_non_utf8_stderr_does_not_raise(self, avail_all, tmp_path):
+        """Converter subprocess stderr with non-UTF-8 bytes must not raise UnicodeDecodeError.
+
+        Regression: a malformed PDF made the ImageMagick fallback call
+        ``result.stderr.decode()`` (strict), which crashed with an uncaught
+        ``UnicodeDecodeError`` traceback when the converter emitted a byte that
+        is not valid UTF-8. Every ``.decode()`` on converter output now uses
+        ``errors="replace"`` so the failure surfaces as a clean ConversionResult
+        instead of a raw traceback.
+        """
+        src = tmp_path / "doc.pdf"
+        src.write_bytes(b"%PDF-1.4 garbage")
+        dest = tmp_path / "out.png"
+
+        def fake_run(cmd, **kwargs):
+            if "pdftoppm" in cmd:
+                # Non-UTF-8 byte in stderr, matching real poppler output on
+                # malformed input (e.g. a stray 0xf7).
+                return MagicMock(returncode=1, stderr=b"\xf7\xf7 invalid")
+            # ImageMagick fallback: also non-UTF-8 stderr on failure
+            return MagicMock(returncode=1, stderr=b"convert: \xf7\xf7 error")
+
+        with (
+            patch("gptme.tools.convert.get_availability", return_value=avail_all),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = self.conv.convert(src, dest)
+
+        assert not result.success
+        assert result.converter_used == "imagemagick"
+        # Error decodes with replacement chars, no UnicodeDecodeError raised
+        assert result.error is not None
+        assert "\ufffd" in result.error
+
 
 # ---------------------------------------------------------------------------
 # ImageConverter


### PR DESCRIPTION
## Problem

Seven `.decode()` calls on converter subprocess stderr used strict UTF-8. When a converter (pdftoppm/ImageMagick/ffmpeg/pdftotext/libreoffice) emitted a non-UTF-8 byte on a failed conversion — reproduced with a malformed PDF — the CLI crashed with an uncaught `UnicodeDecodeError` traceback instead of returning a clean error.

Reproduce (HEAD f4d71ca6a, before fix):
```bash
head -c 500 /dev/urandom > /tmp/fake.pdf
gptme-convert convert -i /tmp/fake.pdf -o /tmp/out.png
# → UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf7 ...
```

## Fix

Decode all converter stderr with `errors=\"replace\"` (7 call sites) so non-UTF-8 output degrades gracefully. The conversion still fails, but with a clean `Conversion failed (imagemagick): …` result and exit code 1 — no traceback.

## Verification

- Added regression test `test_non_utf8_stderr_does_not_raise` asserting the ImageMagick fallback path survives non-UTF-8 stderr and surfaces `�` replacement chars.
- `pytest tests/test_tools_convert.py`: 82 passed.
- `ruff check` + `ruff format --check`: clean.
- No new mypy errors (the 2 pre-existing missing-stub errors on optional `docx`/`magic` modules are unrelated).

## Notes

Found via dogfooding the new `gptme-convert` CLI surface with malformed input (gptme/gptme#3658/#3595).