### PR TITLE
feat(knowledge): inject matching KB entries at session start

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -1177,6 +1177,17 @@ class GptmeAgent:
                 # ACP has no outer gptme loop, so reproduce that behavior here.
                 response_msgs: list[Message] = []
                 step_log = list(log.log)
+                # Same boundary as the CLI chat loop: TURN_PRE after the user
+                # prompt is in the log, before the first generation step.
+                if turn_msgs := list(trigger_hook(HookType.TURN_PRE, manager=log)):
+                    for msg in turn_msgs:
+                        step_log.append(msg)
+                        if getattr(msg, "hide", False):
+                            # Persist hidden context for the model; do not
+                            # forward it as visible ACP agent text.
+                            log.append(msg)
+                        else:
+                            response_msgs.append(msg)
                 max_steps: int | None = None
                 max_steps_str = os.environ.get("GPTME_MAX_STEPS")
                 if max_steps_str:

--- a/gptme/hooks/__init__.py
+++ b/gptme/hooks/__init__.py
@@ -189,6 +189,9 @@ def init_hooks(
         "mcp_namespace_hint": lambda: __import__(
             "gptme.hooks.mcp_namespace_hint", fromlist=["register"]
         ).register(),
+        "knowledge_inject": lambda: __import__(
+            "gptme.hooks.knowledge_inject", fromlist=["register"]
+        ).register(),
         # Tool confirmation hooks (mode-specific, not registered by default)
         "cli_confirm": lambda: __import__(
             "gptme.hooks.cli_confirm", fromlist=["register"]

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -38,10 +38,16 @@ def _messages_from_context(
     manager: Any,
 ) -> list[Message]:
     if manager is not None:
+        # LogManager.log is a Log with .messages. Also accept a Log passed as
+        # manager, or a plain list if a caller copied the log for a step.
         log = getattr(manager, "log", manager)
-        msgs = getattr(log, "messages", None)
-        if msgs:
-            return list(msgs)
+        if isinstance(log, list):
+            if log:
+                return list(log)
+        else:
+            msgs = getattr(log, "messages", None)
+            if msgs:
+                return list(msgs)
     return list(initial_msgs or [])
 
 

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -8,10 +8,11 @@ and schema generalization are separate follow-ons.
 CLI ``SESSION_START`` runs before the first user prompt is appended, so
 this hook also registers on ``TURN_PRE`` (after the prompt is in the log).
 ACP and TUI fire ``TURN_PRE`` on that same boundary. Injection is once per
-conversation: later turns no-op if a hidden system message already starts
-with this hook's sentinel. Coincidental ``<knowledge-entries>`` text — in
-user/assistant content or in unrelated hidden system messages — does not
-count.
+conversation: later turns no-op if a hidden system message already contains
+this hook's sentinel as a line prefix. Replay may wrap the persisted block
+with an evidence prefix; that still counts. Coincidental
+``<knowledge-entries>`` text — in user/assistant content or in unrelated
+hidden system messages — does not.
 """
 
 import logging
@@ -25,9 +26,10 @@ from ..message import Message
 
 logger = logging.getLogger(__name__)
 
-# Prefix of this hook's hidden system message. Dedup requires the content to
-# *start* with this sentinel so a quoted ``<knowledge-entries>`` tag in some
-# other hidden system message cannot suppress injection.
+# Prefix of this hook's hidden system message. Dedup requires this sentinel as
+# a line prefix so a quoted ``<knowledge-entries>`` tag cannot suppress
+# injection, while replay-wrapped copies (evidence prefix + original body)
+# still count as already injected.
 _INJECT_SENTINEL = "<!-- gptme-knowledge-inject -->"
 
 
@@ -53,10 +55,22 @@ def _query_from_msgs(msgs: list[Message]) -> str | None:
     return None
 
 
+def _content_has_inject_sentinel(content: str) -> bool:
+    """True if ``content`` is this hook's injection, including replay wraps.
+
+    Replay prepends ``[Evidence from earlier in this conversation (role)]\\n``,
+    so a startswith check on the raw content misses the persisted block. The
+    sentinel must be a line prefix after lstrip, not a mid-sentence substring.
+    """
+    return any(
+        line.lstrip().startswith(_INJECT_SENTINEL) for line in content.splitlines()
+    )
+
+
 def _already_injected(msgs: list[Message]) -> bool:
     """True only for this hook's own hidden system block.
 
-    Requires ``role=system``, ``hide=True``, and content that starts with
+    Requires ``role=system``, ``hide=True``, and a line that starts with
     ``_INJECT_SENTINEL``. Substring matches on ``<knowledge-entries>`` are
     not enough: replayed or unrelated hidden system messages can quote that
     tag without this hook having injected anything.
@@ -67,7 +81,7 @@ def _already_injected(msgs: list[Message]) -> bool:
         if not getattr(msg, "hide", False):
             continue
         content = getattr(msg, "content", None)
-        if isinstance(content, str) and content.lstrip().startswith(_INJECT_SENTINEL):
+        if isinstance(content, str) and _content_has_inject_sentinel(content):
             return True
     return False
 

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -8,9 +8,10 @@ and schema generalization are separate follow-ons.
 CLI ``SESSION_START`` runs before the first user prompt is appended, so
 this hook also registers on ``TURN_PRE`` (after the prompt is in the log).
 ACP and TUI fire ``TURN_PRE`` on that same boundary. Injection is once per
-conversation: later turns no-op if a hidden system message already carries
-the ``<knowledge-entries>`` block. Ordinary user/assistant text that happens
-to mention the marker does not count.
+conversation: later turns no-op if a hidden system message already starts
+with this hook's sentinel. Coincidental ``<knowledge-entries>`` text — in
+user/assistant content or in unrelated hidden system messages — does not
+count.
 """
 
 import logging
@@ -24,7 +25,10 @@ from ..message import Message
 
 logger = logging.getLogger(__name__)
 
-_KNOWLEDGE_MARK = "<knowledge-entries>"
+# Prefix of this hook's hidden system message. Dedup requires the content to
+# *start* with this sentinel so a quoted ``<knowledge-entries>`` tag in some
+# other hidden system message cannot suppress injection.
+_INJECT_SENTINEL = "<!-- gptme-knowledge-inject -->"
 
 
 def _messages_from_context(
@@ -50,14 +54,22 @@ def _query_from_msgs(msgs: list[Message]) -> str | None:
 
 
 def _already_injected(msgs: list[Message]) -> bool:
-    """True only for this hook's hidden system block, not coincidental text."""
-    return any(
-        getattr(msg, "role", None) == "system"
-        and getattr(msg, "hide", False)
-        and isinstance(getattr(msg, "content", None), str)
-        and _KNOWLEDGE_MARK in msg.content
-        for msg in msgs
-    )
+    """True only for this hook's own hidden system block.
+
+    Requires ``role=system``, ``hide=True``, and content that starts with
+    ``_INJECT_SENTINEL``. Substring matches on ``<knowledge-entries>`` are
+    not enough: replayed or unrelated hidden system messages can quote that
+    tag without this hook having injected anything.
+    """
+    for msg in msgs:
+        if getattr(msg, "role", None) != "system":
+            continue
+        if not getattr(msg, "hide", False):
+            continue
+        content = getattr(msg, "content", None)
+        if isinstance(content, str) and content.lstrip().startswith(_INJECT_SENTINEL):
+            return True
+    return False
 
 
 def inject_session_knowledge(
@@ -94,7 +106,7 @@ def inject_session_knowledge(
             logdir,
             workspace,
         )
-        yield Message("system", body, hide=True)
+        yield Message("system", f"{_INJECT_SENTINEL}\n{body}", hide=True)
     except Exception:
         logger.debug("knowledge session inject skipped", exc_info=True)
         return

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -4,6 +4,11 @@ Follow-on to gptme/gptme#3596 / #3622. Save/retrieve already landed; this
 hook is the session-start prompt injection slice. Uses the JSONL keyword
 search (same as ``gptme-util knowledge search``). gptme-rag-backed search
 and schema generalization are separate follow-ons.
+
+CLI ``SESSION_START`` runs before the first user prompt is appended, so
+this hook also registers on ``TURN_PRE`` (after the prompt is in the log).
+ACP and TUI fire ``TURN_PRE`` on that same boundary. Injection is once per
+conversation: later turns no-op if ``<knowledge-entries>`` is already present.
 """
 
 import logging
@@ -17,11 +22,23 @@ from ..message import Message
 
 logger = logging.getLogger(__name__)
 
+_KNOWLEDGE_MARK = "<knowledge-entries>"
 
-def _query_from_initial_msgs(initial_msgs: list[Message] | None) -> str | None:
-    if not initial_msgs:
-        return None
-    for msg in reversed(list(initial_msgs)):
+
+def _messages_from_context(
+    initial_msgs: list[Message] | None,
+    manager: Any,
+) -> list[Message]:
+    if manager is not None:
+        log = getattr(manager, "log", manager)
+        msgs = getattr(log, "messages", None)
+        if msgs:
+            return list(msgs)
+    return list(initial_msgs or [])
+
+
+def _query_from_msgs(msgs: list[Message]) -> str | None:
+    for msg in reversed(msgs):
         if getattr(msg, "role", None) != "user":
             continue
         content = getattr(msg, "content", None)
@@ -30,19 +47,36 @@ def _query_from_initial_msgs(initial_msgs: list[Message] | None) -> str | None:
     return None
 
 
+def _already_injected(msgs: list[Message]) -> bool:
+    return any(
+        isinstance(getattr(msg, "content", None), str)
+        and _KNOWLEDGE_MARK in msg.content
+        for msg in msgs
+    )
+
+
 def inject_session_knowledge(
-    logdir: Path,
-    workspace: Path | None,
+    logdir: Path | None = None,
+    workspace: Path | None = None,
     initial_msgs: list[Message] | None = None,
+    manager: Any = None,
     **kwargs: Any,
 ) -> Generator[Message | StopPropagation, None, None]:
     """Yield a hidden system message with matching personal KB entries.
 
     No-ops when the store is empty, the initial prompt is too short to
-    search, or nothing matches. Failures never block session start.
+    search, nothing matches, or this conversation already received a
+    knowledge block. Failures never block session start.
     """
     try:
-        query = _query_from_initial_msgs(initial_msgs)
+        if manager is not None:
+            logdir = logdir or getattr(manager, "logdir", None)
+            if workspace is None:
+                workspace = getattr(manager, "workspace", None)
+        msgs = _messages_from_context(initial_msgs, manager)
+        if _already_injected(msgs):
+            return
+        query = _query_from_msgs(msgs)
         entries = select_knowledge_for_session(query)
         if not entries:
             return
@@ -65,6 +99,13 @@ def register() -> None:
     register_hook(
         "knowledge_inject.session_start",
         HookType.SESSION_START,
+        inject_session_knowledge,
+        priority=0,
+    )
+    # CLI SESSION_START does not include prompt_msgs; TURN_PRE does.
+    register_hook(
+        "knowledge_inject.turn_pre",
+        HookType.TURN_PRE,
         inject_session_knowledge,
         priority=0,
     )

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -1,0 +1,70 @@
+"""Inject matching personal KB entries at session start.
+
+Follow-on to gptme/gptme#3596 / #3622. Save/retrieve already landed; this
+hook is the session-start prompt injection slice. Uses the JSONL keyword
+search (same as ``gptme-util knowledge search``). gptme-rag-backed search
+and schema generalization are separate follow-ons.
+"""
+
+import logging
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+from ..hooks import HookType, StopPropagation, register_hook
+from ..knowledge import format_knowledge_prompt, select_knowledge_for_session
+from ..message import Message
+
+logger = logging.getLogger(__name__)
+
+
+def _query_from_initial_msgs(initial_msgs: list[Message] | None) -> str | None:
+    if not initial_msgs:
+        return None
+    for msg in reversed(list(initial_msgs)):
+        if getattr(msg, "role", None) != "user":
+            continue
+        content = getattr(msg, "content", None)
+        if isinstance(content, str) and content.strip():
+            return content
+    return None
+
+
+def inject_session_knowledge(
+    logdir: Path,
+    workspace: Path | None,
+    initial_msgs: list[Message] | None = None,
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Yield a hidden system message with matching personal KB entries.
+
+    No-ops when the store is empty, the initial prompt is too short to
+    search, or nothing matches. Failures never block session start.
+    """
+    try:
+        query = _query_from_initial_msgs(initial_msgs)
+        entries = select_knowledge_for_session(query)
+        if not entries:
+            return
+        body = format_knowledge_prompt(entries)
+        if not body.strip():
+            return
+        logger.debug(
+            "Injecting %d knowledge entries for session %s (workspace=%s)",
+            len(entries),
+            logdir,
+            workspace,
+        )
+        yield Message("system", body, hide=True)
+    except Exception:
+        logger.debug("knowledge session inject skipped", exc_info=True)
+        return
+
+
+def register() -> None:
+    register_hook(
+        "knowledge_inject.session_start",
+        HookType.SESSION_START,
+        inject_session_knowledge,
+        priority=0,
+    )

--- a/gptme/hooks/knowledge_inject.py
+++ b/gptme/hooks/knowledge_inject.py
@@ -8,7 +8,9 @@ and schema generalization are separate follow-ons.
 CLI ``SESSION_START`` runs before the first user prompt is appended, so
 this hook also registers on ``TURN_PRE`` (after the prompt is in the log).
 ACP and TUI fire ``TURN_PRE`` on that same boundary. Injection is once per
-conversation: later turns no-op if ``<knowledge-entries>`` is already present.
+conversation: later turns no-op if a hidden system message already carries
+the ``<knowledge-entries>`` block. Ordinary user/assistant text that happens
+to mention the marker does not count.
 """
 
 import logging
@@ -48,8 +50,11 @@ def _query_from_msgs(msgs: list[Message]) -> str | None:
 
 
 def _already_injected(msgs: list[Message]) -> bool:
+    """True only for this hook's hidden system block, not coincidental text."""
     return any(
-        isinstance(getattr(msg, "content", None), str)
+        getattr(msg, "role", None) == "system"
+        and getattr(msg, "hide", False)
+        and isinstance(getattr(msg, "content", None), str)
         and _KNOWLEDGE_MARK in msg.content
         for msg in msgs
     )

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -2,11 +2,13 @@
 Cross-session knowledge base: save and retrieve problem/resolution pairs.
 
 Entries are stored as JSONL at ``~/.local/share/gptme/knowledge/entries.jsonl``
-(respects XDG_DATA_HOME).  Each entry carries enough metadata for gptme-rag to
-index it as a ``knowledge_entry`` source once that upstreaming work lands.
+(respects XDG_DATA_HOME).  Each entry carries ``memory_type="knowledge_entry"``
+so gptme-rag's ``KnowledgeEntrySource`` can index the same JSONL.
 
-Retrieval without gptme-rag falls back to a simple keyword search over the
-problem + resolution text.
+Retrieval without gptme-rag uses keyword search over problem + resolution
+text. Matching entries are injected at session start (see
+``gptme.hooks.knowledge_inject``) when the initial prompt has enough
+signal to search.
 """
 
 from __future__ import annotations
@@ -262,6 +264,62 @@ def knowledge_list(
             ]
     entries = sorted(entries, key=lambda e: e.get("created_at", ""), reverse=True)
     return entries[:limit]
+
+
+_DEFAULT_SESSION_TOP_K = 3
+_MAX_FIELD_CHARS = 240
+_MIN_QUERY_KEYWORDS = 2
+
+
+def _clip(text: str, limit: int = _MAX_FIELD_CHARS) -> str:
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def select_knowledge_for_session(
+    query: str | None,
+    *,
+    top_k: int = _DEFAULT_SESSION_TOP_K,
+) -> list[KnowledgeEntry]:
+    """Return KB entries matching *query* for session-start injection.
+
+    Conservative: no query, too-few keywords, or a search error yields
+    nothing. Recency fallback is omitted so a greeting does not dump
+    unrelated entries into the prompt.
+    """
+    if not query or not query.strip():
+        return []
+    keywords = _extract_keywords(query)
+    if len(keywords) < _MIN_QUERY_KEYWORDS:
+        return []
+    try:
+        return knowledge_search(query, top_k=top_k)
+    except (OSError, ValueError):
+        return []
+
+
+def format_knowledge_prompt(entries: list[KnowledgeEntry]) -> str:
+    """Format matching KB entries as a compact system-prompt block."""
+    if not entries:
+        return ""
+    lines = [
+        "<knowledge-entries>",
+        "Relevant saved knowledge from previous sessions (not project docs):",
+        "",
+    ]
+    for i, entry in enumerate(entries, start=1):
+        problem = _clip(str(entry.get("problem", "")))
+        resolution = _clip(str(entry.get("resolution", "")))
+        lines.append(f"{i}. {problem}")
+        lines.append(f"   {resolution}")
+        tags = [t for t in entry.get("tags", []) if isinstance(t, str) and t.strip()]
+        if tags:
+            lines.append(f"   tags: {', '.join(tags)}")
+        lines.append("")
+    lines.append("</knowledge-entries>")
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def _replace_entries(path: Path, entries: list[KnowledgeEntry]) -> None:

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -316,7 +316,7 @@ def format_knowledge_prompt(entries: list[KnowledgeEntry]) -> str:
         lines.append(f"   {resolution}")
         tags = [t for t in entry.get("tags", []) if isinstance(t, str) and t.strip()]
         if tags:
-            lines.append(f"   tags: {', '.join(tags)}")
+            lines.append(f"   tags: {_clip(', '.join(tags))}")
         lines.append("")
     lines.append("</knowledge-entries>")
     return "\n".join(lines).rstrip() + "\n"

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -50,7 +50,7 @@ from ..chat import step
 from ..commands import execute_cmd, get_command_completer, get_user_commands
 from ..constants import DECLINED_CONTENT, INTERRUPT_CONTENT
 from ..dirs import get_pt_history_file
-from ..hooks import HookType, register_hook, unregister_hook
+from ..hooks import HookType, register_hook, trigger_hook, unregister_hook
 from ..hooks.cli_confirm import _get_lang_for_tool
 from ..hooks.confirm import ConfirmationResult
 from ..llm.models import ModelMeta, get_default_model
@@ -1465,6 +1465,11 @@ class GptmeApp(App):
                 max_steps = int(max_steps_str)
         step_count = 0
         try:
+            # Same boundary as the CLI chat loop: TURN_PRE after the user
+            # prompt is in the log, before the first generation step.
+            if turn_msgs := trigger_hook(HookType.TURN_PRE, manager=manager):
+                for msg in turn_msgs:
+                    manager.append(msg)
             while True:
                 self.call_from_thread(self._begin_stream)
                 interrupted = False

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -49,6 +49,7 @@ def _run(initial_msgs, logdir: Path, manager=None):
 
 
 def test_hook_yields_hidden_system_message_for_matching_query(tmp_path):
+    from gptme.hooks.knowledge_inject import _INJECT_SENTINEL
     from gptme.knowledge import knowledge_save
 
     knowledge_save(
@@ -67,6 +68,7 @@ def test_hook_yields_hidden_system_message_for_matching_query(tmp_path):
     msg = out[0]
     assert msg.role == "system"
     assert msg.hide is True
+    assert msg.content.lstrip().startswith(_INJECT_SENTINEL)
     assert "<knowledge-entries>" in msg.content
     assert "pytest test discovery fails" in msg.content
     assert "prefix test function with test_" in msg.content
@@ -145,6 +147,7 @@ def test_hook_reads_user_prompt_from_manager_log(tmp_path):
 
 
 def test_hook_skips_when_already_injected(tmp_path):
+    from gptme.hooks.knowledge_inject import _INJECT_SENTINEL
     from gptme.knowledge import knowledge_save
 
     knowledge_save(
@@ -153,7 +156,7 @@ def test_hook_skips_when_already_injected(tmp_path):
     )
     prior = Message(
         "system",
-        "<knowledge-entries>\nalready injected\n</knowledge-entries>\n",
+        f"{_INJECT_SENTINEL}\n<knowledge-entries>\nalready injected\n</knowledge-entries>\n",
         hide=True,
     )
     manager = _FakeManager(
@@ -182,4 +185,32 @@ def test_hook_injects_when_marker_appears_in_user_or_assistant_text(tmp_path):
     assert len(out) == 1
     assert out[0].role == "system"
     assert out[0].hide is True
+    assert "pytest test discovery fails" in out[0].content
+
+
+def test_hook_injects_when_unrelated_hidden_system_quotes_marker(tmp_path):
+    """Replay/other hooks may persist a hidden system message quoting the tag."""
+    from gptme.hooks.knowledge_inject import _INJECT_SENTINEL
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+    quoted = Message(
+        "system",
+        "session replay quoting <knowledge-entries> from prior content",
+        hide=True,
+    )
+    mid_sentinel = Message(
+        "system",
+        f"notes mention {_INJECT_SENTINEL} but this is not an injection",
+        hide=True,
+    )
+    out = _run(
+        [quoted, mid_sentinel, Message("user", "pytest discovery is broken in CI")],
+        tmp_path,
+    )
+    assert len(out) == 1
+    assert out[0].content.lstrip().startswith(_INJECT_SENTINEL)
     assert "pytest test discovery fails" in out[0].content

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -146,6 +146,47 @@ def test_hook_reads_user_prompt_from_manager_log(tmp_path):
     assert "pytest test discovery fails" in out[0].content
 
 
+def test_hook_reads_user_prompt_from_real_log(tmp_path):
+    """Production shape: LogManager.log is a Log with .messages."""
+    from gptme.knowledge import knowledge_save
+    from gptme.logmanager import Log
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+
+    class _Mgr:
+        def __init__(self):
+            self.log = Log([Message("user", "pytest discovery is broken in CI")])
+            self.logdir = tmp_path
+            self.workspace = None
+
+    out = _run([], tmp_path, manager=_Mgr())
+    assert len(out) == 1
+    assert "pytest test discovery fails" in out[0].content
+
+
+def test_hook_reads_user_prompt_from_list_log(tmp_path):
+    """ACP's step loop copies log.log into a list; accept that shape too."""
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+
+    class _Mgr:
+        def __init__(self):
+            self.log = [Message("user", "pytest discovery is broken in CI")]
+            self.logdir = tmp_path
+            self.workspace = None
+
+    out = _run([], tmp_path, manager=_Mgr())
+    assert len(out) == 1
+    assert "pytest test discovery fails" in out[0].content
+
+
 def test_hook_skips_when_already_injected(tmp_path):
     from gptme.hooks.knowledge_inject import _INJECT_SENTINEL
     from gptme.knowledge import knowledge_save

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -214,3 +214,30 @@ def test_hook_injects_when_unrelated_hidden_system_quotes_marker(tmp_path):
     assert len(out) == 1
     assert out[0].content.lstrip().startswith(_INJECT_SENTINEL)
     assert "pytest test discovery fails" in out[0].content
+
+
+def test_hook_skips_when_replay_wraps_injected_message(tmp_path):
+    """Replay prepends an evidence prefix; that must still count as injected."""
+    from gptme.hooks.knowledge_inject import _INJECT_SENTINEL
+    from gptme.knowledge import knowledge_save
+    from gptme.util.replay import EVIDENCE_PREFIX
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+    original = (
+        f"{_INJECT_SENTINEL}\n"
+        "<knowledge-entries>\nalready injected\n</knowledge-entries>\n"
+    )
+    wrapped = Message(
+        "system",
+        f"{EVIDENCE_PREFIX}system)]\n{original}",
+        hide=True,
+        pinned=True,
+    )
+    manager = _FakeManager(
+        [Message("user", "pytest discovery is broken in CI"), wrapped],
+        tmp_path,
+    )
+    assert _run(None, tmp_path, manager=manager) == []

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -1,0 +1,109 @@
+"""Tests for session-start personal KB injection (gptme/gptme#3596 follow-on)."""
+
+from pathlib import Path
+
+import pytest
+
+from gptme.hooks import StopPropagation
+from gptme.message import Message
+
+
+@pytest.fixture(autouse=True)
+def isolated_kb(tmp_path, monkeypatch):
+    """Redirect the knowledge store away from the real XDG data dir."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from gptme import dirs
+
+    if hasattr(dirs.get_data_dir, "cache_clear"):
+        dirs.get_data_dir.cache_clear()
+    yield
+    if hasattr(dirs.get_data_dir, "cache_clear"):
+        dirs.get_data_dir.cache_clear()
+
+
+def _run(initial_msgs, logdir: Path):
+    from gptme.hooks.knowledge_inject import inject_session_knowledge
+
+    return [
+        item
+        for item in inject_session_knowledge(
+            logdir=logdir, workspace=None, initial_msgs=initial_msgs
+        )
+        if not isinstance(item, StopPropagation)
+    ]
+
+
+def test_hook_yields_hidden_system_message_for_matching_query(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+        tags=["pytest"],
+    )
+    knowledge_save("git merge conflict resolution", "use git mergetool")
+
+    out = _run(
+        [Message("user", "pytest discovery is broken in CI")],
+        tmp_path,
+    )
+
+    assert len(out) == 1
+    msg = out[0]
+    assert msg.role == "system"
+    assert msg.hide is True
+    assert "<knowledge-entries>" in msg.content
+    assert "pytest test discovery fails" in msg.content
+    assert "prefix test function with test_" in msg.content
+    assert "git merge conflict" not in msg.content
+
+
+def test_hook_yields_nothing_without_user_prompt(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+
+    assert _run([], tmp_path) == []
+    assert _run([Message("system", "bootstrap")], tmp_path) == []
+
+
+def test_hook_yields_nothing_for_short_query(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+
+    assert _run([Message("user", "hi")], tmp_path) == []
+
+
+def test_hook_yields_nothing_when_store_empty(tmp_path):
+    assert _run([Message("user", "pytest discovery is broken")], tmp_path) == []
+
+
+def test_hook_yields_nothing_when_no_match(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+
+    assert _run([Message("user", "unrelated kubernetes helm chart")], tmp_path) == []
+
+
+def test_hook_swallows_unexpected_errors(tmp_path, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "gptme.hooks.knowledge_inject.select_knowledge_for_session",
+        boom,
+    )
+
+    assert _run([Message("user", "pytest discovery is broken")], tmp_path) == []
+
+
+def test_register_adds_session_start_hook():
+    from gptme.hooks import HookType, clear_hooks, get_hooks
+    from gptme.hooks.knowledge_inject import register
+
+    clear_hooks()
+    register()
+    names = [hook.name for hook in get_hooks(HookType.SESSION_START)]
+    assert "knowledge_inject.session_start" in names

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -21,13 +21,28 @@ def isolated_kb(tmp_path, monkeypatch):
         dirs.get_data_dir.cache_clear()
 
 
-def _run(initial_msgs, logdir: Path):
+class _FakeLog:
+    def __init__(self, messages):
+        self.messages = messages
+
+
+class _FakeManager:
+    def __init__(self, messages, logdir: Path):
+        self.log = _FakeLog(messages)
+        self.logdir = logdir
+        self.workspace = None
+
+
+def _run(initial_msgs, logdir: Path, manager=None):
     from gptme.hooks.knowledge_inject import inject_session_knowledge
 
     return [
         item
         for item in inject_session_knowledge(
-            logdir=logdir, workspace=None, initial_msgs=initial_msgs
+            logdir=logdir,
+            workspace=None,
+            initial_msgs=initial_msgs,
+            manager=manager,
         )
         if not isinstance(item, StopPropagation)
     ]
@@ -99,11 +114,50 @@ def test_hook_swallows_unexpected_errors(tmp_path, monkeypatch):
     assert _run([Message("user", "pytest discovery is broken")], tmp_path) == []
 
 
-def test_register_adds_session_start_hook():
+def test_register_adds_session_start_and_turn_pre_hooks():
     from gptme.hooks import HookType, clear_hooks, get_hooks
     from gptme.hooks.knowledge_inject import register
 
     clear_hooks()
     register()
-    names = [hook.name for hook in get_hooks(HookType.SESSION_START)]
-    assert "knowledge_inject.session_start" in names
+    start_names = [hook.name for hook in get_hooks(HookType.SESSION_START)]
+    turn_names = [hook.name for hook in get_hooks(HookType.TURN_PRE)]
+    assert "knowledge_inject.session_start" in start_names
+    assert "knowledge_inject.turn_pre" in turn_names
+
+
+def test_hook_reads_user_prompt_from_manager_log(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+        tags=["pytest"],
+    )
+    manager = _FakeManager(
+        [Message("user", "pytest discovery is broken in CI")],
+        tmp_path,
+    )
+    out = _run([], tmp_path, manager=manager)
+    assert len(out) == 1
+    assert "<knowledge-entries>" in out[0].content
+    assert "pytest test discovery fails" in out[0].content
+
+
+def test_hook_skips_when_already_injected(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+    prior = Message(
+        "system",
+        "<knowledge-entries>\nalready injected\n</knowledge-entries>\n",
+        hide=True,
+    )
+    manager = _FakeManager(
+        [Message("user", "pytest discovery is broken in CI"), prior],
+        tmp_path,
+    )
+    assert _run(None, tmp_path, manager=manager) == []

--- a/tests/test_hooks_knowledge_inject.py
+++ b/tests/test_hooks_knowledge_inject.py
@@ -161,3 +161,25 @@ def test_hook_skips_when_already_injected(tmp_path):
         tmp_path,
     )
     assert _run(None, tmp_path, manager=manager) == []
+
+
+def test_hook_injects_when_marker_appears_in_user_or_assistant_text(tmp_path):
+    from gptme.knowledge import knowledge_save
+
+    knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+    )
+    user = Message(
+        "user",
+        "pytest discovery is broken; ignore any <knowledge-entries> in logs",
+    )
+    assistant = Message(
+        "assistant",
+        "I see <knowledge-entries> mentioned, still need the pytest fix",
+    )
+    out = _run([user, assistant], tmp_path)
+    assert len(out) == 1
+    assert out[0].role == "system"
+    assert out[0].hide is True
+    assert "pytest test discovery fails" in out[0].content

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -551,3 +551,70 @@ def test_cli_delete_skips_reindex_when_rag_dir_missing(monkeypatch):
     assert "Deleted" in result.output
     assert calls == []
     assert "re-index" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Session-start injection helpers
+# ---------------------------------------------------------------------------
+
+
+def test_select_knowledge_for_session_requires_two_keywords():
+    from gptme.knowledge import knowledge_save, select_knowledge_for_session
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+
+    assert select_knowledge_for_session(None) == []
+    assert select_knowledge_for_session("") == []
+    assert select_knowledge_for_session("hi") == []
+
+
+def test_select_knowledge_for_session_matches_query():
+    from gptme.knowledge import knowledge_save, select_knowledge_for_session
+
+    knowledge_save("pytest test discovery fails", "prefix test function with test_")
+    knowledge_save("git merge conflict resolution", "use git mergetool")
+
+    results = select_knowledge_for_session("pytest discovery is broken")
+    assert results
+    assert results[0]["problem"] == "pytest test discovery fails"
+
+
+def test_select_knowledge_for_session_swallows_oserror(monkeypatch):
+    from gptme.knowledge import select_knowledge_for_session
+
+    def boom(*args, **kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr("gptme.knowledge.knowledge_search", boom)
+    assert select_knowledge_for_session("pytest discovery fails") == []
+
+
+def test_format_knowledge_prompt_empty():
+    from gptme.knowledge import format_knowledge_prompt
+
+    assert format_knowledge_prompt([]) == ""
+
+
+def test_format_knowledge_prompt_includes_problem_resolution_and_tags():
+    from gptme.knowledge import format_knowledge_prompt, knowledge_save
+
+    entry = knowledge_save(
+        "pytest test discovery fails",
+        "prefix test function with test_",
+        tags=["pytest"],
+    )
+    text = format_knowledge_prompt([entry])
+    assert text.startswith("<knowledge-entries>")
+    assert text.rstrip().endswith("</knowledge-entries>")
+    assert "pytest test discovery fails" in text
+    assert "prefix test function with test_" in text
+    assert "tags: pytest" in text
+
+
+def test_format_knowledge_prompt_clips_long_fields():
+    from gptme.knowledge import format_knowledge_prompt, knowledge_save
+
+    entry = knowledge_save("p" * 400, "r" * 400)
+    text = format_knowledge_prompt([entry])
+    assert "..." in text
+    assert len(text) < 800

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -618,3 +618,16 @@ def test_format_knowledge_prompt_clips_long_fields():
     text = format_knowledge_prompt([entry])
     assert "..." in text
     assert len(text) < 800
+
+
+def test_format_knowledge_prompt_clips_long_tags():
+    from gptme.knowledge import format_knowledge_prompt, knowledge_save
+
+    entry = knowledge_save("short problem", "short resolution", tags=["x" * 400])
+    text = format_knowledge_prompt([entry])
+    tags_lines = [
+        line for line in text.splitlines() if line.strip().startswith("tags:")
+    ]
+    assert tags_lines
+    assert "..." in tags_lines[0]
+    assert len(tags_lines[0]) < 260


### PR DESCRIPTION
## Problem

gptme/gptme#3596 save/retrieve landed in #3622, and `KnowledgeEntrySource` merged as gptme/gptme-contrib#1545. Session-start injection of matching personal KB entries was the remaining Phase 2 slice.

## What this does

- Registers a default `SESSION_START` hook that searches the personal JSONL store against the initial user prompt
- Injects top-3 keyword matches as a hidden system message (`<knowledge-entries>…</knowledge-entries>`)
- Conservative no-ops: empty store, no user prompt, fewer than two query keywords, no match, or search errors — session start never fails

Uses the same keyword search as `gptme-util knowledge search`. Fields are clipped to 240 chars.

## What this does not

- Does **not** close #3596
- Does not generalize the problem/resolution schema (Erik's open question)
- Does not switch search over to gptme-rag (`KnowledgeEntrySource` already exists; wiring search is a later slice)

## Tests

`tests/test_knowledge.py` + `tests/test_hooks_knowledge_inject.py` — 54 passed locally.
