### PR TITLE
fix(llm): pin Codex session_id to conversation instead of uuid4 per turn

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -452,6 +452,24 @@ def get_auth(timeout: float | tuple[float, float] = 30) -> SubscriptionAuth:
     )
 
 
+def _codex_model_and_effort(
+    model: str, reasoning_level: str | None = None
+) -> tuple[str, str]:
+    """Normalize a gptme model string to Codex backend model + effort.
+
+    ``gpt-5.6-sol`` and ``gpt-5.6-sol:medium`` both become
+    ``("gpt-5.6-sol", "medium")``. An explicit suffix (``:high``) wins over
+    the default. Used by both the request body and the routing ``session_id``
+    so equivalent spellings keep cache affinity.
+    """
+    base_model = model.split(":")[0] if ":" in model else model
+    if ":" in model:
+        reasoning_level = model.split(":")[1]
+    if reasoning_level is None:
+        reasoning_level = "medium"
+    return base_model, reasoning_level
+
+
 def _transform_to_codex_request(
     input_items: list[dict[str, Any]],
     model: str,
@@ -462,12 +480,7 @@ def _transform_to_codex_request(
     max_output_tokens: int | None = None,
 ) -> dict[str, Any]:
     """Build a Responses API request body from shared Responses helpers."""
-    base_model = model.split(":")[0] if ":" in model else model
-    if ":" in model:
-        reasoning_level = model.split(":")[1]
-
-    if reasoning_level is None:
-        reasoning_level = "medium"
+    base_model, reasoning_level = _codex_model_and_effort(model, reasoning_level)
 
     body: dict[str, Any] = {
         "model": base_model,
@@ -523,14 +536,17 @@ def _codex_session_id(model: str) -> str:
     """Conversation-stable ``session_id`` header for the Codex backend.
 
     A per-request UUID is a pod-routing hint and forces cold-cache pricing
-    (OnlyTerp gotcha 9b). Hash conversation id with model so a model switch
-    does not reuse another model's routing key. Fall back to uuid4 when no
-    conversation context exists (one-shot / isolated tests).
+    (OnlyTerp gotcha 9b). Hash conversation id with the *normalized* Codex
+    request identity (base model + effort) so a model switch does not reuse
+    another model's routing key, while equivalent spellings
+    (``gpt-5.6-sol`` vs ``gpt-5.6-sol:medium``) keep affinity. Fall back to
+    uuid4 when no conversation context exists (one-shot / isolated tests).
     """
     conv_id = _conversation_id_for_codex()
     if not conv_id:
         return str(uuid4())
-    return str(uuid5(NAMESPACE_URL, f"gptme:codex:{conv_id}:{model}"))
+    base_model, effort = _codex_model_and_effort(model)
+    return str(uuid5(NAMESPACE_URL, f"gptme:codex:{conv_id}:{base_model}:{effort}"))
 
 
 def stream(

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -46,7 +46,7 @@ from math import isfinite
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, urlencode, urlparse
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import requests
 
@@ -502,6 +502,37 @@ def _parse_sse_response(line: bytes | str) -> dict[str, Any] | None:
         return None
 
 
+def _conversation_id_for_codex() -> str | None:
+    """Resolve the active conversation id for Codex cache routing.
+
+    Server sessions set ``current_conversation_id``. CLI ``chat()`` sets the
+    telemetry conversation context from ``logdir.name``. Either is stable
+    across turns of one conversation.
+    """
+    from ..hooks.server_confirm import current_conversation_id
+    from ..telemetry import get_conversation_context
+
+    conv_id = current_conversation_id.get()
+    if conv_id:
+        return conv_id
+    conv_id, _ = get_conversation_context()
+    return conv_id
+
+
+def _codex_session_id(model: str) -> str:
+    """Conversation-stable ``session_id`` header for the Codex backend.
+
+    A per-request UUID is a pod-routing hint and forces cold-cache pricing
+    (OnlyTerp gotcha 9b). Hash conversation id with model so a model switch
+    does not reuse another model's routing key. Fall back to uuid4 when no
+    conversation context exists (one-shot / isolated tests).
+    """
+    conv_id = _conversation_id_for_codex()
+    if not conv_id:
+        return str(uuid4())
+    return str(uuid5(NAMESPACE_URL, f"gptme:codex:{conv_id}:{model}"))
+
+
 def stream(
     messages: list[Message],
     model: str,
@@ -535,7 +566,7 @@ def stream(
         "OpenAI-Beta": "responses=experimental",
         "chatgpt-account-id": auth.account_id,
         "originator": "gptme",
-        "session_id": str(uuid4()),
+        "session_id": _codex_session_id(model),
     }
 
     # Timeout is (connect, read). With stream=True the read timeout applies

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -2,13 +2,16 @@ import json
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 import requests
 
+from gptme.hooks.server_confirm import current_conversation_id
 from gptme.llm import llm_openai_subscription
 from gptme.llm.llm_openai_subscription import SubscriptionAuth
 from gptme.message import Message
+from gptme.telemetry import clear_conversation_context, set_conversation_context
 from gptme.tools import get_tool, init_tools
 
 
@@ -585,3 +588,87 @@ def test_stream_closes_response_on_retry():
 
     assert timed_out.closed, "timed-out response must be closed before retry"
     assert ok.closed, "final response must be closed after done event"
+
+
+def _stream_session_ids(n: int, model: str = "gpt-5.4") -> list[str]:
+    responses = [_FakeSSEStreamResponse([{"type": "response.done"}]) for _ in range(n)]
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=_make_auth()),
+        patch(
+            "gptme.llm.llm_openai_subscription.requests.post",
+            side_effect=responses,
+        ) as mock_post,
+    ):
+        for _ in range(n):
+            list(
+                llm_openai_subscription.stream(
+                    [Message(role="user", content="hello")], model
+                )
+            )
+    return [call.kwargs["headers"]["session_id"] for call in mock_post.call_args_list]
+
+
+def test_codex_session_id_stable_within_conversation_and_differs_across():
+    """Same conversation + model must reuse session_id; another conversation must not.
+
+    OnlyTerp gotcha 9b: a per-request UUID as Codex session_id is a pod-routing
+    hint and forces cold-cache pricing. Two stream() calls in one conversation
+    have to send the same header.
+    """
+    token = current_conversation_id.set("conv-stable-a")
+    try:
+        first, second = _stream_session_ids(2, "gpt-5.4")
+    finally:
+        current_conversation_id.reset(token)
+
+    assert first == second
+    UUID(first)
+
+    token = current_conversation_id.set("conv-stable-b")
+    try:
+        (other,) = _stream_session_ids(1, "gpt-5.4")
+    finally:
+        current_conversation_id.reset(token)
+
+    assert other != first
+
+
+def test_codex_session_id_differs_across_models_in_same_conversation():
+    token = current_conversation_id.set("conv-stable-a")
+    try:
+        (model_a,) = _stream_session_ids(1, "gpt-5.4")
+        (model_b,) = _stream_session_ids(1, "gpt-5.6-sol")
+    finally:
+        current_conversation_id.reset(token)
+
+    assert model_a != model_b
+
+
+def test_codex_session_id_uses_telemetry_conversation_when_server_unset():
+    set_conversation_context(conversation_id="cli-logdir-name")
+    try:
+        a = llm_openai_subscription._codex_session_id("gpt-5.4")
+        b = llm_openai_subscription._codex_session_id("gpt-5.4")
+    finally:
+        clear_conversation_context()
+
+    assert a == b
+    UUID(a)
+
+
+def test_codex_session_id_prefers_server_context_over_telemetry():
+    set_conversation_context(conversation_id="cli-logdir-name")
+    token = current_conversation_id.set("server-conv")
+    try:
+        server = llm_openai_subscription._codex_session_id("gpt-5.4")
+    finally:
+        current_conversation_id.reset(token)
+        clear_conversation_context()
+
+    set_conversation_context(conversation_id="cli-logdir-name")
+    try:
+        cli = llm_openai_subscription._codex_session_id("gpt-5.4")
+    finally:
+        clear_conversation_context()
+
+    assert server != cli

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -644,6 +644,28 @@ def test_codex_session_id_differs_across_models_in_same_conversation():
     assert model_a != model_b
 
 
+def test_codex_session_id_same_for_equivalent_default_and_explicit_medium():
+    """Default effort and explicit :medium are the same Codex request.
+
+    Hashing the raw model spelling would split cache affinity between
+    gpt-5.6-sol and gpt-5.6-sol:medium even though both become
+    (model=gpt-5.6-sol, effort=medium). :high must still differ.
+    """
+    token = current_conversation_id.set("conv-stable-a")
+    try:
+        default = llm_openai_subscription._codex_session_id("gpt-5.6-sol")
+        explicit_medium = llm_openai_subscription._codex_session_id(
+            "gpt-5.6-sol:medium"
+        )
+        high = llm_openai_subscription._codex_session_id("gpt-5.6-sol:high")
+    finally:
+        current_conversation_id.reset(token)
+
+    assert default == explicit_medium
+    assert default != high
+    UUID(default)
+
+
 def test_codex_session_id_uses_telemetry_conversation_when_server_unset():
     set_conversation_context(conversation_id="cli-logdir-name")
     try:


### PR DESCRIPTION
## Summary

The ChatGPT-subscription Codex path sent a fresh `session_id` UUID on every `stream()` call. OpenAI uses that header as a pod-routing hint, so a per-request UUID is worse than omitting it — it forces cold-cache pricing ([OnlyTerp gotcha 9b](https://github.com/OnlyTerp/prompt-cache-skills/blob/main/docs/gotchas.md)).

This pins `session_id` to a UUID5 of the active conversation id + model:

- Server: `current_conversation_id`
- CLI: telemetry conversation context (`logdir.name`, set in `chat()`)
- No conversation context: keep `uuid4` (one-shot / isolated tests)

Two `stream()` calls in the same conversation now send the same header; a second conversation or a model switch does not.

Out of scope (deliberately): Anthropic `cache_control.ttl` / 1h beta header, and `prompt_cache_key` on the Platform API.

## Test plan

- [x] `pytest tests/test_llm_openai_subscription.py` (29 passed)
- [ ] Optional follow-up: cold/warm `cached_tokens` probe on the Codex endpoint (not this PR)