### PR TITLE
fix(models): stamp default_tool_format on dynamic listing constructors; serialize in model_to_dict

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -2101,6 +2101,7 @@ def _openai_compatible_model_to_modelmeta(
         supports_reasoning=model_data.get("supports_reasoning", False),
         price_input=0,  # pricing unknown for dynamically discovered models
         price_output=0,
+        default_tool_format="tool",  # custom providers are openai-compat
     )
 
 
@@ -2139,6 +2140,7 @@ def openrouter_model_to_modelmeta(model_data: dict) -> ModelMeta:
         supports_reasoning=reasoning and include_reasoning,
         price_input=price_input,
         price_output=price_output,
+        default_tool_format="tool",  # openai-compat route dialect
     )
 
 

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -42,6 +42,10 @@ def model_to_dict(model: ModelMeta) -> dict[str, Any]:
         d["deprecated"] = True
     if model.preferred_edit_format is not None:
         d["preferred_edit_format"] = model.preferred_edit_format
+    if model.default_tool_format is not None:
+        d["default_tool_format"] = model.default_tool_format
+    if model.supports_strict_tools:
+        d["supports_strict_tools"] = True
     return d
 
 

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -612,3 +612,69 @@ class TestSupportsResponsesAPI:
     def test_gpt4o_is_not_marked_for_responses_api(self):
         model = get_model("openai/gpt-4o")
         assert model.supports_responses_api is False
+
+
+@pytest.mark.parametrize(
+    ("provider", "name"),
+    sorted((p, n) for p, models in MODELS.items() for n in models),
+)
+def test_get_model_preserves_route_dialect_fields(provider: str, name: str):
+    """get_model must preserve dialect/capability metadata for every static registry row."""
+    meta = MODELS[provider][name]  # type: ignore[index]
+    resolved = get_model(f"{provider}/{name}")
+    assert resolved.default_tool_format == meta.get("default_tool_format")
+    assert resolved.supports_strict_tools == meta.get("supports_strict_tools", False)
+    assert resolved.preferred_edit_format == meta.get("preferred_edit_format")
+    assert resolved.deprecated == meta.get("deprecated", False)
+    assert resolved.pricing_type == meta.get("pricing_type", "per_token")
+    assert resolved.supports_parallel_tool_calls == meta.get(
+        "supports_parallel_tool_calls", False
+    )
+
+
+def test_openrouter_constructor_stamps_default_tool_format():
+    """Dynamic OpenRouter listing rows must carry the openai-compat dialect."""
+    from gptme.llm.llm_openai import openrouter_model_to_modelmeta
+
+    meta = openrouter_model_to_modelmeta(
+        {
+            "id": "openrouter/anthropic/claude-3-5-sonnet",
+            "pricing": {"prompt": "0", "completion": "0"},
+            "architecture": {"input_modalities": ["text"]},
+            "supported_parameters": [],
+        }
+    )
+    assert meta.default_tool_format == "tool"
+
+
+def test_openai_compatible_constructor_stamps_default_tool_format():
+    """Dynamic openai-compat listing rows must carry the openai-compat dialect."""
+    from gptme.llm.llm_openai import _openai_compatible_model_to_modelmeta
+
+    meta = _openai_compatible_model_to_modelmeta(
+        {
+            "id": "some-model",
+            "context_length": 8192,
+            "architecture": {"input_modalities": ["text"]},
+        },
+        provider_name="custom",
+    )
+    assert meta.default_tool_format == "tool"
+
+
+def test_model_to_dict_serializes_default_tool_format():
+    """A stamped model serializes default_tool_format; unstamped omits it."""
+    from gptme.llm.models.listing import model_to_dict
+    from gptme.llm.models.types import CustomProvider
+
+    stamped = ModelMeta(
+        provider=CustomProvider("test"),
+        model="m1",
+        context=8192,
+        default_tool_format="tool",
+    )
+    d = model_to_dict(stamped)
+    assert d["default_tool_format"] == "tool"
+
+    unstamped = ModelMeta(provider=CustomProvider("test"), model="m2", context=8192)
+    assert "default_tool_format" not in model_to_dict(unstamped)

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -636,6 +636,8 @@ def test_models_list_json_suppresses_provider_noise(mocker):
                 deprecated=False,
                 preferred_edit_format=None,
                 pricing_type="per_token",
+                default_tool_format="tool",
+                supports_strict_tools=False,
             )
         ]
 
@@ -677,6 +679,8 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
                 deprecated=False,
                 preferred_edit_format=None,
                 pricing_type="per_token",
+                default_tool_format="tool",
+                supports_strict_tools=False,
             ),
             SimpleNamespace(
                 provider="unknown",
@@ -696,6 +700,8 @@ def test_models_list_json_available_keeps_plugin_models(mocker):
                 deprecated=False,
                 preferred_edit_format=None,
                 pricing_type="per_token",
+                default_tool_format="tool",
+                supports_strict_tools=False,
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- Stamp `default_tool_format="tool"` on `openrouter_model_to_modelmeta` and `_openai_compatible_model_to_modelmeta` — dynamic listing rows previously dropped the dialect, so runtime-discovered models resolved to markdown tool format instead of the openai-compat `tool` dialect.
- `model_to_dict` now serializes `default_tool_format` (when set) and `supports_strict_tools` (when True) so `gptme models --json` exposes the dialect.
- Add a parametrized `get_model` preservation test over all 111 static `MODELS` rows (dialect + capability fields), constructor tests for both dynamic builders, and a serialization test.

## Context
Follow-up to gptme/gptme#3566 (static stamp), which verified 111/111 static rows but left the dynamic constructors as the remaining drop. Does not re-stamp MODELS, add eval-derived overrides, or build a protocol gateway.

Refs: ErikBjare/bob idea #1132 / task `gptme-route-dialect-conformance`.