### PR TITLE
fix(util): handle embedded nulls in batch prompts

### DIFF
--- a/gptme/cli/cmd_batch.py
+++ b/gptme/cli/cmd_batch.py
@@ -168,6 +168,18 @@ def _run_one_prompt(
             "error": f"timed out after {timeout:g}s",
             "returncode": None,
         }
+    except ValueError as error:
+        duration_s = time.monotonic() - start
+        return {
+            "index": index,
+            "prompt": prompt,
+            "exit_reason": "error",
+            "tokens": 0,
+            "duration_s": round(duration_s, 3),
+            "tool_calls": 0,
+            "error": str(error),
+            "returncode": None,
+        }
 
     duration_s = time.monotonic() - start
     return _summarize_child_output(

--- a/tests/test_util_cli_batch.py
+++ b/tests/test_util_cli_batch.py
@@ -124,6 +124,27 @@ def test_batch_model_rejects_empty_path_components(monkeypatch, bad_model):
     assert "Model path components cannot be empty" in result.output
 
 
+def test_run_one_prompt_reports_embedded_null_prompt():
+    record = cmd_batch._run_one_prompt(
+        index=0,
+        prompt="hello\0world",
+        model="test/model",
+        max_turns=1,
+        timeout=1,
+    )
+
+    assert record == {
+        "duration_s": pytest.approx(0, abs=0.1),
+        "error": "embedded null byte",
+        "exit_reason": "error",
+        "index": 0,
+        "prompt": "hello\0world",
+        "returncode": None,
+        "tokens": 0,
+        "tool_calls": 0,
+    }
+
+
 def test_summarize_child_output_counts_tokens_and_max_turns():
     stdout = "\n".join(
         [


### PR DESCRIPTION
## Problem

`gptme-util batch` accepts arbitrary stdin prompts, but an embedded NUL reaches `subprocess.run()` as an argv value. Python raises `ValueError: embedded null byte`, escaping the batch runner and printing a traceback instead of one JSONL result for that prompt.

## Fix

- Convert subprocess argument `ValueError`s into the same structured per-prompt error record used by timeouts and child failures.
- Add a regression test exercising an embedded-NUL prompt.

## Verification

- `PYTHONPATH=$PWD pytest tests/test_util_cli_batch.py -q` — 21 passed
- `ruff check gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- `ruff format --check gptme/cli/cmd_batch.py tests/test_util_cli_batch.py`
- End-to-end stdin replay now exits 0, emits one JSON record with `exit_reason: error`, and prints no traceback.

Fixes #3682
