### PR TITLE
fix(webui): gate task creation in demo mode

### DIFF
--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -21,6 +21,7 @@ import { useApi } from '@/contexts/ApiContext';
 import { initConversation } from '@/stores/conversations';
 import { parseConversationImportJSON } from '@/utils/exportConversation';
 import { appRoute } from '@/utils/routes';
+import { isDemoMode } from '@/utils/connectionConfig';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
@@ -139,6 +140,7 @@ export const UnifiedSidebar: FC<Props> = ({
   const isConnected = use$(isConnected$);
   const queryClient = useQueryClient();
   const importInputRef = useRef<HTMLInputElement>(null);
+  const demoMode = isDemoMode();
 
   // Navigation state - agents/workspaces show chat sidebar content
   const currentSection = location.pathname.startsWith('/tasks') ? 'tasks' : 'chat';
@@ -352,16 +354,24 @@ export const UnifiedSidebar: FC<Props> = ({
             >
               <Filter className="h-4 w-4" />
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={onCreateTask}
-              aria-label="Create task"
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
+            {!demoMode && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={onCreateTask}
+                aria-label="Create task"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            )}
           </div>
+
+          {demoMode && (
+            <p className="px-3 pb-2 text-xs text-muted-foreground">
+              Task creation requires a live gptme server.
+            </p>
+          )}
 
           {/* Task Filters */}
           {showFilters && (

--- a/webui/src/components/__tests__/UnifiedSidebar.test.tsx
+++ b/webui/src/components/__tests__/UnifiedSidebar.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { observable } from '@legendapp/state';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { UnifiedSidebar } from '../UnifiedSidebar';
+
+const mockIsDemoMode = jest.fn(() => false);
+
+jest.mock('@/utils/connectionConfig', () => ({
+  isDemoMode: () => mockIsDemoMode(),
+}));
+
+jest.mock('@/contexts/ApiContext', () => {
+  const { observable: createObservable } = jest.requireActual('@legendapp/state');
+  const isConnected$ = createObservable(true);
+  return {
+    useApi: () => ({
+      api: { getExternalSessions: jest.fn() },
+      connectionConfig: { baseUrl: 'demo://offline' },
+      isConnected$,
+    }),
+  };
+});
+
+const selectedConversationId$ = observable<string | null>(null);
+
+const renderTaskSidebar = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/tasks']}>
+        <UnifiedSidebar
+          conversations={[]}
+          selectedConversationId$={selectedConversationId$}
+          onSelectConversation={jest.fn()}
+          fetchNextPage={jest.fn()}
+          tasks={[]}
+          onSelectTask={jest.fn()}
+          onCreateTask={jest.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('UnifiedSidebar task creation', () => {
+  beforeEach(() => {
+    mockIsDemoMode.mockReturnValue(false);
+  });
+
+  it('offers task creation with a live server', () => {
+    renderTaskSidebar();
+
+    expect(screen.getByRole('button', { name: 'Create task' })).toBeInTheDocument();
+  });
+
+  it('does not offer a backend-only create action in offline demo mode', () => {
+    mockIsDemoMode.mockReturnValue(true);
+    renderTaskSidebar();
+
+    expect(screen.queryByRole('button', { name: 'Create task' })).not.toBeInTheDocument();
+    expect(screen.getByText('Task creation requires a live gptme server.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- hide the backend-only task creation affordance in offline demo mode
- explain that task creation requires a live gptme server
- add focused sidebar tests for live-server and demo behavior

## Reproduction

On `https://gptme.ai/chat?demo=1`, **Tasks → Create task** currently submits to `http://127.0.0.1:5700/api/v2/tasks`. Production CSP blocks the request and the dialog fails without user-visible feedback.

## Verification

- `jest src/components/__tests__/UnifiedSidebar.test.tsx --runInBand`
- `tsc -p tsconfig.app.json --noEmit`
- `eslint src/components/UnifiedSidebar.tsx src/components/__tests__/UnifiedSidebar.test.tsx`
- pre-commit hooks

Closes #3683
