### PR TITLE
fix(browser): gate PDF fetches with the shared URL helper

### DIFF
--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -9,37 +9,9 @@ import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
 
+from ._url_safety import _MAX_INPUT_LENGTH, _validate_url_scheme
+
 logger = logging.getLogger(__name__)
-_MAX_INPUT_LENGTH = 2048
-
-
-def _validate_url_scheme(url: str) -> None:
-    """Validate that a URL is safe to pass to lynx.
-
-    Security: Prevents file:// protocol from reading local files.
-    See: https://github.com/gptme/gptme/issues/1021
-    """
-    if not url or len(url) > _MAX_INPUT_LENGTH:
-        raise ValueError(
-            f"URL must be non-empty and no longer than {_MAX_INPUT_LENGTH} characters."
-        )
-
-    try:
-        parsed = urlparse(url)
-        hostname = parsed.hostname
-    except ValueError as exc:
-        raise ValueError("Invalid URL") from exc
-
-    allowed_schemes = {"http", "https"}
-    if parsed.scheme.lower() not in allowed_schemes:
-        raise ValueError(
-            f"URL scheme '{parsed.scheme}' not allowed. "
-            f"Only {allowed_schemes} are permitted for security reasons."
-        )
-    if not hostname:
-        raise ValueError("URL must include a hostname.")
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError("URL must not include embedded credentials.")
 
 
 def read_url(url: str, cookies: dict | None = None) -> str:

--- a/gptme/tools/_url_safety.py
+++ b/gptme/tools/_url_safety.py
@@ -1,0 +1,41 @@
+"""Shared URL safety checks for browser backends.
+
+Used by the lynx backend and the PDF/requests paths in the Playwright browser
+tool so file:// and credentialed URLs never reach a subprocess or HTTP client.
+
+See: https://github.com/gptme/gptme/issues/1021
+     https://github.com/gptme/gptme/pull/3663
+"""
+
+from urllib.parse import urlparse
+
+_MAX_INPUT_LENGTH = 2048
+
+
+def _validate_url_scheme(url: str) -> None:
+    """Validate that a URL is safe to fetch over HTTP(S).
+
+    Security: Prevents file:// protocol from reading local files.
+    See: https://github.com/gptme/gptme/issues/1021
+    """
+    if not url or len(url) > _MAX_INPUT_LENGTH:
+        raise ValueError(
+            f"URL must be non-empty and no longer than {_MAX_INPUT_LENGTH} characters."
+        )
+
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+    except ValueError as exc:
+        raise ValueError("Invalid URL") from exc
+
+    allowed_schemes = {"http", "https"}
+    if parsed.scheme.lower() not in allowed_schemes:
+        raise ValueError(
+            f"URL scheme '{parsed.scheme}' not allowed. "
+            f"Only {allowed_schemes} are permitted for security reasons."
+        )
+    if not hostname:
+        raise ValueError("URL must include a hostname.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("URL must not include embedded credentials.")

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -98,6 +98,7 @@ from functools import lru_cache
 from io import BytesIO
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
 
 import requests
 
@@ -108,6 +109,7 @@ from ..util.gh import (
     parse_github_url,
     transform_github_url,
 )
+from ._url_safety import _validate_url_scheme
 from .base import ToolFunction, ToolSpec, ToolUse
 
 # Availability check only — pypdf itself is imported lazily in _read_pdf_url,
@@ -220,8 +222,9 @@ def pdf_to_images(
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Download PDF if URL
-    if url_or_path.startswith(("http://", "https://")):
+    # Download PDF if URL. Case-insensitive http(s) only; local paths stay
+    # on disk (including Windows drive letters, which urlparse treats as a scheme).
+    if _pdf_source_is_remote(url_or_path):
         logger.info(f"Downloading PDF from: {url_or_path}")
         try:
             response = requests.get(url_or_path, timeout=60)
@@ -618,8 +621,23 @@ def has_browser_tool():
     return browser is not None
 
 
+def _pdf_source_is_remote(url_or_path: str) -> bool:
+    """Return True if *url_or_path* should be fetched over HTTP(S).
+
+    Local filesystem paths (including Windows drive letters) stay local.
+    Any other URL scheme is rejected by the shared validator before a fetch.
+    """
+    scheme = urlparse(url_or_path).scheme.lower()
+    if scheme in {"http", "https"} or "://" in url_or_path:
+        _validate_url_scheme(url_or_path)
+        return True
+    return False
+
+
 def _is_pdf_url(url: str) -> bool:
     """Check if URL points to a PDF file."""
+    _validate_url_scheme(url)
+
     # Check URL extension
     if url.lower().endswith(".pdf"):
         return True
@@ -646,6 +664,8 @@ def _read_pdf_url(url: str, max_pages: int | None = None) -> str:
         max_pages: Maximum number of pages to read (default: 10).
                    Set to 0 to read all pages.
     """
+    _validate_url_scheme(url)
+
     if not has_pypdf:
         return "Error: PDF support requires pypdf. Install with: pip install pypdf"
 

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -624,11 +624,24 @@ def has_browser_tool():
 def _pdf_source_is_remote(url_or_path: str) -> bool:
     """Return True if *url_or_path* should be fetched over HTTP(S).
 
-    Local filesystem paths (including Windows drive letters) stay local.
-    Any other URL scheme is rejected by the shared validator before a fetch.
+    Local filesystem paths stay local, including Windows drive letters and
+    POSIX paths that happen to contain URL-like substrings (a download saved
+    as ``/tmp/https://example.com/doc.pdf``). Non-http(s) URL schemes are
+    rejected by the shared validator before a fetch.
     """
-    scheme = urlparse(url_or_path).scheme.lower()
-    if scheme in {"http", "https"} or "://" in url_or_path:
+    # Absolute or explicit-relative paths are local even if they embed "://".
+    if url_or_path.startswith(("/", "./", "../")):
+        return False
+
+    parsed = urlparse(url_or_path)
+    scheme = parsed.scheme.lower()
+    # urlparse("https:report.pdf") has scheme=https and no host: a POSIX
+    # filename, not a fetchable URL. Require a netloc before treating http(s)
+    # as remote.
+    if scheme in {"http", "https"} and parsed.netloc:
+        _validate_url_scheme(url_or_path)
+        return True
+    if "://" in url_or_path:
         _validate_url_scheme(url_or_path)
         return True
     return False

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -628,7 +628,10 @@ def _pdf_source_is_remote(url_or_path: str) -> bool:
     POSIX paths that happen to contain URL-like substrings (a download saved
     as ``downloads/https://example.com/doc.pdf``). A source is a URL only when
     it begins with ``{scheme}://``; a later ``://`` is just path text.
-    Non-http(s) URL schemes are rejected by the shared validator before a fetch.
+
+    POSIX collapses ``HTTP://x`` to ``HTTP:/x``, so an http(s)-shaped string
+    that already exists on disk is a local path, not a fetch. file:// and
+    gopher:// still fail the shared validator — existence does not un-ban them.
     """
     parsed = urlparse(url_or_path)
     scheme = parsed.scheme.lower()
@@ -636,6 +639,8 @@ def _pdf_source_is_remote(url_or_path: str) -> bool:
     # urlparse("downloads/https://host/doc.pdf") has no scheme: "/" is not a
     # scheme character, so the :// is inside the path.
     if not (scheme and url_or_path.lower().startswith(f"{scheme}://")):
+        return False
+    if scheme in {"http", "https"} and Path(url_or_path).exists():
         return False
     _validate_url_scheme(url_or_path)
     return True

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -624,14 +624,18 @@ def has_browser_tool():
 def _pdf_source_is_remote(url_or_path: str) -> bool:
     """Return True if *url_or_path* should be fetched over HTTP(S).
 
-    Local filesystem paths stay local, including Windows drive letters and
-    POSIX paths that happen to contain URL-like substrings (a download saved
-    as ``downloads/https://example.com/doc.pdf``). A source is a URL only when
+    Classification is syntactic, not filesystem-dependent. Local paths stay
+    local, including Windows drive letters and POSIX paths that contain
+    URL-like substrings (a download saved as
+    ``downloads/https://example.com/doc.pdf``). A source is a URL only when
     it begins with ``{scheme}://``; a later ``://`` is just path text.
 
-    POSIX collapses ``HTTP://x`` to ``HTTP:/x``, so an http(s)-shaped string
-    that already exists on disk is a local path, not a fetch. file:// and
-    gopher:// still fail the shared validator — existence does not un-ban them.
+    An http(s) URL is always remote, even if POSIX would collapse
+    ``https://x`` to a local ``https:/x`` that happens to exist. That
+    existence shortcut let a CWD directory named ``https:`` (or ``HTTP:``)
+    skip host/credential checks and substitute a local PDF for a fetch.
+    file:// and gopher:// still fail the shared validator. Single-letter
+    schemes (``C://temp/file.pdf``) are Windows drive letters, not URLs.
     """
     parsed = urlparse(url_or_path)
     scheme = parsed.scheme.lower()
@@ -640,7 +644,9 @@ def _pdf_source_is_remote(url_or_path: str) -> bool:
     # scheme character, so the :// is inside the path.
     if not (scheme and url_or_path.lower().startswith(f"{scheme}://")):
         return False
-    if scheme in {"http", "https"} and Path(url_or_path).exists():
+    # urlparse("C://temp/file.pdf").scheme == "c" and the string starts
+    # with "c://". That is a drive letter, not a network URL.
+    if len(scheme) == 1:
         return False
     _validate_url_scheme(url_or_path)
     return True

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -626,25 +626,19 @@ def _pdf_source_is_remote(url_or_path: str) -> bool:
 
     Local filesystem paths stay local, including Windows drive letters and
     POSIX paths that happen to contain URL-like substrings (a download saved
-    as ``/tmp/https://example.com/doc.pdf``). Non-http(s) URL schemes are
-    rejected by the shared validator before a fetch.
+    as ``downloads/https://example.com/doc.pdf``). A source is a URL only when
+    it begins with ``{scheme}://``; a later ``://`` is just path text.
+    Non-http(s) URL schemes are rejected by the shared validator before a fetch.
     """
-    # Absolute or explicit-relative paths are local even if they embed "://".
-    if url_or_path.startswith(("/", "./", "../")):
-        return False
-
     parsed = urlparse(url_or_path)
     scheme = parsed.scheme.lower()
-    # urlparse("https:report.pdf") has scheme=https and no host: a POSIX
-    # filename, not a fetchable URL. Require a netloc before treating http(s)
-    # as remote.
-    if scheme in {"http", "https"} and parsed.netloc:
-        _validate_url_scheme(url_or_path)
-        return True
-    if "://" in url_or_path:
-        _validate_url_scheme(url_or_path)
-        return True
-    return False
+    # urlparse("https:report.pdf") has scheme=https but is a filename.
+    # urlparse("downloads/https://host/doc.pdf") has no scheme: "/" is not a
+    # scheme character, so the :// is inside the path.
+    if not (scheme and url_or_path.lower().startswith(f"{scheme}://")):
+        return False
+    _validate_url_scheme(url_or_path)
+    return True
 
 
 def _is_pdf_url(url: str) -> bool:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -602,17 +602,26 @@ def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
         ToolSpec(name="save", desc="Save"),
     ]
 
+    def _warning_count() -> int:
+        return caplog.text.count("Tool allowlist excluded MCP tools")
+
     with (
         patch("gptme.tools.get_available_tools", return_value=fake_tools),
         patch.object(gptme.tools, "_warned_mcp_allowlists", set()),
         caplog.at_level("WARNING", logger="gptme.tools"),
     ):
+        # Isolate from fixture/prior-test records and duplicate log handlers.
+        # The invariant is warn-once, not "exactly one handler emitted one record".
+        caplog.clear()
         tools = get_toolchain(["save"], strict=True)
+        after_first = _warning_count()
         repeated_tools = get_toolchain(["save"], strict=True)
+        after_second = _warning_count()
 
     assert [tool.name for tool in tools] == ["save"]
     assert [tool.name for tool in repeated_tools] == ["save"]
-    assert caplog.text.count("Tool allowlist excluded MCP tools") == 1
+    assert after_first >= 1
+    assert after_second == after_first
     assert "Tool allowlist excluded MCP tools" in caplog.text
     assert "discord.read_channel" in caplog.text
     assert "discord.send_message" in caplog.text

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -588,6 +588,22 @@ class TestPdfSourceIsRemote:
         with pytest.raises(ValueError, match="hostname"):
             _pdf_source_is_remote("https://")
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX // collapse; HTTP: is not a Windows path we can create",
+    )
+    def test_uppercase_url_shaped_relative_path_stays_local_when_it_exists(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        dest = tmp_path / "HTTP:" / "example.com"
+        dest.mkdir(parents=True)
+        (dest / "doc.pdf").write_bytes(b"%PDF-fake")
+        # POSIX: HTTP://example.com/doc.pdf == HTTP:/example.com/doc.pdf
+        assert _pdf_source_is_remote("HTTP://example.com/doc.pdf") is False
+        # Missing local file still classifies as a remote URL.
+        assert _pdf_source_is_remote("HTTP://example.com/missing.pdf") is True
+
 
 class TestPdfToImages:
     """Tests for pdf_to_images — PDF conversion to image files."""
@@ -689,6 +705,29 @@ class TestPdfToImages:
         mock_requests.get.assert_called_once_with(
             "HTTP://example.com/x.pdf", timeout=60
         )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX // collapse; HTTP: is not a Windows path we can create",
+    )
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._convert_with_pdftoppm")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_uppercase_url_shaped_relative_path_is_local(
+        self, _, mock_convert, mock_requests, tmp_path, monkeypatch
+    ):
+        from gptme.tools.browser import pdf_to_images
+
+        monkeypatch.chdir(tmp_path)
+        dest = tmp_path / "HTTP:" / "example.com"
+        dest.mkdir(parents=True)
+        (dest / "doc.pdf").write_bytes(b"%PDF-fake")
+        mock_convert.return_value = []
+
+        pdf_to_images("HTTP://example.com/doc.pdf", output_dir=tmp_path)
+
+        mock_requests.get.assert_not_called()
+        mock_convert.assert_called_once()
 
     @patch("gptme.tools.browser.requests")
     @patch("gptme.tools.browser._convert_with_pdftoppm")

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -26,6 +26,7 @@ from gptme.tools.browser import (
     _get_pdf_to_image_hints,
     _is_github_repo_url,
     _is_pdf_url,
+    _pdf_source_is_remote,
     _read_github_repo,
     _search_failed,
     _search_with_engine,
@@ -550,6 +551,39 @@ class TestReadPdfUrl:
             assert f"Page {DEFAULT_PDF_MAX_PAGES + 1}" not in result
 
 
+class TestPdfSourceIsRemote:
+    """Tests for _pdf_source_is_remote — HTTP vs local path classification."""
+
+    def test_http_urls_are_remote(self):
+        assert _pdf_source_is_remote("https://example.com/doc.pdf") is True
+        assert _pdf_source_is_remote("HTTP://example.com/x.pdf") is True
+
+    def test_posix_local_paths_stay_local(self):
+        assert _pdf_source_is_remote("/tmp/doc.pdf") is False
+        assert _pdf_source_is_remote("./doc.pdf") is False
+        assert _pdf_source_is_remote("../doc.pdf") is False
+        assert _pdf_source_is_remote("doc.pdf") is False
+
+    def test_url_like_local_filenames_stay_local(self):
+        assert _pdf_source_is_remote("https:report.pdf") is False
+        assert _pdf_source_is_remote("/tmp/foo://bar.pdf") is False
+        assert _pdf_source_is_remote("/tmp/https://example.com/doc.pdf") is False
+
+    def test_windows_drive_letter_stays_local(self):
+        assert _pdf_source_is_remote(r"C:\Users\file.pdf") is False
+        assert _pdf_source_is_remote("C:/Users/file.pdf") is False
+
+    def test_file_and_gopher_schemes_are_rejected(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            _pdf_source_is_remote("file:///tmp/x.pdf")
+        with pytest.raises(ValueError, match="not allowed"):
+            _pdf_source_is_remote("gopher://example.com/x.pdf")
+
+    def test_https_empty_host_is_rejected(self):
+        with pytest.raises(ValueError, match="hostname"):
+            _pdf_source_is_remote("https://")
+
+
 class TestPdfToImages:
     """Tests for pdf_to_images — PDF conversion to image files."""
 
@@ -650,6 +684,46 @@ class TestPdfToImages:
         mock_requests.get.assert_called_once_with(
             "HTTP://example.com/x.pdf", timeout=60
         )
+
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._convert_with_pdftoppm")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_absolute_path_with_embedded_url_substring(
+        self, _, mock_convert, mock_requests, tmp_path
+    ):
+        from gptme.tools.browser import pdf_to_images
+
+        url_dir = tmp_path / "https:" / "example.com"
+        url_dir.mkdir(parents=True)
+        pdf_file = url_dir / "doc.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+        mock_convert.return_value = []
+
+        # POSIX collapses the extra slash, so this string contains "://"
+        # but names the same local file.
+        weird = f"{tmp_path}/https://example.com/doc.pdf"
+        pdf_to_images(weird, output_dir=tmp_path)
+
+        mock_requests.get.assert_not_called()
+        mock_convert.assert_called_once()
+
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._convert_with_pdftoppm")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_https_colon_filename_is_local(
+        self, _, mock_convert, mock_requests, tmp_path, monkeypatch
+    ):
+        from gptme.tools.browser import pdf_to_images
+
+        monkeypatch.chdir(tmp_path)
+        pdf_file = tmp_path / "https:report.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+        mock_convert.return_value = []
+
+        pdf_to_images("https:report.pdf", output_dir=tmp_path)
+
+        mock_requests.get.assert_not_called()
+        mock_convert.assert_called_once()
 
     @patch("gptme.tools.browser.requests")
     @patch("gptme.tools.browser._has_pdftoppm", return_value=True)

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -577,6 +577,9 @@ class TestPdfSourceIsRemote:
     def test_windows_drive_letter_stays_local(self):
         assert _pdf_source_is_remote(r"C:\Users\file.pdf") is False
         assert _pdf_source_is_remote("C:/Users/file.pdf") is False
+        # urlparse scheme is "c" and the string starts with "c://". Still a
+        # drive letter, not a network URL.
+        assert _pdf_source_is_remote("C://temp/file.pdf") is False
 
     def test_file_and_gopher_schemes_are_rejected(self):
         with pytest.raises(ValueError, match="not allowed"):
@@ -588,21 +591,36 @@ class TestPdfSourceIsRemote:
         with pytest.raises(ValueError, match="hostname"):
             _pdf_source_is_remote("https://")
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="POSIX // collapse; HTTP: is not a Windows path we can create",
-    )
-    def test_uppercase_url_shaped_relative_path_stays_local_when_it_exists(
+    def test_embedded_credentials_are_rejected(self):
+        with pytest.raises(ValueError, match="credentials"):
+            _pdf_source_is_remote("https://user:pass@example.com/x.pdf")
+
+    def test_http_url_stays_remote_even_if_cwd_has_scheme_dir(
         self, tmp_path, monkeypatch
     ):
+        # POSIX collapses https://x to https:/x. A CWD directory named
+        # "https:" must not skip host/credential checks or substitute a
+        # local PDF for a fetch.
         monkeypatch.chdir(tmp_path)
-        dest = tmp_path / "HTTP:" / "example.com"
+        dest = tmp_path / "https:" / "example.com"
         dest.mkdir(parents=True)
-        (dest / "doc.pdf").write_bytes(b"%PDF-fake")
-        # POSIX: HTTP://example.com/doc.pdf == HTTP:/example.com/doc.pdf
-        assert _pdf_source_is_remote("HTTP://example.com/doc.pdf") is False
-        # Missing local file still classifies as a remote URL.
-        assert _pdf_source_is_remote("HTTP://example.com/missing.pdf") is True
+        (dest / "x.pdf").write_bytes(b"%PDF-fake")
+        cred_dest = tmp_path / "https:" / "user:pass@example.com"
+        cred_dest.mkdir(parents=True)
+        (cred_dest / "x.pdf").write_bytes(b"%PDF-fake")
+        assert _pdf_source_is_remote("https://example.com/x.pdf") is True
+        with pytest.raises(ValueError, match="credentials"):
+            _pdf_source_is_remote("https://user:pass@example.com/x.pdf")
+
+    def test_posix_collapsed_single_slash_spelling_stays_local(self):
+        # Already-collapsed HTTP:/host/file is a path, not a URL (no ://).
+        assert _pdf_source_is_remote("HTTP:/example.com/doc.pdf") is False
+
+    def test_dotdot_in_http_url_stays_remote(self):
+        assert (
+            _pdf_source_is_remote("https://example.com/../../etc/ssh-report.pdf")
+            is True
+        )
 
 
 class TestPdfToImages:
@@ -706,14 +724,10 @@ class TestPdfToImages:
             "HTTP://example.com/x.pdf", timeout=60
         )
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="POSIX // collapse; HTTP: is not a Windows path we can create",
-    )
     @patch("gptme.tools.browser.requests")
     @patch("gptme.tools.browser._convert_with_pdftoppm")
     @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
-    def test_uppercase_url_shaped_relative_path_is_local(
+    def test_http_url_fetches_even_if_cwd_has_scheme_dir(
         self, _, mock_convert, mock_requests, tmp_path, monkeypatch
     ):
         from gptme.tools.browser import pdf_to_images
@@ -722,12 +736,16 @@ class TestPdfToImages:
         dest = tmp_path / "HTTP:" / "example.com"
         dest.mkdir(parents=True)
         (dest / "doc.pdf").write_bytes(b"%PDF-fake")
+        mock_response = MagicMock()
+        mock_response.content = b"%PDF-remote"
+        mock_requests.get.return_value = mock_response
         mock_convert.return_value = []
 
         pdf_to_images("HTTP://example.com/doc.pdf", output_dir=tmp_path)
 
-        mock_requests.get.assert_not_called()
-        mock_convert.assert_called_once()
+        mock_requests.get.assert_called_once_with(
+            "HTTP://example.com/doc.pdf", timeout=60
+        )
 
     @patch("gptme.tools.browser.requests")
     @patch("gptme.tools.browser._convert_with_pdftoppm")

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -568,6 +568,11 @@ class TestPdfSourceIsRemote:
         assert _pdf_source_is_remote("https:report.pdf") is False
         assert _pdf_source_is_remote("/tmp/foo://bar.pdf") is False
         assert _pdf_source_is_remote("/tmp/https://example.com/doc.pdf") is False
+        assert _pdf_source_is_remote("./https://example.com/doc.pdf") is False
+        assert _pdf_source_is_remote("../https://example.com/doc.pdf") is False
+        # Implicit-relative: :// is inside a path component, not a URL scheme.
+        assert _pdf_source_is_remote("downloads/https://example.com/doc.pdf") is False
+        assert _pdf_source_is_remote("C:/Users/https://example.com/doc.pdf") is False
 
     def test_windows_drive_letter_stays_local(self):
         assert _pdf_source_is_remote(r"C:\Users\file.pdf") is False

--- a/tests/test_tools_browser.py
+++ b/tests/test_tools_browser.py
@@ -94,6 +94,30 @@ class TestIsPdfUrl:
             mock_req.RequestException = Exception
             assert _is_pdf_url("https://example.com/doc.pdf?v=2") is False
 
+    def test_rejects_file_scheme_before_head(self):
+        with patch("gptme.tools.browser.requests") as mock_req:
+            with pytest.raises(ValueError, match="not allowed"):
+                _is_pdf_url("file:///etc/passwd")
+            mock_req.head.assert_not_called()
+            mock_req.get.assert_not_called()
+
+    def test_rejects_gopher_scheme_before_head(self):
+        with patch("gptme.tools.browser.requests") as mock_req:
+            with pytest.raises(ValueError, match="not allowed"):
+                _is_pdf_url("gopher://example.com/x.pdf")
+            mock_req.head.assert_not_called()
+
+    def test_accepts_uppercase_http_scheme(self):
+        assert _is_pdf_url("HTTP://example.com/x.pdf") is True
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(ValueError, match="hostname"):
+            _is_pdf_url("https://")
+
+    def test_rejects_embedded_credentials(self):
+        with pytest.raises(ValueError, match="credentials"):
+            _is_pdf_url("https://user:pass@example.com/x.pdf")
+
 
 class TestIsGithubRepoUrl:
     """Tests for _is_github_repo_url — detects GitHub repository root URLs."""
@@ -377,6 +401,24 @@ class TestReadPdfUrl:
 
     @patch("gptme.tools.browser.has_pypdf", True)
     @patch("gptme.tools.browser.requests")
+    def test_rejects_file_scheme_before_get(self, mock_requests):
+        from gptme.tools.browser import _read_pdf_url
+
+        with pytest.raises(ValueError, match="not allowed"):
+            _read_pdf_url("file:///tmp/x.pdf")
+        mock_requests.get.assert_not_called()
+
+    @patch("gptme.tools.browser.has_pypdf", True)
+    @patch("gptme.tools.browser.requests")
+    def test_rejects_gopher_scheme_before_get(self, mock_requests):
+        from gptme.tools.browser import _read_pdf_url
+
+        with pytest.raises(ValueError, match="not allowed"):
+            _read_pdf_url("gopher://example.com/x.pdf")
+        mock_requests.get.assert_not_called()
+
+    @patch("gptme.tools.browser.has_pypdf", True)
+    @patch("gptme.tools.browser.requests")
     def test_download_failure(self, mock_requests):
         from gptme.tools.browser import _read_pdf_url
 
@@ -589,6 +631,43 @@ class TestPdfToImages:
         pdf_to_images("https://example.com/doc.pdf", output_dir=tmp_path)
 
         mock_requests.get.assert_called_once()
+
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._convert_with_pdftoppm")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_downloads_uppercase_http_url(
+        self, _, mock_convert, mock_requests, tmp_path
+    ):
+        from gptme.tools.browser import pdf_to_images
+
+        mock_response = MagicMock()
+        mock_response.content = b"%PDF-fake"
+        mock_requests.get.return_value = mock_response
+        mock_convert.return_value = []
+
+        pdf_to_images("HTTP://example.com/x.pdf", output_dir=tmp_path)
+
+        mock_requests.get.assert_called_once_with(
+            "HTTP://example.com/x.pdf", timeout=60
+        )
+
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_rejects_file_url(self, _, mock_requests, tmp_path):
+        from gptme.tools.browser import pdf_to_images
+
+        with pytest.raises(ValueError, match="not allowed"):
+            pdf_to_images("file:///tmp/x.pdf", output_dir=tmp_path)
+        mock_requests.get.assert_not_called()
+
+    @patch("gptme.tools.browser.requests")
+    @patch("gptme.tools.browser._has_pdftoppm", return_value=True)
+    def test_rejects_gopher_url(self, _, mock_requests, tmp_path):
+        from gptme.tools.browser import pdf_to_images
+
+        with pytest.raises(ValueError, match="not allowed"):
+            pdf_to_images("gopher://example.com/x.pdf", output_dir=tmp_path)
+        mock_requests.get.assert_not_called()
 
     @patch("gptme.tools.browser._convert_with_pdftoppm")
     @patch("gptme.tools.browser._has_pdftoppm", return_value=True)


### PR DESCRIPTION
## Summary

Lynx URL hardening landed in #3663, but the PDF/`requests` paths in `gptme/tools/browser.py` still had no helper:

- `_read_pdf_url` and `_is_pdf_url` called `requests.get`/`head` with no scheme check. `file://` / `gopher://` currently die as `InvalidSchema` (no file leak), which is adapter absence, not gptme policy.
- `pdf_to_images` used case-sensitive `startswith(("http://", "https://"))`, so `HTTP://example.com/x.pdf` was treated as a local path.

This PR extracts the #3663 helper to `gptme/tools/_url_safety.py` and applies it **before** any `requests.*` on the PDF paths. Local files still work (including Windows drive letters). Playwright `page.goto` is **not** in this PR.

Supersedes the remaining slice of #3666 (that PR is still on pre-#3663 HEAD `dd9c3aaa96`, lint-red, and the claimed rebase never landed). Does **not** close #3643 (already closed by #3663).

## Test plan

- [x] `pytest tests/test_tools_browser.py tests/test_browser_lynx.py tests/test_pdf_to_images.py` — 139 passed
- [x] pre-commit / ruff on the four files