### PR TITLE
fix(shell): require confirmation for git-credentials and gptme config.toml reads

### DIFF
--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -50,6 +50,7 @@ _SENSITIVE_HOME_DIRS = (
     "~/.pypirc",
     "~/.git-credentials",
     "~/.config/gptme/config.toml",
+    "~/.config/gptme/config.local.toml",
 )
 
 # Commands that are safe to auto-approve without user confirmation

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -48,6 +48,8 @@ _SENSITIVE_HOME_DIRS = (
     "~/.netrc",
     "~/.npmrc",
     "~/.pypirc",
+    "~/.git-credentials",
+    "~/.config/gptme/config.toml",
 )
 
 # Commands that are safe to auto-approve without user confirmation

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -822,13 +822,15 @@ class TestSensitiveArgs:
         [
             "~/.git-credentials",
             "~/.config/gptme/config.toml",
+            "~/.config/gptme/config.local.toml",
         ],
     )
     def test_home_credential_leftovers_not_allowlisted(self, reader: str, path: str):
-        """Phase 4 leftovers: git-credentials and gptme config.toml.
+        """Phase 4 leftovers: git-credentials and gptme config files.
 
         #3636 covered ~/.netrc / ~/.ssh / ~/.aws / ~/.npmrc / ~/.pypirc, but
-        these two home-relative credential files were still auto-approved.
+        these home-relative credential files were still auto-approved.
+        config.local.toml is the overlay that actually holds API keys.
         """
         assert not is_allowlisted(f"{reader} {path}")
 
@@ -837,9 +839,13 @@ class TestSensitiveArgs:
         assert is_allowlisted("cat ~/.git-credentials-backup")
 
     def test_gptme_config_dir_listing_still_allowlisted(self):
-        """Only config.toml is sensitive, not the whole ~/.config/gptme dir."""
+        """Only the two config files are sensitive, not the whole ~/.config/gptme dir."""
         assert is_allowlisted("ls ~/.config/gptme")
         assert is_allowlisted("cat ~/.config/gptme/SOUL.md")
+
+    def test_gptme_config_local_sibling_still_allowlisted(self):
+        """Prefix boundary: config.local.toml.bak is not the secrets overlay."""
+        assert is_allowlisted("cat ~/.config/gptme/config.local.toml.bak")
 
     def test_ls_ssh_dir_not_allowlisted(self):
         """`ls ~/.ssh` must require confirmation — reveals key file names."""
@@ -856,6 +862,10 @@ class TestSensitiveArgs:
     def test_cat_home_var_ssh_not_allowlisted(self):
         """`cat $HOME/.ssh/id_rsa` must be blocked — $HOME is not expanded by shlex."""
         assert not is_allowlisted('cat "$HOME/.ssh/id_rsa"')
+
+    def test_cat_home_var_gptme_config_local_not_allowlisted(self):
+        """config.local.toml via $HOME must also require confirmation."""
+        assert not is_allowlisted('cat "$HOME/.config/gptme/config.local.toml"')
 
     def test_cat_brace_home_var_ssh_not_allowlisted(self):
         assert not is_allowlisted("cat ${HOME}/.ssh/id_rsa")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -813,6 +813,34 @@ class TestSensitiveArgs:
     def test_cat_netrc_not_allowlisted(self):
         assert not is_allowlisted("cat ~/.netrc")
 
+    @pytest.mark.parametrize(
+        "reader",
+        ["cat", "grep token", "head", "tail"],
+    )
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "~/.git-credentials",
+            "~/.config/gptme/config.toml",
+        ],
+    )
+    def test_home_credential_leftovers_not_allowlisted(self, reader: str, path: str):
+        """Phase 4 leftovers: git-credentials and gptme config.toml.
+
+        #3636 covered ~/.netrc / ~/.ssh / ~/.aws / ~/.npmrc / ~/.pypirc, but
+        these two home-relative credential files were still auto-approved.
+        """
+        assert not is_allowlisted(f"{reader} {path}")
+
+    def test_git_credentials_sibling_still_allowlisted(self):
+        """Prefix boundary: ~/.git-credentials-backup is not the credential file."""
+        assert is_allowlisted("cat ~/.git-credentials-backup")
+
+    def test_gptme_config_dir_listing_still_allowlisted(self):
+        """Only config.toml is sensitive, not the whole ~/.config/gptme dir."""
+        assert is_allowlisted("ls ~/.config/gptme")
+        assert is_allowlisted("cat ~/.config/gptme/SOUL.md")
+
     def test_ls_ssh_dir_not_allowlisted(self):
         """`ls ~/.ssh` must require confirmation — reveals key file names."""
         assert not is_allowlisted("ls ~/.ssh")


### PR DESCRIPTION
## Problem

#3636 (`d4a6b8f65`) closed the home-relative credential-dir gap from Phase 3 (#3495): `~/.ssh`, `~/.aws`, `~/.netrc`, `~/.npmrc`, `~/.pypirc`, etc. now require confirmation.

These files from the original Phase 4 matrix were still auto-approved:

```sh
cat ~/.git-credentials
cat ~/.config/gptme/config.toml         # may hold provider API keys
cat ~/.config/gptme/config.local.toml   # the overlay that actually holds keys
```

Same for `grep`/`head`/`tail`. Boundary matching does not treat `config.local.toml` as a child of `config.toml`, so it needs its own prefix.

## Change

Add those bounded prefixes to `_SENSITIVE_HOME_DIRS`. The existing suffix/boundary matcher already covers `$HOME` / `~user` / `//` / `./` spellings.

Out of scope: blocking the whole `~/.config/gptme` directory (`ls ~/.config/gptme` and `cat ~/.config/gptme/SOUL.md` stay AUTO). Sibling `config.local.toml.bak` stays AUTO.

## Tests

Parameterized regressions across `cat`/`grep`/`head`/`tail` plus prefix-boundary controls. `tests/test_tools_shell_validation.py::TestSensitiveArgs` — 432 passed for the full file.

## Related

- Phase 3: gptme/gptme#3495
- Home-dir coverage: gptme/gptme#3636
- Bob task: `agent-permission-audit-phase4-home-credential-paths`