### PR TITLE
fix(knowledge): don't block on gptme-rag index after save/delete

### DIFF
--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -91,19 +91,19 @@ def knowledge_save_cmd(
         except (OSError, ValueError) as e:
             click.echo(f"Warning: gptme-rag mirror export failed: {e}", err=True)
         else:
+            # Fire-and-forget: the entry is already persisted in JSONL, so
+            # keyword search works immediately.  gptme-rag indexing is a
+            # semantic-search enhancement; blocking the CLI for it (up to
+            # the full 30 s timeout) is a poor UX trade-off.
             try:
-                subprocess.run(
+                subprocess.Popen(
                     ["gptme-rag", "index", str(kb_dir / "rag")],
-                    check=True,
-                    capture_output=True,
-                    timeout=30,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
                 )
-            except (
-                OSError,
-                subprocess.CalledProcessError,
-                subprocess.TimeoutExpired,
-            ) as e:
-                click.echo(f"Warning: gptme-rag index failed: {e}", err=True)
+            except OSError as e:
+                click.echo(f"Warning: could not start gptme-rag: {e}", err=True)
 
 
 def _export_for_rag(kb_dir: Path) -> None:
@@ -275,15 +275,18 @@ def knowledge_delete_cmd(entry_id: str):
     # "re-index failed" warning after a successful JSONL delete.
     rag_dir = _knowledge_dir() / "rag"
     if mirror_removed and shutil.which("gptme-rag") and rag_dir.is_dir():
+        # Fire-and-forget: re-indexing after delete is best-effort; the JSONL
+        # store is already consistent and keyword search will not return the
+        # deleted entry.  Don't block the CLI on the RAG index operation.
         try:
-            subprocess.run(
+            subprocess.Popen(
                 ["gptme-rag", "index", str(rag_dir)],
-                check=True,
-                capture_output=True,
-                timeout=30,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
             )
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except OSError as e:
             click.echo(
-                f"Warning: gptme-rag re-index after delete failed: {e}",
+                f"Warning: could not start gptme-rag re-index after delete: {e}",
                 err=True,
             )

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -302,7 +302,8 @@ def test_cli_rag_index_oserror_is_nonfatal(monkeypatch, command):
     def fail(*args, **kwargs):
         raise PermissionError("cannot execute gptme-rag")
 
-    monkeypatch.setattr("gptme.cli.cmd_knowledge.subprocess.run", fail)
+    # Production uses fire-and-forget Popen, not subprocess.run.
+    monkeypatch.setattr("gptme.cli.cmd_knowledge.subprocess.Popen", fail)
     runner = CliRunner()
     if command == "save":
         result = runner.invoke(main, ["knowledge", "save", "problem", "resolution"])
@@ -314,7 +315,7 @@ def test_cli_rag_index_oserror_is_nonfatal(monkeypatch, command):
         result = runner.invoke(main, ["knowledge", "delete", entry["id"]])
 
     assert result.exit_code == 0, result.output
-    assert "Warning: gptme-rag" in result.output
+    assert "could not start gptme-rag" in result.output
     assert "cannot execute gptme-rag" in result.output
 
 
@@ -406,7 +407,7 @@ def test_cli_save_skips_index_when_mirror_export_fails(monkeypatch):
     monkeypatch.setattr("gptme.cli.cmd_knowledge._export_for_rag", fail_export)
     calls = []
     monkeypatch.setattr(
-        "gptme.cli.cmd_knowledge.subprocess.run",
+        "gptme.cli.cmd_knowledge.subprocess.Popen",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
 
@@ -507,7 +508,7 @@ def test_cli_delete_skips_reindex_when_mirror_removal_fails(monkeypatch):
     monkeypatch.setattr(type(mirror), "unlink", fail_unlink)
     calls = []
     monkeypatch.setattr(
-        "gptme.cli.cmd_knowledge.subprocess.run",
+        "gptme.cli.cmd_knowledge.subprocess.Popen",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
 
@@ -541,7 +542,7 @@ def test_cli_delete_skips_reindex_when_rag_dir_missing(monkeypatch):
     monkeypatch.setattr("gptme.cli.cmd_knowledge.shutil.which", lambda _: "gptme-rag")
     calls = []
     monkeypatch.setattr(
-        "gptme.cli.cmd_knowledge.subprocess.run",
+        "gptme.cli.cmd_knowledge.subprocess.Popen",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1320,6 +1320,11 @@ def test_knowledge_save_uses_popen_not_blocking_run(tmp_path, monkeypatch):
 
     assert kwargs.get("stdout") == subprocess.DEVNULL
     assert kwargs.get("stderr") == subprocess.DEVNULL
+    # MagicMock.wait()/communicate() do not block, so without these
+    # assertions the test would still pass if production later added a
+    # proc.wait(timeout=30) and reintroduced the original bug.
+    mock_proc.wait.assert_not_called()
+    mock_proc.communicate.assert_not_called()
 
 
 def test_knowledge_search_empty_query_exits_nonzero(tmp_path, monkeypatch):

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1231,3 +1231,101 @@ def test_context_search_conversations_top_k(tmp_path):
     assert result.exit_code == 0, result.output
     assert "Top 5 relevant conversations" in result.output
     mock_search.assert_called_once_with("pytest", return_full=True, top_k=5)
+
+
+# ---------------------------------------------------------------------------
+# Knowledge sub-commands
+# ---------------------------------------------------------------------------
+
+
+def test_knowledge_save_search_delete_roundtrip(tmp_path, monkeypatch):
+    """save → search → delete works with the JSONL store."""
+    from unittest.mock import patch
+
+    runner = CliRunner()
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    # Stub out gptme-rag so tests run without it installed.
+    with (
+        patch("shutil.which", return_value=None),
+    ):
+        result = runner.invoke(
+            main, ["knowledge", "save", "pytest finds no tests", "add test_ prefix"]
+        )
+    assert result.exit_code == 0, result.output
+    assert "Saved knowledge entry" in result.output
+
+    with (
+        patch("shutil.which", return_value=None),
+    ):
+        result = runner.invoke(main, ["knowledge", "search", "pytest"])
+    assert result.exit_code == 0, result.output
+    assert "pytest finds no tests" in result.output
+
+    # Grab the entry id from the saved output
+    entry_id = result.output.split("[1]")[1].split()[0]
+
+    with (
+        patch("shutil.which", return_value=None),
+    ):
+        result = runner.invoke(main, ["knowledge", "delete", entry_id])
+    assert result.exit_code == 0, result.output
+    assert "Deleted entry" in result.output
+
+    # Should be empty after delete
+    with (
+        patch("shutil.which", return_value=None),
+    ):
+        result = runner.invoke(main, ["knowledge", "search", "pytest"])
+    assert result.exit_code == 0, result.output
+    assert "No matching entries" in result.output
+
+
+def test_knowledge_save_uses_popen_not_blocking_run(tmp_path, monkeypatch):
+    """knowledge save fires gptme-rag in the background (Popen), not subprocess.run.
+
+    Regression test for the 30-second blocking-wait bug: when gptme-rag is
+    installed but slow, ``gptme-util knowledge save`` must not block the CLI.
+    The fix replaces subprocess.run(timeout=30) with subprocess.Popen so the
+    process runs asynchronously.
+    """
+    from unittest.mock import MagicMock, patch
+
+    runner = CliRunner()
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    mock_proc = MagicMock()
+    with (
+        patch("shutil.which", return_value="/usr/bin/gptme-rag"),
+        patch(
+            "gptme.cli.cmd_knowledge._export_for_rag",
+            return_value=None,
+        ),
+        patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+    ):
+        result = runner.invoke(
+            main, ["knowledge", "save", "blocking rag bug", "use Popen not run"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Saved knowledge entry" in result.output
+
+    # Popen must be called (not subprocess.run)
+    mock_popen.assert_called_once()
+    args, kwargs = mock_popen.call_args
+    assert args[0][0] == "gptme-rag", f"Expected gptme-rag as command, got {args[0]}"
+    assert args[0][1] == "index", f"Expected 'index' subcommand, got {args[0]}"
+    # Must be fire-and-forget: DEVNULL fds, no wait
+    import subprocess
+
+    assert kwargs.get("stdout") == subprocess.DEVNULL
+    assert kwargs.get("stderr") == subprocess.DEVNULL
+
+
+def test_knowledge_search_empty_query_exits_nonzero(tmp_path, monkeypatch):
+    """knowledge search with empty query must exit 1 (guarded input)."""
+    runner = CliRunner()
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    result = runner.invoke(main, ["knowledge", "search", ""])
+    assert result.exit_code != 0
+    assert "empty" in result.output.lower() or "empty" in (result.stderr or "").lower()


### PR DESCRIPTION
## Problem

`gptme-util knowledge save` blocks for up to 30 seconds waiting for `gptme-rag index` to complete:

```
$ time gptme-util knowledge save "p" "r"
Saved knowledge entry 4aa4fd1d
Warning: gptme-rag index failed: Command ... timed out after 30 seconds

real    0m30.281s   ← 30 s for a write to a local JSONL file
```

The entry is already persisted in JSONL before the RAG indexing starts, so keyword search works immediately. The 30-second synchronous wait is a UX regression added alongside the knowledge feature.

## Fix

Replace `subprocess.run(timeout=30)` with `subprocess.Popen` (fire-and-forget) in both `knowledge save` and `knowledge delete`. The OS reaps the orphaned gptme-rag indexer when it finishes; the CLI returns in < 0.2 s.

```
$ time gptme-util knowledge save "p" "r"
Saved knowledge entry fbd2a7cb

real    0m0.170s   ✓
```

## Tests

Three new tests in `tests/test_util_cli.py`:

- **`test_knowledge_save_uses_popen_not_blocking_run`** — regression guard: asserts `subprocess.Popen` is called (not `subprocess.run`) and that stdout/stderr are `DEVNULL` (fire-and-forget, no wait)
- **`test_knowledge_save_search_delete_roundtrip`** — end-to-end JSONL path: save → search finds entry → delete → search returns empty
- **`test_knowledge_search_empty_query_exits_nonzero`** — empty query is rejected with a non-zero exit code