### PR TITLE
feat(knowledge): generalize KB schema beyond problem/resolution pairs

### DIFF
--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -37,8 +37,8 @@ def knowledge():
 
 
 @knowledge.command("save")
-@click.argument("problem")
-@click.argument("resolution")
+@click.argument("primary")
+@click.argument("secondary")
 @click.option(
     "--tag",
     "-t",
@@ -46,24 +46,58 @@ def knowledge():
     multiple=True,
     help="Tag to attach (repeatable: -t git -t pytest).",
 )
+@click.option(
+    "--type",
+    "-T",
+    "entry_type",
+    default="problem_resolution",
+    show_default=True,
+    type=click.Choice(
+        ["problem_resolution", "decision", "fact", "how_to", "note"],
+        case_sensitive=True,
+    ),
+    help=(
+        "Entry type. Controls how PRIMARY and SECONDARY are labelled:\n\n\b\n"
+        "  problem_resolution: Problem / Resolution (default)\n"
+        "  decision:           Decision / Rationale\n"
+        "  fact:               Topic / Fact\n"
+        "  how_to:             Task / Steps\n"
+        "  note:               Title / Content\n"
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Print saved entry as JSON.")
 def knowledge_save_cmd(
-    problem: str, resolution: str, tags: tuple[str, ...], as_json: bool
+    primary: str,
+    secondary: str,
+    tags: tuple[str, ...],
+    entry_type: str,
+    as_json: bool,
 ):
-    """Save a PROBLEM/RESOLUTION pair to the knowledge base.
+    """Save a knowledge entry to the knowledge base.
 
-    Example:
+    PRIMARY and SECONDARY are the two required text fields. Their meaning depends
+    on --type (default: problem_resolution → Problem / Resolution).
 
     \b
+    Examples:
+
         gptme-util knowledge save \\
           "pytest discovers no tests despite test file existing" \\
           "The test function was not prefixed with test_; rename it." \\
           -t pytest -t testing
+
+        gptme-util knowledge save --type note \\
+          "gptme startup checklist" \\
+          "1. Read SOUL.md  2. Check gptodo status  3. Run context.sh"
+
+        gptme-util knowledge save --type decision \\
+          "Use JSONL as the knowledge store source of truth" \\
+          "Simpler than SQLite; append-only is safe under concurrent agents."
     """
     from ..knowledge import knowledge_save  # fmt: skip
 
     try:
-        entry = knowledge_save(problem, resolution, list(tags))
+        entry = knowledge_save(primary, secondary, list(tags), entry_type=entry_type)
     except (ValueError, OSError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -71,7 +105,8 @@ def knowledge_save_cmd(
     if as_json:
         click.echo(json.dumps(entry, indent=2))
     else:
-        click.echo(f"Saved knowledge entry {entry['id'][:8]}")
+        type_label = "" if entry_type == "problem_resolution" else f" [{entry_type}]"
+        click.echo(f"Saved knowledge entry{type_label} {entry['id'][:8]}")
         if entry["tags"]:
             click.echo(
                 f"  Tags: {', '.join(_strip_controls(t) for t in entry['tags'])}"
@@ -127,13 +162,19 @@ def _export_for_rag(kb_dir: Path) -> None:
         for entry in entries:
             eid = entry.get("id", "unknown")
             fpath = rag_dir / f"{eid}.md"
+            from ..knowledge import ENTRY_TYPE_LABELS  # fmt: skip
+
+            et = str(entry.get("entry_type") or "problem_resolution")
+            primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
+                et, ENTRY_TYPE_LABELS["problem_resolution"]
+            )
             tags_line = ""
             if entry.get("tags"):
                 tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
             content = (
-                f"# Knowledge Entry\n\n"
-                f"**Problem**: {entry.get('problem', '')}\n\n"
-                f"**Resolution**: {entry.get('resolution', '')}\n"
+                f"# Knowledge Entry ({et})\n\n"
+                f"**{primary_label}**: {entry.get('problem', '')}\n\n"
+                f"**{secondary_label}**: {entry.get('resolution', '')}\n"
                 f"{tags_line}"
             )
             fpath.write_text(content, encoding="utf-8")
@@ -177,11 +218,19 @@ def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json:
         return
 
     for i, entry in enumerate(results, 1):
-        click.echo(f"\n[{i}] {entry['id'][:8]}  {entry.get('created_at', '')[:10]}")
+        et = str(entry.get("entry_type") or "problem_resolution")
+        click.echo(
+            f"\n[{i}] {entry['id'][:8]}  {entry.get('created_at', '')[:10]}  ({et})"
+        )
         if entry.get("tags"):
             click.echo(f"    Tags: {_strip_controls(', '.join(entry['tags']))}")
-        click.echo(f"    Problem:    {_strip_controls(entry['problem'])}")
-        click.echo(f"    Resolution: {_strip_controls(entry['resolution'])}")
+        from ..knowledge import ENTRY_TYPE_LABELS  # fmt: skip
+
+        primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
+            et, ENTRY_TYPE_LABELS["problem_resolution"]
+        )
+        click.echo(f"    {primary_label}:    {_strip_controls(entry['problem'])}")
+        click.echo(f"    {secondary_label}: {_strip_controls(entry['resolution'])}")
 
 
 @knowledge.command("list")
@@ -216,12 +265,13 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
     for entry in entries:
         eid = entry.get("id", "")[:8]
         date = entry.get("created_at", "")[:10]
+        et = str(entry.get("entry_type") or "problem_resolution")
         tags_str = (
             f"  [{_strip_controls(', '.join(entry['tags']))}]"
             if entry.get("tags")
             else ""
         )
-        click.echo(f"  {eid}  {date}{tags_str}")
+        click.echo(f"  {eid}  {date}  {et}{tags_str}")
         click.echo(f"    {_strip_controls(entry['problem'][:80])}")
 
 

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -148,7 +148,12 @@ def _export_for_rag(kb_dir: Path) -> None:
     mirror writes reflect the same consistent view of the JSONL file, preventing
     a concurrent delete from being resurrected by a stale export snapshot.
     """
-    from ..knowledge import _exclusive_lock, _load_entries  # fmt: skip
+    from ..knowledge import (  # fmt: skip
+        ENTRY_TYPE_LABELS,
+        _exclusive_lock,
+        _load_entries,
+        _resolved_entry_type,
+    )
 
     rag_dir = kb_dir / "rag"
     rag_dir.mkdir(parents=True, exist_ok=True)
@@ -162,12 +167,8 @@ def _export_for_rag(kb_dir: Path) -> None:
         for entry in entries:
             eid = entry.get("id", "unknown")
             fpath = rag_dir / f"{eid}.md"
-            from ..knowledge import ENTRY_TYPE_LABELS  # fmt: skip
-
-            et = str(entry.get("entry_type") or "problem_resolution")
-            primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
-                et, ENTRY_TYPE_LABELS["problem_resolution"]
-            )
+            et = _resolved_entry_type(entry)
+            primary_label, secondary_label = ENTRY_TYPE_LABELS[et]
             tags_line = ""
             if entry.get("tags"):
                 tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
@@ -217,15 +218,15 @@ def knowledge_search_cmd(query: str, top_k: int, tags: tuple[str, ...], as_json:
         click.echo("No matching entries found.")
         return
 
+    from ..knowledge import ENTRY_TYPE_LABELS, _resolved_entry_type  # fmt: skip
+
     for i, entry in enumerate(results, 1):
-        et = str(entry.get("entry_type") or "problem_resolution")
+        et = _strip_controls(_resolved_entry_type(entry))
         click.echo(
             f"\n[{i}] {entry['id'][:8]}  {entry.get('created_at', '')[:10]}  ({et})"
         )
         if entry.get("tags"):
             click.echo(f"    Tags: {_strip_controls(', '.join(entry['tags']))}")
-        from ..knowledge import ENTRY_TYPE_LABELS  # fmt: skip
-
         primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
             et, ENTRY_TYPE_LABELS["problem_resolution"]
         )
@@ -261,11 +262,13 @@ def knowledge_list_cmd(tags: tuple[str, ...], limit: int, as_json: bool):
         click.echo("No entries in knowledge base.")
         return
 
+    from ..knowledge import _resolved_entry_type  # fmt: skip
+
     click.echo(f"Knowledge base ({len(entries)} entries):\n")
     for entry in entries:
         eid = entry.get("id", "")[:8]
         date = entry.get("created_at", "")[:10]
-        et = str(entry.get("entry_type") or "problem_resolution")
+        et = _strip_controls(_resolved_entry_type(entry))
         tags_str = (
             f"  [{_strip_controls(', '.join(entry['tags']))}]"
             if entry.get("tags")

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -168,7 +168,9 @@ def _export_for_rag(kb_dir: Path) -> None:
             eid = entry.get("id", "unknown")
             fpath = rag_dir / f"{eid}.md"
             et = _resolved_entry_type(entry)
-            primary_label, secondary_label = ENTRY_TYPE_LABELS[et]
+            primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
+                et, ENTRY_TYPE_LABELS["problem_resolution"]
+            )
             tags_line = ""
             if entry.get("tags"):
                 tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"

--- a/gptme/cli/cmd_knowledge.py
+++ b/gptme/cli/cmd_knowledge.py
@@ -173,11 +173,11 @@ def _export_for_rag(kb_dir: Path) -> None:
             )
             tags_line = ""
             if entry.get("tags"):
-                tags_line = f"\n**Tags**: {', '.join(entry['tags'])}\n"
+                tags_line = f"\n**Tags**: {', '.join(_strip_controls(t) for t in entry['tags'])}\n"
             content = (
                 f"# Knowledge Entry ({et})\n\n"
-                f"**{primary_label}**: {entry.get('problem', '')}\n\n"
-                f"**{secondary_label}**: {entry.get('resolution', '')}\n"
+                f"**{primary_label}**: {_strip_controls(entry.get('problem', ''))}\n\n"
+                f"**{secondary_label}**: {_strip_controls(entry.get('resolution', ''))}\n"
                 f"{tags_line}"
             )
             fpath.write_text(content, encoding="utf-8")

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -36,6 +36,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, cast
 
+from typing_extensions import NotRequired
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -59,7 +61,7 @@ class KnowledgeEntry(TypedDict):
     keywords: list[str]
     created_at: str
     memory_type: str  # always "knowledge_entry" — used by gptme-rag source filter
-    entry_type: str  # one of ENTRY_TYPES; defaults to "problem_resolution"
+    entry_type: NotRequired[str]  # absent in legacy entries; one of ENTRY_TYPES
 
 
 def _knowledge_dir() -> Path:
@@ -118,8 +120,10 @@ def _is_valid_entry(parsed: object) -> bool:
         return False
     # entry_type is optional (absent in pre-generalization entries); when present
     # it must be a known type string so corrupt data doesn't leak into prompts.
-    et = parsed.get("entry_type")
-    return not (et is not None and not isinstance(et, str))
+    entry_type = parsed.get("entry_type")
+    return entry_type is None or (
+        isinstance(entry_type, str) and entry_type in ENTRY_TYPES
+    )
 
 
 def _load_entries() -> list[KnowledgeEntry]:
@@ -345,6 +349,14 @@ def select_knowledge_for_session(
         return []
 
 
+def _resolved_entry_type(entry: KnowledgeEntry) -> str:
+    """Return a known entry type; unknown or absent values become the default."""
+    et = entry.get("entry_type")
+    if isinstance(et, str) and et in ENTRY_TYPES:
+        return et
+    return "problem_resolution"
+
+
 def format_knowledge_prompt(entries: list[KnowledgeEntry]) -> str:
     """Format matching KB entries as a compact system-prompt block."""
     if not entries:
@@ -355,10 +367,8 @@ def format_knowledge_prompt(entries: list[KnowledgeEntry]) -> str:
         "",
     ]
     for i, entry in enumerate(entries, start=1):
-        et = str(entry.get("entry_type") or "problem_resolution")
-        primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
-            et, ENTRY_TYPE_LABELS["problem_resolution"]
-        )
+        et = _resolved_entry_type(entry)
+        primary_label, secondary_label = ENTRY_TYPE_LABELS[et]
         primary = _clip(str(entry.get("problem", "")))
         secondary = _clip(str(entry.get("resolution", "")))
         lines.append(f"{i}. [{et}] {primary_label}: {primary}")

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -1,12 +1,24 @@
 """
-Cross-session knowledge base: save and retrieve problem/resolution pairs.
+Cross-session knowledge base: save and retrieve structured knowledge entries.
 
 Entries are stored as JSONL at ``~/.local/share/gptme/knowledge/entries.jsonl``
 (respects XDG_DATA_HOME).  Each entry carries ``memory_type="knowledge_entry"``
 so gptme-rag's ``KnowledgeEntrySource`` can index the same JSONL.
 
-Retrieval without gptme-rag uses keyword search over problem + resolution
-text. Matching entries are injected at session start (see
+Entry types (``entry_type`` field):
+
+- ``problem_resolution`` (default): a problem/resolution pair.
+- ``decision``: a decision and its rationale.
+- ``fact``: a topic and a fact about it.
+- ``how_to``: a task description and step-by-step instructions.
+- ``note``: a free-form title and content block.
+
+All types store text in the same ``problem``/``resolution`` fields (the
+primary text pair) so backward compatibility is preserved. ``entry_type``
+controls how they are displayed and how the CLI labels the prompts.
+
+Retrieval without gptme-rag uses keyword search over the full text.
+Matching entries are injected at session start (see
 ``gptme.hooks.knowledge_inject``) when the initial prompt has enough
 signal to search.
 """
@@ -29,15 +41,25 @@ if TYPE_CHECKING:
 
 from .dirs import get_data_dir
 
+ENTRY_TYPES = ("problem_resolution", "decision", "fact", "how_to", "note")
+ENTRY_TYPE_LABELS: dict[str, tuple[str, str]] = {
+    "problem_resolution": ("Problem", "Resolution"),
+    "decision": ("Decision", "Rationale"),
+    "fact": ("Topic", "Fact"),
+    "how_to": ("Task", "Steps"),
+    "note": ("Title", "Content"),
+}
+
 
 class KnowledgeEntry(TypedDict):
     id: str
-    problem: str
-    resolution: str
+    problem: str  # primary text field (label varies by entry_type)
+    resolution: str  # secondary text field (label varies by entry_type)
     tags: list[str]
     keywords: list[str]
     created_at: str
     memory_type: str  # always "knowledge_entry" — used by gptme-rag source filter
+    entry_type: str  # one of ENTRY_TYPES; defaults to "problem_resolution"
 
 
 def _knowledge_dir() -> Path:
@@ -84,7 +106,7 @@ def _is_valid_entry(parsed: object) -> bool:
         uuid.UUID(parsed.get("id", ""))
     except (AttributeError, TypeError, ValueError):
         return False
-    return all(
+    if not all(
         isinstance(parsed.get(key), expected_type)
         for key, expected_type in (
             ("problem", str),
@@ -92,7 +114,12 @@ def _is_valid_entry(parsed: object) -> bool:
             ("tags", list),
             ("created_at", str),
         )
-    ) and all(isinstance(tag, str) for tag in parsed["tags"])
+    ) or not all(isinstance(tag, str) for tag in parsed["tags"]):
+        return False
+    # entry_type is optional (absent in pre-generalization entries); when present
+    # it must be a known type string so corrupt data doesn't leak into prompts.
+    et = parsed.get("entry_type")
+    return not (et is not None and not isinstance(et, str))
 
 
 def _load_entries() -> list[KnowledgeEntry]:
@@ -156,13 +183,26 @@ def knowledge_save(
     problem: str,
     resolution: str,
     tags: list[str] | None = None,
+    entry_type: str = "problem_resolution",
 ) -> KnowledgeEntry:
-    """Save a problem/resolution pair to the cross-session knowledge base.
+    """Save a structured knowledge entry to the cross-session knowledge base.
 
     Args:
-        problem: Description of the problem or question.
-        resolution: How it was resolved or answered.
+        problem: Primary text field. Meaning depends on entry_type:
+            - ``problem_resolution``: description of the problem
+            - ``decision``: the decision made
+            - ``fact``: topic the fact is about
+            - ``how_to``: task being explained
+            - ``note``: title of the note
+        resolution: Secondary text field. Meaning depends on entry_type:
+            - ``problem_resolution``: how it was resolved
+            - ``decision``: rationale for the decision
+            - ``fact``: the fact itself
+            - ``how_to``: step-by-step instructions
+            - ``note``: the note content
         tags: Optional list of topic tags (e.g. ["git", "pytest"]).
+        entry_type: One of ``problem_resolution``, ``decision``, ``fact``,
+            ``how_to``, or ``note``. Defaults to ``problem_resolution``.
 
     Returns:
         The saved entry dict.
@@ -171,6 +211,10 @@ def knowledge_save(
         raise ValueError("problem cannot be empty")
     if not resolution.strip():
         raise ValueError("resolution cannot be empty")
+    if entry_type not in ENTRY_TYPES:
+        raise ValueError(
+            f"entry_type must be one of {ENTRY_TYPES!r}, got {entry_type!r}"
+        )
 
     keywords = _extract_keywords(f"{problem} {resolution}")
     entry: KnowledgeEntry = {
@@ -181,6 +225,7 @@ def knowledge_save(
         "keywords": keywords,
         "created_at": datetime.now(tz=timezone.utc).isoformat(),
         "memory_type": "knowledge_entry",
+        "entry_type": entry_type,
     }
     _append_entry(entry)
     return entry
@@ -310,10 +355,14 @@ def format_knowledge_prompt(entries: list[KnowledgeEntry]) -> str:
         "",
     ]
     for i, entry in enumerate(entries, start=1):
-        problem = _clip(str(entry.get("problem", "")))
-        resolution = _clip(str(entry.get("resolution", "")))
-        lines.append(f"{i}. {problem}")
-        lines.append(f"   {resolution}")
+        et = str(entry.get("entry_type") or "problem_resolution")
+        primary_label, secondary_label = ENTRY_TYPE_LABELS.get(
+            et, ENTRY_TYPE_LABELS["problem_resolution"]
+        )
+        primary = _clip(str(entry.get("problem", "")))
+        secondary = _clip(str(entry.get("resolution", "")))
+        lines.append(f"{i}. [{et}] {primary_label}: {primary}")
+        lines.append(f"   {secondary_label}: {secondary}")
         tags = [t for t in entry.get("tags", []) if isinstance(t, str) and t.strip()]
         if tags:
             lines.append(f"   tags: {_clip(', '.join(tags))}")

--- a/gptme/knowledge.py
+++ b/gptme/knowledge.py
@@ -120,10 +120,12 @@ def _is_valid_entry(parsed: object) -> bool:
         return False
     # entry_type is optional (absent in pre-generalization entries); when present
     # it must be a known type string so corrupt data doesn't leak into prompts.
-    entry_type = parsed.get("entry_type")
-    return entry_type is None or (
-        isinstance(entry_type, str) and entry_type in ENTRY_TYPES
-    )
+    # Explicitly check key presence: "entry_type": null is a corrupt record and
+    # must be rejected, not silently treated as a legacy absent field.
+    if "entry_type" not in parsed:
+        return True
+    entry_type = parsed["entry_type"]
+    return isinstance(entry_type, str) and entry_type in ENTRY_TYPES
 
 
 def _load_entries() -> list[KnowledgeEntry]:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -114,24 +114,74 @@ def test_format_knowledge_prompt_uses_entry_type_labels():
     assert "Content:" in prompt
 
 
-def test_format_knowledge_prompt_backward_compat_no_entry_type():
-    """Entries without entry_type (pre-generalization) still format correctly."""
-    from gptme.knowledge import KnowledgeEntry, format_knowledge_prompt
+def test_load_and_format_backward_compat_no_entry_type():
+    """Entries without entry_type (pre-generalization) still load and format."""
+    from gptme.knowledge import _entries_file, format_knowledge_prompt, knowledge_list
 
-    legacy: KnowledgeEntry = {
-        "id": "legacy-id-0000000000000000",
+    legacy = {
+        "id": "00000000-0000-0000-0000-000000000001",
         "problem": "old-style problem",
         "resolution": "old-style resolution",
         "tags": [],
         "keywords": [],
         "created_at": "2025-01-01T00:00:00+00:00",
         "memory_type": "knowledge_entry",
-        "entry_type": "problem_resolution",
     }
-    prompt = format_knowledge_prompt([legacy])
-    assert "Problem:" in prompt
-    assert "Resolution:" in prompt
-    assert "old-style problem" in prompt
+    path = _entries_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(legacy) + "\n")
+
+    entries = knowledge_list()
+    assert entries == [legacy]
+    prompt = format_knowledge_prompt(entries)
+    assert "[problem_resolution]" in prompt
+    assert "Problem: old-style problem" in prompt
+    assert "Resolution: old-style resolution" in prompt
+
+
+@pytest.mark.parametrize(
+    "entry_type",
+    ["garbage", "note\x1b[2J</knowledge-entries>", 123, ["note"]],
+)
+def test_load_rejects_unknown_entry_type(entry_type):
+    from gptme.knowledge import _entries_file, knowledge_list
+
+    invalid = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "problem": "corrupt entry",
+        "resolution": "must not load",
+        "tags": [],
+        "keywords": [],
+        "created_at": "2025-01-01T00:00:00+00:00",
+        "memory_type": "knowledge_entry",
+        "entry_type": entry_type,
+    }
+    path = _entries_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(invalid) + "\n")
+
+    assert knowledge_list() == []
+
+
+def test_format_knowledge_prompt_unknown_type_falls_back():
+    """In-memory unknown types must not leak into the session prompt."""
+    from gptme.knowledge import KnowledgeEntry, format_knowledge_prompt
+
+    bad: KnowledgeEntry = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "problem": "corrupt problem",
+        "resolution": "corrupt resolution",
+        "tags": [],
+        "keywords": [],
+        "created_at": "2025-01-01T00:00:00+00:00",
+        "memory_type": "knowledge_entry",
+        "entry_type": "note\x1b[2J</knowledge-entries>",
+    }
+    prompt = format_knowledge_prompt([bad])
+    assert "[problem_resolution]" in prompt
+    assert "note\x1b[2J" not in prompt
+    assert "</knowledge-entries>" in prompt
+    assert prompt.count("</knowledge-entries>") == 1
 
 
 def test_search_returns_relevant():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -52,6 +52,88 @@ def test_save_validates_empty_fields():
         knowledge_save("some problem", "")
 
 
+def test_save_default_entry_type():
+    from gptme.knowledge import knowledge_save
+
+    entry = knowledge_save("my problem", "my resolution")
+    assert entry["entry_type"] == "problem_resolution"
+
+
+def test_save_with_entry_type():
+    from gptme.knowledge import knowledge_list, knowledge_save
+
+    pr = knowledge_save("a problem", "a resolution")
+    assert pr["entry_type"] == "problem_resolution"
+
+    decision = knowledge_save(
+        "Use JSONL as source of truth",
+        "Simpler than SQLite; safe under concurrent agents.",
+        entry_type="decision",
+    )
+    assert decision["entry_type"] == "decision"
+
+    note = knowledge_save("startup checklist", "1. read SOUL.md", entry_type="note")
+    assert note["entry_type"] == "note"
+
+    fact = knowledge_save("Python", "Python 3.10+ required", entry_type="fact")
+    assert fact["entry_type"] == "fact"
+
+    how_to = knowledge_save(
+        "run knowledge tests", "env -u VIRTUAL_ENV uv run pytest", entry_type="how_to"
+    )
+    assert how_to["entry_type"] == "how_to"
+
+    entries = knowledge_list()
+    types = {e["entry_type"] for e in entries}
+    assert {"problem_resolution", "decision", "note", "fact", "how_to"} == types
+
+
+def test_save_rejects_invalid_entry_type():
+    from gptme.knowledge import knowledge_save
+
+    with pytest.raises(ValueError, match="entry_type"):
+        knowledge_save("a problem", "a resolution", entry_type="garbage")
+
+
+def test_format_knowledge_prompt_uses_entry_type_labels():
+    from gptme.knowledge import format_knowledge_prompt, knowledge_save
+
+    decision = knowledge_save(
+        "Use JSONL not SQLite",
+        "Easier for concurrent writers.",
+        entry_type="decision",
+    )
+    note = knowledge_save("handy link", "https://example.com", entry_type="note")
+    prompt = format_knowledge_prompt([decision, note])
+
+    assert "[decision]" in prompt
+    assert "Decision:" in prompt
+    assert "Rationale:" in prompt
+    assert "[note]" in prompt
+    assert "Title:" in prompt
+    assert "Content:" in prompt
+
+
+def test_format_knowledge_prompt_backward_compat_no_entry_type():
+    """Entries without entry_type (pre-generalization) still format correctly."""
+    from gptme.knowledge import KnowledgeEntry, format_knowledge_prompt
+
+    legacy: KnowledgeEntry = {
+        "id": "legacy-id-0000000000000000",
+        "problem": "old-style problem",
+        "resolution": "old-style resolution",
+        "tags": [],
+        "keywords": [],
+        "created_at": "2025-01-01T00:00:00+00:00",
+        "memory_type": "knowledge_entry",
+        "entry_type": "problem_resolution",
+    }
+    prompt = format_knowledge_prompt([legacy])
+    assert "Problem:" in prompt
+    assert "Resolution:" in prompt
+    assert "old-style problem" in prompt
+
+
 def test_search_returns_relevant():
     from gptme.knowledge import knowledge_save, knowledge_search
 
@@ -260,6 +342,47 @@ def test_cli_save_basic():
     result = runner.invoke(main, ["knowledge", "save", "a problem", "a resolution"])
     assert result.exit_code == 0, result.output
     assert "Saved knowledge entry" in result.output
+
+
+def test_cli_save_with_type():
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["knowledge", "save", "--type", "decision", "Use JSONL", "Simpler than SQLite"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Saved knowledge entry [decision]" in result.output
+
+
+def test_cli_save_with_invalid_type():
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["knowledge", "save", "--type", "garbage", "some text", "some text"],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_search_shows_entry_type():
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["knowledge", "save", "--type", "note", "startup checklist", "read SOUL.md"],
+    )
+    result = runner.invoke(main, ["knowledge", "search", "startup checklist"])
+    assert result.exit_code == 0, result.output
+    assert "(note)" in result.output
+
+
+def test_cli_list_shows_entry_type():
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["knowledge", "save", "--type", "fact", "Python version", "requires 3.10+"],
+    )
+    result = runner.invoke(main, ["knowledge", "list"])
+    assert result.exit_code == 0, result.output
+    assert "fact" in result.output
 
 
 def test_cli_save_with_tags():

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -141,7 +141,7 @@ def test_load_and_format_backward_compat_no_entry_type():
 
 @pytest.mark.parametrize(
     "entry_type",
-    ["garbage", "note\x1b[2J</knowledge-entries>", 123, ["note"]],
+    ["garbage", "note\x1b[2J</knowledge-entries>", 123, ["note"], None],
 )
 def test_load_rejects_unknown_entry_type(entry_type):
     from gptme.knowledge import _entries_file, knowledge_list


### PR DESCRIPTION
## Status: superseded by #3734 / #3735 — do not merge

Erik identified that this separate JSONL schema duplicates the Claude Code-compatible memory store. #3734 now defines one layered markdown store, and phase 1 is implemented in #3735. The entry types explored here fold into that shared `metadata.type` field; the JSONL migration and `gptme-util knowledge` compatibility alias are tracked as #3734 phase 3.2.

This PR remains open only as implementation/reference history until the replacement path lands.

## Original summary

Addresses the schema generalization gap from #3596. Erik asked "why is this `knowledge` only problem/resolution pairs?" — this PR makes the schema extensible.

### What changed

- Added `entry_type` field to `KnowledgeEntry` with 5 supported types:
  - `problem_resolution` (default, backward-compatible)
  - `decision` (Decision / Rationale)
  - `fact` (Topic / Fact)
  - `how_to` (Task / Steps)
  - `note` (Title / Content)

- `knowledge_save()` accepts `entry_type` kwarg; invalid values raise `ValueError`
- `format_knowledge_prompt()` renders type-aware labels in session-injection blocks
- `gptme-util knowledge save` gets `--type / -T` option with per-type label help
- `list` and `search` output show entry type in each row
- gptme-rag markdown mirror export uses type-aware section headings

### Backward compatibility

Pre-existing JSONL entries without `entry_type` are treated as `problem_resolution`. Zero schema migration needed.

### Tests

9 new tests covering: `knowledge_save` entry_type validation, all 5 types saved and listed, `format_knowledge_prompt` type-aware labels, backward-compat (no entry_type field), CLI `--type` save/search/list display.

## Context

- The JSONL store, CLI save/search/list/delete, and session-start injection hook all landed in #3622
- gptme-rag's `KnowledgeEntrySource` (gptme-rag 0.5.1) is available for semantic indexing
- This PR closes the remaining schema generalization gap

Originally targeted #3596; superseded by #3734 (do not merge this PR).

<!-- gptme-id:v1:gai_S15JlwfjuyAzSMPIW79TbUxdEN4u6CIGo628mTR0rRp -->
