### PR TITLE
fix(codeblock): skip depth-1 look-ahead for execution langs (shell, ipython)

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -102,22 +102,42 @@ class Codeblock:
 def _find_heredoc_terminator(line: str) -> str | None:
     """Return the heredoc terminator word if ``line`` opens a heredoc.
 
-    Only recognizes ``<<`` operators at top-level (outside quoted strings):
-    a heredoc operator is shell syntax and never occurs inside a quoted
-    literal, so ``echo "a << b"`` is correctly ignored while
-    ``cat << 'EOF' > file.md`` is recognized. Unquoted ``<<`` arithmetic
+    Only recognizes ``<<`` operators at top-level (outside quoted strings,
+    outside comments, and not backslash-escaped): a heredoc operator is
+    shell syntax and never occurs inside a quoted literal or a ``#``
+    comment, so ``echo "a << b"`` and ``# see a << b`` are correctly
+    ignored while ``cat << 'EOF' > file.md`` is recognized. A backslash
+    escapes the next character (matching shell quoting rules), so
+    ``echo \\# not-a-comment`` and escaped quotes inside a double-quoted
+    string don't desync the quote tracker. The terminator word accepts any
+    run of non-whitespace, non-quote characters (bash heredoc words aren't
+    restricted to ``\\w``, e.g. ``<<'END-TAG'``). Unquoted ``<<`` arithmetic
     shifts (e.g. ipython ``x << 2``) can still false-positive; the
     terminator word must then appear alone on a line to matter, which is
     rare in practice.
     """
     in_single = in_double = False
     i = 0
-    while i < len(line) - 1:
+    n = len(line)
+    while i < n - 1:
         c = line[i]
+        if c == "\\" and not in_single:
+            # Backslash escapes the next char outside single quotes (bash
+            # doesn't allow escaping inside single quotes at all).
+            i += 2
+            continue
         if c == "'" and not in_double:
             in_single = not in_single
         elif c == '"' and not in_single:
             in_double = not in_double
+        elif (
+            c == "#"
+            and not in_single
+            and not in_double
+            and (i == 0 or line[i - 1].isspace())
+        ):
+            # Start of a shell comment - nothing after it is executable syntax.
+            return None
         elif (
             c == "<"
             and line[i + 1] == "<"
@@ -125,7 +145,7 @@ def _find_heredoc_terminator(line: str) -> str | None:
             and not in_double
             and (i == 0 or line[i - 1] != "<")
         ):
-            m = re.match(r"<<-?\s*['\"]?(\w+)['\"]?", line[i:])
+            m = re.match(r"<<-?\s*['\"]?([^\s'\"]+)['\"]?", line[i:])
             if m:
                 return m.group(1)
         i += 1

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -233,6 +233,10 @@ def _extract_codeblocks(
 
             # Track nesting depth to handle nested code blocks
             nesting_depth = 1
+            # For exec langs: track heredoc state so embedded fences inside a heredoc
+            # body (e.g. a shell script writing a markdown file) are treated as literal
+            # content and never as block closers.
+            heredoc_terminator: str | None = None
 
             # Collect content until we find the matching closing ```
             while i < len(lines):
@@ -276,6 +280,18 @@ def _extract_codeblocks(
                         lines[i] = rest
                         reprocess_current_line = True
                         break
+
+                # Update heredoc state for exec langs before fence detection.
+                # A heredoc body may contain literal fence lines (e.g. a shell script
+                # writing a markdown file via cat << EOF).  Track open/close so the
+                # fence-termination logic below can distinguish them from block closers.
+                if lang in _EXEC_LANGS:
+                    if heredoc_terminator is None:
+                        m = re.search(r"<<-?\s*['\"]?(\w+)['\"]?", line)
+                        if m:
+                            heredoc_terminator = m.group(1)
+                    elif line.strip() == heredoc_terminator:
+                        heredoc_terminator = None
 
                 # Check if this line starts with backticks (potential opening or closing)
                 line_fence_match = re.match(r"^(`{3,})", line)
@@ -338,11 +354,15 @@ def _extract_codeblocks(
                         elif (
                             next_has_content
                             and not next_is_fence
-                            and lang not in _EXEC_LANGS
+                            and (
+                                lang not in _EXEC_LANGS
+                                or heredoc_terminator is not None
+                            )
                         ):
                             # Next line has content - check if this is a real nested block.
-                            # Skipped for execution languages (shell, ipython, etc.) where
-                            # a bare fence is always a closer, never a nested opener.
+                            # For exec langs outside a heredoc: bare fence is always a
+                            # closer (no triple-backtick syntax).  Inside a heredoc the
+                            # fence is literal content, so apply the look-ahead as normal.
                             if nesting_depth > 1:
                                 # We're already nested, this opens another level
                                 nesting_depth += 1

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -110,11 +110,17 @@ def _find_heredoc_terminator(line: str) -> str | None:
     escapes the next character (matching shell quoting rules), so
     ``echo \\# not-a-comment`` and escaped quotes inside a double-quoted
     string don't desync the quote tracker. The terminator word accepts any
-    run of non-whitespace, non-quote characters (bash heredoc words aren't
-    restricted to ``\\w``, e.g. ``<<'END-TAG'``). Unquoted ``<<`` arithmetic
-    shifts (e.g. ipython ``x << 2``) can still false-positive; the
-    terminator word must then appear alone on a line to matter, which is
-    rare in practice.
+    run of non-whitespace, non-quote, non-backslash characters (bash
+    heredoc words aren't restricted to ``\\w``, e.g. ``<<'END-TAG'``), with
+    an optional single leading quote-or-backslash consumed but not part of
+    the terminator (``<<'EOF'``, ``<<"EOF"``, and ``<<\\EOF`` all use the
+    plain word ``EOF``). A ``<<<`` here-string takes one inline value and
+    never opens a multi-line body, so it's explicitly not matched here -
+    otherwise the capture group would swallow the third ``<`` as part of
+    the (bogus) terminator and heredoc state would never close. Unquoted
+    ``<<`` arithmetic shifts (e.g. ipython ``x << 2``) can still
+    false-positive; the terminator word must then appear alone on a line
+    to matter, which is rare in practice.
     """
     in_single = in_double = False
     i = 0
@@ -145,7 +151,11 @@ def _find_heredoc_terminator(line: str) -> str | None:
             and not in_double
             and (i == 0 or line[i - 1] != "<")
         ):
-            m = re.match(r"<<-?\s*['\"]?([^\s'\"]+)['\"]?", line[i:])
+            if i + 2 < n and line[i + 2] == "<":
+                # `<<<` here-string, not a heredoc operator - skip past it.
+                i += 2
+                continue
+            m = re.match(r"<<-?\s*['\"\\]?([^\s'\"\\]+)", line[i:])
             if m:
                 return m.group(1)
         i += 1
@@ -338,9 +348,20 @@ def _extract_codeblocks(
                 # A heredoc body may contain literal fence lines (e.g. a shell script
                 # writing a markdown file via cat << EOF).  Track open/close so the
                 # fence-termination logic below can distinguish them from block closers.
+                #
+                # A candidate terminator is only trusted once it's confirmed to appear
+                # alone on some later line. Without this check, an unrelated unquoted
+                # `<<` (e.g. an arithmetic shift `x << 2`, or ipython `x << 2`) sets a
+                # phantom terminator that never matches anything, so heredoc state would
+                # stay "open" for the rest of the message - permanently disabling the
+                # bare-fence-is-a-closer rule and swallowing every block that follows.
                 if lang in _EXEC_LANGS:
                     if heredoc_terminator is None:
-                        heredoc_terminator = _find_heredoc_terminator(line)
+                        candidate = _find_heredoc_terminator(line)
+                        if candidate is not None and any(
+                            later.strip() == candidate for later in lines[i + 1 :]
+                        ):
+                            heredoc_terminator = candidate
                     elif line.strip() == heredoc_terminator:
                         heredoc_terminator = None
 

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -99,6 +99,39 @@ class Codeblock:
         return list(_extract_codeblocks(markdown, streaming=streaming))
 
 
+def _find_heredoc_terminator(line: str) -> str | None:
+    """Return the heredoc terminator word if ``line`` opens a heredoc.
+
+    Only recognizes ``<<`` operators at top-level (outside quoted strings):
+    a heredoc operator is shell syntax and never occurs inside a quoted
+    literal, so ``echo "a << b"`` is correctly ignored while
+    ``cat << 'EOF' > file.md`` is recognized. Unquoted ``<<`` arithmetic
+    shifts (e.g. ipython ``x << 2``) can still false-positive; the
+    terminator word must then appear alone on a line to matter, which is
+    rare in practice.
+    """
+    in_single = in_double = False
+    i = 0
+    while i < len(line) - 1:
+        c = line[i]
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif (
+            c == "<"
+            and line[i + 1] == "<"
+            and not in_single
+            and not in_double
+            and (i == 0 or line[i - 1] != "<")
+        ):
+            m = re.match(r"<<-?\s*['\"]?(\w+)['\"]?", line[i:])
+            if m:
+                return m.group(1)
+        i += 1
+    return None
+
+
 def _extract_codeblocks(
     markdown: str, streaming: bool = False
 ) -> Generator[Codeblock, None, None]:
@@ -287,9 +320,7 @@ def _extract_codeblocks(
                 # fence-termination logic below can distinguish them from block closers.
                 if lang in _EXEC_LANGS:
                     if heredoc_terminator is None:
-                        m = re.search(r"<<-?\s*['\"]?(\w+)['\"]?", line)
-                        if m:
-                            heredoc_terminator = m.group(1)
+                        heredoc_terminator = _find_heredoc_terminator(line)
                     elif line.strip() == heredoc_terminator:
                         heredoc_terminator = None
 

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -350,16 +350,24 @@ def _extract_codeblocks(
                 # fence-termination logic below can distinguish them from block closers.
                 #
                 # A candidate terminator is only trusted once it's confirmed to appear
-                # alone on some later line. Without this check, an unrelated unquoted
-                # `<<` (e.g. an arithmetic shift `x << 2`, or ipython `x << 2`) sets a
-                # phantom terminator that never matches anything, so heredoc state would
-                # stay "open" for the rest of the message - permanently disabling the
-                # bare-fence-is-a-closer rule and swallowing every block that follows.
+                # alone on a later line within a bounded window. Without this check, an
+                # unrelated unquoted `<<` (e.g. an arithmetic shift `x << 2`, or ipython
+                # `x << 2`) sets a phantom terminator that never matches anything, so
+                # heredoc state would stay "open" for the rest of the message -
+                # permanently disabling the bare-fence-is-a-closer rule and swallowing
+                # every block that follows. The window can't stop at the next bare
+                # fence: a real heredoc body legitimately contains fence-like lines
+                # (that's the case this tracking exists to handle), so a fence-bounded
+                # scan would break on the very heredocs it's meant to support. A wide
+                # but finite window instead bounds both the false-confirm blast radius
+                # (an unrelated standalone line matching the candidate far later in the
+                # message) and the O(n^2) worst case on very large documents.
                 if lang in _EXEC_LANGS:
                     if heredoc_terminator is None:
                         candidate = _find_heredoc_terminator(line)
+                        _confirm_window = lines[i + 1 : i + 1 + 200]
                         if candidate is not None and any(
-                            later.strip() == candidate for later in lines[i + 1 :]
+                            later.strip() == candidate for later in _confirm_window
                         ):
                             heredoc_terminator = candidate
                     elif line.strip() == heredoc_terminator:

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -186,6 +186,25 @@ def _extract_codeblocks(
     # Normalize line endings so CRLF input does not leak carriage returns into content.
     markdown = markdown.replace("\r\n", "\n").replace("\r", "\n")
 
+    # Languages where a bare fence at depth 1 is never a nested opener.
+    # Shell/ipython have no triple-backtick syntax; the look-ahead heuristic
+    # only produces false positives (swallowing prose + output blocks into
+    # the command). See gptme/gptme#3697.
+    _EXEC_LANGS = frozenset(
+        {
+            "shell",
+            "sh",
+            "bash",
+            "zsh",
+            "fish",
+            "ksh",
+            "nu",
+            "ps1",
+            "powershell",
+            "ipython",
+        }
+    )
+
     lines = markdown.split("\n")
     i = 0
 
@@ -316,8 +335,14 @@ def _extract_codeblocks(
                                 break
                             else:
                                 content_lines.append(line)
-                        elif next_has_content and not next_is_fence:
-                            # Next line has content - check if this is a real nested block
+                        elif (
+                            next_has_content
+                            and not next_is_fence
+                            and lang not in _EXEC_LANGS
+                        ):
+                            # Next line has content - check if this is a real nested block.
+                            # Skipped for execution languages (shell, ipython, etc.) where
+                            # a bare fence is always a closer, never a nested opener.
                             if nesting_depth > 1:
                                 # We're already nested, this opens another level
                                 nesting_depth += 1

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -290,6 +290,10 @@ def _extract_codeblocks(
             "ipython",
         }
     )
+    # Shell languages that support heredoc syntax (``<<``).  IPython/Python's
+    # ``<<`` is always the bitwise left-shift operator — there is no heredoc
+    # syntax in Python — so ipython is excluded from heredoc state tracking.
+    _SHELL_LANGS = _EXEC_LANGS - {"ipython"}
 
     lines = markdown.split("\n")
     i = 0
@@ -385,7 +389,7 @@ def _extract_codeblocks(
                 # but finite window instead bounds both the false-confirm blast radius
                 # (an unrelated standalone line matching the candidate far later in the
                 # message) and the O(n^2) worst case on very large documents.
-                if lang in _EXEC_LANGS:
+                if lang in _SHELL_LANGS:
                     if heredoc_terminator is None:
                         candidate = _find_heredoc_terminator(line)
                         _confirm_window = lines[i + 1 : i + 1 + 200]

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -117,10 +117,11 @@ def _find_heredoc_terminator(line: str) -> str | None:
     plain word ``EOF``). A ``<<<`` here-string takes one inline value and
     never opens a multi-line body, so it's explicitly not matched here -
     otherwise the capture group would swallow the third ``<`` as part of
-    the (bogus) terminator and heredoc state would never close. Unquoted
-    ``<<`` arithmetic shifts (e.g. ipython ``x << 2``) can still
-    false-positive; the terminator word must then appear alone on a line
-    to matter, which is rare in practice.
+    the (bogus) terminator and heredoc state would never close. A ``<<``
+    inside ``$((...))`` arithmetic expansion is always a bit-shift, and a
+    ``<<`` whose right operand is a bare integer literal is too, so both
+    are rejected to avoid minting a phantom terminator that could swallow
+    later fences.
     """
     in_single = in_double = False
     i = 0
@@ -145,6 +146,19 @@ def _find_heredoc_terminator(line: str) -> str | None:
             # Start of a shell comment - nothing after it is executable syntax.
             return None
         elif (
+            c == "$"
+            and not in_single
+            and not in_double
+            and i + 2 < n
+            and line[i + 1 : i + 3] == "(("
+        ):
+            # `$((...))` arithmetic expansion: `<<` inside is always a
+            # bit-shift, never a heredoc. Skip to the matching `))` so a
+            # shift like `$((1 << 3))` can't mint a phantom terminator.
+            j = line.find("))", i + 2)
+            i = (j + 2) if j != -1 else n
+            continue
+        elif (
             c == "<"
             and line[i + 1] == "<"
             and not in_single
@@ -157,7 +171,16 @@ def _find_heredoc_terminator(line: str) -> str | None:
                 continue
             m = re.match(r"<<-?\s*['\"\\]?([^\s'\"\\]+)", line[i:])
             if m:
-                return m.group(1)
+                term = m.group(1)
+                if term.lstrip("+-").isdigit():
+                    # `<< N` with an integer N is an arithmetic bit-shift
+                    # (`x << 2`, `1 << 3`), not a heredoc opener. A bare
+                    # integer heredoc delimiter is effectively never written
+                    # in real shell, so reject it rather than mint a phantom
+                    # terminator that could swallow later fences.
+                    i += 2
+                    continue
+                return term
         i += 1
     return None
 

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -308,6 +308,78 @@ output here
     ]
 
 
+def test_extract_codeblocks_shell_herestring_is_not_a_heredoc():
+    """A ``<<<`` here-string takes one inline value and never opens a
+    multi-line body. Regression for the Greptile P1 on gptme/gptme#3703:
+    the terminator regex matched the third ``<`` as a bogus terminator
+    (e.g. ``"<"``), so heredoc state never closed and the real closing
+    fence was absorbed as a nested opener.
+    """
+    markdown = """```shell
+cat <<< "hello"
+```
+prose after
+
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", 'cat <<< "hello"'),
+        Codeblock("", "output here"),
+    ]
+
+
+def test_extract_codeblocks_shell_heredoc_backslash_escaped_terminator():
+    """``<<\\EOF`` (backslash-escaped, unquoted) uses the plain word ``EOF``
+    as its terminator, same as ``<<EOF`` and ``<<'EOF'``. Regression for the
+    Greptile P1 on gptme/gptme#3703: the terminator regex captured the
+    backslash as part of the word (``"\\\\EOF"``), which never matched the
+    real closing line ``EOF``, so heredoc state persisted forever and
+    swallowed the rest of the message into the command.
+    """
+    markdown = """```shell
+cat <<\\EOF > file.md
+```
+some markdown
+```
+EOF
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 1, f"expected 1 block, got {len(blocks)}: {blocks!r}"
+    assert blocks[0] == Codeblock(
+        "shell", "cat <<\\EOF > file.md\n```\nsome markdown\n```\nEOF"
+    )
+
+
+def test_extract_codeblocks_ipython_arithmetic_shift_is_not_a_heredoc():
+    """An unquoted ``<<`` that's actually an arithmetic left-shift (e.g.
+    ipython ``x << 2``) must not permanently wedge heredoc state open.
+
+    Regression for the bob-ai-review P2 on gptme/gptme#3703: a phantom
+    terminator (``"2"``) that never appears alone on a later line used to
+    stay "open" for the rest of the message, so the real closing fence was
+    absorbed as a nested opener and the following prose/output blocks were
+    swallowed into the ipython command.
+    """
+    markdown = """```ipython
+x = 1 << 2
+```
+prose after
+
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("ipython", "x = 1 << 2"),
+        Codeblock("", "output here"),
+    ]
+
+
 def test_extract_codeblocks_concatenated_adjacent_fences():
     """Recover when a closing fence and the next opening fence are concatenated."""
     markdown = """```shell

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -238,6 +238,76 @@ EOF
     assert blocks[0] == Codeblock("shell", expected_content)
 
 
+def test_extract_codeblocks_shell_heredoc_punctuated_terminator():
+    """Heredoc terminator words aren't restricted to \\w (bash allows any
+    unquoted word without whitespace, e.g. hyphens). Regression for the
+    Greptile P1 on gptme/gptme#3703: ``\\w+`` failed to match ``END-TAG``,
+    so the embedded fence closed the block early.
+    """
+    markdown = """```shell
+cat << 'END-TAG' > file.md
+```
+some markdown
+```
+END-TAG
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 1, f"expected 1 block, got {len(blocks)}: {blocks!r}"
+    assert blocks[0] == Codeblock(
+        "shell", "cat << 'END-TAG' > file.md\n```\nsome markdown\n```\nEND-TAG"
+    )
+
+
+def test_extract_codeblocks_shell_comment_with_lt_lt_not_a_heredoc():
+    """A ``<<`` inside a ``#`` comment must not be treated as a heredoc
+    operator. Regression for the Greptile P1 on gptme/gptme#3703: the
+    heredoc scanner didn't know about comments, so inert ``<<`` text in a
+    comment falsely opened heredoc state, re-enabling the depth-1
+    look-ahead and absorbing the following prose/output blocks into the
+    command.
+    """
+    markdown = """```shell
+# see the << operator docs
+echo hi
+```
+prose after
+
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", "# see the << operator docs\necho hi"),
+        Codeblock("", "output here"),
+    ]
+
+
+def test_extract_codeblocks_shell_escaped_quote_not_a_heredoc():
+    """A backslash-escaped quote inside a double-quoted string must not
+    desync the quote tracker. Regression for the Greptile P1 on
+    gptme/gptme#3703: the scanner treated ``\\"`` as closing the string,
+    so a later unquoted-looking ``<<`` inside the (still-open) string
+    falsely opened heredoc state and absorbed the following prose/output
+    blocks into the command.
+    """
+    markdown = """```shell
+echo "value \\" << not-a-heredoc"
+```
+prose after
+
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", 'echo "value \\" << not-a-heredoc"'),
+        Codeblock("", "output here"),
+    ]
+
+
 def test_extract_codeblocks_concatenated_adjacent_fences():
     """Recover when a closing fence and the next opening fence are concatenated."""
     markdown = """```shell

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1614,3 +1614,27 @@ def test_from_markdown_leading_whitespace_after_fence():
     cb = Codeblock.from_markdown("``` save path/to/file.py\nprint(1)\n```")
     assert cb.lang == "save path/to/file.py"
     assert cb.content == "print(1)\n"
+
+
+def test_extract_codeblocks_shell_quoted_non_heredoc_lt():
+    """A ``<<`` inside a quoted string is not a heredoc operator.
+
+    Regression for the Greptile P1 on gptme/gptme#3703: ``echo "a << b"``
+    recorded ``b`` as a heredoc terminator, re-enabling the depth-1
+    look-ahead so the real closer was treated as a nested opener and
+    subsequent prose/output blocks were absorbed into the command.
+    """
+    markdown = """```shell
+echo "a << b"
+```
+prose after
+
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", 'echo "a << b"'),
+        Codeblock("", "output here"),
+    ]

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -158,6 +158,46 @@ echo "second"
     assert codeblocks[1].start == 3
 
 
+def test_extract_codeblocks_tooluse_then_output_block():
+    """Tooluse + prose + output fence must not swallow into one command.
+
+    Regression for gptme/gptme#3697: at depth 1 the nested-fence lookahead
+    treated the shell closer as a nested opener because a later bare fence
+    had non-blank content after it. The shell tool then received the prose
+    and inner fences as part of the command.
+    """
+    markdown = """```shell
+echo hello
+```
+The exact output is:
+
+```
+hello
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 2, f"expected 2 blocks, got {len(blocks)}: {blocks!r}"
+    assert blocks[0] == Codeblock("shell", "echo hello")
+    assert blocks[1] == Codeblock("", "hello")
+
+
+def test_extract_codeblocks_ipython_then_output_block():
+    """Same swallow hazard for the ipython tool (also executed)."""
+    markdown = """```ipython
+1 + 1
+```
+The exact output is:
+
+```
+2
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 2, f"expected 2 blocks, got {len(blocks)}: {blocks!r}"
+    assert blocks[0] == Codeblock("ipython", "1 + 1")
+    assert blocks[1] == Codeblock("", "2")
+
+
 def test_extract_codeblocks_concatenated_adjacent_fences():
     """Recover when a closing fence and the next opening fence are concatenated."""
     markdown = """```shell

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -198,6 +198,46 @@ The exact output is:
     assert blocks[1] == Codeblock("", "2")
 
 
+def test_extract_codeblocks_shell_heredoc_with_embedded_fence():
+    """Shell block containing a heredoc whose body has literal fence lines must
+    not be truncated at the embedded fence.
+
+    Regression for gptme/gptme#3703: the EXEC_LANGS bare-fence-is-always-a-closer
+    fix broke any shell command that writes a markdown file via heredoc, because the
+    parser terminated the shell block at the first ``` inside the heredoc body.
+    """
+    markdown = """```shell
+cat << 'EOF' > file.md
+```
+some markdown
+```
+EOF
+echo done
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 1, f"expected 1 block, got {len(blocks)}: {blocks!r}"
+    assert blocks[0] == Codeblock(
+        "shell", "cat << 'EOF' > file.md\n```\nsome markdown\n```\nEOF\necho done"
+    )
+
+
+def test_extract_codeblocks_shell_heredoc_unquoted_terminator():
+    """Same heredoc case with an unquoted terminator (<<EOF vs <<'EOF')."""
+    markdown = """```shell
+cat <<EOF > readme.md
+```
+content
+```
+EOF
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert len(blocks) == 1, f"expected 1 block, got {len(blocks)}: {blocks!r}"
+    expected_content = "cat <<EOF > readme.md\n```\ncontent\n```\nEOF"
+    assert blocks[0] == Codeblock("shell", expected_content)
+
+
 def test_extract_codeblocks_concatenated_adjacent_fences():
     """Recover when a closing fence and the next opening fence are concatenated."""
     markdown = """```shell

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -380,6 +380,59 @@ output here
     ]
 
 
+def test_extract_codeblocks_shift_operand_alone_is_not_a_heredoc():
+    """A shift operand that later appears alone on a line must not mint a
+    phantom heredoc terminator and swallow the closing fence.
+
+    Regression for gptme/gptme#3703: ``x << 2`` used to return ``"2"`` as a
+    candidate heredoc terminator; when a standalone ``2`` appeared within the
+    200-line confirmation window, heredoc state stayed open past the real
+    closing fence and the following block was absorbed into the shell command.
+    """
+    markdown = """```shell
+x << 2
+echo "result"
+```
+prose after
+
+2
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", 'x << 2\necho "result"'),
+        Codeblock("", "output here"),
+    ]
+
+
+def test_extract_codeblocks_arithmetic_expansion_shift_is_not_a_heredoc():
+    """A ``<<`` inside ``$((...))`` arithmetic expansion is a bit-shift, not a
+    heredoc, even when its operand appears alone on a later line.
+
+    Regression for gptme/gptme#3703: ``$((1 << 3))`` used to mint ``"3))"`` as
+    a phantom terminator, and a standalone ``3`` in following content confirmed
+    it, swallowing the closing fence.
+    """
+    markdown = """```shell
+result=$((1 << 3))
+echo "done"
+```
+prose
+
+3
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", 'result=$((1 << 3))\necho "done"'),
+        Codeblock("", "output here"),
+    ]
+
+
 def test_extract_codeblocks_concatenated_adjacent_fences():
     """Recover when a closing fence and the next opening fence are concatenated."""
     markdown = """```shell

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -380,6 +380,35 @@ output here
     ]
 
 
+def test_extract_codeblocks_ipython_nonnumeric_shift_is_not_a_heredoc():
+    """An ipython ``<<`` with a nonnumeric operand (e.g. ``x << marker``) must
+    not activate heredoc state even when ``marker`` appears alone on a later line.
+
+    IPython/Python has no heredoc syntax — ``<<`` is always bitwise left-shift.
+    Regression for gptme/gptme#3703 (Greptile P1 "Nonnumeric shifts mimic heredocs"):
+    before the _SHELL_LANGS fix, the heredoc scanner ran on ipython blocks and
+    returned ``"marker"`` as a candidate terminator; when ``marker`` appeared
+    standalone in the prose, heredoc state opened and the actual closing fence
+    was treated as a nested opener, swallowing the output block.
+    """
+    markdown = """```ipython
+x << marker
+result = x
+```
+prose after
+
+marker
+```
+output here
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("ipython", "x << marker\nresult = x"),
+        Codeblock("", "output here"),
+    ]
+
+
 def test_extract_codeblocks_shift_operand_alone_is_not_a_heredoc():
     """A shift operand that later appears alone on a line must not mint a
     phantom heredoc terminator and swallow the closing fence.


### PR DESCRIPTION
## Summary

Fixes #3697. When an assistant reply contains a tooluse block followed by prose and a plain output codeblock, `_extract_codeblocks` swallowed everything into one shell command. The depth-1 bare-fence look-ahead found content after a later bare fence and treated the shell closer as a nested opener.

**Root cause**: The look-ahead heuristic at depth 1 asks "is there content after the next bare fence?" — for the shape `tooluse + prose + output block` this is always true, so the shell block never closes.

**Fix**: Define `_EXEC_LANGS` (shell, bash, sh, zsh, fish, ksh, nu, ps1, powershell, ipython) and skip the look-ahead when the outer block's language is in that set. These languages have no triple-backtick syntax, so a bare fence at depth 1 is always the outer closer, never a nested opener.

Existing tests (`test_extract_codeblocks_nested` for Python and `test_extract_codeblocks_markdown_with_nested_no_langtag`) both continue passing since python/markdown are not in `_EXEC_LANGS`.

## Test plan

- [x] `test_extract_codeblocks_tooluse_then_output_block` — shell block closes at first bare fence; output block extracted separately
- [x] `test_extract_codeblocks_ipython_then_output_block` — same for ipython tool
- [x] `test_extract_codeblocks_nested` — python nested blocks unaffected
- [x] `test_extract_codeblocks_markdown_with_nested_no_langtag` — markdown nested blocks unaffected
- [x] Full `tests/test_codeblock.py` — 70/70 passed