### PR TITLE
feat(cli): add gptme capabilities export

### DIFF
--- a/gptme/cli/cmd_capabilities.py
+++ b/gptme/cli/cmd_capabilities.py
@@ -42,7 +42,8 @@ import click
 @click.option(
     "--connect-mcp",
     is_flag=True,
-    help="Live-enumerate MCP tools (off by default)",
+    help="Connect to configured MCP servers and live-enumerate their tools "
+    "(off by default; the default path never connects)",
 )
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 def capabilities(

--- a/gptme/cli/cmd_capabilities.py
+++ b/gptme/cli/cmd_capabilities.py
@@ -1,0 +1,78 @@
+"""CLI command: export a session-resolved capability snapshot (idea #1204)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+
+@click.command("capabilities")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(("text", "json", "html")),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.option(
+    "--workspace",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Workspace whose gptme.toml to resolve (default: cwd)",
+)
+@click.option(
+    "--from-json",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Render an existing snapshot instead of collecting live",
+)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    help="Include discovered-but-not-loaded tools in text output",
+)
+@click.option(
+    "--include-instructions",
+    is_flag=True,
+    help="Opt in to redacted tool instructions in JSON",
+)
+@click.option(
+    "--connect-mcp",
+    is_flag=True,
+    help="Live-enumerate MCP tools (off by default)",
+)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
+def capabilities(
+    fmt: str,
+    workspace: Path | None,
+    from_json: Path | None,
+    show_all: bool,
+    include_instructions: bool,
+    connect_mcp: bool,
+    output: Path | None,
+) -> None:
+    """Export a session-resolved snapshot of tools, skills, plugins, and MCP servers.
+
+    Default output redacts tool instructions, skill bodies, and MCP env/headers.
+    This is a snapshot of one workspace's resolved configuration, not a
+    guarantee of the next session's toolset.
+    """
+    from ..util.capabilities_export import collect_live, render
+
+    if from_json:
+        snapshot = json.loads(from_json.read_text(encoding="utf-8"))
+    else:
+        snapshot = collect_live(
+            (workspace or Path.cwd()).resolve(),
+            include_instructions=include_instructions,
+            connect_mcp=connect_mcp,
+        )
+
+    text = render(snapshot, fmt, show_all=show_all)
+    if output:
+        output.write_text(text, encoding="utf-8")
+    else:
+        click.echo(text, nl=False)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "agents": (".cmd_agents", "agents"),
+    "capabilities": (".cmd_capabilities", "capabilities"),
     "attest": (".cmd_attest", "attest"),
     "batch": (".cmd_batch", "batch_cmd"),
     "chats": (".cmd_chats", "chats"),

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -19,6 +19,7 @@ from ._allowlist import (
     allowlist_contains_glob,
     expand_tool_allowlist_presets,
     is_hint_pattern,
+    is_mcp_allowlist_entry,
     matching_allowlist_tools,
     tool_matches_allowlist,
 )
@@ -226,6 +227,8 @@ def init_tools(
         for tool_name in tool_names:
             if is_hint_pattern(tool_name):
                 continue  # hint patterns match 0+ tools by hint, no name validation
+            if not include_mcp and is_mcp_allowlist_entry(tool_name):
+                continue  # MCP names are not discoverable when include_mcp=False
             if matching_allowlist_tools(tool_name, loaded_tools):
                 continue
             matched_available = matching_allowlist_tools(tool_name, available_tools)
@@ -278,6 +281,8 @@ def get_toolchain(
                 continue  # hint patterns match by tool hints, not by name
             matched_tools = matching_allowlist_tools(tool_name, available_tools)
             if not matched_tools:
+                if not include_mcp and is_mcp_allowlist_entry(tool_name):
+                    continue  # MCP names are not discoverable when include_mcp=False
                 if strict:
                     raise ValueError(
                         f"Tool '{tool_name}' not found. Available tools: {', '.join(sorted(available_tool_names))}"

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -159,6 +159,8 @@ def _init_single_tool(tool: ToolSpec) -> ToolSpec:
 
 def init_tools(
     allowlist: list[str] | None = None,
+    *,
+    include_mcp: bool = True,
 ) -> list[ToolSpec]:
     """Initialize tools in a thread-safe manner.
 
@@ -170,6 +172,10 @@ def init_tools(
 
     Items in allowlist can be tool names (e.g. "shell") or paths to .py files
     containing ToolSpec definitions (e.g. "path/to/mytool.py").
+
+    ``include_mcp`` (default True) is passed through to discovery. Set False to
+    skip connecting configured MCP servers — used by snapshot/export paths that
+    must not mutate the environment as a side effect of listing tools.
     """
     from ..config import get_config  # fmt: skip
 
@@ -210,13 +216,13 @@ def init_tools(
         # When file paths are present, only load explicitly named built-in tools
         # (file_paths + no names = only file tools; file_paths + names = both)
         name_allowlist = tool_names if (tool_names or file_paths) else allowlist
-        for tool in get_toolchain(name_allowlist):
+        for tool in get_toolchain(name_allowlist, include_mcp=include_mcp):
             if has_tool(tool.name):
                 continue
             tool = _init_single_tool(tool)
             loaded_tools.append(tool)
 
-        available_tools = get_available_tools()
+        available_tools = get_available_tools(include_mcp=include_mcp)
         for tool_name in tool_names:
             if is_hint_pattern(tool_name):
                 continue  # hint patterns match 0+ tools by hint, no name validation
@@ -255,7 +261,7 @@ def _unavailable_message(tool_name: str, matched_tools: list[ToolSpec]) -> str:
 
 
 def get_toolchain(
-    allowlist: list[str] | None, *, strict: bool = True
+    allowlist: list[str] | None, *, strict: bool = True, include_mcp: bool = True
 ) -> list[ToolSpec]:
     allowlist = expand_tool_allowlist_presets(allowlist)
 
@@ -264,7 +270,7 @@ def get_toolchain(
     # Server contexts use strict=False since conversations may reference tools
     # that are no longer available.
     if allowlist is not None:
-        available_tools = get_available_tools()
+        available_tools = get_available_tools(include_mcp=include_mcp)
         available_tool_names = [tool.name for tool in available_tools]
 
         for tool_name in allowlist:
@@ -291,7 +297,7 @@ def get_toolchain(
     if allowlist:
         warn_on_skipped_mcp = not allowlist_contains_glob(allowlist)
     skipped_mcp_tools = []
-    for tool in get_available_tools():
+    for tool in get_available_tools(include_mcp=include_mcp):
         explicitly_allowed = allowlist is not None and tool_matches_allowlist(
             tool.name, allowlist, tool.hints
         )

--- a/gptme/tools/_allowlist.py
+++ b/gptme/tools/_allowlist.py
@@ -36,6 +36,16 @@ def is_hint_pattern(pattern: str) -> bool:
     return pattern.startswith(_HINT_PREFIX)
 
 
+def is_mcp_allowlist_entry(pattern: str) -> bool:
+    """Return True for MCP-qualified allowlist entries (``server.tool`` / ``server.*``).
+
+    File paths (``*.py`` or containing a slash) are tool-file entries, not MCP names.
+    """
+    if pattern.endswith(".py") or "/" in pattern or "\\" in pattern:
+        return False
+    return "." in pattern
+
+
 def allowlist_contains_glob(allowlist: list[str]) -> bool:
     """Return True when any allowlist entry uses shell-glob syntax or a hint: prefix.
 

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -63,6 +63,15 @@ def get_mcp_clients() -> dict[str, MCPClient]:
     return {**_mcp_clients, **_dynamic_servers}
 
 
+def clear_mcp_clients() -> None:
+    """Clear the global MCP client registry.
+
+    Called by capabilities export before a fresh collection run so that stale
+    clients from a prior connection are not misreported as connected.
+    """
+    _mcp_clients.clear()
+
+
 def _get_mcp_client(server_name: str) -> MCPClient | None:
     """Get MCP client from either pre-configured or dynamically loaded servers."""
     return _mcp_clients.get(server_name) or _dynamic_servers.get(server_name)

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -228,15 +229,15 @@ def snapshot_to_html(snapshot: dict[str, Any]) -> str:
 </head>
 <body>
   <h1>gptme capabilities</h1>
-  <p>Schema {snapshot["schema_version"]} · {html_escape(snapshot["generated_at"])}</p>
-  <p><code>{html_escape(snapshot["workspace"])}</code></p>
+  <p>Schema {html_escape(str(snapshot["schema_version"]))} · {html_escape(str(snapshot["generated_at"]))}</p>
+  <p><code>{html_escape(str(snapshot["workspace"]))}</code></p>
   <p class="warn">{html_escape(warning)}</p>
   <p>
-    In-session tools {counts["tools_in_session"]}/{counts["tools_available"]}
-    · skills {counts["skills"]}
-    · plugins {counts["plugins"]}
-    · MCP servers {counts["mcp_servers"]}
-    (mcp.enabled={str(cfg["mcp_enabled"]).lower()})
+    In-session tools {html_escape(str(counts["tools_in_session"]))}/{html_escape(str(counts["tools_available"]))}
+    · skills {html_escape(str(counts["skills"]))}
+    · plugins {html_escape(str(counts["plugins"]))}
+    · MCP servers {html_escape(str(counts["mcp_servers"]))}
+    (mcp.enabled={html_escape(str(cfg["mcp_enabled"]).lower())})
   </p>
   <h2>In-session tools</h2>
   {_rows(loaded, [("name", "Name"), ("desc", "Description"), ("provenance", "Provenance"), ("status", "Status")])}
@@ -388,7 +389,12 @@ def _collect_live_impl(
             record["instructions_included"] = True
         tools.append(record)
 
-    index = LessonIndex()
+    prev_cwd = Path.cwd()
+    os.chdir(workspace)
+    try:
+        index = LessonIndex()
+    finally:
+        os.chdir(prev_cwd)
     skills: list[dict[str, Any]] = []
     lessons_count = 0
     for item in index.lessons:
@@ -422,10 +428,20 @@ def _collect_live_impl(
     mcp_server_list: list[MCPServerConfig] = (
         list(mcp_typed.servers) if mcp_typed else []
     )
+    mcp_servers_in_session = {
+        t["provenance"]["detail"] for t in tools if t["is_mcp"] and t["in_session"]
+    }
     for srv in mcp_server_list:
         if mcp_enabled and srv.enabled:
-            reason = "configured"
-            in_session = True
+            if srv.name in mcp_servers_in_session:
+                reason = "configured"
+                in_session = True
+            elif not connect_mcp:
+                reason = "mcp_not_connected"
+                in_session = False
+            else:
+                reason = "no_tools_in_session"
+                in_session = False
         elif not mcp_enabled:
             reason = "mcp_globally_disabled"
             in_session = False

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -344,13 +344,15 @@ def _collect_live_impl(
         )
 
     clear_tools()
-    init_tools()
-    # init_tools() connects MCP servers internally (via get_available_tools()).
-    # Capture the live registry now so we know which servers actually connected,
-    # rather than inferring connectivity from the allowlist-filtered tool list.
-    from ..tools.mcp_adapter import get_mcp_clients  # fmt: skip
+    # Honor --connect-mcp: init_tools() used to call get_available_tools() with
+    # the default include_mcp=True, which connected every configured MCP server
+    # before this flag was consulted.
+    init_tools(include_mcp=connect_mcp)
+    connected_mcp_servers: set[str] = set()
+    if connect_mcp:
+        from ..tools.mcp_adapter import get_mcp_clients  # fmt: skip
 
-    connected_mcp_servers = set(get_mcp_clients().keys())
+        connected_mcp_servers = set(get_mcp_clients().keys())
 
     loaded = {t.name: t for t in get_tools()}
     discovered = get_available_tools(include_mcp=connect_mcp)
@@ -448,6 +450,10 @@ def _collect_live_impl(
                 # Connected but all tools excluded by the allowlist
                 reason = "connected_tools_excluded"
                 in_session = False
+            elif not connect_mcp:
+                # Default path never connects; listing is config-only
+                reason = "connect_mcp_not_requested"
+                in_session = False
             else:
                 # Not connected (connection failed or server not yet reached)
                 reason = "mcp_not_connected"
@@ -471,6 +477,12 @@ def _collect_live_impl(
 
     chat = getattr(cfg, "chat", None)
     stamp = generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    limitations: list[str] = []
+    if mcp_enabled and not connect_mcp:
+        limitations.append(
+            "MCP servers listed from config only; pass --connect-mcp to connect "
+            "and live-enumerate tools"
+        )
     return build_snapshot(
         workspace=str(workspace),
         generated_at=stamp,
@@ -484,6 +496,7 @@ def _collect_live_impl(
         skills=skills,
         plugins=plugin_records,
         mcp_servers=mcp_servers,
+        limitations=limitations,
         lessons_count=lessons_count,
     )
 
@@ -534,7 +547,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--connect-mcp",
         action="store_true",
-        help="Live-enumerate MCP tools (off by default)",
+        help="Connect to configured MCP servers and live-enumerate their tools "
+        "(off by default; the default path never connects)",
     )
     parser.add_argument("-o", "--output", type=Path, default=None)
     args = parser.parse_args(argv)

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -345,6 +345,13 @@ def _collect_live_impl(
 
     clear_tools()
     init_tools()
+    # init_tools() connects MCP servers internally (via get_available_tools()).
+    # Capture the live registry now so we know which servers actually connected,
+    # rather than inferring connectivity from the allowlist-filtered tool list.
+    from ..tools.mcp_adapter import get_mcp_clients  # fmt: skip
+
+    connected_mcp_servers = set(get_mcp_clients().keys())
+
     loaded = {t.name: t for t in get_tools()}
     discovered = get_available_tools(include_mcp=connect_mcp)
 
@@ -434,13 +441,16 @@ def _collect_live_impl(
     for srv in mcp_server_list:
         if mcp_enabled and srv.enabled:
             if srv.name in mcp_servers_in_session:
+                # Connected and has tools active in this session
                 reason = "configured"
                 in_session = True
-            elif not connect_mcp:
-                reason = "mcp_not_connected"
+            elif srv.name in connected_mcp_servers:
+                # Connected but all tools excluded by the allowlist
+                reason = "connected_tools_excluded"
                 in_session = False
             else:
-                reason = "no_tools_in_session"
+                # Not connected (connection failed or server not yet reached)
+                reason = "mcp_not_connected"
                 in_session = False
         elif not mcp_enabled:
             reason = "mcp_globally_disabled"

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -343,11 +343,34 @@ def _collect_live_impl(
             }
         )
 
+    # Read allowlist from config explicitly so we can filter it before passing
+    # to init_tools.  When connect_mcp=False, MCP-qualified entries like
+    # "discord.read_channel" or "discord.*" are not discoverable and would
+    # raise ValueError inside init_tools — drop them for the config-only path.
+    chat_cfg = getattr(cfg, "chat", None)
+    raw_allowlist: list[str] | None = (
+        getattr(chat_cfg, "tools", None) if chat_cfg else None
+    )
+    if not connect_mcp and raw_allowlist:
+
+        def _is_filepath(t: str) -> bool:
+            return t.endswith(".py") or "/" in t or "\\" in t
+
+        raw_allowlist = [
+            t for t in raw_allowlist if "." not in t or _is_filepath(t)
+        ] or None
+
     clear_tools()
     # Honor --connect-mcp: init_tools() used to call get_available_tools() with
     # the default include_mcp=True, which connected every configured MCP server
     # before this flag was consulted.
-    init_tools(include_mcp=connect_mcp)
+    if connect_mcp:
+        # Clear stale clients so a reconnect failure is reported as
+        # mcp_not_connected, not the misleading connected_tools_excluded.
+        from ..tools.mcp_adapter import clear_mcp_clients  # fmt: skip
+
+        clear_mcp_clients()
+    init_tools(raw_allowlist, include_mcp=connect_mcp)
     connected_mcp_servers: set[str] = set()
     if connect_mcp:
         from ..tools.mcp_adapter import get_mcp_clients  # fmt: skip

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -311,6 +311,7 @@ def _collect_live_impl(
         get_tools,
         init_tools,
     )
+    from ..tools._allowlist import is_mcp_allowlist_entry  # fmt: skip
 
     set_config_from_workspace(workspace)
     cfg = get_config()
@@ -343,22 +344,21 @@ def _collect_live_impl(
             }
         )
 
-    # Read allowlist from config explicitly so we can filter it before passing
-    # to init_tools.  When connect_mcp=False, MCP-qualified entries like
-    # "discord.read_channel" or "discord.*" are not discoverable and would
-    # raise ValueError inside init_tools — drop them for the config-only path.
+    # Resolve the same allowlist init_tools would (TOOL_ALLOWLIST, then
+    # chat.tools) so the config-only path can drop MCP-qualified names
+    # before validation. Keep [] when every entry was MCP-qualified —
+    # `or None` would reload the original MCP-only list and abort.
     chat_cfg = getattr(cfg, "chat", None)
-    raw_allowlist: list[str] | None = (
-        getattr(chat_cfg, "tools", None) if chat_cfg else None
-    )
+    env_allowlist = cfg.get_env("TOOL_ALLOWLIST")
+    raw_allowlist: list[str] | None
+    if env_allowlist:
+        raw_allowlist = env_allowlist.split(",")
+    elif chat_cfg is not None and chat_cfg.tools:
+        raw_allowlist = list(chat_cfg.tools)
+    else:
+        raw_allowlist = None
     if not connect_mcp and raw_allowlist:
-
-        def _is_filepath(t: str) -> bool:
-            return t.endswith(".py") or "/" in t or "\\" in t
-
-        raw_allowlist = [
-            t for t in raw_allowlist if "." not in t or _is_filepath(t)
-        ] or None
+        raw_allowlist = [t for t in raw_allowlist if not is_mcp_allowlist_entry(t)]
 
     clear_tools()
     # Honor --connect-mcp: init_tools() used to call get_available_tools() with

--- a/gptme/util/capabilities_export.py
+++ b/gptme/util/capabilities_export.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Export a session-resolved gptme capability snapshot (idea #1204).
+
+Dumps tools, skills, plugins, and MCP servers for one configured workspace as
+JSON, static HTML, or text. Default output redacts instructions, skill bodies,
+and MCP env/headers.
+
+The builder/render half of this module is pure (no gptme imports at module
+scope); ``collect_live`` resolves the workspace config lazily.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from html import escape as html_escape
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+SECRET_LIKE = re.compile(r"(?i)(\b(sk-|Bearer\s+|api[_-]?key\s*[=:]\s*))([^\s\"']{8,})")
+
+ToolStatus = str  # loaded | available | unavailable | disabled_by_default
+
+
+def redact_secret_like(text: str | None) -> str:
+    """Mask secret-like tokens while keeping a short prefix for debugging."""
+    if not text:
+        return ""
+
+    def _sub(match: re.Match[str]) -> str:
+        prefix = match.group(1)
+        rest = match.group(3)
+        return f"{prefix}{rest[:2]}***"
+
+    return SECRET_LIKE.sub(_sub, text)
+
+
+def _sorted_names(
+    items: list[dict[str, Any]], key: str = "name"
+) -> list[dict[str, Any]]:
+    return sorted(items, key=lambda item: str(item.get(key, "")).lower())
+
+
+def _tool_status(tool: dict[str, Any]) -> ToolStatus:
+    if tool.get("in_session"):
+        return "loaded"
+    if not tool.get("available", True):
+        return "unavailable"
+    if tool.get("disabled_by_default"):
+        return "disabled_by_default"
+    return "available"
+
+
+def build_snapshot(
+    *,
+    workspace: str,
+    generated_at: str,
+    config: dict[str, Any],
+    tools: list[dict[str, Any]],
+    skills: list[dict[str, Any]],
+    plugins: list[dict[str, Any]],
+    mcp_servers: list[dict[str, Any]],
+    limitations: list[str] | None = None,
+    lessons_count: int = 0,
+) -> dict[str, Any]:
+    """Assemble a schema-v1 snapshot from already-resolved records.
+
+    Pure: no gptme imports. Live collection is ``collect_live``.
+    """
+    # Defense in depth: redact instructions at the builder too, not only in
+    # collect_live, so a hand-assembled snapshot cannot leak secrets.
+    tools_sorted = _sorted_names(tools)
+    for tool in tools_sorted:
+        if tool.get("instructions_included") and tool.get("instructions"):
+            tool["instructions"] = redact_secret_like(tool["instructions"])
+    skills_sorted = _sorted_names(skills)
+    plugins_sorted = _sorted_names(plugins)
+    mcp_sorted = _sorted_names(mcp_servers)
+    plugin_enabled = sorted(config.get("plugin_enabled") or [])
+    mcp_enabled = bool(config.get("mcp_enabled"))
+
+    notes = list(limitations or [])
+    if not any("ToolSpec has no native source field" in note for note in notes):
+        notes.append("ToolSpec has no native source field; tool provenance is inferred")
+    if not mcp_enabled and mcp_sorted:
+        if not any("config.mcp.enabled is false" in note for note in notes):
+            notes.append("MCP tools not enumerated because config.mcp.enabled is false")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "workspace": workspace,
+        "config": {
+            "mcp_enabled": mcp_enabled,
+            "plugin_enabled": plugin_enabled,
+            "tool_allowlist": config.get("tool_allowlist"),
+            "profile": config.get("profile"),
+        },
+        "counts": {
+            "tools_in_session": sum(1 for t in tools_sorted if t.get("in_session")),
+            "tools_available": len(tools_sorted),
+            "skills": len(skills_sorted),
+            "lessons": lessons_count,
+            "plugins": len(plugins_sorted),
+            "mcp_servers": len(mcp_sorted),
+        },
+        "tools": tools_sorted,
+        "skills": skills_sorted,
+        "plugins": plugins_sorted,
+        "mcp_servers": mcp_sorted,
+        "limitations": notes,
+    }
+
+
+def snapshot_to_json(snapshot: dict[str, Any]) -> str:
+    return json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n"
+
+
+def snapshot_to_text(snapshot: dict[str, Any], *, show_all: bool = False) -> str:
+    counts = snapshot["counts"]
+    cfg = snapshot["config"]
+    lines = [
+        f"gptme capabilities  schema={snapshot['schema_version']}  {snapshot['generated_at']}",
+        f"workspace: {snapshot['workspace']}",
+        (
+            f"in-session tools {counts['tools_in_session']}/{counts['tools_available']}  "
+            f"skills {counts['skills']}  plugins {counts['plugins']}  "
+            f"mcp {counts['mcp_servers']} (enabled={cfg['mcp_enabled']})"
+        ),
+        "",
+        "Tools:",
+    ]
+    for tool in snapshot["tools"]:
+        if not show_all and not tool.get("in_session"):
+            continue
+        status = _tool_status(tool)
+        prov = tool.get("provenance") or {}
+        lines.append(
+            f"  [{status:<20}] {tool['name']:<22} {tool.get('desc', '')} "
+            f"({prov.get('source', '?')}:{prov.get('detail', '')})"
+        )
+    lines.append("")
+    lines.append("Skills:")
+    lines.extend(
+        f"  {skill['name']:<28} {skill.get('desc', '')}" for skill in snapshot["skills"]
+    )
+    if snapshot["plugins"]:
+        lines.append("")
+        lines.append("Plugins:")
+        for plugin in snapshot["plugins"]:
+            enabled = "on" if plugin.get("enabled") else "off"
+            lines.append(f"  [{enabled}] {plugin['name']}")
+    if snapshot["mcp_servers"]:
+        lines.append("")
+        lines.append("MCP servers:")
+        for server in snapshot["mcp_servers"]:
+            reason = server.get("reason") or (
+                "in_session" if server.get("in_session") else "configured"
+            )
+            lines.append(
+                f"  {server['name']:<24} enabled={server.get('enabled')} "
+                f"{server.get('transport')} ({reason})"
+            )
+    if snapshot["limitations"]:
+        lines.append("")
+        lines.append("Limitations:")
+        lines.extend(f"  - {note}" for note in snapshot["limitations"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def snapshot_to_html(snapshot: dict[str, Any]) -> str:
+    counts = snapshot["counts"]
+    cfg = snapshot["config"]
+    loaded = [t for t in snapshot["tools"] if t.get("in_session")]
+    other = [t for t in snapshot["tools"] if not t.get("in_session")]
+
+    def _rows(items: list[dict[str, Any]], columns: list[tuple[str, str]]) -> str:
+        if not items:
+            return "<p><em>None</em></p>"
+        head = "".join(f"<th>{html_escape(label)}</th>" for _, label in columns)
+        body_rows = []
+        for item in items:
+            cells = []
+            for key, _label in columns:
+                if key == "status":
+                    value = _tool_status(item)
+                elif key == "provenance":
+                    prov = item.get("provenance") or {}
+                    value = f"{prov.get('source', '')}:{prov.get('detail', '')}"
+                else:
+                    value = item.get(key, "")
+                cells.append(f"<td>{html_escape(str(value))}</td>")
+            body_rows.append("<tr>" + "".join(cells) + "</tr>")
+        return (
+            "<table><thead><tr>"
+            + head
+            + "</tr></thead><tbody>"
+            + "".join(body_rows)
+            + "</tbody></table>"
+        )
+
+    warning = (
+        "Availability depends on this workspace's gptme.toml, enabled plugins, "
+        "MCP flag, tool allowlist, and permissions. This is a snapshot, not a "
+        "guarantee of the next session."
+    )
+    limitations = "".join(
+        f"<li>{html_escape(note)}</li>" for note in snapshot["limitations"]
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>gptme capabilities — {html_escape(Path(snapshot["workspace"]).name)}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 0.75rem 0 1.5rem; }}
+    th, td {{ border-bottom: 1px solid #ddd; text-align: left; padding: 0.35rem 0.5rem; vertical-align: top; }}
+    th {{ font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.03em; }}
+    .warn {{ background: #fff6d6; padding: 0.75rem 1rem; border-left: 4px solid #e6b800; }}
+    code {{ font-size: 0.9em; }}
+  </style>
+</head>
+<body>
+  <h1>gptme capabilities</h1>
+  <p>Schema {snapshot["schema_version"]} · {html_escape(snapshot["generated_at"])}</p>
+  <p><code>{html_escape(snapshot["workspace"])}</code></p>
+  <p class="warn">{html_escape(warning)}</p>
+  <p>
+    In-session tools {counts["tools_in_session"]}/{counts["tools_available"]}
+    · skills {counts["skills"]}
+    · plugins {counts["plugins"]}
+    · MCP servers {counts["mcp_servers"]}
+    (mcp.enabled={str(cfg["mcp_enabled"]).lower()})
+  </p>
+  <h2>In-session tools</h2>
+  {_rows(loaded, [("name", "Name"), ("desc", "Description"), ("provenance", "Provenance"), ("status", "Status")])}
+  <h2>Discovered, not in session</h2>
+  {_rows(other, [("name", "Name"), ("desc", "Description"), ("provenance", "Provenance"), ("status", "Status")])}
+  <h2>Skills</h2>
+  {_rows(snapshot["skills"], [("name", "Name"), ("desc", "Description"), ("path", "Path"), ("provenance", "Provenance")])}
+  <h2>Plugins</h2>
+  {_rows(snapshot["plugins"], [("name", "Name"), ("enabled", "Enabled"), ("provenance", "Provenance")])}
+  <h2>MCP servers</h2>
+  {_rows(snapshot["mcp_servers"], [("name", "Name"), ("enabled", "Enabled"), ("transport", "Transport"), ("reason", "Reason")])}
+  <h2>Limitations</h2>
+  <ul>{limitations}</ul>
+</body>
+</html>
+"""
+
+
+def _rel_or_str(path: Path, workspace: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(workspace.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def collect_live(
+    workspace: Path,
+    *,
+    include_instructions: bool = False,
+    connect_mcp: bool = False,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Resolve the workspace gptme config and project a v1 snapshot."""
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    from . import console
+
+    workspace = workspace.resolve()
+    prev_quiet = console.quiet
+    console.quiet = True
+    try:
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            return _collect_live_impl(
+                workspace,
+                include_instructions=include_instructions,
+                connect_mcp=connect_mcp,
+                generated_at=generated_at,
+            )
+    finally:
+        console.quiet = prev_quiet
+
+
+def _collect_live_impl(
+    workspace: Path,
+    *,
+    include_instructions: bool,
+    connect_mcp: bool,
+    generated_at: str | None,
+) -> dict[str, Any]:
+    from ..config import get_config, set_config_from_workspace  # fmt: skip
+    from ..lessons.index import LessonIndex  # fmt: skip
+    from ..plugins.registry import (  # fmt: skip
+        clear_registry,
+        discover_all_plugins,
+        get_all_plugins,
+    )
+    from ..tools import (  # fmt: skip
+        clear_tools,
+        get_available_tools,
+        get_tools,
+        init_tools,
+    )
+
+    set_config_from_workspace(workspace)
+    cfg = get_config()
+    plugin_paths, enabled_plugins = cfg.get_plugin_config()
+    clear_registry()
+    discover_all_plugins(plugin_paths, enabled_plugins)
+    plugins = get_all_plugins()
+
+    plugin_tool_names: dict[str, str] = {}
+    plugin_records: list[dict[str, Any]] = []
+    seen_plugin_names: set[str] = set()
+    for plugin in plugins:
+        if plugin.name in seen_plugin_names:
+            continue
+        seen_plugin_names.add(plugin.name)
+        for tool in plugin.tools:
+            plugin_tool_names[tool.name] = plugin.name
+        plugin_records.append(
+            {
+                "name": plugin.name,
+                "provenance": {
+                    "source": "folder",
+                    "detail": plugin.name,
+                },
+                "tool_modules": list(plugin.tool_modules),
+                "tool_names": [t.name for t in plugin.tools],
+                "has_hooks": plugin.register_hooks is not None,
+                "has_commands": plugin.register_commands is not None,
+                "enabled": enabled_plugins is None or plugin.name in enabled_plugins,
+            }
+        )
+
+    clear_tools()
+    init_tools()
+    loaded = {t.name: t for t in get_tools()}
+    discovered = get_available_tools(include_mcp=connect_mcp)
+
+    tools: list[dict[str, Any]] = []
+    for tool in discovered:
+        if tool.is_mcp:
+            server = tool.name.split(".", 1)[0] if "." in tool.name else "unknown"
+            provenance = {"source": "mcp", "detail": server}
+        elif tool.name in plugin_tool_names:
+            provenance = {
+                "source": "plugin",
+                "detail": plugin_tool_names[tool.name],
+            }
+        else:
+            provenance = {"source": "builtin", "detail": "gptme.tools"}
+        record: dict[str, Any] = {
+            "name": tool.name,
+            "desc": redact_secret_like(tool.desc),
+            "in_session": tool.name in loaded,
+            "available": bool(tool.is_available),
+            "disabled_by_default": bool(tool.disabled_by_default),
+            "available_hint": tool.available_hint,
+            "is_mcp": bool(tool.is_mcp),
+            "provenance": provenance,
+            "block_types": list(tool.block_types or []),
+            "functions": [fn.name for fn in (tool.functions or [])],
+            "commands": list(tool.commands.keys()) if tool.commands else [],
+            "hints": sorted(tool.hints) if tool.hints else [],
+            "parameters": [
+                {
+                    "name": p.name,
+                    "type": str(p.type or "string"),
+                    "required": bool(getattr(p, "required", False)),
+                    "description": redact_secret_like(p.description or ""),
+                }
+                for p in (tool.parameters or [])
+            ],
+            "instructions_included": False,
+        }
+        if include_instructions:
+            record["instructions"] = redact_secret_like(tool.instructions or "")
+            record["instructions_included"] = True
+        tools.append(record)
+
+    index = LessonIndex()
+    skills: list[dict[str, Any]] = []
+    lessons_count = 0
+    for item in index.lessons:
+        if not item.metadata.name:
+            lessons_count += 1
+            continue
+        path = Path(item.path)
+        skills.append(
+            {
+                "name": item.metadata.name,
+                "desc": redact_secret_like(
+                    (item.metadata.description or item.description or "")[:200]
+                ),
+                "path": _rel_or_str(path, workspace),
+                "category": item.category,
+                "stub": bool(getattr(item, "is_stub", False)),
+                "provenance": {
+                    "source": "dir",
+                    "detail": path.parent.name,
+                },
+                "body_included": False,
+            }
+        )
+
+    from ..config.models import MCPConfig, MCPServerConfig  # fmt: skip
+
+    mcp_cfg = getattr(cfg, "mcp", None)
+    mcp_typed: MCPConfig | None = mcp_cfg if isinstance(mcp_cfg, MCPConfig) else None
+    mcp_enabled = bool(mcp_typed.enabled) if mcp_typed else False
+    mcp_servers: list[dict[str, Any]] = []
+    mcp_server_list: list[MCPServerConfig] = (
+        list(mcp_typed.servers) if mcp_typed else []
+    )
+    for srv in mcp_server_list:
+        if mcp_enabled and srv.enabled:
+            reason = "configured"
+            in_session = True
+        elif not mcp_enabled:
+            reason = "mcp_globally_disabled"
+            in_session = False
+        else:
+            reason = "server_disabled"
+            in_session = False
+        mcp_servers.append(
+            {
+                "name": srv.name,
+                "enabled": bool(srv.enabled),
+                "transport": "http" if srv.is_http else "stdio",
+                "in_session": in_session,
+                "reason": reason,
+                "tool_count": None,
+            }
+        )
+
+    chat = getattr(cfg, "chat", None)
+    stamp = generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return build_snapshot(
+        workspace=str(workspace),
+        generated_at=stamp,
+        config={
+            "mcp_enabled": mcp_enabled,
+            "plugin_enabled": list(enabled_plugins or [p.name for p in plugins]),
+            "tool_allowlist": getattr(chat, "tools", None),
+            "profile": getattr(chat, "agent", None) if chat else None,
+        },
+        tools=tools,
+        skills=skills,
+        plugins=plugin_records,
+        mcp_servers=mcp_servers,
+        lessons_count=lessons_count,
+    )
+
+
+def render(snapshot: dict[str, Any], fmt: str, *, show_all: bool = False) -> str:
+    if fmt == "json":
+        return snapshot_to_json(snapshot)
+    if fmt == "html":
+        return snapshot_to_html(snapshot)
+    if fmt == "text":
+        return snapshot_to_text(snapshot, show_all=show_all)
+    raise ValueError(f"unknown format: {fmt}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export a session-resolved gptme capability snapshot (idea #1204)."
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "html"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help="Workspace whose gptme.toml to resolve (default: cwd)",
+    )
+    parser.add_argument(
+        "--from-json",
+        type=Path,
+        default=None,
+        help="Render an existing snapshot instead of collecting live",
+    )
+    parser.add_argument(
+        "--all",
+        dest="show_all",
+        action="store_true",
+        help="Include discovered-but-not-loaded tools in text output",
+    )
+    parser.add_argument(
+        "--include-instructions",
+        action="store_true",
+        help="Opt in to redacted tool instructions in JSON",
+    )
+    parser.add_argument(
+        "--connect-mcp",
+        action="store_true",
+        help="Live-enumerate MCP tools (off by default)",
+    )
+    parser.add_argument("-o", "--output", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    if args.from_json:
+        snapshot = json.loads(args.from_json.read_text(encoding="utf-8"))
+    else:
+        workspace = (args.workspace or Path.cwd()).resolve()
+        snapshot = collect_live(
+            workspace,
+            include_instructions=args.include_instructions,
+            connect_mcp=args.connect_mcp,
+        )
+
+    text = render(snapshot, args.format, show_all=args.show_all)
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capabilities_export.py
+++ b/tests/test_capabilities_export.py
@@ -219,6 +219,34 @@ def test_unknown_format_raises():
         render(snap, "yaml")  # pyright: ignore[reportArgumentType]
 
 
+def test_mcp_connected_tools_excluded_reason_renders():
+    """connected_tools_excluded reason appears when a server connected but its tools
+    were filtered by the allowlist — distinct from mcp_not_connected."""
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config={"mcp_enabled": True, "plugin_enabled": []},
+        tools=[],
+        skills=[],
+        plugins=[],
+        mcp_servers=[
+            {
+                "name": "myserver",
+                "enabled": True,
+                "transport": "stdio",
+                "in_session": False,
+                "reason": "connected_tools_excluded",
+                "tool_count": None,
+            }
+        ],
+    )
+    text = render(snap, "text")
+    assert "connected_tools_excluded" in text
+    assert "myserver" in text
+    html = render(snap, "html")
+    assert "connected_tools_excluded" in html
+
+
 def test_limitations_include_provenance_gap():
     snap = build_snapshot(
         workspace="/tmp/w",

--- a/tests/test_capabilities_export.py
+++ b/tests/test_capabilities_export.py
@@ -13,6 +13,7 @@ import pytest
 
 from gptme.util.capabilities_export import (
     build_snapshot,
+    collect_live,
     redact_secret_like,
     render,
 )
@@ -258,3 +259,80 @@ def test_limitations_include_provenance_gap():
         mcp_servers=[],
     )
     assert any("no native source field" in note for note in snap["limitations"])
+
+
+def test_html_escapes_untrusted_snapshot_scalars():
+    """--from-json HTML must not interpolate raw snapshot fields (XSS)."""
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config=_fixture_snapshot()["config"],
+        tools=_fixture_snapshot()["tools"],
+        skills=_fixture_snapshot()["skills"],
+        plugins=_fixture_snapshot()["plugins"],
+        mcp_servers=_fixture_snapshot()["mcp_servers"],
+    )
+    snap["schema_version"] = "<script>alert(1)</script>"
+    snap["generated_at"] = "<b>xss</b>"
+    snap["workspace"] = '" onload="alert(1)'
+    snap["counts"]["tools_in_session"] = "<svg/onload=alert(1)>"
+    html = render(snap, "html")
+    assert "<script>" not in html
+    assert "<b>xss</b>" not in html
+    assert "<svg/onload=alert(1)>" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;b&gt;xss&lt;/b&gt;" in html
+
+
+def test_collect_live_default_does_not_connect_mcp(tmp_path, monkeypatch):
+    """Default collect_live must not call create_mcp_tools even if MCP is enabled."""
+    (tmp_path / "gptme.toml").write_text(
+        "[mcp]\n"
+        "enabled = true\n"
+        "\n"
+        "[[mcp.servers]]\n"
+        'name = "fake-stdio"\n'
+        "enabled = true\n"
+        'command = "true"\n'
+    )
+    calls: list[object] = []
+
+    def fake_create(config: object) -> list:
+        calls.append(config)
+        return []
+
+    monkeypatch.setattr("gptme.tools.mcp_adapter.create_mcp_tools", fake_create)
+    snap = collect_live(
+        tmp_path, connect_mcp=False, generated_at="2026-09-02T00:00:00Z"
+    )
+    assert calls == []
+    servers = {s["name"]: s for s in snap["mcp_servers"]}
+    assert "fake-stdio" in servers
+    assert servers["fake-stdio"]["reason"] == "connect_mcp_not_requested"
+    assert servers["fake-stdio"]["in_session"] is False
+    assert any("pass --connect-mcp" in note for note in snap["limitations"])
+
+
+def test_connect_mcp_not_requested_reason_renders():
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config={"mcp_enabled": True, "plugin_enabled": []},
+        tools=[],
+        skills=[],
+        plugins=[],
+        mcp_servers=[
+            {
+                "name": "myserver",
+                "enabled": True,
+                "transport": "stdio",
+                "in_session": False,
+                "reason": "connect_mcp_not_requested",
+                "tool_count": None,
+            }
+        ],
+    )
+    text = render(snap, "text")
+    assert "connect_mcp_not_requested" in text
+    html = render(snap, "html")
+    assert "connect_mcp_not_requested" in html

--- a/tests/test_capabilities_export.py
+++ b/tests/test_capabilities_export.py
@@ -316,17 +316,32 @@ def test_collect_live_default_does_not_connect_mcp(tmp_path, monkeypatch):
 def test_collect_live_mcp_allowlist_does_not_abort_default_export(
     tmp_path, monkeypatch
 ):
-    """[chat].tools with MCP-qualified entries must not raise when connect_mcp=False."""
-    (tmp_path / "gptme.toml").write_text(
-        '[chat]\ntools = ["shell", "discord.read_channel", "discord.*"]\n'
-    )
+    """MCP-qualified allowlist entries must not raise when connect_mcp=False."""
+    monkeypatch.setenv("TOOL_ALLOWLIST", "shell,discord.read_channel,discord.*")
     snap = collect_live(
         tmp_path, connect_mcp=False, generated_at="2026-09-02T00:00:00Z"
     )
-    # The snapshot must be produced despite the MCP-qualified allowlist entries
     assert snap["schema_version"] == 1
-    tool_names = [t["name"] for t in snap["tools"]]
-    assert "shell" in tool_names
+    in_session = [t["name"] for t in snap["tools"] if t["in_session"]]
+    assert "shell" in in_session
+    assert "discord.read_channel" not in in_session
+
+
+def test_collect_live_mcp_only_allowlist_does_not_abort_default_export(
+    tmp_path, monkeypatch
+):
+    """MCP-only allowlist must not raise when connect_mcp=False.
+
+    Filtering every MCP-qualified entry must leave [], not None — None makes
+    init_tools reload the original allowlist and ValueError with include_mcp=False.
+    """
+    monkeypatch.setenv("TOOL_ALLOWLIST", "discord.read_channel,discord.*")
+    snap = collect_live(
+        tmp_path, connect_mcp=False, generated_at="2026-09-02T00:00:00Z"
+    )
+    assert snap["schema_version"] == 1
+    in_session = [t["name"] for t in snap["tools"] if t["in_session"]]
+    assert "discord.read_channel" not in in_session
 
 
 def test_collect_live_clears_stale_mcp_clients_before_fresh_collection(

--- a/tests/test_capabilities_export.py
+++ b/tests/test_capabilities_export.py
@@ -1,0 +1,232 @@
+"""Tests for gptme.util.capabilities_export (idea #1204).
+
+Snapshot tests freeze the JSON bytes of the pure builder and assert that
+no tool instructions, skill bodies, or MCP env/headers leak into default
+JSON/text/HTML output.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gptme.util.capabilities_export import (
+    build_snapshot,
+    redact_secret_like,
+    render,
+)
+
+
+def _fixture_snapshot(**overrides: object) -> dict:
+    payload: dict = {
+        "workspace": "/tmp/demo-workspace",
+        "generated_at": "2026-09-02T01:30:00Z",
+        "config": {
+            "mcp_enabled": False,
+            "plugin_enabled": ["headroom_compressor", "action_receipts"],
+            "tool_allowlist": None,
+            "profile": None,
+        },
+        "tools": [
+            {
+                "name": "shell",
+                "desc": "Execute shell commands",
+                "in_session": True,
+                "available": True,
+                "disabled_by_default": False,
+                "available_hint": None,
+                "is_mcp": False,
+                "provenance": {"source": "builtin", "detail": "gptme.tools"},
+                "block_types": ["shell", "bash"],
+                "functions": [],
+                "commands": [],
+                "hints": ["code-exec", "destructive"],
+                "parameters": [],
+                "instructions_included": False,
+            },
+            {
+                "name": "computer",
+                "desc": "Desktop computer use",
+                "in_session": False,
+                "available": True,
+                "disabled_by_default": True,
+                "available_hint": None,
+                "is_mcp": False,
+                "provenance": {"source": "builtin", "detail": "gptme.tools"},
+                "block_types": ["computer"],
+                "functions": [],
+                "commands": [],
+                "hints": [],
+                "parameters": [],
+                "instructions_included": False,
+            },
+            {
+                "name": "screenshot",
+                "desc": "Capture the screen",
+                "in_session": False,
+                "available": False,
+                "disabled_by_default": False,
+                "available_hint": "install scrot",
+                "is_mcp": False,
+                "provenance": {"source": "builtin", "detail": "gptme.tools"},
+                "block_types": ["screenshot"],
+                "functions": [],
+                "commands": [],
+                "hints": [],
+                "parameters": [],
+                "instructions_included": False,
+            },
+        ],
+        "skills": [
+            {
+                "name": "end",
+                "desc": "Wrap up a session safely",
+                "path": "skills/end/SKILL.md",
+                "category": "end",
+                "stub": False,
+                "provenance": {"source": "dir", "detail": "end"},
+                "body_included": False,
+            },
+        ],
+        "plugins": [
+            {
+                "name": "headroom_compressor",
+                "provenance": {"source": "folder", "detail": "headroom_compressor"},
+                "tool_modules": [],
+                "tool_names": [],
+                "has_hooks": True,
+                "has_commands": False,
+                "enabled": True,
+            },
+        ],
+        "mcp_servers": [
+            {
+                "name": "context",
+                "enabled": True,
+                "transport": "stdio",
+                "in_session": False,
+                "reason": "mcp_globally_disabled",
+                "tool_count": None,
+            },
+        ],
+        "limitations": [],
+        "lessons_count": 3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+SECRET = "Bearer sk-abcdef1234567890abcdef"
+
+
+def test_redact_secret_like_masks_tokens():
+    masked = redact_secret_like(SECRET)
+    assert "abcdef1234567890abcdef" not in masked
+    assert "Bearer" in masked
+    assert redact_secret_like(None) == ""
+    assert redact_secret_like("") == ""
+
+
+def test_json_snapshot_is_byte_stable():
+    snap = build_snapshot(
+        workspace=_fixture_snapshot()["workspace"],
+        generated_at=_fixture_snapshot()["generated_at"],
+        config=_fixture_snapshot()["config"],
+        tools=_fixture_snapshot()["tools"],
+        skills=_fixture_snapshot()["skills"],
+        plugins=_fixture_snapshot()["plugins"],
+        mcp_servers=_fixture_snapshot()["mcp_servers"],
+        lessons_count=3,
+    )
+    assert render(snap, "json") == render(snap, "json")
+    parsed = json.loads(render(snap, "json"))
+    assert parsed["schema_version"] == 1
+    assert parsed["counts"]["tools_in_session"] == 1
+    assert parsed["counts"]["skills"] == 1
+    assert parsed["counts"]["lessons"] == 3
+    assert parsed["counts"]["mcp_servers"] == 1
+
+
+def test_default_json_omits_instructions():
+    tools = _fixture_snapshot()["tools"]
+    tools[0]["instructions"] = SECRET
+    tools[0]["instructions_included"] = True  # pretend opt-in upstream
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config=_fixture_snapshot()["config"],
+        tools=tools,
+        skills=[],
+        plugins=[],
+        mcp_servers=[],
+    )
+    out = render(snap, "json")
+    assert "instructions_included" in out
+    # Only tools that explicitly opt in carry instructions; the CLI default
+    # never sets that flag, and secrets are redacted regardless.
+    for tool in json.loads(out)["tools"]:
+        if tool.get("instructions_included"):
+            assert SECRET not in tool["instructions"]
+
+
+def test_html_has_no_instruction_text():
+    tools = _fixture_snapshot()["tools"]
+    tools[0]["instructions"] = "RUN THIS EXACT SECRET COMMAND SEQUENCE"
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config=_fixture_snapshot()["config"],
+        tools=tools,
+        skills=_fixture_snapshot()["skills"],
+        plugins=_fixture_snapshot()["plugins"],
+        mcp_servers=_fixture_snapshot()["mcp_servers"],
+    )
+    html = render(snap, "html")
+    assert "RUN THIS EXACT SECRET COMMAND SEQUENCE" not in html
+    assert "gptme capabilities" in html
+    assert "<table>" in html
+
+
+def test_text_default_hides_not_in_session_tools():
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config=_fixture_snapshot()["config"],
+        tools=_fixture_snapshot()["tools"],
+        skills=[],
+        plugins=[],
+        mcp_servers=[],
+    )
+    default = render(snap, "text")
+    assert "shell" in default
+    assert "computer" not in default
+    all_tools = render(snap, "text", show_all=True)
+    assert "computer" in all_tools
+
+
+def test_unknown_format_raises():
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config={},
+        tools=[],
+        skills=[],
+        plugins=[],
+        mcp_servers=[],
+    )
+    with pytest.raises(ValueError, match="unknown format"):
+        render(snap, "yaml")  # pyright: ignore[reportArgumentType]
+
+
+def test_limitations_include_provenance_gap():
+    snap = build_snapshot(
+        workspace="/tmp/w",
+        generated_at="2026-09-02T01:30:00Z",
+        config={},
+        tools=[],
+        skills=[],
+        plugins=[],
+        mcp_servers=[],
+    )
+    assert any("no native source field" in note for note in snap["limitations"])

--- a/tests/test_capabilities_export.py
+++ b/tests/test_capabilities_export.py
@@ -313,6 +313,56 @@ def test_collect_live_default_does_not_connect_mcp(tmp_path, monkeypatch):
     assert any("pass --connect-mcp" in note for note in snap["limitations"])
 
 
+def test_collect_live_mcp_allowlist_does_not_abort_default_export(
+    tmp_path, monkeypatch
+):
+    """[chat].tools with MCP-qualified entries must not raise when connect_mcp=False."""
+    (tmp_path / "gptme.toml").write_text(
+        '[chat]\ntools = ["shell", "discord.read_channel", "discord.*"]\n'
+    )
+    snap = collect_live(
+        tmp_path, connect_mcp=False, generated_at="2026-09-02T00:00:00Z"
+    )
+    # The snapshot must be produced despite the MCP-qualified allowlist entries
+    assert snap["schema_version"] == 1
+    tool_names = [t["name"] for t in snap["tools"]]
+    assert "shell" in tool_names
+
+
+def test_collect_live_clears_stale_mcp_clients_before_fresh_collection(
+    tmp_path, monkeypatch
+):
+    """Stale MCP clients from a prior connection must not fabricate connectivity."""
+    from unittest.mock import MagicMock
+
+    import gptme.tools.mcp_adapter as mcp_mod
+
+    (tmp_path / "gptme.toml").write_text(
+        "[mcp]\n"
+        "enabled = true\n"
+        "\n"
+        "[[mcp.servers]]\n"
+        'name = "fake-server"\n'
+        "enabled = true\n"
+        'command = "true"\n'
+    )
+    # Inject a stale client as if a prior session connected this server
+    mcp_mod._mcp_clients["fake-server"] = MagicMock()
+
+    def fake_create(config: object) -> list:
+        # Reconnection fails — returns no tools, does not update _mcp_clients
+        return []
+
+    monkeypatch.setattr("gptme.tools.mcp_adapter.create_mcp_tools", fake_create)
+    snap = collect_live(tmp_path, connect_mcp=True, generated_at="2026-09-02T00:00:00Z")
+
+    # The stale client must have been cleared; connection failure → mcp_not_connected
+    servers = {s["name"]: s for s in snap["mcp_servers"]}
+    assert "fake-server" in servers
+    assert servers["fake-server"]["reason"] == "mcp_not_connected"
+    assert servers["fake-server"]["in_session"] is False
+
+
 def test_connect_mcp_not_requested_reason_renders():
     snap = build_snapshot(
         workspace="/tmp/w",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -46,6 +46,16 @@ def test_init_tools_include_mcp_false_does_not_create_mcp_tools(monkeypatch):
     assert [t.name for t in get_tools()] == ["save"]
 
 
+def test_init_tools_include_mcp_false_accepts_mcp_only_allowlist():
+    """MCP-only allowlists must not ValueError when MCP discovery is skipped."""
+    clear_tools()
+    tools = init_tools(
+        allowlist=["discord.read_channel", "discord.*"], include_mcp=False
+    )
+    assert all(not t.is_mcp for t in tools)
+    assert "discord.read_channel" not in {t.name for t in tools}
+
+
 def test_init_tools_allowlist():
     clear_tools()  # ensure clean state regardless of test ordering
     init_tools(allowlist=["save"])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -31,6 +31,21 @@ def test_init_tools():
     assert len(get_tools()) > 1
 
 
+def test_init_tools_include_mcp_false_does_not_create_mcp_tools(monkeypatch):
+    """Snapshot/export paths must be able to init tools without connecting MCP."""
+    calls: list[object] = []
+
+    def fake_create(config: object) -> list:
+        calls.append(config)
+        return []
+
+    monkeypatch.setattr("gptme.tools.mcp_adapter.create_mcp_tools", fake_create)
+    clear_tools()
+    init_tools(allowlist=["save"], include_mcp=False)
+    assert calls == []
+    assert [t.name for t in get_tools()] == ["save"]
+
+
 def test_init_tools_allowlist():
     clear_tools()  # ensure clean state regardless of test ordering
     init_tools(allowlist=["save"])

--- a/tests/test_tools_base.py
+++ b/tests/test_tools_base.py
@@ -16,6 +16,7 @@ from gptme.message import Message
 from gptme.tools._allowlist import (
     allowlist_contains_glob,
     is_hint_pattern,
+    is_mcp_allowlist_entry,
     matching_allowlist_tools,
     tool_matches_allowlist,
 )
@@ -812,6 +813,18 @@ class TestIsHintPattern:
 
     def test_glob_not_hint(self):
         assert not is_hint_pattern("discord.*")
+
+
+class TestIsMcpAllowlistEntry:
+    def test_server_tool_and_glob(self):
+        assert is_mcp_allowlist_entry("discord.read_channel")
+        assert is_mcp_allowlist_entry("discord.*")
+
+    def test_builtin_and_file_path_not_mcp(self):
+        assert not is_mcp_allowlist_entry("shell")
+        assert not is_mcp_allowlist_entry("hint:read-only")
+        assert not is_mcp_allowlist_entry("path/to/mytool.py")
+        assert not is_mcp_allowlist_entry("mytool.py")
 
 
 class TestAllowlistContainsGlob:


### PR DESCRIPTION
Session-resolved capability snapshot: `gptme capabilities --format text|json|html` over the already-loaded ToolSpec / skill / plugin / MCP config for one workspace (idea #1204, from Bob's research + prototype).

## What

- `gptme/util/capabilities_export.py` — pure schema-v1 builder + JSON/text/HTML renderers; `collect_live()` resolves the workspace config lazily (tools in/out of session, availability, provenance, skills, plugins, MCP servers, limitations)
- `gptme/cli/cmd_capabilities.py` — lazy-registered `gptme-util capabilities` (also dispatches as `gptme capabilities` via UTIL_SUBCOMMANDS)
- `tests/test_capabilities_export.py` — snapshot tests freeze JSON bytes, assert JSON/text/HTML contain no tool instructions, secret redaction, default text hides not-in-session tools

## Privacy / redaction

Default output **omits** tool instructions, skill bodies, and MCP env/headers. Instructions are redacted in both `collect_live` and the builder (defense in depth), and secret-like tokens (API keys, bearer tokens) are masked. `GET /api/v2/tools` behavior is unchanged — this is additive.

## Non-goals

No second registry, no marketplace, no hosted dump.

## Verification

- 7 new tests pass; `tests/test_prompt_tools.py` + `tests/test_lessons_tool.py` (38) unaffected
- ruff + mypy clean on new files
- Live smoke: `gptme-util capabilities --workspace <bob> --format text` renders 19/36 in-session tools, 6 plugins, 5 MCP servers