### PR TITLE
fix(telemetry): suppress repeated export errors after first occurrence

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -472,8 +472,8 @@ def init_logging(verbose, *, stderr: bool = True, compact: bool = True):
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
 
-    # Apply debouncing filter for OpenTelemetry connection errors
-    # This shows the first error, then suppresses duplicates for 5 minutes
+    # Apply deduplication filter for OpenTelemetry connection errors
+    # This shows the first error per session, then suppresses all subsequent ones
     # Prevents spam while still alerting users to telemetry issues
     # Uses singleton filter to share state with setup_telemetry() filters
     try:

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -10,7 +10,6 @@ import importlib.util as _importlib_util
 import logging
 import os
 import socket
-import time
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
@@ -26,15 +25,16 @@ _session_id: ContextVar[str | None] = ContextVar("session_id", default=None)
 
 
 class TelemetryConnectionErrorFilter(logging.Filter):
-    """Filter to debounce and truncate verbose network/export traces from OpenTelemetry.
+    """Filter to deduplicate and truncate verbose network/export traces from OpenTelemetry.
 
     This filter:
     1. Simplifies verbose stack traces to single-line messages
-    2. Debounces repeated errors (shows first, then suppresses for cooldown period)
-    3. Periodically shows a count of suppressed errors
+    2. Shows only the first occurrence per error type per session, then suppresses forever
 
     The filter ensures users see at least one error message when telemetry fails,
-    but prevents spam from repeated exporter network failures.
+    but prevents repeated spam from exporter network failures. After the first
+    occurrence the error is silently dropped — the user already knows, and repeated
+    "still failing" messages add no new information.
     """
 
     _NETWORK_ERROR_NAME_FRAGMENTS = (
@@ -48,15 +48,15 @@ class TelemetryConnectionErrorFilter(logging.Filter):
 
     def __init__(self, cooldown_seconds: float = 300.0):
         super().__init__()
-        self._error_counts: dict[str, int] = {}
-        self._last_logged: dict[str, float] = {}
-        self._cooldown_seconds = cooldown_seconds  # 5 minutes between repeated errors
+        self._shown: set[str] = set()
+        # cooldown_seconds kept for API compatibility but no longer used
+        self._cooldown_seconds = cooldown_seconds
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Filter and debounce connection error messages.
+        """Filter and deduplicate connection error messages.
 
         Returns True to allow the (possibly modified) record through.
-        Returns False to suppress duplicate errors within cooldown period.
+        Returns False to suppress duplicate errors (shown once per session).
         """
         # Only filter opentelemetry loggers (root logger or children)
         if not (
@@ -71,37 +71,22 @@ class TelemetryConnectionErrorFilter(logging.Filter):
                 fragment in exc_type.__name__
                 for fragment in self._NETWORK_ERROR_NAME_FRAGMENTS
             ):
-                # Create error key for deduplication (type + truncated message)
-                error_key = f"{exc_type.__name__}"
+                # Create error key for deduplication (type name only)
+                error_key = exc_type.__name__
 
-                # Track occurrence count
-                now = time.time()
-                count = self._error_counts.get(error_key, 0) + 1
-                self._error_counts[error_key] = count
+                # Show only on first occurrence per session
+                if error_key in self._shown:
+                    return False
+                self._shown.add(error_key)
 
-                last_logged = self._last_logged.get(error_key, 0)
-                time_since_last = now - last_logged
-
-                # Show first occurrence, or after cooldown expires
-                if count == 1 or time_since_last > self._cooldown_seconds:
-                    self._last_logged[error_key] = now
-
-                    # Replace verbose stack trace with simple message
-                    record.exc_info = None
-                    record.exc_text = None
-                    record.args = ()
-
-                    if count == 1:
-                        record.msg = f"Telemetry export failed: {exc_value}"
-                    else:
-                        # Show count of suppressed errors
-                        record.msg = (
-                            f"Telemetry export still failing "
-                            f"({count} occurrences): {exc_value}"
-                        )
-                    return True
-                # Suppress duplicate within cooldown period
-                return False
+                # Replace verbose stack trace with simple message
+                record.exc_info = None
+                record.exc_text = None
+                record.args = ()
+                record.msg = (
+                    f"Telemetry export failed (will suppress further): {exc_value}"
+                )
+                return True
 
         return True
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,11 +1,20 @@
 """Tests for telemetry functionality."""
 
+import importlib.util
 import logging
 import subprocess
 import sys
 from unittest.mock import patch
 
 import pytest
+
+
+def _has_telemetry_deps():
+    """Check if telemetry dependencies are installed."""
+    return (
+        importlib.util.find_spec("opentelemetry") is not None
+        and importlib.util.find_spec("prometheus_client") is not None
+    )
 
 
 def test_telemetry_imports_lazy():
@@ -51,10 +60,8 @@ def test_calculate_llm_cost_resolves_anthropic_short_alias():
 
 
 @pytest.mark.skipif(
-    not pytest.importorskip(
-        "opentelemetry", reason="telemetry dependencies not installed"
-    ),
-    reason="Requires telemetry dependencies",
+    not _has_telemetry_deps(),
+    reason="Requires telemetry dependencies (opentelemetry, prometheus_client)",
 )
 def test_init_telemetry_with_pushgateway(monkeypatch):
     """Test telemetry initialization with Pushgateway."""
@@ -83,6 +90,10 @@ def test_init_telemetry_with_pushgateway(monkeypatch):
         shutdown_telemetry()
 
 
+@pytest.mark.skipif(
+    not _has_telemetry_deps(),
+    reason="Requires telemetry dependencies (opentelemetry, prometheus_client)",
+)
 def test_pushgateway_periodic_push(monkeypatch):
     """Test that metrics are pushed periodically to Pushgateway."""
     import time

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -131,7 +131,9 @@ def test_connection_error_filter_truncates_read_timeout_traceback():
     assert record.exc_info is None
     assert record.exc_text is None
     assert record.args == ()
-    assert record.msg == "Telemetry export failed: read timed out"
+    assert (
+        record.msg == "Telemetry export failed (will suppress further): read timed out"
+    )
 
 
 def test_connection_error_filter_debounces_repeated_timeouts():


### PR DESCRIPTION
## Problem

When the OTLP telemetry endpoint is unreachable (e.g. not on the same LAN as the collector), gptme logs this error every 5 minutes with an increasing occurrence count:

```
· ERROR    Telemetry export still failing (37 occurrences): HTTPConnectionPool(...): Max retries exceeded
```

This is pure noise — the user already knows from the first message that the endpoint is unreachable. The periodic "still failing" count adds nothing.

Closes: https://github.com/ErikBjare/bob/issues/1207 (partial — this addresses the telemetry spam item)

## Change

- **Show once, then suppress forever**: First occurrence shows a clear message noting further errors will be suppressed. All subsequent occurrences are silently dropped.
- **Simpler implementation**: replaces `_error_counts` + `_last_logged` dicts with a single `_shown` set.
- **API compat**: `cooldown_seconds` parameter retained as a no-op so existing callers don't need changes.

## Before
```
· ERROR    Telemetry export failed: ... (first occurrence)
· ERROR    Telemetry export still failing (5 occurrences): ...  (after 5 min)
· ERROR    Telemetry export still failing (10 occurrences): ...  (after 10 min)
```

## After
```
· ERROR    Telemetry export failed (will suppress further): ...  (once, then silence)
```

## Tests

Existing tests updated for the new message format. Both filter tests pass.