### PR TITLE
fix(server/tasks): reject task ID null bytes with 400 Bad Request (#3709)

### DIFF
--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -32,6 +32,7 @@ def _validate_task_id(
         not isinstance(task_id, str)
         or not task_id
         or "\x00" in task_id
+        or len(task_id.encode()) > _MAX_ID_LENGTH
         or not _TASK_ID_PATTERN.fullmatch(task_id)
     ):
         return flask.jsonify({"error": "Invalid task_id"}), 400

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -3,6 +3,7 @@ Common types and utilities for the gptme server API.
 """
 
 import os
+import re
 from pathlib import Path
 from typing import Literal, TypedDict
 
@@ -17,6 +18,24 @@ _MAX_ID_LENGTH = 255  # Linux NAME_MAX: 255 UTF-8 bytes for a single path compon
 _BRANCH_SUFFIX_LEN = len(
     ".jsonl"
 )  # branches/{name}.jsonl on disk — suffix counts against NAME_MAX
+_TASK_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
+
+
+def _validate_task_id(
+    task_id: str,
+) -> tuple[flask.Response, int] | None:
+    """Validate task_id to prevent path traversal attacks, null bytes, and invalid input.
+
+    Returns None if valid, or (error_response, status_code) if invalid.
+    """
+    if (
+        not isinstance(task_id, str)
+        or not task_id
+        or "\x00" in task_id
+        or not _TASK_ID_PATTERN.fullmatch(task_id)
+    ):
+        return flask.jsonify({"error": "Invalid task_id"}), 400
+    return None
 
 
 def _validate_conversation_id(

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -26,6 +26,7 @@ from ..message import Message
 from ..prompts import get_prompt
 from ..tools import get_toolchain
 from ..util.git_cmd import GIT_CMD
+from .api_v2_common import _validate_task_id
 from .auth import require_auth
 from .openapi_docs import ErrorResponse, StatusResponse, api_doc_simple
 
@@ -147,13 +148,13 @@ class TaskListResponse(BaseModel):
     tasks: list[TaskResponse] = Field(..., description="List of tasks")
 
 
-# Task IDs must be alphanumeric with hyphens/underscores, no path separators
+# Task IDs must be alphanumeric with hyphens/underscores, no path separators or null bytes
 _TASK_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
 
 
-def _validate_task_id(task_id: str) -> bool:
-    """Check that task_id doesn't contain path traversal characters."""
-    return bool(_TASK_ID_PATTERN.fullmatch(task_id))
+def _is_valid_task_id(task_id: str) -> bool:
+    """Check that task_id doesn't contain path traversal characters or null bytes."""
+    return bool(task_id) and "\x00" not in task_id and bool(_TASK_ID_PATTERN.fullmatch(task_id))
 
 
 def get_tasks_dir() -> Path:
@@ -163,7 +164,7 @@ def get_tasks_dir() -> Path:
 
 def load_task(task_id: str) -> Task | None:
     """Load a task from storage."""
-    if not _validate_task_id(task_id):
+    if not _is_valid_task_id(task_id):
         logger.warning(f"Rejected load_task with invalid task_id: {task_id!r}")
         return None
 
@@ -184,7 +185,7 @@ def load_task(task_id: str) -> Task | None:
 
 def save_task(task: Task) -> None:
     """Save a task to storage."""
-    if not _validate_task_id(task.id):
+    if not _is_valid_task_id(task.id):
         raise ValueError(f"Invalid task_id: {task.id!r}")
 
     tasks_dir = get_tasks_dir()
@@ -580,7 +581,7 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
 def create_task_conversation(task: Task) -> str:
     """Create a conversation for a task."""
-    if not _validate_task_id(task.id):
+    if not _is_valid_task_id(task.id):
         raise ValueError(f"Invalid task_id: {task.id!r}")
 
     # Use simple incremental suffix instead of timestamp
@@ -630,7 +631,7 @@ def create_task_conversation(task: Task) -> str:
 
 def setup_task_workspace(task_id: str, target_repo: str | None = None) -> Path:
     """Setup workspace for task. All conversations for this task will share this workspace."""
-    if not _validate_task_id(task_id):
+    if not _is_valid_task_id(task_id):
         raise ValueError(f"Invalid task_id: {task_id!r}")
 
     # Use task-level workspace that all conversations for this task will share
@@ -794,7 +795,7 @@ def api_tasks_create():
 @tasks_api.route("/api/v2/tasks/<string:task_id>")
 @require_auth
 @api_doc_simple(
-    responses={200: TaskResponse, 404: ErrorResponse, 500: ErrorResponse},
+    responses={200: TaskResponse, 400: ErrorResponse, 404: ErrorResponse, 500: ErrorResponse},
     tags=["tasks"],
 )
 def api_tasks_get(task_id: str):
@@ -803,6 +804,9 @@ def api_tasks_get(task_id: str):
     Retrieve comprehensive information about a task including git status,
     conversation details, and derived status information.
     """
+    if error := _validate_task_id(task_id):
+        return error
+
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -842,6 +846,9 @@ def api_tasks_update(task_id: str):
     Update task content, target type, target repository, or metadata.
     Only provided fields will be updated.
     """
+    if error := _validate_task_id(task_id):
+        return error
+
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -925,6 +932,9 @@ def api_tasks_archive(task_id: str):
     Archive a task to hide it from active view while preserving all data.
     Archived tasks can be restored using the unarchive endpoint.
     """
+    if error := _validate_task_id(task_id):
+        return error
+
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -961,6 +971,9 @@ def api_tasks_unarchive(task_id: str):
     Restore an archived task to active view, making it visible
     in the standard task listings again.
     """
+    if error := _validate_task_id(task_id):
+        return error
+
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -154,7 +154,11 @@ _TASK_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
 
 def _is_valid_task_id(task_id: str) -> bool:
     """Check that task_id doesn't contain path traversal characters or null bytes."""
-    return bool(task_id) and "\x00" not in task_id and bool(_TASK_ID_PATTERN.fullmatch(task_id))
+    return (
+        bool(task_id)
+        and "\x00" not in task_id
+        and bool(_TASK_ID_PATTERN.fullmatch(task_id))
+    )
 
 
 def get_tasks_dir() -> Path:
@@ -795,7 +799,12 @@ def api_tasks_create():
 @tasks_api.route("/api/v2/tasks/<string:task_id>")
 @require_auth
 @api_doc_simple(
-    responses={200: TaskResponse, 400: ErrorResponse, 404: ErrorResponse, 500: ErrorResponse},
+    responses={
+        200: TaskResponse,
+        400: ErrorResponse,
+        404: ErrorResponse,
+        500: ErrorResponse,
+    },
     tags=["tasks"],
 )
 def api_tasks_get(task_id: str):

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -26,7 +26,7 @@ from ..message import Message
 from ..prompts import get_prompt
 from ..tools import get_toolchain
 from ..util.git_cmd import GIT_CMD
-from .api_v2_common import _validate_task_id
+from .api_v2_common import _MAX_ID_LENGTH, _validate_task_id
 from .auth import require_auth
 from .openapi_docs import ErrorResponse, StatusResponse, api_doc_simple
 
@@ -153,10 +153,11 @@ _TASK_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
 
 
 def _is_valid_task_id(task_id: str) -> bool:
-    """Check that task_id doesn't contain path traversal characters or null bytes."""
+    """Check that task_id doesn't contain path traversal characters, null bytes, or exceed NAME_MAX."""
     return (
         bool(task_id)
         and "\x00" not in task_id
+        and len(task_id.encode()) <= _MAX_ID_LENGTH
         and bool(_TASK_ID_PATTERN.fullmatch(task_id))
     )
 

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1057,12 +1057,17 @@ class TestTaskIdPathTraversal:
         assert resp.status_code == 404
 
     def test_api_routes_reject_null_bytes(self, client):
-        """API endpoints must return 400 Bad Request with 'Invalid task_id' for null bytes."""
+        """API endpoints must return 400 Bad Request with 'Invalid task_id' for null bytes and overlong IDs."""
+        overlong_id = "a" * 256
         for method, path in [
             ("get", "/api/v2/tasks/test%00malicious"),
             ("put", "/api/v2/tasks/test%00malicious"),
             ("post", "/api/v2/tasks/test%00malicious/archive"),
             ("post", "/api/v2/tasks/test%00malicious/unarchive"),
+            ("get", f"/api/v2/tasks/{overlong_id}"),
+            ("put", f"/api/v2/tasks/{overlong_id}"),
+            ("post", f"/api/v2/tasks/{overlong_id}/archive"),
+            ("post", f"/api/v2/tasks/{overlong_id}/unarchive"),
         ]:
             fn = getattr(client, method)
             resp = fn(path)
@@ -1088,3 +1093,6 @@ class TestTaskIdPathTraversal:
 
             res_empty = _validate_task_id("")
             assert res_empty is not None and res_empty[1] == 400
+
+            res_long = _validate_task_id("a" * 256)
+            assert res_long is not None and res_long[1] == 400

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1080,6 +1080,11 @@ class TestTaskIdPathTraversal:
             assert res[1] == 400
             assert res[0].get_json() == {"error": "Invalid task_id"}
 
-            assert _validate_task_id("../traversal")[1] == 400
-            assert _validate_task_id("invalid/char")[1] == 400
-            assert _validate_task_id("")[1] == 400
+            res_trav = _validate_task_id("../traversal")
+            assert res_trav is not None and res_trav[1] == 400
+
+            res_slash = _validate_task_id("invalid/char")
+            assert res_slash is not None and res_slash[1] == 400
+
+            res_empty = _validate_task_id("")
+            assert res_empty is not None and res_empty[1] == 400

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1055,3 +1055,31 @@ class TestTaskIdPathTraversal:
     def test_api_get_rejects_traversal(self, client):
         resp = client.get("/api/v2/tasks/../../etc/passwd")
         assert resp.status_code == 404
+
+    def test_api_routes_reject_null_bytes(self, client):
+        """API endpoints must return 400 Bad Request with 'Invalid task_id' for null bytes."""
+        for method, path in [
+            ("get", "/api/v2/tasks/test%00malicious"),
+            ("put", "/api/v2/tasks/test%00malicious"),
+            ("post", "/api/v2/tasks/test%00malicious/archive"),
+            ("post", "/api/v2/tasks/test%00malicious/unarchive"),
+        ]:
+            fn = getattr(client, method)
+            resp = fn(path)
+            assert resp.status_code == 400
+            assert resp.json == {"error": "Invalid task_id"}
+
+    def test_validate_task_id_helper(self, app):
+        """Unit tests for _validate_task_id helper function."""
+        from gptme.server.api_v2_common import _validate_task_id
+
+        with app.app_context():
+            assert _validate_task_id("valid-task-123_abc") is None
+            res = _validate_task_id("test\x00malicious")
+            assert res is not None
+            assert res[1] == 400
+            assert res[0].get_json() == {"error": "Invalid task_id"}
+
+            assert _validate_task_id("../traversal")[1] == 400
+            assert _validate_task_id("invalid/char")[1] == 400
+            assert _validate_task_id("")[1] == 400


### PR DESCRIPTION
﻿## Summary

Fixes #3709 — rejects task ID containing null bytes or invalid traversal characters with `400 Bad Request` (`{"error": "Invalid task_id"}`), making behavior consistent with the conversations API.

## Problem

When calling `GET /api/v2/tasks/<task_id>` (or `PUT`, archive, unarchive) with a null byte in the task ID (e.g. `/api/v2/tasks/test%00malicious`), `load_task()` rejected the ID internally, returning `None`. The route handler then treated it as a 404 missing resource and reflected the raw null byte back into the JSON error message:
```json
{"error": "Task not found: test\x00malicious"}
```
By contrast, the conversations API (`api_v2_common.py`) defines `_validate_conversation_id()` to explicitly block null bytes and return `400 Bad Request` with `{"error": "Invalid conversation_id"}`.

## Solution

1. Added `_validate_task_id(task_id: str) -> tuple[flask.Response, int] | None` to `gptme/server/api_v2_common.py`, returning `{"error": "Invalid task_id"}, 400` for null bytes, empty strings, or characters outside `[a-zA-Z0-9_-]+`.
2. Renamed the internal storage validation helper in `tasks_api.py` to `_is_valid_task_id(task_id)`.
3. Applied `_validate_task_id(task_id)` at the entry point of:
   - `GET /api/v2/tasks/<task_id>` (`api_tasks_get`)
   - `PUT /api/v2/tasks/<task_id>` (`api_tasks_update`)
   - `POST /api/v2/tasks/<task_id>/archive` (`api_tasks_archive`)
   - `POST /api/v2/tasks/<task_id>/unarchive` (`api_tasks_unarchive`)
4. Added tests in `TestTaskIdPathTraversal` verifying:
   - All 4 task endpoints return 400 with `{"error": "Invalid task_id"}` for null bytes.
   - Unit validation of `_validate_task_id` for valid and invalid identifiers.

## Verification

- Ran `pytest tests/test_tasks_api.py`: **95/95 passed**.
- Verified local HTTP client tests against all 4 endpoints:
  - `GET /api/v2/tasks/test%00malicious` -> `400 {'error': 'Invalid task_id'}`
  - `PUT /api/v2/tasks/test%00malicious` -> `400 {'error': 'Invalid task_id'}`
  - `POST /api/v2/tasks/test%00malicious/archive` -> `400 {'error': 'Invalid task_id'}`
  - `POST /api/v2/tasks/test%00malicious/unarchive` -> `400 {'error': 'Invalid task_id'}`
- Staged as Draft PR for maintainer review.
