### PR TITLE
fix(server/tasks): reject invalid task IDs at API routes with 400

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -156,6 +156,21 @@ def _validate_task_id(task_id: str) -> bool:
     return bool(_TASK_ID_PATTERN.fullmatch(task_id))
 
 
+def _validate_task_id_response(
+    task_id: str,
+) -> tuple[flask.Response, int] | None:
+    """Validate task_id for API route handlers.
+
+    Returns None if valid, or (error_response, 400) if invalid.
+    Mirrors ``_validate_conversation_id`` in api_v2_common so the tasks API
+    rejects malformed IDs (null bytes, path separators, …) with an explicit
+    400 rather than silently echoing them in a 404 message.
+    """
+    if not _validate_task_id(task_id):
+        return flask.jsonify({"error": "Invalid task_id"}), 400
+    return None
+
+
 def get_tasks_dir() -> Path:
     """Get the tasks storage directory."""
     return get_logs_dir().parent / "tasks"
@@ -803,6 +818,8 @@ def api_tasks_get(task_id: str):
     Retrieve comprehensive information about a task including git status,
     conversation details, and derived status information.
     """
+    if err := _validate_task_id_response(task_id):
+        return err
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -842,6 +859,8 @@ def api_tasks_update(task_id: str):
     Update task content, target type, target repository, or metadata.
     Only provided fields will be updated.
     """
+    if err := _validate_task_id_response(task_id):
+        return err
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -925,6 +944,8 @@ def api_tasks_archive(task_id: str):
     Archive a task to hide it from active view while preserving all data.
     Archived tasks can be restored using the unarchive endpoint.
     """
+    if err := _validate_task_id_response(task_id):
+        return err
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
@@ -961,6 +982,8 @@ def api_tasks_unarchive(task_id: str):
     Restore an archived task to active view, making it visible
     in the standard task listings again.
     """
+    if err := _validate_task_id_response(task_id):
+        return err
     task = load_task(task_id)
     if not task:
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1055,3 +1055,31 @@ class TestTaskIdPathTraversal:
     def test_api_get_rejects_traversal(self, client):
         resp = client.get("/api/v2/tasks/../../etc/passwd")
         assert resp.status_code == 404
+
+    # -- null-byte injection via %-encoding ----------------------------------
+    # Before the fix (gptme/gptme#3709), these returned 404 with the raw
+    # task_id (including the null byte) echoed in the error message.  After
+    # the fix they must return 400 with {"error": "Invalid task_id"}.
+
+    def test_api_get_rejects_null_byte(self, client):
+        resp = client.get("/api/v2/tasks/test%00malicious")
+        assert resp.status_code == 400
+        assert resp.json == {"error": "Invalid task_id"}
+
+    def test_api_update_rejects_null_byte(self, client):
+        resp = client.put(
+            "/api/v2/tasks/test%00malicious",
+            json={"content": "x"},
+        )
+        assert resp.status_code == 400
+        assert resp.json == {"error": "Invalid task_id"}
+
+    def test_api_archive_rejects_null_byte(self, client):
+        resp = client.post("/api/v2/tasks/test%00malicious/archive")
+        assert resp.status_code == 400
+        assert resp.json == {"error": "Invalid task_id"}
+
+    def test_api_unarchive_rejects_null_byte(self, client):
+        resp = client.post("/api/v2/tasks/test%00malicious/unarchive")
+        assert resp.status_code == 400
+        assert resp.json == {"error": "Invalid task_id"}


### PR DESCRIPTION
## Summary

Fixes #3709 — task ID null byte not rejected (inconsistent with conversations API).

**Before:** `GET /api/v2/tasks/test%00malicious` → 404 with raw task_id (including null byte) echoed in the error message.

**After:** Returns 400 with `{"error": "Invalid task_id"}` — consistent with how the conversations API handles malformed IDs via `_validate_conversation_id()`.

## Changes

### `gptme/server/tasks_api.py`
- Add `_validate_task_id_response()` — a Flask-aware wrapper around the existing `_validate_task_id()` (which was already used by `load_task()` and `save_task()` for filesystem safety, but never exposed as a proper 400 to callers)
- Call it at the top of the four route handlers that accept a `task_id` path parameter: `api_tasks_get`, `api_tasks_update`, `api_tasks_archive`, `api_tasks_unarchive`

### `tests/test_tasks_api.py`
- Add 4 tests to the existing `TestTaskIdPathTraversal` class verifying each affected endpoint returns 400 with `{"error": "Invalid task_id"}` for null-byte IDs (`%00`)

## Found via dogfooding

This was discovered via a systematic HTTP API dogfood sweep of the gptme server's task surfaces (session bcaa, 2026-09-03).