### PR TITLE
fix(cli): suppress ANSI in redirected tools list

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -975,7 +975,14 @@ def tools_list(available: bool, langtags: bool, compact: bool, as_json: bool):
         print(format_langtags(tools))
         return
 
-    print(format_tools_list(tools, show_all=not available, compact=compact))
+    print(
+        format_tools_list(
+            tools,
+            show_all=not available,
+            compact=compact,
+            use_color=sys.stdout.isatty(),
+        )
+    )
 
 
 @tools.command("info")

--- a/gptme/util/tool_format.py
+++ b/gptme/util/tool_format.py
@@ -107,6 +107,7 @@ def format_tools_list(
     show_status: bool = True,
     compact: bool = False,
     show_defaults: bool = True,
+    use_color: bool = True,
 ) -> str:
     """Format a list of tools for display.
 
@@ -116,6 +117,7 @@ def format_tools_list(
         show_status: Show ✓/✗ status icons
         compact: Use more compact format
         show_defaults: Mark tools that are disabled by default with [+]
+        use_color: Whether to colorize status icons and default markers
 
     Returns:
         Formatted multi-line string
@@ -140,7 +142,13 @@ def format_tools_list(
             lines.append("")
 
         lines.extend(
-            prefix + format_tool_summary(tool, show_status, show_default=show_defaults)
+            prefix
+            + format_tool_summary(
+                tool,
+                show_status,
+                use_color=use_color,
+                show_default=show_defaults,
+            )
             for tool in sorted(available, key=lambda t: t.name)
         )
 
@@ -150,7 +158,12 @@ def format_tools_list(
             lines.append("")
             lines.extend(
                 prefix
-                + format_tool_summary(tool, show_status, show_default=show_defaults)
+                + format_tool_summary(
+                    tool,
+                    show_status,
+                    use_color=use_color,
+                    show_default=show_defaults,
+                )
                 for tool in sorted(unavailable, key=lambda t: t.name)
             )
     else:
@@ -162,7 +175,13 @@ def format_tools_list(
             lines.append("")
 
         lines.extend(
-            prefix + format_tool_summary(tool, show_status, show_default=show_defaults)
+            prefix
+            + format_tool_summary(
+                tool,
+                show_status,
+                use_color=use_color,
+                show_default=show_defaults,
+            )
             for tool in sorted(available, key=lambda t: t.name)
         )
 

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -419,6 +419,7 @@ def test_tools_list(mocker):
     result = runner.invoke(main, ["tools", "list"])
     assert "Available tools" in result.output
     assert result.exit_code == 0
+    assert "\x1b[" not in result.output
     assert "Using browser tool with" not in result.output
     assert "Failed to register hook" not in getattr(result, "stderr", "")
 


### PR DESCRIPTION
## Summary
- disable color in `gptme tools list` when stdout is not a TTY
- thread the existing `use_color` formatter option through `format_tools_list`
- add a CLI regression assertion for ANSI-free redirected output

## Dogfood Evidence
Found while smoke-testing the `gptme==0.33.1.dev20260903` package from `uvx` under a disposable HOME. Redirected `gptme tools list` output contained ANSI escapes despite stdout being a file.

Reproduced on current `origin/master` before the fix:

```text
exit=0
stdout_has_ansi=True
```

After this patch:

```text
exit=0
stdout_has_ansi=False
```

## Validation
- `uv run --directory /tmp/bob-wt-b22d-gptme-tools-list-ansi --with pytest --with pytest-mock --with pytest-asyncio --with pytest-timeout --with pytest-retry pytest tests/test_util_cli.py::test_tools_list tests/test_util_tool_format.py -q` → 56 passed
- `uv run --directory /tmp/bob-wt-b22d-gptme-tools-list-ansi --with ruff ruff check gptme/cli/util.py gptme/util/tool_format.py tests/test_util_cli.py` → all checks passed
- Bob PR quality gate → OPEN; note: #3705 also touches `gptme/cli/util.py`, so this may need a tiny rebase if that lands first.
