### PR TITLE
fix(cli): reject negative context tree depth

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -650,7 +650,7 @@ def context_git():
 @click.option(
     "--path", type=click.Path(exists=True), default=".", help="Workspace root"
 )
-@click.option("--max-depth", type=int, default=1, help="Tree depth")
+@click.option("--max-depth", type=click.IntRange(min=0), default=1, help="Tree depth")
 def context_tree(path: str, max_depth: int):
     """Print workspace directory tree (respects .gitignore)."""
     from rich.console import Console

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1097,6 +1097,16 @@ def test_context_tree(tmp_path):
     assert "\x1b[" not in result.output
 
 
+def test_context_tree_rejects_negative_max_depth(tmp_path):
+    """context tree rejects negative depths instead of printing an empty tree."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["context", "tree", "--path", str(tmp_path), "--max-depth", "-1"]
+    )
+    assert result.exit_code == 2
+    assert "Invalid value for '--max-depth'" in result.output
+
+
 def test_context_files(tmp_path):
     """context files reads gptme.toml [prompt] files and prints them."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- reject negative values for `gptme-util context tree --max-depth`
- add a regression test for the CLI boundary

## Verification
- manual CliRunner probe: default tree exits 0, negative depth exits 2
- `uv run --with pytest pytest tests/test_util_cli.py::test_context_tree tests/test_util_cli.py::test_context_tree_rejects_negative_max_depth -q`
