### PR TITLE
fix(logmanager): bound trajectory write amplification

### DIFF
--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -14,6 +14,7 @@ import logging
 import os
 import tempfile
 import threading
+import weakref
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -34,7 +35,10 @@ try:
 except ImportError:  # pragma: no cover - POSIX
     msvcrt = None
 
-_event_log_thread_lock = threading.Lock()
+_event_log_thread_locks_guard = threading.Lock()
+_event_log_thread_locks: weakref.WeakValueDictionary[Path, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,13 +72,25 @@ def _make_event(seq: int, type: str, payload: dict[str, Any]) -> dict[str, Any]:
 # ── public API ───────────────────────────────────────────────────────
 
 
+def _get_event_log_thread_lock(path: Path) -> threading.Lock:
+    """Return the in-process lock shared by users of one recovery log."""
+    key = path.resolve()
+    with _event_log_thread_locks_guard:
+        lock = _event_log_thread_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _event_log_thread_locks[key] = lock
+        return lock
+
+
 @contextmanager
 def _event_log_lock(logdir: Path) -> Iterator[None]:
     """Serialize event appends and compaction for one recovery log."""
     path = _event_log_path(logdir)
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.parent / f".{path.name}.lock"
-    with _event_log_thread_lock, lock_path.open("a+b") as lock:
+    thread_lock = _get_event_log_thread_lock(path)
+    with thread_lock, lock_path.open("a+b") as lock:
         if fcntl is not None:
             fcntl.flock(lock, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows
@@ -118,6 +134,39 @@ def append_next_event(
     return event
 
 
+def _compact_events_unlocked(logdir: Path) -> None:
+    """Drop events superseded by the latest checkpoint; caller holds lock."""
+    path = _event_log_path(logdir)
+    events = read_events(logdir)
+    checkpoint = find_latest_checkpoint(events)
+    if checkpoint is None:
+        return
+
+    retained = [event for event in events if event["seq"] >= checkpoint["seq"]]
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        try:
+            tmp_file = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            # fdopen did not take ownership, so the raw descriptor is ours.
+            os.close(fd)
+            raise
+        # From here the file object owns fd and closes it exactly once; never
+        # close fd directly, or a concurrently opened file reusing the number
+        # gets closed instead.
+        with tmp_file as f:
+            f.writelines(json.dumps(event, default=str) + "\n" for event in retained)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+        raise
+
+
 def compact_events(logdir: Path) -> None:
     """Drop events superseded by the latest checkpoint.
 
@@ -126,38 +175,8 @@ def compact_events(logdir: Path) -> None:
     and replacement is atomic, so neither partial files nor lost appends are
     observable.
     """
-    path = _event_log_path(logdir)
     with _event_log_lock(logdir):
-        events = read_events(logdir)
-        checkpoint = find_latest_checkpoint(events)
-        if checkpoint is None:
-            return
-
-        retained = [event for event in events if event["seq"] >= checkpoint["seq"]]
-        fd, tmp_name = tempfile.mkstemp(
-            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
-        )
-        try:
-            try:
-                tmp_file = os.fdopen(fd, "w", encoding="utf-8")
-            except BaseException:
-                # fdopen did not take ownership, so the raw descriptor is ours.
-                os.close(fd)
-                raise
-            # From here the file object owns fd and closes it exactly once; never
-            # close fd directly, or a concurrently opened file reusing the number
-            # gets closed instead.
-            with tmp_file as f:
-                f.writelines(
-                    json.dumps(event, default=str) + "\n" for event in retained
-                )
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_name, path)
-        except BaseException:
-            with suppress(FileNotFoundError):
-                os.unlink(tmp_name)
-            raise
+        _compact_events_unlocked(logdir)
 
 
 def read_events(logdir: Path) -> list[dict[str, Any]]:
@@ -203,16 +222,18 @@ def sequence_number(logdir: Path) -> int:
 
 def write_checkpoint(
     logdir: Path,
-    seq: int,
     messages: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Write a checkpoint event and compact superseded recovery history.
+    """Assign, write, and compact a checkpoint under one lock.
 
     Returns the written checkpoint event.
     """
-    event = _make_event(seq, EVENT_CHECKPOINT, {"messages": messages})
-    append_event(logdir, event)
-    compact_events(logdir)
+    with _event_log_lock(logdir):
+        event = _make_event(
+            sequence_number(logdir), EVENT_CHECKPOINT, {"messages": messages}
+        )
+        _append_event_unlocked(logdir, event)
+        _compact_events_unlocked(logdir)
     return event
 
 

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -78,9 +78,12 @@ def _event_log_lock(logdir: Path) -> Iterator[None]:
         if fcntl is not None:
             fcntl.flock(lock, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows
-            lock.seek(0)
-            lock.write(b"\0")
-            lock.flush()
+            # Append mode is needed to atomically create the sidecar, but Windows
+            # append semantics ignore seek() for writes.  Only initialize an empty
+            # sidecar so repeated acquisitions do not grow it indefinitely.
+            if lock.seek(0, os.SEEK_END) == 0:
+                lock.write(b"\0")
+                lock.flush()
             lock.seek(0)
             msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
         try:

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -74,7 +74,8 @@ def _event_log_lock(logdir: Path) -> Iterator[None]:
     path = _event_log_path(logdir)
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.parent / f".{path.name}.lock"
-    with _event_log_thread_lock, lock_path.open("a+b") as lock:
+    lock_path.touch(exist_ok=True)
+    with _event_log_thread_lock, lock_path.open("r+b") as lock:
         if fcntl is not None:
             fcntl.flock(lock, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -58,6 +60,41 @@ def append_event(logdir: Path, event: dict[str, Any]) -> None:
         f.write(json.dumps(event, default=str) + "\n")
 
 
+def compact_events(logdir: Path) -> None:
+    """Drop events superseded by the latest checkpoint.
+
+    Checkpoints contain the full message state, so events before the newest one
+    are redundant for recovery.  Replace the log atomically to avoid exposing a
+    partially rewritten recovery source after an interrupted write.
+    """
+    path = _event_log_path(logdir)
+    events = read_events(logdir)
+    checkpoint = find_latest_checkpoint(events)
+    if checkpoint is None:
+        return
+
+    retained = [event for event in events if event["seq"] >= checkpoint["seq"]]
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.writelines(json.dumps(event, default=str) + "\n" for event in retained)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def read_events(logdir: Path) -> list[dict[str, Any]]:
     """Read all events from the event log, oldest first.
 
@@ -104,12 +141,13 @@ def write_checkpoint(
     seq: int,
     messages: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Write a checkpoint event that snapshots the full message state.
+    """Write a checkpoint event and compact superseded recovery history.
 
     Returns the written checkpoint event.
     """
     event = _make_event(seq, EVENT_CHECKPOINT, {"messages": messages})
     append_event(logdir, event)
+    compact_events(logdir)
     return event
 
 

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
     from ..message import Message
@@ -96,11 +96,26 @@ def _event_log_lock(logdir: Path) -> Iterator[None]:
                 msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
 
 
+def _append_event_unlocked(logdir: Path, event: dict[str, Any]) -> None:
+    path = _event_log_path(logdir)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event, default=str) + "\n")
+
+
 def append_event(logdir: Path, event: dict[str, Any]) -> None:
     """Append a single event record to the event log."""
-    path = _event_log_path(logdir)
-    with _event_log_lock(logdir), open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(event, default=str) + "\n")
+    with _event_log_lock(logdir):
+        _append_event_unlocked(logdir, event)
+
+
+def append_next_event(
+    logdir: Path, build_event: Callable[[int], dict[str, Any]]
+) -> dict[str, Any]:
+    """Assign the next sequence and append an event under one lock."""
+    with _event_log_lock(logdir):
+        event = build_event(sequence_number(logdir))
+        _append_event_unlocked(logdir, event)
+    return event
 
 
 def compact_events(logdir: Path) -> None:

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -14,7 +14,7 @@ import logging
 import os
 import tempfile
 import threading
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -123,7 +123,16 @@ def compact_events(logdir: Path) -> None:
             dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
         )
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
+            try:
+                tmp_file = os.fdopen(fd, "w", encoding="utf-8")
+            except BaseException:
+                # fdopen did not take ownership, so the raw descriptor is ours.
+                os.close(fd)
+                raise
+            # From here the file object owns fd and closes it exactly once; never
+            # close fd directly, or a concurrently opened file reusing the number
+            # gets closed instead.
+            with tmp_file as f:
                 f.writelines(
                     json.dumps(event, default=str) + "\n" for event in retained
                 )
@@ -131,14 +140,8 @@ def compact_events(logdir: Path) -> None:
                 os.fsync(f.fileno())
             os.replace(tmp_name, path)
         except BaseException:
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-            try:
+            with suppress(FileNotFoundError):
                 os.unlink(tmp_name)
-            except FileNotFoundError:
-                pass
             raise
 
 

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -74,8 +74,7 @@ def _event_log_lock(logdir: Path) -> Iterator[None]:
     path = _event_log_path(logdir)
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.parent / f".{path.name}.lock"
-    lock_path.touch(exist_ok=True)
-    with _event_log_thread_lock, lock_path.open("r+b") as lock:
+    with _event_log_thread_lock, lock_path.open("a+b") as lock:
         if fcntl is not None:
             fcntl.flock(lock, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -12,10 +12,12 @@ import json
 import logging
 import os
 import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from ..message import Message
@@ -52,11 +54,25 @@ def _make_event(seq: int, type: str, payload: dict[str, Any]) -> dict[str, Any]:
 # ── public API ───────────────────────────────────────────────────────
 
 
+@contextmanager
+def _event_log_lock(logdir: Path) -> Iterator[None]:
+    """Serialize event appends and compaction for one recovery log."""
+    import fcntl
+
+    path = _event_log_path(logdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path.parent / f".{path.name}.lock", "a", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
 def append_event(logdir: Path, event: dict[str, Any]) -> None:
     """Append a single event record to the event log."""
     path = _event_log_path(logdir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a", encoding="utf-8") as f:
+    with _event_log_lock(logdir), open(path, "a", encoding="utf-8") as f:
         f.write(json.dumps(event, default=str) + "\n")
 
 
@@ -64,35 +80,39 @@ def compact_events(logdir: Path) -> None:
     """Drop events superseded by the latest checkpoint.
 
     Checkpoints contain the full message state, so events before the newest one
-    are redundant for recovery.  Replace the log atomically to avoid exposing a
-    partially rewritten recovery source after an interrupted write.
+    are redundant for recovery.  Appends and compaction share a per-log lock,
+    and replacement is atomic, so neither partial files nor lost appends are
+    observable.
     """
     path = _event_log_path(logdir)
-    events = read_events(logdir)
-    checkpoint = find_latest_checkpoint(events)
-    if checkpoint is None:
-        return
+    with _event_log_lock(logdir):
+        events = read_events(logdir)
+        checkpoint = find_latest_checkpoint(events)
+        if checkpoint is None:
+            return
 
-    retained = [event for event in events if event["seq"] >= checkpoint["seq"]]
-    fd, tmp_name = tempfile.mkstemp(
-        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.writelines(json.dumps(event, default=str) + "\n" for event in retained)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_name, path)
-    except BaseException:
+        retained = [event for event in events if event["seq"] >= checkpoint["seq"]]
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+        )
         try:
-            os.close(fd)
-        except OSError:
-            pass
-        try:
-            os.unlink(tmp_name)
-        except FileNotFoundError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.writelines(
+                    json.dumps(event, default=str) + "\n" for event in retained
+                )
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_name, path)
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+            raise
 
 
 def read_events(logdir: Path) -> list[dict[str, Any]]:

--- a/gptme/logmanager/eventlog.py
+++ b/gptme/logmanager/eventlog.py
@@ -8,10 +8,12 @@ message list from the event log alone — skipping replay from event 1.
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import os
 import tempfile
+import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -21,6 +23,18 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from ..message import Message
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    msvcrt: Any = importlib.import_module("msvcrt")
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
+
+_event_log_thread_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -57,16 +71,26 @@ def _make_event(seq: int, type: str, payload: dict[str, Any]) -> dict[str, Any]:
 @contextmanager
 def _event_log_lock(logdir: Path) -> Iterator[None]:
     """Serialize event appends and compaction for one recovery log."""
-    import fcntl
-
     path = _event_log_path(logdir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path.parent / f".{path.name}.lock", "a", encoding="utf-8") as lock:
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+    lock_path = path.parent / f".{path.name}.lock"
+    with _event_log_thread_lock, lock_path.open("a+b") as lock:
+        if fcntl is not None:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            lock.seek(0)
+            lock.write(b"\0")
+            lock.flush()
+            lock.seek(0)
+            msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
         try:
             yield
         finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            if fcntl is not None:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 def append_event(logdir: Path, event: dict[str, Any]) -> None:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -73,7 +73,12 @@ def conversation_name_error(value: str) -> str | None:
 @dataclass(frozen=True, repr=False)
 class Log:
     messages: list[Message] = field(default_factory=list)
-    persisted_messages: int = 0
+    # The exact message objects last written to ``path``, used to decide whether
+    # a write can append instead of rewriting the whole file.  Compared by
+    # identity, not count: an in-place edit of an already-persisted message
+    # (``messages[i] = msg.replace(...)``) keeps the count but must still force
+    # a full rewrite, or the edit would never reach disk.
+    persisted: tuple[Message, ...] = field(default=(), compare=False, repr=False)
 
     def __getitem__(self, key):
         return self.messages[key]
@@ -90,6 +95,11 @@ class Log:
     def __repr__(self) -> str:
         return f"Log(messages=<{len(self.messages)} msgs>)"
 
+    @property
+    def persisted_messages(self) -> int:
+        """Number of messages known to be on disk already."""
+        return len(self.persisted)
+
     def replace(self, **kwargs) -> "Log":
         return replace(self, **kwargs)
 
@@ -105,22 +115,34 @@ class Log:
         if limit:
             gen = islice(gen, limit)
         messages = list(gen)
-        return Log(messages, persisted_messages=len(messages))
+        return Log(messages, persisted=tuple(messages))
+
+    def _can_append(self, output: Path) -> bool:
+        """Whether the persisted prefix is still intact, so we may append.
+
+        Requires every already-written message to still be the *same object* at
+        the same index.  Callers that edit history in place replace the list
+        entry with a new ``Message`` (dataclasses are frozen), so identity
+        catches truncation, reordering, and in-place edits alike.
+        """
+        prefix = self.persisted
+        if len(prefix) > len(self.messages):
+            return False
+        if not prefix:
+            # Nothing known-persisted: appending would duplicate existing lines.
+            return not output.exists()
+        return all(old is new for old, new in zip(prefix, self.messages))
 
     def write_jsonl(self, path: PathLike, *, append: bool = False) -> "Log":
         output = Path(path)
-        append_safe = (
-            append
-            and self.persisted_messages <= len(self.messages)
-            and (self.persisted_messages > 0 or not output.exists())
-        )
+        append_safe = append and self._can_append(output)
         mode = "a" if append_safe else "w"
-        start = self.persisted_messages if append_safe else 0
+        start = len(self.persisted) if append_safe else 0
         with open(output, mode, encoding="utf-8") as file:
             file.writelines(
                 json.dumps(msg.to_dict()) + "\n" for msg in self.messages[start:]
             )
-        return self.replace(persisted_messages=len(self.messages))
+        return self.replace(persisted=tuple(self.messages))
 
     def print(self, show_hidden: bool = False) -> int:
         """Prints the log to the console. Returns the number of messages shown."""
@@ -631,7 +653,7 @@ class LogManager:
         """backup the current log to a new branch, usually before editing/undoing"""
         branch_prefix = f"{self.current_branch}-{type}-"
         n = len([b for b in self._branches if b.startswith(branch_prefix)])
-        self._branches[f"{branch_prefix}{n}"] = self.log.replace(persisted_messages=0)
+        self._branches[f"{branch_prefix}{n}"] = self.log.replace(persisted=())
         self.write()
 
     def edit(self, new_log: Log | list[Message]) -> None:
@@ -713,7 +735,7 @@ class LogManager:
         msgs = log.messages or initial_msgs or []
         manager = cls(msgs, logdir=logdir, branch=branch, lock=lock, **kwargs)
         if log.messages:
-            manager.log = manager.log.replace(persisted_messages=log.persisted_messages)
+            manager.log = manager.log.replace(persisted=log.persisted)
         return manager
 
     def branch(self, name: str) -> None:
@@ -721,7 +743,7 @@ class LogManager:
         self.write()
         if name not in self._branches:
             logger.info(f"Creating a new branch '{name}'")
-            self._branches[name] = self.log.replace(persisted_messages=0)
+            self._branches[name] = self.log.replace(persisted=())
         self.current_branch = name
 
     def diff(self, branch: str) -> str | None:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -207,8 +207,8 @@ class LogManager:
             _branch = "main"
             if _branch not in self._branches:
                 branch_log = Log.read_jsonl(self.logdir / "conversation.jsonl")
-                self._branches[_branch] = Log(
-                    self.snapshot_message_files(branch_log.messages)
+                self._branches[_branch] = branch_log.replace(
+                    messages=self.snapshot_message_files(branch_log.messages)
                 )
         for file in self.logdir.glob("branches/*.jsonl"):
             if file.name == self.logdir.name:
@@ -216,8 +216,8 @@ class LogManager:
             _branch = file.stem
             if _branch not in self._branches:
                 branch_log = Log.read_jsonl(file)
-                self._branches[_branch] = Log(
-                    self.snapshot_message_files(branch_log.messages)
+                self._branches[_branch] = branch_log.replace(
+                    messages=self.snapshot_message_files(branch_log.messages)
                 )
 
         # Load view branches (compacted views stored in views/ directory)
@@ -227,8 +227,8 @@ class LogManager:
             for file in views_dir.glob("*.jsonl"):
                 view_name = file.stem
                 view_log = Log.read_jsonl(file)
-                self._views[view_name] = Log(
-                    self.snapshot_message_files(view_log.messages)
+                self._views[view_name] = view_log.replace(
+                    messages=self.snapshot_message_files(view_log.messages)
                 )
                 logger.debug(f"Loaded view branch: {view_name}")
 
@@ -710,7 +710,10 @@ class LogManager:
 
         log = Log.read_jsonl(logfile)
         msgs = log.messages or initial_msgs or []
-        return cls(msgs, logdir=logdir, branch=branch, lock=lock, **kwargs)
+        manager = cls(msgs, logdir=logdir, branch=branch, lock=lock, **kwargs)
+        if log.messages:
+            manager.log = manager.log.replace(persisted_messages=log.persisted_messages)
+        return manager
 
     def branch(self, name: str) -> None:
         """Switches to a branch."""

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -630,7 +630,7 @@ class LogManager:
         """backup the current log to a new branch, usually before editing/undoing"""
         branch_prefix = f"{self.current_branch}-{type}-"
         n = len([b for b in self._branches if b.startswith(branch_prefix)])
-        self._branches[f"{branch_prefix}{n}"] = self.log
+        self._branches[f"{branch_prefix}{n}"] = self.log.replace(persisted_messages=0)
         self.write()
 
     def edit(self, new_log: Log | list[Message]) -> None:
@@ -717,7 +717,7 @@ class LogManager:
         self.write()
         if name not in self._branches:
             logger.info(f"Creating a new branch '{name}'")
-            self._branches[name] = self.log
+            self._branches[name] = self.log.replace(persisted_messages=0)
         self.current_branch = name
 
     def diff(self, branch: str) -> str | None:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -73,6 +73,7 @@ def conversation_name_error(value: str) -> str | None:
 @dataclass(frozen=True, repr=False)
 class Log:
     messages: list[Message] = field(default_factory=list)
+    persisted_messages: int = 0
 
     def __getitem__(self, key):
         return self.messages[key]
@@ -103,11 +104,21 @@ class Log:
         gen: Iterator[Message] = _gen_read_jsonl(path)
         if limit:
             gen = islice(gen, limit)
-        return Log(list(gen))
+        messages = list(gen)
+        return Log(messages, persisted_messages=len(messages))
 
-    def write_jsonl(self, path: PathLike) -> None:
-        with open(path, "w", encoding="utf-8") as file:
-            file.writelines(json.dumps(msg.to_dict()) + "\n" for msg in self.messages)
+    def write_jsonl(self, path: PathLike) -> "Log":
+        output = Path(path)
+        append_safe = self.persisted_messages <= len(self.messages) and (
+            self.persisted_messages > 0 or not output.exists()
+        )
+        mode = "a" if append_safe else "w"
+        start = self.persisted_messages if append_safe else 0
+        with open(output, mode, encoding="utf-8") as file:
+            file.writelines(
+                json.dumps(msg.to_dict()) + "\n" for msg in self.messages[start:]
+            )
+        return self.replace(persisted_messages=len(self.messages))
 
     def print(self, show_hidden: bool = False) -> int:
         """Prints the log to the console. Returns the number of messages shown."""
@@ -506,9 +517,9 @@ class LogManager:
         # When on a view, conversation.jsonl must always contain the full main
         # branch history — the view is persisted separately in views/ directory.
         if self.current_view is not None:
-            self._branches["main"].write_jsonl(self.logfile)
+            self._branches["main"] = self._branches["main"].write_jsonl(self.logfile)
         else:
-            self.log.write_jsonl(self.logfile)
+            self.log = self.log.write_jsonl(self.logfile)
 
         # write other branches
         if branches:
@@ -520,10 +531,10 @@ class LogManager:
                     if self.current_branch != "main":
                         main_path = get_logs_dir() / self.chat_id / "conversation.jsonl"
                         main_path.parent.mkdir(parents=True, exist_ok=True)
-                        log.write_jsonl(main_path)
+                        self._branches[branch] = log.write_jsonl(main_path)
                     continue
                 branch_path = branches_dir / f"{branch}.jsonl"
-                log.write_jsonl(branch_path)
+                self._branches[branch] = log.write_jsonl(branch_path)
 
             # Write view branches
             if self._views:
@@ -531,7 +542,7 @@ class LogManager:
                 views_dir.mkdir(parents=True, exist_ok=True)
                 for view_name, log in self._views.items():
                     view_path = views_dir / f"{view_name}.jsonl"
-                    log.write_jsonl(view_path)
+                    self._views[view_name] = log.write_jsonl(view_path)
 
         # Persist model selection trace alongside the conversation
         trace_path = self.write_model_trace()
@@ -749,7 +760,7 @@ class LogManager:
         views_dir = self.logdir / "views"
         views_dir.mkdir(parents=True, exist_ok=True)
         view_path = views_dir / f"{name}.jsonl"
-        log.write_jsonl(view_path)
+        self._views[name] = log.write_jsonl(view_path)
         logger.info(f"Created view branch: {name} ({len(log)} messages)")
 
     def switch_view(self, name: str) -> None:

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -489,7 +489,6 @@ class LogManager:
         if eventlog.should_checkpoint(seq):
             eventlog.write_checkpoint(
                 event_dir,
-                seq + 1,  # next seq for the checkpoint
                 [m.to_dict() for m in self.log.messages],
             )
 
@@ -552,6 +551,8 @@ class LogManager:
             # Use full path as key to avoid collisions with same-named files
             file_hashes[str(filepath)] = file_hash
 
+        if file_hashes == msg.file_hashes:
+            return msg
         # Return message with updated hashes (Message is frozen, so replace)
         return replace(msg, file_hashes=file_hashes)
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -81,6 +81,7 @@ class Log:
     # view file containing different bytes.
     persisted: tuple[Message, ...] = field(default=(), compare=False, repr=False)
     persisted_path: Path | None = field(default=None, compare=False, repr=False)
+    persisted_size: int | None = field(default=None, compare=False, repr=False)
 
     def __getitem__(self, key):
         return self.messages[key]
@@ -122,6 +123,7 @@ class Log:
             messages,
             persisted=tuple(messages),
             persisted_path=output,
+            persisted_size=output.stat().st_size,
         )
 
     def _can_append(self, output: Path) -> bool:
@@ -140,6 +142,14 @@ class Log:
         if not prefix:
             # Nothing known-persisted: appending would duplicate existing lines.
             return not output.exists()
+        try:
+            if (
+                self.persisted_size is None
+                or output.stat().st_size != self.persisted_size
+            ):
+                return False
+        except OSError:
+            return False
         return all(old is new for old, new in zip(prefix, self.messages))
 
     def write_jsonl(self, path: PathLike, *, append: bool = False) -> "Log":
@@ -154,6 +164,7 @@ class Log:
         return self.replace(
             persisted=tuple(self.messages),
             persisted_path=output.resolve(),
+            persisted_size=output.stat().st_size,
         )
 
     def print(self, show_hidden: bool = False) -> int:
@@ -447,22 +458,32 @@ class LogManager:
         else:
             event_dir = self.logdir / "branches" / self.current_branch
         event_dir.mkdir(parents=True, exist_ok=True)
-        seq = eventlog.sequence_number(event_dir)
         if event_type == eventlog.EVENT_MESSAGE_APPEND:
-            if self.log.messages:
-                event = eventlog.build_message_append_event(seq, self.log.messages[-1])
-            else:
+            if not self.log.messages:
                 return
+            message = self.log.messages[-1]
+
+            def build_event(seq: int) -> dict[str, object]:
+                return eventlog.build_message_append_event(seq, message)
+
         elif event_type == eventlog.EVENT_MESSAGE_EDIT:
-            event = eventlog.build_message_edit_event(seq, list(self.log.messages))
+            messages = list(self.log.messages)
+
+            def build_event(seq: int) -> dict[str, object]:
+                return eventlog.build_message_edit_event(seq, messages)
+
         elif event_type == eventlog.EVENT_UNDO:
             n_raw = extra.get("n", 1)
             n = n_raw if isinstance(n_raw, int) else 1
-            event = eventlog.build_undo_event(seq, n=n)
+
+            def build_event(seq: int) -> dict[str, object]:
+                return eventlog.build_undo_event(seq, n=n)
+
         else:
             return  # unknown type, skip
 
-        eventlog.append_event(event_dir, event)
+        event = eventlog.append_next_event(event_dir, build_event)
+        seq = event["seq"]
 
         # Checkpoint if due
         if eventlog.should_checkpoint(seq):
@@ -749,6 +770,7 @@ class LogManager:
             manager.log = manager.log.replace(
                 persisted=log.persisted,
                 persisted_path=log.persisted_path,
+                persisted_size=log.persisted_size,
             )
         return manager
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -73,12 +73,14 @@ def conversation_name_error(value: str) -> str | None:
 @dataclass(frozen=True, repr=False)
 class Log:
     messages: list[Message] = field(default_factory=list)
-    # The exact message objects last written to ``path``, used to decide whether
-    # a write can append instead of rewriting the whole file.  Compared by
+    # The exact message objects last written to ``persisted_path``. Compared by
     # identity, not count: an in-place edit of an already-persisted message
     # (``messages[i] = msg.replace(...)``) keeps the count but must still force
-    # a full rewrite, or the edit would never reach disk.
+    # a full rewrite, or the edit would never reach disk. The path prevents a
+    # cursor recorded for conversation.jsonl from being reused for a branch or
+    # view file containing different bytes.
     persisted: tuple[Message, ...] = field(default=(), compare=False, repr=False)
+    persisted_path: Path | None = field(default=None, compare=False, repr=False)
 
     def __getitem__(self, key):
         return self.messages[key]
@@ -111,11 +113,16 @@ class Log:
 
     @classmethod
     def read_jsonl(cls, path: PathLike, limit=None) -> "Log":
-        gen: Iterator[Message] = _gen_read_jsonl(path)
+        output = Path(path).resolve()
+        gen: Iterator[Message] = _gen_read_jsonl(output)
         if limit:
             gen = islice(gen, limit)
         messages = list(gen)
-        return Log(messages, persisted=tuple(messages))
+        return Log(
+            messages,
+            persisted=tuple(messages),
+            persisted_path=output,
+        )
 
     def _can_append(self, output: Path) -> bool:
         """Whether the persisted prefix is still intact, so we may append.
@@ -125,6 +132,8 @@ class Log:
         entry with a new ``Message`` (dataclasses are frozen), so identity
         catches truncation, reordering, and in-place edits alike.
         """
+        if self.persisted_path != output.resolve():
+            return False
         prefix = self.persisted
         if len(prefix) > len(self.messages):
             return False
@@ -142,7 +151,10 @@ class Log:
             file.writelines(
                 json.dumps(msg.to_dict()) + "\n" for msg in self.messages[start:]
             )
-        return self.replace(persisted=tuple(self.messages))
+        return self.replace(
+            persisted=tuple(self.messages),
+            persisted_path=output.resolve(),
+        )
 
     def print(self, show_hidden: bool = False) -> int:
         """Prints the log to the console. Returns the number of messages shown."""
@@ -542,9 +554,8 @@ class LogManager:
         # branch history — the view is persisted separately in views/ directory.
         if self.current_view is not None:
             main_path = self.logdir / "conversation.jsonl"
-            self._branches["main"] = self._branches["main"].write_jsonl(
-                main_path, append=True
-            )
+            main_log = self._branches["main"]
+            self._branches["main"] = main_log.write_jsonl(main_path, append=True)
         else:
             self.log = self.log.write_jsonl(self.logfile, append=True)
 

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -148,6 +148,10 @@ class Log:
                 or output.stat().st_size != self.persisted_size
             ):
                 return False
+            with output.open("rb") as file:
+                file.seek(-1, os.SEEK_END)
+                if file.read(1) != b"\n":
+                    return False
         except OSError:
             return False
         return all(old is new for old, new in zip(prefix, self.messages))

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -107,10 +107,12 @@ class Log:
         messages = list(gen)
         return Log(messages, persisted_messages=len(messages))
 
-    def write_jsonl(self, path: PathLike) -> "Log":
+    def write_jsonl(self, path: PathLike, *, append: bool = False) -> "Log":
         output = Path(path)
-        append_safe = self.persisted_messages <= len(self.messages) and (
-            self.persisted_messages > 0 or not output.exists()
+        append_safe = (
+            append
+            and self.persisted_messages <= len(self.messages)
+            and (self.persisted_messages > 0 or not output.exists())
         )
         mode = "a" if append_safe else "w"
         start = self.persisted_messages if append_safe else 0
@@ -517,9 +519,11 @@ class LogManager:
         # When on a view, conversation.jsonl must always contain the full main
         # branch history — the view is persisted separately in views/ directory.
         if self.current_view is not None:
-            self._branches["main"] = self._branches["main"].write_jsonl(self.logfile)
+            self._branches["main"] = self._branches["main"].write_jsonl(
+                self.logfile, append=True
+            )
         else:
-            self.log = self.log.write_jsonl(self.logfile)
+            self.log = self.log.write_jsonl(self.logfile, append=True)
 
         # write other branches
         if branches:
@@ -531,10 +535,10 @@ class LogManager:
                     if self.current_branch != "main":
                         main_path = get_logs_dir() / self.chat_id / "conversation.jsonl"
                         main_path.parent.mkdir(parents=True, exist_ok=True)
-                        self._branches[branch] = log.write_jsonl(main_path)
+                        self._branches[branch] = log.write_jsonl(main_path, append=True)
                     continue
                 branch_path = branches_dir / f"{branch}.jsonl"
-                self._branches[branch] = log.write_jsonl(branch_path)
+                self._branches[branch] = log.write_jsonl(branch_path, append=True)
 
             # Write view branches
             if self._views:
@@ -542,7 +546,7 @@ class LogManager:
                 views_dir.mkdir(parents=True, exist_ok=True)
                 for view_name, log in self._views.items():
                     view_path = views_dir / f"{view_name}.jsonl"
-                    self._views[view_name] = log.write_jsonl(view_path)
+                    self._views[view_name] = log.write_jsonl(view_path, append=True)
 
         # Persist model selection trace alongside the conversation
         trace_path = self.write_model_trace()

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -519,8 +519,9 @@ class LogManager:
         # When on a view, conversation.jsonl must always contain the full main
         # branch history — the view is persisted separately in views/ directory.
         if self.current_view is not None:
+            main_path = self.logdir / "conversation.jsonl"
             self._branches["main"] = self._branches["main"].write_jsonl(
-                self.logfile, append=True
+                main_path, append=True
             )
         else:
             self.log = self.log.write_jsonl(self.logfile, append=True)

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -746,7 +746,10 @@ class LogManager:
         msgs = log.messages or initial_msgs or []
         manager = cls(msgs, logdir=logdir, branch=branch, lock=lock, **kwargs)
         if log.messages:
-            manager.log = manager.log.replace(persisted=log.persisted)
+            manager.log = manager.log.replace(
+                persisted=log.persisted,
+                persisted_path=log.persisted_path,
+            )
         return manager
 
     def branch(self, name: str) -> None:

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -19,6 +19,7 @@ from gptme.logmanager.eventlog import (
     EVENT_UNDO,
     _event_log_path,
     append_event,
+    compact_events,
     find_latest_checkpoint,
     read_events,
     recover_messages,
@@ -124,6 +125,55 @@ def test_find_latest_among_multiple(logdir: Path):
     assert cp is not None
     assert cp["seq"] == 100
     assert cp["payload"]["messages"][0]["content"] == "last"
+
+
+def test_compact_events_keeps_latest_checkpoint_and_tail(logdir: Path):
+    """Compaction drops history already represented by the latest checkpoint."""
+    append_event(
+        logdir,
+        {
+            "seq": 49,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "old"}},
+        },
+    )
+    write_checkpoint(logdir, 50, [{"role": "user", "content": "snapshot"}])
+    append_event(
+        logdir,
+        {
+            "seq": 51,
+            "ts": "2026-01-01T00:00:01Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "assistant", "content": "tail"}},
+        },
+    )
+
+    compact_events(logdir)
+
+    events = read_events(logdir)
+    assert [event["seq"] for event in events] == [50, 51]
+    recovered = recover_messages(logdir)
+    assert recovered is not None
+    assert [message["content"] for message in recovered] == ["snapshot", "tail"]
+
+
+def test_compact_events_without_checkpoint_is_noop(logdir: Path):
+    """Compaction preserves append-only history until a checkpoint exists."""
+    append_event(
+        logdir,
+        {
+            "seq": 1,
+            "ts": "2026-01-01T00:00:00Z",
+            "type": EVENT_MESSAGE_APPEND,
+            "payload": {"message": {"role": "user", "content": "hello"}},
+        },
+    )
+    before = (logdir / EVENT_LOG_NAME).read_bytes()
+
+    compact_events(logdir)
+
+    assert (logdir / EVENT_LOG_NAME).read_bytes() == before
 
 
 def test_recover_messages_no_event_log(logdir: Path):
@@ -403,13 +453,19 @@ def test_integration_recovery(logdir: Path):
 
 
 def test_integration_checkpoint_logmanager(logdir: Path):
-    """LogManager with many appends produces checkpoints."""
+    """LogManager checkpoints compact superseded append events."""
     with LogManager(logdir=logdir) as lm:
         for i in range(CHECKPOINT_INTERVAL + 5):
             lm.append(Message("user", f"msg{i}"))
 
     events = read_events(logdir)
     checkpoints = [e for e in events if e["type"] == EVENT_CHECKPOINT]
-    assert len(checkpoints) >= 1, (
-        f"Expected at least 1 checkpoint, got {len(checkpoints)}"
-    )
+    assert len(checkpoints) == 1
+    assert events[0]["type"] == EVENT_CHECKPOINT
+    assert len(events) == 1 + 5
+
+    recovered = recover_messages(logdir)
+    assert recovered is not None
+    assert [message["content"] for message in recovered] == [
+        f"msg{i}" for i in range(CHECKPOINT_INTERVAL + 5)
+    ]

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -22,6 +22,7 @@ from gptme.logmanager.eventlog import (
     EVENT_UNDO,
     _event_log_path,
     append_event,
+    append_next_event,
     compact_events,
     find_latest_checkpoint,
     read_events,
@@ -130,6 +131,21 @@ def test_sequence_number_increments(logdir: Path):
 
     append_event(logdir, {"seq": 2, "ts": "", "type": "test", "payload": {}})
     assert sequence_number(logdir) == 3
+
+
+def test_append_next_event_assigns_unique_sequences_concurrently(logdir: Path):
+    """Sequence assignment and append are one serialized operation."""
+
+    def build(seq: int) -> dict[str, object]:
+        return {"seq": seq, "ts": "", "type": "test", "payload": {}}
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        events = list(
+            executor.map(lambda _: append_next_event(logdir, build), range(40))
+        )
+
+    assert sorted(event["seq"] for event in events) == list(range(1, 41))
+    assert sorted(event["seq"] for event in read_events(logdir)) == list(range(1, 41))
 
 
 def test_should_checkpoint(logdir: Path):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -65,6 +67,39 @@ def test_append_and_read_events(logdir: Path):
     assert len(events) == 2
     assert events[0]["seq"] == 1
     assert events[1]["seq"] == 2
+
+
+def test_event_log_lock_uses_windows_fallback(logdir: Path):
+    """Event persistence remains available when fcntl is unavailable."""
+    calls: list[tuple[int, int]] = []
+
+    class FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(fd: int, mode: int, count: int) -> None:
+            assert count == 1
+            calls.append((mode, count))
+
+    @contextmanager
+    def unlocked_thread_lock():
+        yield
+
+    with (
+        patch("gptme.logmanager.eventlog.fcntl", None),
+        patch("gptme.logmanager.eventlog.msvcrt", FakeMsvcrt),
+        patch(
+            "gptme.logmanager.eventlog._event_log_thread_lock", unlocked_thread_lock()
+        ),
+    ):
+        append_event(
+            logdir,
+            {"seq": 1, "ts": "", "type": "test", "payload": {}},
+        )
+
+    assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
+    assert read_events(logdir)[0]["seq"] == 1
 
 
 def test_read_events_empty_logdir(logdir: Path):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -82,25 +81,35 @@ def test_event_log_lock_uses_windows_fallback(logdir: Path):
             assert count == 1
             calls.append((mode, count))
 
-    @contextmanager
-    def unlocked_thread_lock():
-        yield
+    class UnlockedThreadLock:
+        def __enter__(self) -> None:
+            pass
+
+        def __exit__(self, *args: object) -> None:
+            pass
 
     with (
         patch("gptme.logmanager.eventlog.fcntl", None),
         patch("gptme.logmanager.eventlog.msvcrt", FakeMsvcrt),
-        patch(
-            "gptme.logmanager.eventlog._event_log_thread_lock", unlocked_thread_lock()
-        ),
+        patch("gptme.logmanager.eventlog._event_log_thread_lock", UnlockedThreadLock()),
     ):
         append_event(
             logdir,
             {"seq": 1, "ts": "", "type": "test", "payload": {}},
         )
+        append_event(
+            logdir,
+            {"seq": 2, "ts": "", "type": "test", "payload": {}},
+        )
 
-    assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
+    assert calls == [
+        (FakeMsvcrt.LK_LOCK, 1),
+        (FakeMsvcrt.LK_UNLCK, 1),
+        (FakeMsvcrt.LK_LOCK, 1),
+        (FakeMsvcrt.LK_UNLCK, 1),
+    ]
     assert (logdir / f".{EVENT_LOG_NAME}.lock").read_bytes() == b"\0"
-    assert read_events(logdir)[0]["seq"] == 1
+    assert [event["seq"] for event in read_events(logdir)] == [1, 2]
 
 
 def test_read_events_empty_logdir(logdir: Path):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -93,7 +93,10 @@ def test_event_log_lock_uses_windows_fallback(logdir: Path):
     with (
         patch("gptme.logmanager.eventlog.fcntl", None),
         patch("gptme.logmanager.eventlog.msvcrt", FakeMsvcrt),
-        patch("gptme.logmanager.eventlog._event_log_thread_lock", UnlockedThreadLock()),
+        patch(
+            "gptme.logmanager.eventlog._get_event_log_thread_lock",
+            return_value=UnlockedThreadLock(),
+        ),
     ):
         append_event(
             logdir,
@@ -148,6 +151,32 @@ def test_append_next_event_assigns_unique_sequences_concurrently(logdir: Path):
     assert sorted(event["seq"] for event in read_events(logdir)) == list(range(1, 41))
 
 
+def test_checkpoint_and_append_assign_unique_sequences_concurrently(logdir: Path):
+    """A checkpoint cannot race another append onto the same sequence."""
+    message = {"role": "user", "content": "tail"}
+
+    def append_message() -> dict[str, object]:
+        return append_next_event(
+            logdir,
+            lambda seq: {
+                "seq": seq,
+                "ts": "",
+                "type": EVENT_MESSAGE_APPEND,
+                "payload": {"message": message},
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        checkpoint = executor.submit(write_checkpoint, logdir, [message])
+        append = executor.submit(append_message)
+
+    events = [checkpoint.result(), append.result()]
+    assert sorted(event["seq"] for event in events) == [1, 2]
+    persisted = read_events(logdir)
+    assert len({event["seq"] for event in persisted}) == len(persisted)
+    assert recover_messages(logdir) in ([message], [message, message])
+
+
 def test_should_checkpoint(logdir: Path):
     """Checkpoint is due every CHECKPOINT_INTERVAL events."""
     assert should_checkpoint(0) is False
@@ -164,29 +193,29 @@ def test_write_and_find_checkpoint(logdir: Path):
         {"role": "user", "content": "hello"},
         {"role": "assistant", "content": "hi"},
     ]
-    write_checkpoint(logdir, 50, messages)
+    write_checkpoint(logdir, messages)
 
     # Read events, find checkpoint
     events = read_events(logdir)
     assert len(events) == 1
     assert events[0]["type"] == EVENT_CHECKPOINT
-    assert events[0]["seq"] == 50
+    assert events[0]["seq"] == 1
     assert len(events[0]["payload"]["messages"]) == 2
 
     # find_latest_checkpoint
     cp = find_latest_checkpoint(events)
     assert cp is not None
-    assert cp["seq"] == 50
+    assert cp["seq"] == 1
 
 
 def test_find_latest_among_multiple(logdir: Path):
     """find_latest_checkpoint returns the most recent checkpoint."""
-    write_checkpoint(logdir, 50, [])
-    write_checkpoint(logdir, 100, [{"role": "user", "content": "last"}])
+    write_checkpoint(logdir, [])
+    write_checkpoint(logdir, [{"role": "user", "content": "last"}])
 
     cp = find_latest_checkpoint(read_events(logdir))
     assert cp is not None
-    assert cp["seq"] == 100
+    assert cp["seq"] == 2
     assert cp["payload"]["messages"][0]["content"] == "last"
 
 
@@ -201,7 +230,7 @@ def test_compact_events_keeps_latest_checkpoint_and_tail(logdir: Path):
             "payload": {"message": {"role": "user", "content": "old"}},
         },
     )
-    write_checkpoint(logdir, 50, [{"role": "user", "content": "snapshot"}])
+    write_checkpoint(logdir, [{"role": "user", "content": "snapshot"}])
     append_event(
         logdir,
         {
@@ -241,9 +270,9 @@ def test_compact_events_without_checkpoint_is_noop(logdir: Path):
 
 def test_compaction_does_not_lose_concurrent_append(logdir: Path):
     """The compaction replacement is serialized with append_event."""
-    write_checkpoint(logdir, 50, [{"role": "user", "content": "snapshot"}])
+    write_checkpoint(logdir, [{"role": "user", "content": "snapshot"}])
     tail = {
-        "seq": 51,
+        "seq": 2,
         "ts": "2026-01-01T00:00:01Z",
         "type": EVENT_MESSAGE_APPEND,
         "payload": {"message": {"role": "assistant", "content": "tail"}},
@@ -257,7 +286,7 @@ def test_compaction_does_not_lose_concurrent_append(logdir: Path):
         for future in futures:
             future.result()
 
-    assert [event["seq"] for event in read_events(logdir)] == [50, 51]
+    assert [event["seq"] for event in read_events(logdir)] == [1, 2]
 
 
 def test_recover_messages_no_event_log(logdir: Path):
@@ -300,7 +329,6 @@ def test_recover_messages_with_checkpoint_and_replay(logdir: Path):
     # Write a checkpoint with 2 messages
     write_checkpoint(
         logdir,
-        10,
         [
             {"role": "user", "content": "msg1"},
             {"role": "assistant", "content": "msg2"},
@@ -311,7 +339,7 @@ def test_recover_messages_with_checkpoint_and_replay(logdir: Path):
     append_event(
         logdir,
         {
-            "seq": 11,
+            "seq": 2,
             "ts": "2026-01-01T00:00:00Z",
             "type": EVENT_MESSAGE_APPEND,
             "payload": {"message": {"role": "user", "content": "msg3"}},
@@ -562,7 +590,7 @@ def test_compact_events_write_failure_does_not_close_reused_fd(logdir: Path):
     object closes it on error.  Closing the raw number again would hit whatever
     file a concurrent thread opened in the meantime.
     """
-    write_checkpoint(logdir, 1, [{"role": "user", "content": "snapshot"}])
+    write_checkpoint(logdir, [{"role": "user", "content": "snapshot"}])
 
     closed: list[int] = []
     real_close = os.close

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -174,6 +175,27 @@ def test_compact_events_without_checkpoint_is_noop(logdir: Path):
     compact_events(logdir)
 
     assert (logdir / EVENT_LOG_NAME).read_bytes() == before
+
+
+def test_compaction_does_not_lose_concurrent_append(logdir: Path):
+    """The compaction replacement is serialized with append_event."""
+    write_checkpoint(logdir, 50, [{"role": "user", "content": "snapshot"}])
+    tail = {
+        "seq": 51,
+        "ts": "2026-01-01T00:00:01Z",
+        "type": EVENT_MESSAGE_APPEND,
+        "payload": {"message": {"role": "assistant", "content": "tail"}},
+    }
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(compact_events, logdir),
+            executor.submit(append_event, logdir, tail),
+        ]
+        for future in futures:
+            future.result()
+
+    assert [event["seq"] for event in read_events(logdir)] == [50, 51]
 
 
 def test_recover_messages_no_event_log(logdir: Path):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -20,6 +20,7 @@ from gptme.logmanager.eventlog import (
     EVENT_MESSAGE_APPEND,
     EVENT_MESSAGE_EDIT,
     EVENT_UNDO,
+    _event_log_lock,
     _event_log_path,
     append_event,
     append_next_event,
@@ -134,6 +135,20 @@ def test_sequence_number_increments(logdir: Path):
 
     append_event(logdir, {"seq": 2, "ts": "", "type": "test", "payload": {}})
     assert sequence_number(logdir) == 3
+
+
+def test_different_event_logs_do_not_share_an_io_lock(logdir: Path):
+    """Holding one conversation lock must not block another conversation."""
+    other_logdir = logdir.parent / "other-conversation"
+    event = {"seq": 1, "ts": "", "type": "test", "payload": {}}
+
+    with (
+        _event_log_lock(logdir),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        executor.submit(append_event, other_logdir, event).result(timeout=1)
+
+    assert read_events(other_logdir) == [event]
 
 
 def test_append_next_event_assigns_unique_sequences_concurrently(logdir: Path):

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -536,3 +537,46 @@ def test_integration_checkpoint_logmanager(logdir: Path):
     assert [message["content"] for message in recovered] == [
         f"msg{i}" for i in range(CHECKPOINT_INTERVAL + 5)
     ]
+
+
+def test_compact_events_write_failure_does_not_close_reused_fd(logdir: Path):
+    """A failed compaction must not close a descriptor it no longer owns.
+
+    ``os.fdopen`` takes ownership of the ``mkstemp`` descriptor, so the file
+    object closes it on error.  Closing the raw number again would hit whatever
+    file a concurrent thread opened in the meantime.
+    """
+    write_checkpoint(logdir, 1, [{"role": "user", "content": "snapshot"}])
+
+    closed: list[int] = []
+    real_close = os.close
+    real_fdopen = os.fdopen
+    opened_fd: list[int] = []
+
+    def tracking_close(fd: int) -> None:
+        closed.append(fd)
+        real_close(fd)
+
+    def tracking_fdopen(fd: int, *args, **kwargs):
+        opened_fd.append(fd)
+        return real_fdopen(fd, *args, **kwargs)
+
+    def boom(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    with (
+        patch("gptme.logmanager.eventlog.os.close", tracking_close),
+        patch("gptme.logmanager.eventlog.os.fdopen", tracking_fdopen),
+        patch("gptme.logmanager.eventlog.os.fsync", boom),
+        pytest.raises(OSError, match="no space left on device"),
+    ):
+        compact_events(logdir)
+
+    assert opened_fd, "fdopen was never reached"
+    assert opened_fd[0] not in closed, (
+        "raw descriptor closed after fdopen took ownership — "
+        "a concurrently opened file could be reusing that number"
+    )
+    # The temp file is still cleaned up and the log is left intact.
+    assert not list(logdir.glob(f".{EVENT_LOG_NAME}.*.tmp"))
+    assert [event["seq"] for event in read_events(logdir)] == [1]

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -99,6 +99,7 @@ def test_event_log_lock_uses_windows_fallback(logdir: Path):
         )
 
     assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
+    assert (logdir / f".{EVENT_LOG_NAME}.lock").read_bytes() == b"\0"
     assert read_events(logdir)[0]["seq"] == 1
 
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -3045,12 +3045,14 @@ class TestMaybeApplyVerbosity:
         model = get_model("openai/gpt-5")
         import logging
 
-        with caplog.at_level(logging.WARNING, logger="gptme.llm.llm_openai"):
+        logger_name = "gptme.llm.llm_openai"
+        with caplog.at_level(logging.WARNING, logger=logger_name):
             _maybe_apply_verbosity({}, model)
             # Verify the flag was persisted (guards against parallel-state interference)
             assert llm_openai._verbosity_warned is True
             _maybe_apply_verbosity({}, model)
-        assert caplog.text.count("OPENAI_VERBOSITY") == 1
+        records = [record for record in caplog.records if record.name == logger_name]
+        assert sum("OPENAI_VERBOSITY" in record.getMessage() for record in records) == 1
 
 
 class TestOpenrouterModelToModelmeta:

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -1,7 +1,9 @@
 import builtins
 import json
 from contextlib import contextmanager
+from io import TextIOWrapper
 from pathlib import Path
+from types import TracebackType
 from unittest.mock import patch
 
 import pytest
@@ -151,15 +153,27 @@ def test_load_preserves_persistence_cursors(tmp_path: Path):
         manager._branches["main"].persisted_path
         == (logdir / "conversation.jsonl").resolve()
     )
+    assert (
+        manager._branches["main"].persisted_size
+        == (logdir / "conversation.jsonl").stat().st_size
+    )
     assert manager._branches["dev"].persisted_messages == 1
     assert (
         manager._branches["dev"].persisted_path
         == (logdir / "branches" / "dev.jsonl").resolve()
     )
+    assert (
+        manager._branches["dev"].persisted_size
+        == (logdir / "branches" / "dev.jsonl").stat().st_size
+    )
     assert manager._views["compact"].persisted_messages == 1
     assert (
         manager._views["compact"].persisted_path
         == (logdir / "views" / "compact.jsonl").resolve()
+    )
+    assert (
+        manager._views["compact"].persisted_size
+        == (logdir / "views" / "compact.jsonl").stat().st_size
     )
 
 
@@ -777,6 +791,77 @@ def test_write_jsonl_appends_only_new_messages(tmp_path: Path):
     ]
     assert log.persisted_messages == 2
     assert log.persisted_path == jsonl_file.resolve()
+
+
+def test_write_jsonl_repairs_partial_failed_append_on_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed append must not leave bytes that a retry duplicates."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    log = Log([Message("user", "first")]).write_jsonl(jsonl_file, append=True)
+    log = log.append(Message("assistant", "second"))
+    real_open = builtins.open
+
+    class FailingAppendWriter:
+        def __init__(self, file: TextIOWrapper):
+            self.file = file
+
+        def __enter__(self):
+            self.file.__enter__()
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
+            self.file.__exit__(exc_type, exc_value, traceback)
+
+        def writelines(self, lines) -> None:
+            line = next(iter(lines))
+            self.file.write(line[: len(line) // 2])
+            self.file.flush()
+            raise OSError("no space left on device")
+
+    failed = False
+
+    def fail_first_append(path, mode="r", *args, **kwargs):
+        nonlocal failed
+        file = real_open(path, mode, *args, **kwargs)
+        if mode == "a" and not failed:
+            failed = True
+            return FailingAppendWriter(file)
+        return file
+
+    monkeypatch.setattr(builtins, "open", fail_first_append)
+    with pytest.raises(OSError, match="no space left on device"):
+        log.write_jsonl(jsonl_file, append=True)
+
+    repaired = log.write_jsonl(jsonl_file, append=True)
+
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == [
+        "first",
+        "second",
+    ]
+    assert repaired.persisted_messages == 2
+
+
+def test_write_jsonl_rewrites_when_destination_is_truncated(tmp_path: Path):
+    """A changed destination invalidates the append cursor."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    log = Log([Message("user", "first")]).write_jsonl(jsonl_file, append=True)
+    log = log.append(Message("assistant", "second"))
+    jsonl_file.write_bytes(b"")
+
+    with _record_open_calls() as calls:
+        log.write_jsonl(jsonl_file, append=True)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == [
+        "first",
+        "second",
+    ]
 
 
 def test_write_jsonl_rewrites_for_a_different_destination(tmp_path: Path):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -147,8 +147,20 @@ def test_load_preserves_persistence_cursors(tmp_path: Path):
     manager = LogManager.load(logdir, lock=False)
 
     assert manager._branches["main"].persisted_messages == 1
+    assert (
+        manager._branches["main"].persisted_path
+        == (logdir / "conversation.jsonl").resolve()
+    )
     assert manager._branches["dev"].persisted_messages == 1
+    assert (
+        manager._branches["dev"].persisted_path
+        == (logdir / "branches" / "dev.jsonl").resolve()
+    )
     assert manager._views["compact"].persisted_messages == 1
+    assert (
+        manager._views["compact"].persisted_path
+        == (logdir / "views" / "compact.jsonl").resolve()
+    )
 
 
 def test_initial_message_directories_are_not_snapshotted(tmp_path: Path):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -672,10 +672,57 @@ def test_write_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):
         log.write_jsonl(jsonl_file)
 
     assert len(calls) == 1, f"expected one open() call, got {calls}"
-    assert "w" in calls[0]["mode"]
+    assert "a" in calls[0]["mode"]
     assert calls[0]["encoding"] == "utf-8", (
         f"write_jsonl must pass encoding='utf-8', got encoding={calls[0]['encoding']!r}"
     )
+
+
+def test_write_jsonl_appends_only_new_messages(tmp_path: Path):
+    """Repeated persistence does not rewrite the existing conversation."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    log = Log([Message("user", "first")]).write_jsonl(jsonl_file)
+    first_size = jsonl_file.stat().st_size
+
+    log = log.append(Message("assistant", "second"))
+    with _record_open_calls() as calls:
+        log = log.write_jsonl(jsonl_file)
+
+    assert calls[0]["mode"] == "a"
+    assert jsonl_file.stat().st_size > first_size
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == [
+        "first",
+        "second",
+    ]
+    assert log.persisted_messages == 2
+
+
+def test_write_jsonl_rewrites_after_messages_are_removed(tmp_path: Path):
+    """Undo-like changes replace stale persisted trailing messages."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    log = Log(
+        [Message("user", "first"), Message("assistant", "remove me")]
+    ).write_jsonl(jsonl_file)
+
+    log = log.pop()
+    with _record_open_calls() as calls:
+        log = log.write_jsonl(jsonl_file)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == ["first"]
+    assert log.persisted_messages == 1
+
+
+def test_write_jsonl_replaces_unknown_existing_file(tmp_path: Path):
+    """A fresh Log object must not append onto stale on-disk content."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    jsonl_file.write_text('{"role":"user","content":"stale"}\n')
+
+    with _record_open_calls() as calls:
+        Log([Message("user", "fresh")]).write_jsonl(jsonl_file)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == ["fresh"]
 
 
 def test_read_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -764,6 +764,28 @@ def test_write_jsonl_appends_only_new_messages(tmp_path: Path):
         "second",
     ]
     assert log.persisted_messages == 2
+    assert log.persisted_path == jsonl_file.resolve()
+
+
+def test_write_jsonl_rewrites_for_a_different_destination(tmp_path: Path):
+    """A persistence cursor belongs only to the file it was recorded for."""
+    conversation_file = tmp_path / "conversation.jsonl"
+    branch_file = tmp_path / "branches" / "dev.jsonl"
+    branch_file.parent.mkdir()
+    log = Log([Message("user", "inherited")]).write_jsonl(
+        conversation_file, append=True
+    )
+    log = log.append(Message("assistant", "branch message"))
+
+    with _record_open_calls() as calls:
+        log = log.write_jsonl(branch_file, append=True)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(branch_file)] == [
+        "inherited",
+        "branch message",
+    ]
+    assert log.persisted_path == branch_file.resolve()
 
 
 def test_write_jsonl_rewrites_after_in_place_message_edit(tmp_path: Path):

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -216,6 +216,34 @@ def test_conversation_name_error_rejects_control_and_edge_whitespace(
     assert conversation_name_error(value) == expected
 
 
+def test_new_branch_persists_inherited_history(tmp_path: Path, monkeypatch):
+    """A new branch writes its inherited prefix to its own destination."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    logdir = tmp_path / "logs" / "test-conv"
+    manager = LogManager(logdir=logdir)
+    manager.append(Message("user", "inherited"))
+
+    manager.branch("dev")
+    manager.append(Message("assistant", "branch-only"))
+
+    persisted = Log.read_jsonl(logdir / "branches" / "dev.jsonl")
+    assert [message.content for message in persisted] == ["inherited", "branch-only"]
+
+
+def test_edit_backup_persists_complete_history(tmp_path: Path, monkeypatch):
+    """An edit backup writes all messages despite originating from a persisted log."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    logdir = tmp_path / "logs" / "test-conv"
+    manager = LogManager(logdir=logdir)
+    manager.append(Message("user", "first"))
+    manager.append(Message("assistant", "second"))
+
+    manager.edit(Log([Message("user", "replacement")]))
+
+    persisted = Log.read_jsonl(logdir / "branches" / "main-edit-0.jsonl")
+    assert [message.content for message in persisted] == ["first", "second"]
+
+
 def test_write_persists_main_branch_when_on_other_branch(tmp_path: Path, monkeypatch):
     """Regression test: writing while on a non-main branch should also persist
     the main branch to conversation.jsonl."""

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -134,6 +134,23 @@ def test_constructor_snapshots_initial_message_files(tmp_path: Path):
     assert manager.log.messages[0].file_hashes[str(bootstrap_file)]
 
 
+def test_load_preserves_persistence_cursors(tmp_path: Path):
+    """Loaded active, branch, and view logs continue with incremental appends."""
+    logdir = tmp_path / "conversation"
+    (logdir / "branches").mkdir(parents=True)
+    (logdir / "views").mkdir()
+    message = Message("user", "persisted")
+    Log([message]).write_jsonl(logdir / "conversation.jsonl")
+    Log([message]).write_jsonl(logdir / "branches" / "dev.jsonl")
+    Log([message]).write_jsonl(logdir / "views" / "compact.jsonl")
+
+    manager = LogManager.load(logdir, lock=False)
+
+    assert manager._branches["main"].persisted_messages == 1
+    assert manager._branches["dev"].persisted_messages == 1
+    assert manager._views["compact"].persisted_messages == 1
+
+
 def test_initial_message_directories_are_not_snapshotted(tmp_path: Path):
     """Directory prompt matches are context references, not file snapshots."""
     context_dir = tmp_path / "docs"

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -427,6 +427,30 @@ def test_view_write_preserves_main_history(tmp_path: Path, monkeypatch):
     assert "new message after compact" in view_contents
 
 
+def test_view_on_non_main_branch_persists_each_destination(tmp_path: Path, monkeypatch):
+    """A view must not advance main's cursor against the current branch file."""
+    monkeypatch.setenv("GPTME_LOGS_HOME", str(tmp_path / "logs"))
+    logdir = tmp_path / "logs" / "test-conv"
+    manager = LogManager(logdir=logdir)
+    manager.append(Message("user", "main history"))
+    manager.branch("dev")
+    manager.append(Message("assistant", "branch history"))
+    manager.create_view("compacted-001", Log([Message("system", "summary")]))
+    manager.switch_view("compacted-001")
+
+    manager.append(Message("user", "view message"))
+
+    main = Log.read_jsonl(logdir / "conversation.jsonl")
+    branch = Log.read_jsonl(logdir / "branches" / "dev.jsonl")
+    view = Log.read_jsonl(logdir / "views" / "compacted-001.jsonl")
+    assert [message.content for message in main] == ["main history", "view message"]
+    assert [message.content for message in branch] == [
+        "main history",
+        "branch history",
+    ]
+    assert [message.content for message in view] == ["summary", "view message"]
+
+
 def test_view_log_setter_updates_view(tmp_path: Path, monkeypatch):
     """Regression test: the log setter should update the view when current_view
     is set, not silently update the branch."""

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -887,6 +887,24 @@ def test_write_jsonl_rewrites_when_destination_is_truncated(tmp_path: Path):
     ]
 
 
+def test_read_jsonl_with_partial_tail_rewrites_before_append(tmp_path: Path):
+    """Reloading a partial final line must not make that tail append-safe."""
+    jsonl_file = tmp_path / "conversation.jsonl"
+    Log([Message("user", "first")]).write_jsonl(jsonl_file)
+    with jsonl_file.open("ab") as file:
+        file.write(b'{"role":"assistant","content":"partial')
+
+    log = Log.read_jsonl(jsonl_file).append(Message("assistant", "second"))
+    with _record_open_calls() as calls:
+        log.write_jsonl(jsonl_file, append=True)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == [
+        "first",
+        "second",
+    ]
+
+
 def test_write_jsonl_rewrites_for_a_different_destination(tmp_path: Path):
     """A persistence cursor belongs only to the file it was recorded for."""
     conversation_file = tmp_path / "conversation.jsonl"

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -177,6 +177,29 @@ def test_load_preserves_persistence_cursors(tmp_path: Path):
     )
 
 
+def test_load_with_snapshotted_file_keeps_incremental_cursor(tmp_path: Path):
+    """Preserving an existing attachment hash must keep message identity."""
+    logdir = tmp_path / "conversation"
+    attachment = tmp_path / "context.md"
+    attachment.write_text("context")
+    with patch("gptme.logmanager.manager.get_logs_dir", return_value=tmp_path):
+        manager = LogManager(
+            [Message("system", "context", files=[attachment])],
+            logdir=logdir,
+            lock=False,
+        )
+        manager.write()
+
+        loaded = LogManager.load(logdir, lock=False)
+        persisted_message = loaded.log.messages[0]
+        assert loaded.log.persisted[0] is persisted_message
+        loaded.append(Message("user", "next"))
+
+    assert [
+        message.content for message in Log.read_jsonl(logdir / "conversation.jsonl")
+    ] == ["context", "next"]
+
+
 def test_initial_message_directories_are_not_snapshotted(tmp_path: Path):
     """Directory prompt matches are context references, not file snapshots."""
     context_dir = tmp_path / "docs"

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -672,7 +672,7 @@ def test_write_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):
         log.write_jsonl(jsonl_file)
 
     assert len(calls) == 1, f"expected one open() call, got {calls}"
-    assert "a" in calls[0]["mode"]
+    assert "w" in calls[0]["mode"]
     assert calls[0]["encoding"] == "utf-8", (
         f"write_jsonl must pass encoding='utf-8', got encoding={calls[0]['encoding']!r}"
     )
@@ -681,12 +681,12 @@ def test_write_jsonl_uses_explicit_utf8_encoding(tmp_path: Path):
 def test_write_jsonl_appends_only_new_messages(tmp_path: Path):
     """Repeated persistence does not rewrite the existing conversation."""
     jsonl_file = tmp_path / "conversation.jsonl"
-    log = Log([Message("user", "first")]).write_jsonl(jsonl_file)
+    log = Log([Message("user", "first")]).write_jsonl(jsonl_file, append=True)
     first_size = jsonl_file.stat().st_size
 
     log = log.append(Message("assistant", "second"))
     with _record_open_calls() as calls:
-        log = log.write_jsonl(jsonl_file)
+        log = log.write_jsonl(jsonl_file, append=True)
 
     assert calls[0]["mode"] == "a"
     assert jsonl_file.stat().st_size > first_size

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -766,6 +766,31 @@ def test_write_jsonl_appends_only_new_messages(tmp_path: Path):
     assert log.persisted_messages == 2
 
 
+def test_write_jsonl_rewrites_after_in_place_message_edit(tmp_path: Path):
+    """Editing already-persisted history must reach disk, not be skipped.
+
+    Append-mode tracks the persisted prefix by identity precisely because the
+    message count is unchanged here: callers like ``_attach_tool_timings``
+    rewrite one earlier message in place, and a count-only check would append
+    zero lines and silently drop the edit.
+    """
+    jsonl_file = tmp_path / "conversation.jsonl"
+    log = Log([Message("user", "first"), Message("assistant", "second")]).write_jsonl(
+        jsonl_file, append=True
+    )
+
+    log.messages[-1] = log.messages[-1].replace(content="second (edited)")
+    with _record_open_calls() as calls:
+        log = log.write_jsonl(jsonl_file, append=True)
+
+    assert calls[0]["mode"] == "w"
+    assert [message.content for message in Log.read_jsonl(jsonl_file)] == [
+        "first",
+        "second (edited)",
+    ]
+    assert log.persisted_messages == 2
+
+
 def test_write_jsonl_rewrites_after_messages_are_removed(tmp_path: Path):
     """Undo-like changes replace stale persisted trailing messages."""
     jsonl_file = tmp_path / "conversation.jsonl"


### PR DESCRIPTION
## Problem

Long gptme sessions rewrite the complete `conversation.jsonl` after every appended message. The recovery event log also accumulates every duplicated append plus full checkpoints forever. On five live Bob runs, the leaf gptme processes wrote 91-894 MB while final trajectory directories held 1.8-4.7 MB; checkpoint records alone were 0.63-1.44 MB per sampled run.

## Changes

- append only newly-added conversation messages during the normal append path
- retain full rewrite behavior after edit/undo or when a fresh `Log` encounters an existing file
- compact recovery events atomically after each checkpoint, retaining the latest full checkpoint plus its replay tail
- preserve branch and compacted-view persistence state independently

## Verification

- `pytest tests/test_logmanager.py tests/test_eventlog.py tests/test_auto_compact.py`: 120 passed
- `pytest tests/test_conversations.py tests/test_cli_from_turn.py tests/test_tools_subagent.py`: 156 passed
- Ruff check/format clean
- scoped `prek` hooks, including mypy, pass
- pre-PR quality gate: 100/100

The existing trajectory filenames/layout are unchanged, so current readers and backup globs continue to apply.
