### PR TITLE
fix(shell): use poll() instead of select() to survive fds above FD_SETSIZE

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -357,6 +357,26 @@ def _get_memory_limit() -> int | None:
     return limit
 
 
+def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
+    """Return the subset of `fds` that are readable, waiting up to `timeout` seconds.
+
+    Uses `poll()` rather than `select()`. `select()` is backed by `fd_set`, which
+    cannot represent a descriptor >= FD_SETSIZE (1024) and raises
+    `ValueError: filedescriptor out of range in select()` instead of degrading.
+    Long-lived processes and highly parallel test runs (`pytest -n 16`) routinely
+    push descriptors past that line. `poll()` has no such ceiling.
+    """
+    poller = select.poll()
+    for fd in fds:
+        # POLLHUP/POLLERR are reported regardless of the requested mask, so EOF
+        # still wakes the poll — matching select(), which reports EOF as readable.
+        poller.register(fd, select.POLLIN)
+    # select() takes seconds (None == block forever); poll() takes milliseconds
+    # (negative == block forever).
+    timeout_ms = -1 if timeout is None else int(timeout * 1000)
+    return [fd for fd, _event in poller.poll(timeout_ms)]
+
+
 class ShellSession:
     process: subprocess.Popen
     stdout_fd: int
@@ -634,7 +654,7 @@ class ShellSession:
         else:
             assert select is not None
             while True:
-                pre_drain_rlist, _, _ = select.select([self.stderr_fd], [], [], 0.05)
+                pre_drain_rlist = _wait_readable([self.stderr_fd], 0.05)
                 if not pre_drain_rlist:
                     break
                 pre_drain_data = os.read(self.stderr_fd, 2**16).decode(
@@ -912,9 +932,7 @@ class ShellSession:
                         1.0, timeout - elapsed
                     )  # Check at least every second
 
-                rlist, _, _ = select.select(
-                    [self.stdout_fd, self.stderr_fd], [], [], select_timeout
-                )
+                rlist = _wait_readable([self.stdout_fd, self.stderr_fd], select_timeout)
 
                 # Handle timeout in select
                 if not rlist and timeout and start_time:
@@ -1002,9 +1020,7 @@ class ShellSession:
                             # has time to arrive from bash.
                             drain_empty_count = 0
                             while drain_empty_count < 2:
-                                drain_rlist, _, _ = select.select(
-                                    [self.stderr_fd], [], [], 0.1
-                                )
+                                drain_rlist = _wait_readable([self.stderr_fd], 0.1)
                                 if not drain_rlist:
                                     drain_empty_count += 1
                                     continue

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -371,9 +371,12 @@ def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
         # POLLHUP/POLLERR are reported regardless of the requested mask, so EOF
         # still wakes the poll — matching select(), which reports EOF as readable.
         poller.register(fd, select.POLLIN)
-    # select() takes seconds (None == block forever); poll() takes milliseconds
-    # (negative == block forever).
-    timeout_ms = -1 if timeout is None else int(timeout * 1000)
+    # select() takes seconds (None == block forever); poll() takes integer
+    # milliseconds (negative == block forever). Round positive sub-millisecond
+    # waits up so they do not become busy-spinning non-blocking polls.
+    timeout_ms = (
+        -1 if timeout is None else max(0 if timeout == 0 else 1, int(timeout * 1000))
+    )
     return [fd for fd, _event in poller.poll(timeout_ms)]
 
 

--- a/tests/test_shell_high_fd.py
+++ b/tests/test_shell_high_fd.py
@@ -11,6 +11,7 @@ POSIX-only: `resource`, `fcntl`, and `select.poll()` do not exist on Windows.
 """
 
 import os
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -95,3 +96,21 @@ def test_wait_readable_times_out_with_no_data():
     finally:
         os.close(read_fd)
         os.close(write_fd)
+
+
+def test_wait_readable_rounds_positive_submillisecond_timeout_up():
+    """A positive timeout must not turn into a non-blocking poll."""
+    poller = Mock()
+    poller.poll.return_value = []
+    with patch("gptme.tools.shell.select.poll", return_value=poller):
+        assert _wait_readable([7], 0.0001) == []
+    poller.poll.assert_called_once_with(1)
+
+
+def test_wait_readable_preserves_zero_timeout():
+    """An explicit zero timeout remains a non-blocking poll."""
+    poller = Mock()
+    poller.poll.return_value = []
+    with patch("gptme.tools.shell.select.poll", return_value=poller):
+        assert _wait_readable([7], 0) == []
+    poller.poll.assert_called_once_with(0)

--- a/tests/test_shell_high_fd.py
+++ b/tests/test_shell_high_fd.py
@@ -6,25 +6,45 @@ select()` rather than degrading. Long-lived processes and parallel test runs
 (`pytest -n 16`) push descriptors past that line, which surfaced as spurious
 `test_tools_shell` / `test_shell_output_mixing_issue408` failures across every
 PR in the repo. See gptme/gptme#3715.
+
+POSIX-only: `resource`, `fcntl`, and `select.poll()` do not exist on Windows.
 """
 
 import os
-import resource
 
 import pytest
 
 from gptme.tools.shell import _wait_readable
 
+fcntl = pytest.importorskip("fcntl", reason="POSIX-only test")
+resource = pytest.importorskip("resource", reason="POSIX-only test")
+
 # Anything at or above FD_SETSIZE is unrepresentable in an fd_set.
 FD_SETSIZE = 1024
-HIGH_FD = 1100
+# Headroom for the descriptors the scan may need to walk past.
+_FD_SCAN_WINDOW = 256
+
+
+def _find_free_fd(start: int) -> int:
+    """Return an unused descriptor >= `start`.
+
+    Never hardcode a target for `dup2`: it silently closes whatever already
+    occupies that number, and in the high-descriptor parallel environment this
+    test targets, that could be a live pytest/xdist descriptor.
+    """
+    for candidate in range(start, start + _FD_SCAN_WINDOW):
+        try:
+            fcntl.fcntl(candidate, fcntl.F_GETFD)
+        except OSError:
+            return candidate  # EBADF — nothing is using it
+    pytest.skip(f"no free descriptor in [{start}, {start + _FD_SCAN_WINDOW})")
 
 
 @pytest.fixture
 def high_fd_limit():
-    """Raise the soft RLIMIT_NOFILE far enough to allocate HIGH_FD, then restore."""
+    """Raise the soft RLIMIT_NOFILE far enough to allocate a high fd, then restore."""
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    needed = HIGH_FD + 16
+    needed = FD_SETSIZE + _FD_SCAN_WINDOW + 16
     if soft < needed:
         if hard != resource.RLIM_INFINITY and hard < needed:
             pytest.skip(f"RLIMIT_NOFILE hard limit {hard} < {needed}")
@@ -38,8 +58,8 @@ def test_wait_readable_handles_fd_above_fd_setsize(high_fd_limit):
     read_fd, write_fd = os.pipe()
     high_read_fd = None
     try:
-        os.dup2(read_fd, HIGH_FD)
-        high_read_fd = HIGH_FD
+        high_read_fd = _find_free_fd(FD_SETSIZE)
+        os.dup2(read_fd, high_read_fd)
         assert high_read_fd >= FD_SETSIZE
 
         os.write(write_fd, b"payload")

--- a/tests/test_shell_high_fd.py
+++ b/tests/test_shell_high_fd.py
@@ -1,0 +1,77 @@
+"""Regression tests for shell fd handling above FD_SETSIZE.
+
+`select.select()` is backed by `fd_set`, which cannot represent a descriptor
+>= FD_SETSIZE (1024): it raises `ValueError: filedescriptor out of range in
+select()` rather than degrading. Long-lived processes and parallel test runs
+(`pytest -n 16`) push descriptors past that line, which surfaced as spurious
+`test_tools_shell` / `test_shell_output_mixing_issue408` failures across every
+PR in the repo. See gptme/gptme#3715.
+"""
+
+import os
+import resource
+
+import pytest
+
+from gptme.tools.shell import _wait_readable
+
+# Anything at or above FD_SETSIZE is unrepresentable in an fd_set.
+FD_SETSIZE = 1024
+HIGH_FD = 1100
+
+
+@pytest.fixture
+def high_fd_limit():
+    """Raise the soft RLIMIT_NOFILE far enough to allocate HIGH_FD, then restore."""
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    needed = HIGH_FD + 16
+    if soft < needed:
+        if hard != resource.RLIM_INFINITY and hard < needed:
+            pytest.skip(f"RLIMIT_NOFILE hard limit {hard} < {needed}")
+        resource.setrlimit(resource.RLIMIT_NOFILE, (needed, hard))
+    yield
+    resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+
+
+def test_wait_readable_handles_fd_above_fd_setsize(high_fd_limit):
+    """A readable descriptor >= FD_SETSIZE must be reported, not raise."""
+    read_fd, write_fd = os.pipe()
+    high_read_fd = None
+    try:
+        os.dup2(read_fd, HIGH_FD)
+        high_read_fd = HIGH_FD
+        assert high_read_fd >= FD_SETSIZE
+
+        os.write(write_fd, b"payload")
+        # Pre-fix this raised ValueError: filedescriptor out of range in select()
+        assert _wait_readable([high_read_fd], 1.0) == [high_read_fd]
+        assert os.read(high_read_fd, 16) == b"payload"
+    finally:
+        for fd in (high_read_fd, read_fd, write_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+
+def test_wait_readable_reports_only_ready_fds():
+    """An idle descriptor is not reported; a written-to one is."""
+    idle_r, idle_w = os.pipe()
+    ready_r, ready_w = os.pipe()
+    try:
+        os.write(ready_w, b"x")
+        assert _wait_readable([idle_r, ready_r], 0.1) == [ready_r]
+    finally:
+        for fd in (idle_r, idle_w, ready_r, ready_w):
+            os.close(fd)
+
+
+def test_wait_readable_times_out_with_no_data():
+    """No readable descriptors within the timeout returns an empty list."""
+    read_fd, write_fd = os.pipe()
+    try:
+        assert _wait_readable([read_fd], 0.05) == []
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)


### PR DESCRIPTION
Fixes the intermittent `test_tools_shell.py` / `test_shell_output_mixing_issue408.py` failures that are currently red on `master` and on every open PR.

Closes #3715

## Root cause

`select.select()` is backed by `fd_set`, which cannot represent a descriptor `>= FD_SETSIZE` (1024). Given such an fd it **raises** rather than degrading:

```
ValueError: filedescriptor out of range in select()
```

Under `pytest -n 16`, accumulated descriptors push the shell tool's pipes past 1024. Because *which* test happens to be running when the fds cross the line varies run to run, the failures move around — which is why they present as flaky rather than as a deterministic bug.

Recent evidence, all the same signature:
- `master` runs 33885146088, 33877865588
- PR run 33919002483 — 14 tests across `test_tools_shell.py`, `test_shell_output_mixing_issue408.py`

## Fix

Replace all three `select.select()` call sites with a `_wait_readable()` helper backed by `select.poll()`, which has no descriptor ceiling.

`POLLHUP`/`POLLERR` are reported by `poll()` regardless of the requested event mask, so EOF still wakes the poll — matching `select()`'s treatment of EOF as readable. Behavior is otherwise unchanged; only the timeout unit conversion (seconds → milliseconds) is new.

## Verification

`tests/test_shell_high_fd.py` `dup2`'s a pipe read end to fd 1100 and asserts it is reported readable. It is genuinely falsifying — against the old implementation:

```text
OLD select() -> ValueError filedescriptor out of range in select()
NEW _wait_readable() -> [1100]
```

Local runs on this branch:
- `test_shell_high_fd.py` — 3 passed
- `test_tools_shell.py`, `test_shell_output_mixing_issue408.py`, `test_shell_fd_leak.py` — 129 passed
- `test_shell_background.py`, `test_tools_shell_background.py`, `test_tools_shell_multiline.py`, `test_shell_issue729.py`, `test_shell_issue772.py`, `test_shell_for_loop_issue724.py` — 140 passed

ruff check/format clean; `mypy gptme/tools/shell.py` reports no new errors (the 3 it emits are pre-existing, in `gptme/acp/`).