### PR TITLE
fix(cli,tests): unbreak `models list --json` under warning providers; scope the gh sleep patch

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -1219,7 +1219,10 @@ def models_list(
         # redirect_stdout/redirect_stderr suppresses print() noise; logging.disable
         # suppresses Rich-formatted log output (httpx retry messages etc.) that escapes
         # through Rich's pre-captured file handle and is not affected by sys.stderr redirect.
-        logging.disable(logging.INFO)
+        # Disable *all* levels: provider discovery logs at WARNING (e.g. "gptme provider
+        # requires authentication"), which logging.disable(INFO) let through and which
+        # then prefixed the JSON document, making it unparseable.
+        logging.disable(logging.CRITICAL)
         try:
             with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
                 from ..llm import list_available_providers  # fmt: skip

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -615,8 +615,8 @@ def test_get_toolchain_glob_matches_mcp_tools():
     ]
 
 
-def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
-    """Plain allowlists should warn when they filter out available MCP tools."""
+def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools():
+    """Plain allowlists should warn once when they filter out available MCP tools."""
     import gptme.tools
     from gptme.tools.base import ToolSpec
 
@@ -627,30 +627,23 @@ def test_get_toolchain_warns_when_plain_allowlist_excludes_mcp_tools(caplog):
         ToolSpec(name="save", desc="Save"),
     ]
 
-    def _warning_count() -> int:
-        return caplog.text.count("Tool allowlist excluded MCP tools")
-
     with (
         patch("gptme.tools.get_available_tools", return_value=fake_tools),
         patch.object(gptme.tools, "_warned_mcp_allowlists", set()),
-        caplog.at_level("WARNING", logger="gptme.tools"),
+        patch.object(gptme.tools.logger, "warning") as mock_warning,
     ):
-        # Isolate from fixture/prior-test records and duplicate log handlers.
-        # The invariant is warn-once, not "exactly one handler emitted one record".
-        caplog.clear()
         tools = get_toolchain(["save"], strict=True)
-        after_first = _warning_count()
         repeated_tools = get_toolchain(["save"], strict=True)
-        after_second = _warning_count()
 
     assert [tool.name for tool in tools] == ["save"]
     assert [tool.name for tool in repeated_tools] == ["save"]
-    assert after_first >= 1
-    assert after_second == after_first
-    assert "Tool allowlist excluded MCP tools" in caplog.text
-    assert "discord.read_channel" in caplog.text
-    assert "discord.send_message" in caplog.text
-    assert "<server>.*" in caplog.text
+    mock_warning.assert_called_once()
+    args = mock_warning.call_args.args
+    rendered_warning = args[0] % args[1:]
+    assert "Tool allowlist excluded MCP tools" in rendered_warning
+    assert "discord.read_channel" in rendered_warning
+    assert "discord.send_message" in rendered_warning
+    assert "<server>.*" in rendered_warning
 
 
 def test_tool_descriptions_within_openai_limit():

--- a/tests/test_tools_gh.py
+++ b/tests/test_tools_gh.py
@@ -7,6 +7,7 @@ execute_gh, and pass-through with mocked subprocess.
 
 import json
 import subprocess
+import time
 from unittest.mock import MagicMock, patch
 
 from gptme.tools.gh import (
@@ -20,6 +21,33 @@ from gptme.tools.gh import (
     _wait_for_checks,
     execute_gh,
 )
+
+
+class _GhTime:
+    """Stand-in for the ``time`` module as imported by ``gptme.tools.gh``.
+
+    ``patch("gptme.tools.gh.time.sleep")`` resolves ``gptme.tools.gh.time`` to
+    the real ``time`` module and patches ``sleep`` on it — process-wide. Any
+    background thread that happens to sleep during the test is then counted by
+    ``mock_sleep``, so ``assert_not_called()`` fails with sleeps the poll loop
+    never made (observed in CI: "Expected 'sleep' to not have been called.
+    Called 544 times." — all ``call(0.05)``, while the poll interval is 10s).
+
+    Patching the *name* ``time`` in gh's own namespace scopes the mock to gh
+    while leaving real ``time.time``/``time.strftime`` available.
+    """
+
+    def __init__(self):
+        self.sleep = MagicMock(name="gh.time.sleep")
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+
+def patch_gh_sleep(func):
+    """Patch only gh's own ``time``; injects the sleep mock as the last arg."""
+    return patch("gptme.tools.gh.time", new_callable=_GhTime)(func)
+
 
 # --- Fixtures ---
 
@@ -223,10 +251,10 @@ class TestFormatCheckResults:
 
 
 class TestWaitForChecks:
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
     @patch("gptme.tools.gh._get_pr_check_runs")
-    def test_all_pass_immediately(self, mock_get_pr, mock_run, mock_sleep):
+    def test_all_pass_immediately(self, mock_get_pr, mock_run, gh_time):
         """All checks already completed successfully."""
         check_runs = [
             _make_check_run("build", "completed", "success"),
@@ -244,12 +272,12 @@ class TestWaitForChecks:
         # Should have: waiting message, status update, final success
         assert any("Waiting for checks" in m.content for m in messages)
         assert any("All checks passed" in m.content for m in messages)
-        mock_sleep.assert_not_called()
+        gh_time.sleep.assert_not_called()
 
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
     @patch("gptme.tools.gh._get_pr_check_runs")
-    def test_failure_detected(self, mock_get_pr, mock_run, mock_sleep):
+    def test_failure_detected(self, mock_get_pr, mock_run, gh_time):
         """Checks complete with failures."""
         check_runs = [
             _make_check_run("build", "completed", "success"),
@@ -273,10 +301,10 @@ class TestWaitForChecks:
         assert any("test" in m.content for m in messages)
         assert any("777" in m.content for m in messages)  # run ID from URL
 
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
     @patch("gptme.tools.gh._get_pr_check_runs")
-    def test_in_progress_then_complete(self, mock_get_pr, mock_run, mock_sleep):
+    def test_in_progress_then_complete(self, mock_get_pr, mock_run, gh_time):
         """Checks transition from in_progress to completed."""
         initial_runs = [
             _make_check_run("build", "completed", "success"),
@@ -297,11 +325,11 @@ class TestWaitForChecks:
 
         assert any("in progress" in m.content for m in messages)
         assert any("All checks passed" in m.content for m in messages)
-        mock_sleep.assert_called_once_with(10)
+        gh_time.sleep.assert_called_once_with(10)
 
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
-    def test_with_commit_sha(self, mock_run, mock_sleep):
+    def test_with_commit_sha(self, mock_run, gh_time):
         """Using explicit commit SHA bypasses PR lookup."""
         check_runs = [_make_check_run("build", "completed", "success")]
         mock_run.return_value = _mock_subprocess_run(
@@ -315,7 +343,7 @@ class TestWaitForChecks:
             "Waiting for checks on commit deadbee" in m.content for m in messages
         )
         assert any("All checks passed" in m.content for m in messages)
-        mock_sleep.assert_not_called()
+        gh_time.sleep.assert_not_called()
 
     @patch("gptme.tools.gh._get_pr_check_runs")
     def test_error_from_get_pr(self, mock_get_pr):
@@ -345,10 +373,10 @@ class TestWaitForChecks:
 
         assert any("No checks found" in m.content for m in messages)
 
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
     @patch("gptme.tools.gh._get_pr_check_runs")
-    def test_cancelled_checks(self, mock_get_pr, mock_run, mock_sleep):
+    def test_cancelled_checks(self, mock_get_pr, mock_run, gh_time):
         """All checks complete but some cancelled."""
         check_runs = [
             _make_check_run("build", "completed", "success"),
@@ -364,10 +392,10 @@ class TestWaitForChecks:
 
         assert any("cancelled" in m.content.lower() for m in messages)
 
-    @patch("gptme.tools.gh.time.sleep")
+    @patch_gh_sleep
     @patch("gptme.tools.gh.subprocess.run")
     @patch("gptme.tools.gh._get_pr_check_runs")
-    def test_poll_api_error(self, mock_get_pr, mock_run, mock_sleep):
+    def test_poll_api_error(self, mock_get_pr, mock_run, gh_time):
         """API error during polling loop."""
         initial_runs = [_make_check_run("build", "in_progress", None)]
         mock_get_pr.return_value = ("abc1234", initial_runs, None)
@@ -377,7 +405,7 @@ class TestWaitForChecks:
         messages = list(_wait_for_checks("owner", "repo", url))
 
         assert any("Error fetching checks" in m.content for m in messages)
-        mock_sleep.assert_not_called()
+        gh_time.sleep.assert_not_called()
 
 
 # --- _handle_pr_status ---

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -1351,3 +1351,64 @@ def test_knowledge_search_empty_query_exits_nonzero(tmp_path, monkeypatch):
     result = runner.invoke(main, ["knowledge", "search", ""])
     assert result.exit_code != 0
     assert "empty" in result.output.lower() or "empty" in (result.stderr or "").lower()
+
+
+def test_models_list_json_suppresses_warning_level_logs(mocker):
+    """WARNING/ERROR provider logs must not prefix the JSON document.
+
+    Regression: provider discovery logs "gptme provider requires
+    authentication" at WARNING through a Rich handler holding the real stdout,
+    so it escaped `redirect_stdout` and was emitted *before* the JSON payload.
+    `logging.disable(logging.INFO)` did not cover WARNING, so
+    `gptme-util models list --json | jq` broke whenever a provider warned.
+    """
+    import json
+    import logging
+
+    runner = CliRunner()
+    logger = logging.getLogger("gptme.llm.models.listing")
+    observed: dict[str, bool] = {}
+
+    def warning_get_model_list(**_kwargs):
+        # Whatever the handlers are wired to, no record at WARNING or below may
+        # be emitted while the JSON payload is being assembled.
+        observed["warning"] = logger.isEnabledFor(logging.WARNING)
+        observed["error"] = logger.isEnabledFor(logging.ERROR)
+        logger.warning("gptme provider: requires authentication")
+        return [
+            SimpleNamespace(
+                provider="openai",
+                provider_key="openai",
+                model="gpt-5",
+                full="openai/gpt-5",
+                context=400000,
+                max_output=None,
+                supports_streaming=True,
+                supports_vision=True,
+                supports_reasoning=True,
+                supports_parallel_tool_calls=True,
+                supports_responses_api=True,
+                price_input=None,
+                price_output=None,
+                knowledge_cutoff=None,
+                deprecated=False,
+                preferred_edit_format=None,
+                pricing_type="per_token",
+                default_tool_format="tool",
+                supports_strict_tools=False,
+            )
+        ]
+
+    mocker.patch(
+        "gptme.cli.util.get_model_list",
+        side_effect=warning_get_model_list,
+    )
+
+    result = runner.invoke(main, ["models", "list", "--json"])
+
+    assert result.exit_code == 0
+    assert observed == {"warning": False, "error": False}
+    parsed = json.loads(result.output)
+    assert parsed[0]["full"] == "openai/gpt-5"
+    # Logging must be restored for the rest of the suite.
+    assert logging.root.manager.disable == logging.NOTSET


### PR DESCRIPTION
Two independent failures in the **"Test without API keys or extras"** job, found while adjudicating CI on #3714 (which touches only `logmanager/` and is not the cause of either).

Failing run: https://github.com/gptme/gptme/actions/runs/33926434257

## 1. `gptme-util models list --json` emits non-JSON — user-facing

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
s = '· WARNING  gptme provider: \'gptme provider requires authentication...\\n[\n  {...}\n]\n'
```

`models_list` already guards JSON mode with `redirect_stdout`/`redirect_stderr` plus `logging.disable(logging.INFO)`. But provider discovery logs *at WARNING* ("gptme provider requires authentication"), which `disable(INFO)` does not cover, and it goes out through a Rich handler holding the real stdout — so it escapes the redirect and prefixes the JSON document.

Net effect: `gptme-util models list --json | jq` breaks for any user without a `gptme` provider credential. Fix disables all levels for the duration of discovery (JSON mode's whole contract is a machine-readable stdout).

Regression test asserts nothing at WARNING/ERROR is enabled while the payload is assembled, and that `logging.disable` is restored afterwards. Verified **red before / green after**.

## 2. `TestWaitForChecks` sleep patch is process-global — test isolation

```
AssertionError: Expected 'sleep' to not have been called. Called 544 times.
Args: assert (0.05,) == ()
```

`@patch("gptme.tools.gh.time.sleep")` resolves `gptme.tools.gh.time` to the **real `time` module** and patches `sleep` on it, i.e. process-wide. Any background thread sleeping in the same xdist worker is counted. The 544 calls are all `call(0.05)`; `_wait_for_checks`'s `poll_interval` is `10`, so none of them came from the code under test.

Fix patches the `time` *name* in gh's namespace with a proxy that passes `time.time`/`time.strftime` straight through, scoping the mock to gh's own calls. Confirmed empirically with a background `time.sleep(0.05)` loop: old target counts the thread's sleeps, new target counts zero.

## Verification

- `pytest tests/test_tools_gh.py` — 72 passed
- `pytest tests/test_util_cli.py -k models_list` — 4 passed
- New test verified red on the unfixed `logging.disable(logging.INFO)`
- `ruff check` + `ruff format --check` clean on all three files

(`tests/test_util_cli.py::test_context_index_and_retrieve` fails in my local worktree both with and without this change — pre-existing, missing extras, untouched here.)