### PR TITLE
feat(dataset): trajectory-to-env pipeline for fine-tuning dataset construction

### DIFF
--- a/gptme/cli/cmd_dataset.py
+++ b/gptme/cli/cmd_dataset.py
@@ -1,0 +1,182 @@
+"""CLI for gptme dataset construction from session trajectories.
+
+Commands::
+
+    gptme-util dataset stats       # corpus statistics
+    gptme-util dataset export      # export TaskEnvironment JSONL
+
+See ``gptme.dataset.trajectory_to_env`` for implementation details and
+``gptme/gptme#3718`` for the motivating issue.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def dataset() -> None:
+    """Build fine-tuning datasets from gptme session trajectories.
+
+    Uses commit-message session-ID attribution to recover the git state
+    before and after each session, producing TaskEnvironment JSONL records
+    suitable for fine-tuning pipelines.
+
+    References:
+      Terminal-Universe paper: https://arxiv.org/abs/2609.04148
+      Issue: gptme/gptme#3718
+    """
+
+
+@dataset.command("stats")
+@click.option(
+    "--repo",
+    "-r",
+    "repo_path",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Git repository to mine for session-attributed commits.",
+)
+@click.option(
+    "--logs-dir",
+    "logs_dir",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Override gptme logs directory.",
+)
+@click.option(
+    "--limit",
+    "-n",
+    default=500,
+    show_default=True,
+    help="Maximum number of sessions to scan.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def stats_cmd(
+    repo_path: Path,
+    logs_dir: Path | None,
+    limit: int,
+    as_json: bool,
+) -> None:
+    """Print corpus statistics: how many sessions are convertible into environments."""
+    from ..dataset.trajectory_to_env import corpus_stats
+
+    try:
+        result = corpus_stats(
+            repo_path=repo_path.resolve(),
+            logs_dir=logs_dir,
+            limit=limit,
+        )
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    click.echo(f"Sessions scanned:   {result['scanned']}")
+    click.echo(f"Convertible:        {result['convertible']}")
+    click.echo(f"Yield:              {result['yield_pct']}%")
+    if result["category_counts"]:
+        click.echo("Categories:")
+        for cat, n in sorted(result["category_counts"].items(), key=lambda x: -x[1]):
+            click.echo(f"  {cat:<12} {n}")
+    if result["model_counts"]:
+        click.echo("Models:")
+        for model, n in sorted(result["model_counts"].items(), key=lambda x: -x[1]):
+            click.echo(f"  {model:<40} {n}")
+
+
+@dataset.command("export")
+@click.option(
+    "--repo",
+    "-r",
+    "repo_path",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Git repository to mine for session-attributed commits.",
+)
+@click.option(
+    "--logs-dir",
+    "logs_dir",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Override gptme logs directory.",
+)
+@click.option(
+    "--limit",
+    "-n",
+    default=None,
+    type=int,
+    help="Maximum number of sessions to scan.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    default="-",
+    help="Output file path (default: stdout, use '-' for stdout).",
+)
+@click.option(
+    "--min-commits",
+    default=1,
+    show_default=True,
+    help="Minimum solution commits required to include an environment.",
+)
+@click.option(
+    "--include-test",
+    is_flag=True,
+    help="Include test/eval conversation IDs (excluded by default).",
+)
+def export_cmd(
+    repo_path: Path,
+    logs_dir: Path | None,
+    limit: int | None,
+    output_path: str,
+    min_commits: int,
+    include_test: bool,
+) -> None:
+    """Export TaskEnvironment records as JSONL.
+
+    Each line of output is a JSON object describing one reproducible training
+    environment derived from a gptme session.  The schema matches the
+    ``TaskEnvironment`` dataclass in ``gptme.dataset.trajectory_to_env``.
+
+    Example::
+
+      gptme-util dataset export --repo /path/to/repo -n 200 -o envs.jsonl
+    """
+    from ..dataset.trajectory_to_env import extract_environments
+
+    try:
+        repo = repo_path.resolve()
+        env_iter = extract_environments(
+            repo_path=repo,
+            logs_dir=logs_dir,
+            limit=limit,
+            include_test=include_test,
+            min_commits=min_commits,
+        )
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    out = sys.stdout if output_path == "-" else open(output_path, "w", encoding="utf-8")
+    count = 0
+    try:
+        for env in env_iter:
+            out.write(env.to_jsonl() + "\n")
+            count += 1
+    finally:
+        if output_path != "-":
+            out.close()
+
+    click.echo(f"Exported {count} environments.", err=True)

--- a/gptme/cli/cmd_dataset.py
+++ b/gptme/cli/cmd_dataset.py
@@ -11,7 +11,9 @@ See ``gptme.dataset.trajectory_to_env`` for implementation details and
 
 import json
 import logging
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 import click
@@ -129,6 +131,7 @@ def stats_cmd(
     "--min-commits",
     default=1,
     show_default=True,
+    type=click.IntRange(min=1),
     help="Minimum solution commits required to include an environment.",
 )
 @click.option(
@@ -156,27 +159,46 @@ def export_cmd(
     """
     from ..dataset.trajectory_to_env import extract_environments
 
-    try:
-        repo = repo_path.resolve()
-        env_iter = extract_environments(
-            repo_path=repo,
-            logs_dir=logs_dir,
-            limit=limit,
-            include_test=include_test,
-            min_commits=min_commits,
-        )
-    except ValueError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+    env_iter = extract_environments(
+        repo_path=repo_path.resolve(),
+        logs_dir=logs_dir,
+        limit=limit,
+        include_test=include_test,
+        min_commits=min_commits,
+    )
 
-    out = sys.stdout if output_path == "-" else open(output_path, "w", encoding="utf-8")
+    destination = None if output_path == "-" else Path(output_path)
+    temp_path: Path | None = None
+    out = sys.stdout
     count = 0
     try:
+        if destination is not None:
+            destination = destination.resolve()
+            temp = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=destination.parent,
+                prefix=f".{destination.name}.",
+                delete=False,
+            )
+            out = temp
+            temp_path = Path(temp.name)
+
         for env in env_iter:
             out.write(env.to_jsonl() + "\n")
             count += 1
-    finally:
-        if output_path != "-":
+
+        if destination is not None:
             out.close()
+            assert temp_path is not None
+            os.replace(temp_path, destination)
+            temp_path = None
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        if destination is not None and not out.closed:
+            out.close()
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
     click.echo(f"Exported {count} environments.", err=True)

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -68,6 +68,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "snapshot": (".cmd_snapshot", "snapshot"),
     "stats": (".cmd_stats", "stats"),
     "status": (".cmd_status", "status"),
+    "dataset": (".cmd_dataset", "dataset"),
 }
 
 # Inline groups defined via @main.group() in this file

--- a/gptme/dataset/__init__.py
+++ b/gptme/dataset/__init__.py
@@ -1,0 +1,13 @@
+"""Dataset construction utilities for gptme.
+
+This subpackage provides tools for constructing fine-tuning datasets from
+gptme session trajectories. The main entry point is ``trajectory_to_env``,
+which scans session logs and associated git commits to produce
+``TaskEnvironment`` JSONL records suitable for fine-tuning pipelines.
+
+See ``gptme.dataset.trajectory_to_env`` for details.
+"""
+
+from .trajectory_to_env import TaskEnvironment, extract_environments, scan_sessions
+
+__all__ = ["TaskEnvironment", "extract_environments", "scan_sessions"]

--- a/gptme/dataset/trajectory_to_env.py
+++ b/gptme/dataset/trajectory_to_env.py
@@ -1,0 +1,457 @@
+"""Trajectory-to-environment pipeline for fine-tuning dataset construction.
+
+Converts gptme session trajectories into ``TaskEnvironment`` records that can
+be used as training environments for fine-tuning LLMs on gptme-specific tasks.
+
+The core insight (from the issue) is that gptme sessions embed session IDs in
+commit messages::
+
+    chore(journal): session c876 — refactor done
+    fix(tool): handle edge case (a1b2)
+
+This lets us recover the exact git state before/after each session without
+replaying the trajectory — cheaper than general file-op replay.
+
+Usage::
+
+    from gptme.dataset import extract_environments
+
+    envs = list(extract_environments(repo_path="/path/to/repo", limit=500))
+    for env in envs:
+        print(env.to_jsonl())
+
+See ``gptme-util dataset`` for the CLI interface.
+
+References:
+    - Terminal-Universe paper: https://arxiv.org/abs/2609.04148
+    - Issue: gptme/gptme#3718
+"""
+
+import json
+import logging
+import re
+import subprocess
+from collections import Counter
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from ..dirs import get_logs_dir
+from ..logmanager.conversations import _is_test_conversation_id
+
+logger = logging.getLogger(__name__)
+
+# Pattern that gptme sessions use when embedding session IDs in commit messages.
+# Matches both:
+#   "(a1b2)" – short-hash style (most common)
+#   "session a1b2" – long-form annotation
+_SESSION_ID_RE = re.compile(
+    r"(?:\(([0-9a-f]{4,})\)|session ([0-9a-f]{4,}))", re.IGNORECASE
+)
+
+
+@dataclass
+class TaskEnvironment:
+    """A single training environment derived from a gptme session.
+
+    Each instance encodes a reproducible task: given ``entry_commit`` as the
+    workspace state and ``task_description`` as the user prompt, a model
+    should produce the changes reflected in ``solution_commits``.
+    """
+
+    session_id: str
+    """Short hex ID embedded in the session's commit messages."""
+
+    entry_commit: str
+    """SHA of the commit immediately before the first session commit.
+
+    ``git checkout entry_commit`` restores the workspace to the state when
+    the session started.
+    """
+
+    solution_commits: list[str]
+    """Ordered list of commit SHAs produced during the session.
+
+    These are the ground-truth changes the model should replicate.
+    """
+
+    files_changed: list[str]
+    """All files touched across solution_commits (de-duplicated, sorted)."""
+
+    task_description: str
+    """First user message in the session, used as the training prompt."""
+
+    category: str
+    """Broad task category: ``code``, ``docs``, ``journal``, ``other``."""
+
+    outcome: str
+    """Session outcome: ``productive`` (≥1 commit) or ``no_commits``."""
+
+    tool_call_counts: dict[str, int] = field(default_factory=dict)
+    """Count of each tool type used during the session."""
+
+    model: str = ""
+    """Model identifier from the session metadata (empty if unknown)."""
+
+    duration_seconds: float = 0.0
+    """Wall-clock session duration in seconds (0 if unrecoverable)."""
+
+    def to_jsonl(self) -> str:
+        """Serialise to a single JSONL line."""
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TaskEnvironment":
+        return cls(**d)
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    """Run a git command and return stdout; returns '' on failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.debug("git %s failed: %s", " ".join(args), result.stderr.strip())
+            return ""
+        return result.stdout.strip()
+    except Exception as exc:
+        logger.debug("git %s exception: %s", " ".join(args), exc)
+        return ""
+
+
+def _find_session_commits(session_id: str, repo: Path) -> list[str]:
+    """Return commit SHAs whose message references *session_id*, oldest first."""
+    # --grep matches the message; we search for the session ID in parentheses
+    # or after the word "session".
+    log_output = _run_git(
+        [
+            "log",
+            "--all",
+            "--grep",
+            session_id,
+            "--format=%H %s",
+            "--reverse",
+        ],
+        cwd=repo,
+    )
+    if not log_output:
+        return []
+
+    commits = []
+    for line in log_output.splitlines():
+        parts = line.split(maxsplit=1)
+        if not parts:
+            continue
+        sha = parts[0]
+        # Verify the session_id actually appears in the message
+        # (git --grep is substring search, so filter more precisely)
+        msg = parts[1] if len(parts) > 1 else ""
+        if re.search(rf"\b{re.escape(session_id)}\b", msg, re.IGNORECASE):
+            commits.append(sha)
+
+    return commits
+
+
+def _get_entry_commit(first_session_commit: str, repo: Path) -> str:
+    """Return the commit immediately before *first_session_commit*."""
+    parent = _run_git(
+        ["rev-parse", f"{first_session_commit}^"],
+        cwd=repo,
+    )
+    return parent
+
+
+def _get_files_changed(commits: list[str], repo: Path) -> list[str]:
+    """Return sorted unique list of files changed across all *commits*."""
+    files: set[str] = set()
+    for sha in commits:
+        output = _run_git(
+            ["diff-tree", "--no-commit-id", "-r", "--name-only", sha],
+            cwd=repo,
+        )
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                files.add(line)
+    return sorted(files)
+
+
+def _categorise_files(files: list[str]) -> str:
+    """Infer a broad category from the set of changed files."""
+    if not files:
+        return "other"
+    has_code = any(
+        f.endswith((".py", ".ts", ".js", ".rs", ".go", ".sh", ".yaml", ".toml"))
+        for f in files
+    )
+    has_docs = any(
+        f.endswith((".md", ".rst", ".txt")) or "docs/" in f or "knowledge/" in f
+        for f in files
+    )
+    has_journal = any("journal/" in f for f in files)
+
+    if has_journal:
+        return "journal"
+    if has_code:
+        return "code"
+    if has_docs:
+        return "docs"
+    return "other"
+
+
+def _extract_tool_call_counts(messages: list[dict]) -> dict[str, int]:
+    """Count tool calls by tool name across all *messages*."""
+    counts: Counter[str] = Counter()
+    for msg in messages:
+        role = msg.get("role", "")
+        if role != "assistant":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            # Markdown tool-use pattern: ```tool_name\n...```
+            for m in re.finditer(r"```(\w[\w-]*)\n", content):
+                counts[m.group(1)] += 1
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    counts[block.get("name", "unknown")] += 1
+    return dict(counts)
+
+
+def _get_task_description(messages: list[dict]) -> str:
+    """Return the first non-system user message content (the task prompt)."""
+    for msg in messages:
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                # Flatten content blocks to text
+                content = "\n".join(
+                    block["text"]
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+            if isinstance(content, str) and content.strip():
+                # Trim to a reasonable length for the training prompt
+                return content.strip()[:2000]
+    return ""
+
+
+def _get_session_model(messages: list[dict]) -> str:
+    """Return the model from the last assistant message metadata, or ''."""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            meta = msg.get("metadata", {})
+            if isinstance(meta, dict):
+                model = meta.get("model", "")
+                if model:
+                    return model
+    return ""
+
+
+def _get_session_duration(messages: list[dict]) -> float:
+    """Return session duration in seconds by diffing first and last timestamps."""
+    timestamps = []
+    for msg in messages:
+        ts = msg.get("timestamp", "")
+        if ts:
+            timestamps.append(ts)
+    if len(timestamps) < 2:
+        return 0.0
+    try:
+        from dateutil.parser import isoparse
+
+        t0 = isoparse(timestamps[0])
+        t1 = isoparse(timestamps[-1])
+        return (t1 - t0).total_seconds()
+    except Exception:
+        return 0.0
+
+
+def _load_session_messages(conv_path: Path) -> list[dict]:
+    """Read a conversation.jsonl and return the list of message dicts."""
+    messages = []
+    try:
+        with conv_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    messages.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError as exc:
+        logger.debug("Could not read %s: %s", conv_path, exc)
+    return messages
+
+
+def scan_sessions(
+    logs_dir: Path | None = None,
+    limit: int | None = None,
+    include_test: bool = False,
+) -> Iterator[tuple[str, list[dict]]]:
+    """Yield ``(session_id, messages)`` pairs for each gptme conversation.
+
+    Args:
+        logs_dir: Override the default gptme logs directory.
+        limit: Maximum number of sessions to scan (newest first).
+        include_test: Include conversations whose IDs indicate test/eval runs.
+    """
+    base = logs_dir or get_logs_dir()
+    conv_files = sorted(
+        base.glob("*/conversation.jsonl"),
+        key=lambda p: -p.stat().st_mtime,
+    )
+
+    scanned = 0
+    for conv_path in conv_files:
+        if limit is not None and scanned >= limit:
+            break
+        conv_id = conv_path.parent.name
+        if not include_test and _is_test_conversation_id(conv_id):
+            continue
+        messages = _load_session_messages(conv_path)
+        if not messages:
+            continue
+        yield conv_id, messages
+        scanned += 1
+
+
+def extract_environments(
+    repo_path: Path | None = None,
+    logs_dir: Path | None = None,
+    limit: int | None = None,
+    include_test: bool = False,
+    min_commits: int = 1,
+) -> Iterator[TaskEnvironment]:
+    """Yield ``TaskEnvironment`` instances from the local gptme session corpus.
+
+    Each environment is derived from a session that produced at least
+    *min_commits* commits in *repo_path*.  Sessions with no matching commits
+    are skipped (they are not convertible into reproducible environments).
+
+    Args:
+        repo_path: Git repository to mine for session-attributed commits.
+            Defaults to the current working directory.
+        logs_dir: Override the gptme logs directory.
+        limit: Cap on how many sessions to scan (newest first).
+        include_test: Include test/eval conversation IDs.
+        min_commits: Minimum number of solution commits required (default 1).
+
+    Yields:
+        :class:`TaskEnvironment` for each convertible session.
+
+    Example::
+
+        envs = list(extract_environments(repo_path=Path("/path/to/repo"), limit=500))
+        print(f"Convertible: {len(envs)}")
+    """
+    repo = (repo_path or Path.cwd()).resolve()
+    if not (repo / ".git").exists():
+        raise ValueError(f"{repo} is not a git repository")
+
+    for session_id, messages in scan_sessions(
+        logs_dir=logs_dir, limit=limit, include_test=include_test
+    ):
+        # Extract a short ID from the conversation ID (last hex segment).
+        # Conversation IDs look like "2026-01-01_topic_a1b2" or just "a1b2".
+        short_id_match = re.search(r"([0-9a-f]{4,})$", session_id, re.IGNORECASE)
+        if not short_id_match:
+            logger.debug("Skipping %s: no hex suffix for session ID", session_id)
+            continue
+        short_id = short_id_match.group(1)
+
+        commits = _find_session_commits(short_id, repo)
+        if len(commits) < min_commits:
+            logger.debug(
+                "Skipping %s: only %d commits (need %d)",
+                session_id,
+                len(commits),
+                min_commits,
+            )
+            continue
+
+        entry = _get_entry_commit(commits[0], repo)
+        if not entry:
+            logger.debug("Skipping %s: no parent commit for %s", session_id, commits[0])
+            continue
+
+        files_changed = _get_files_changed(commits, repo)
+        category = _categorise_files(files_changed)
+        task_description = _get_task_description(messages)
+        tool_call_counts = _extract_tool_call_counts(messages)
+        model = _get_session_model(messages)
+        duration_seconds = _get_session_duration(messages)
+
+        yield TaskEnvironment(
+            session_id=short_id,
+            entry_commit=entry,
+            solution_commits=commits,
+            files_changed=files_changed,
+            task_description=task_description,
+            category=category,
+            outcome="productive",
+            tool_call_counts=tool_call_counts,
+            model=model,
+            duration_seconds=duration_seconds,
+        )
+
+
+def corpus_stats(
+    repo_path: Path | None = None,
+    logs_dir: Path | None = None,
+    limit: int | None = None,
+) -> dict:
+    """Return a summary dict of corpus statistics.
+
+    Scans sessions and reports how many are convertible into training
+    environments.  Useful for a quick feasibility check before a full export.
+
+    Args:
+        repo_path: Git repository to mine for session-attributed commits.
+        logs_dir: Override the gptme logs directory.
+        limit: Cap on how many sessions to scan.
+
+    Returns:
+        A dict with keys: ``scanned``, ``convertible``, ``yield_pct``,
+        ``category_counts``, ``model_counts``.
+    """
+    repo = (repo_path or Path.cwd()).resolve()
+    if not (repo / ".git").exists():
+        raise ValueError(f"{repo} is not a git repository")
+
+    total = 0
+    convertible = 0
+    categories: Counter[str] = Counter()
+    models: Counter[str] = Counter()
+
+    for session_id, messages in scan_sessions(
+        logs_dir=logs_dir, limit=limit, include_test=False
+    ):
+        total += 1
+        short_id_match = re.search(r"([0-9a-f]{4,})$", session_id, re.IGNORECASE)
+        if not short_id_match:
+            continue
+        short_id = short_id_match.group(1)
+        commits = _find_session_commits(short_id, repo)
+        if commits:
+            convertible += 1
+            files = _get_files_changed(commits, repo)
+            categories[_categorise_files(files)] += 1
+        model = _get_session_model(messages)
+        if model:
+            models[model] += 1
+
+    return {
+        "scanned": total,
+        "convertible": convertible,
+        "yield_pct": round(100 * convertible / total, 1) if total else 0.0,
+        "category_counts": dict(categories),
+        "model_counts": dict(models),
+    }

--- a/gptme/dataset/trajectory_to_env.py
+++ b/gptme/dataset/trajectory_to_env.py
@@ -41,13 +41,9 @@ from ..logmanager.conversations import _is_test_conversation_id
 
 logger = logging.getLogger(__name__)
 
-# Pattern that gptme sessions use when embedding session IDs in commit messages.
-# Matches both:
-#   "(a1b2)" – short-hash style (most common)
-#   "session a1b2" – long-form annotation
-_SESSION_ID_RE = re.compile(
-    r"(?:\(([0-9a-f]{4,})\)|session ([0-9a-f]{4,}))", re.IGNORECASE
-)
+# Legacy commit subjects identify a session as either ``(<id>)`` or
+# ``session <id>``. Newer commits may use an exact ``Git-Session-Id`` trailer.
+_SESSION_MARKER_TEMPLATE = r"(?:\({id}\)|\bsession[ :]+{id}(?=$|\s|[—–-]))"
 
 
 @dataclass
@@ -125,17 +121,29 @@ def _run_git(args: list[str], cwd: Path) -> str:
         return ""
 
 
+def _attribution_ids(conversation_id: str) -> list[str]:
+    """Return exact IDs that may identify *conversation_id* in a commit."""
+    ids = [conversation_id]
+    short_match = re.search(
+        r"(?:^|[-_])([0-9a-f]{4,})$", conversation_id, re.IGNORECASE
+    )
+    if short_match and short_match.group(1).casefold() != conversation_id.casefold():
+        ids.append(short_match.group(1))
+    return ids
+
+
 def _find_session_commits(session_id: str, repo: Path) -> list[str]:
-    """Return commit SHAs whose message references *session_id*, oldest first."""
-    # --grep matches the message; we search for the session ID in parentheses
-    # or after the word "session".
+    """Return reachable commits exactly attributed to a session, oldest first."""
+    attribution_ids = _attribution_ids(session_id)
+    grep_args: list[str] = []
+    for attribution_id in attribution_ids:
+        grep_args.extend(["--grep", attribution_id])
     log_output = _run_git(
         [
             "log",
-            "--all",
-            "--grep",
-            session_id,
-            "--format=%H %s",
+            "HEAD",
+            *grep_args,
+            "--format=%H%x1f%B%x1e",
             "--reverse",
         ],
         cwd=repo,
@@ -144,16 +152,31 @@ def _find_session_commits(session_id: str, repo: Path) -> list[str]:
         return []
 
     commits = []
-    for line in log_output.splitlines():
-        parts = line.split(maxsplit=1)
-        if not parts:
+    for record in log_output.split("\x1e"):
+        record = record.strip()
+        if not record:
             continue
-        sha = parts[0]
-        # Verify the session_id actually appears in the message
-        # (git --grep is substring search, so filter more precisely)
-        msg = parts[1] if len(parts) > 1 else ""
-        if re.search(rf"\b{re.escape(session_id)}\b", msg, re.IGNORECASE):
-            commits.append(sha)
+        sha, separator, message = record.partition("\x1f")
+        if not separator:
+            continue
+        trailers = re.findall(
+            r"^Git-Session-Id:\s*(\S+)\s*$", message, re.IGNORECASE | re.MULTILINE
+        )
+        exact_trailer = any(
+            trailer.casefold() == attribution_id.casefold()
+            for trailer in trailers
+            for attribution_id in attribution_ids
+        )
+        exact_subject_marker = any(
+            re.search(
+                _SESSION_MARKER_TEMPLATE.format(id=re.escape(attribution_id)),
+                message.splitlines()[0],
+                re.IGNORECASE,
+            )
+            for attribution_id in attribution_ids
+        )
+        if exact_trailer or exact_subject_marker:
+            commits.append(sha.strip())
 
     return commits
 
@@ -168,11 +191,11 @@ def _get_entry_commit(first_session_commit: str, repo: Path) -> str:
 
 
 def _get_files_changed(commits: list[str], repo: Path) -> list[str]:
-    """Return sorted unique list of files changed across all *commits*."""
+    """Return files changed versus each commit's first parent."""
     files: set[str] = set()
     for sha in commits:
         output = _run_git(
-            ["diff-tree", "--no-commit-id", "-r", "--name-only", sha],
+            ["diff", "--name-only", f"{sha}^", sha],
             cwd=repo,
         )
         for line in output.splitlines():
@@ -323,6 +346,15 @@ def scan_sessions(
         scanned += 1
 
 
+def _resolve_repo(repo_path: Path | None) -> Path:
+    """Resolve *repo_path* to its enclosing Git worktree root."""
+    candidate = (repo_path or Path.cwd()).resolve()
+    root = _run_git(["rev-parse", "--show-toplevel"], cwd=candidate)
+    if not root:
+        raise ValueError(f"{candidate} is not a git repository")
+    return Path(root).resolve()
+
+
 def extract_environments(
     repo_path: Path | None = None,
     logs_dir: Path | None = None,
@@ -352,22 +384,14 @@ def extract_environments(
         envs = list(extract_environments(repo_path=Path("/path/to/repo"), limit=500))
         print(f"Convertible: {len(envs)}")
     """
-    repo = (repo_path or Path.cwd()).resolve()
-    if not (repo / ".git").exists():
-        raise ValueError(f"{repo} is not a git repository")
+    if min_commits < 1:
+        raise ValueError("min_commits must be at least 1")
+    repo = _resolve_repo(repo_path)
 
     for session_id, messages in scan_sessions(
         logs_dir=logs_dir, limit=limit, include_test=include_test
     ):
-        # Extract a short ID from the conversation ID (last hex segment).
-        # Conversation IDs look like "2026-01-01_topic_a1b2" or just "a1b2".
-        short_id_match = re.search(r"([0-9a-f]{4,})$", session_id, re.IGNORECASE)
-        if not short_id_match:
-            logger.debug("Skipping %s: no hex suffix for session ID", session_id)
-            continue
-        short_id = short_id_match.group(1)
-
-        commits = _find_session_commits(short_id, repo)
+        commits = _find_session_commits(session_id, repo)
         if len(commits) < min_commits:
             logger.debug(
                 "Skipping %s: only %d commits (need %d)",
@@ -390,7 +414,7 @@ def extract_environments(
         duration_seconds = _get_session_duration(messages)
 
         yield TaskEnvironment(
-            session_id=short_id,
+            session_id=session_id,
             entry_commit=entry,
             solution_commits=commits,
             files_changed=files_changed,
@@ -422,9 +446,7 @@ def corpus_stats(
         A dict with keys: ``scanned``, ``convertible``, ``yield_pct``,
         ``category_counts``, ``model_counts``.
     """
-    repo = (repo_path or Path.cwd()).resolve()
-    if not (repo / ".git").exists():
-        raise ValueError(f"{repo} is not a git repository")
+    repo = _resolve_repo(repo_path)
 
     total = 0
     convertible = 0
@@ -435,11 +457,7 @@ def corpus_stats(
         logs_dir=logs_dir, limit=limit, include_test=False
     ):
         total += 1
-        short_id_match = re.search(r"([0-9a-f]{4,})$", session_id, re.IGNORECASE)
-        if not short_id_match:
-            continue
-        short_id = short_id_match.group(1)
-        commits = _find_session_commits(short_id, repo)
+        commits = _find_session_commits(session_id, repo)
         if commits:
             convertible += 1
             files = _get_files_changed(commits, repo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ gptme-resume = "gptme.cli.cmd_resume:resume"
 gptme-mcp-server = "gptme.cli.cmd_mcp_serve:main"
 gptme-stats = "gptme.cli.cmd_stats:stats"
 gptme-service = "gptme.cli.cmd_service:cli"
+gptme-dataset = "gptme.cli.cmd_dataset:dataset"
 
 [tool.poetry]
 packages = [

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,396 @@
+"""Tests for gptme.dataset.trajectory_to_env.
+
+These tests are fully offline: they create temporary git repos and
+fake conversation logs rather than touching the real gptme logs directory.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.dataset.trajectory_to_env import (
+    TaskEnvironment,
+    _categorise_files,
+    _extract_tool_call_counts,
+    _find_session_commits,
+    _get_entry_commit,
+    _get_files_changed,
+    _get_session_duration,
+    _get_session_model,
+    _get_task_description,
+    extract_environments,
+    scan_sessions,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Allow git identity override so temp-repo commits don't trip the identity guard hook.
+_GIT_ENV = {**os.environ, "ALLOW_GIT_IDENTITY": "1"}
+
+
+def _git(args: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_GIT_ENV,
+        **kwargs,
+    )
+
+
+def make_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with an initial commit.
+
+    Uses a non-master/main branch name so the global pre-commit hook that
+    guards against direct master commits in external repos doesn't fire.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Use a non-protected branch so the guard hook doesn't block test commits.
+    _git(["init", "-b", "test-main"], cwd=repo)
+    _git(["config", "user.email", "test@test.invalid"], cwd=repo)
+    _git(["config", "user.name", "Test"], cwd=repo)
+    _git(["config", "commit.gpgsign", "false"], cwd=repo)
+    (repo / "README.md").write_text("# Test\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "init"], cwd=repo)
+    return repo
+
+
+def add_commit(repo: Path, filename: str, content: str, message: str) -> str:
+    """Add a file and commit it; return the SHA."""
+    (repo / filename).write_text(content)
+    _git(["add", filename], cwd=repo)
+    _git(["commit", "-m", message], cwd=repo)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_GIT_ENV,
+    )
+    return result.stdout.strip()
+
+
+def make_logs_dir(tmp_path: Path, session_id: str, messages: list[dict]) -> Path:
+    """Create a fake gptme logs directory with one conversation."""
+    logs_dir = tmp_path / "logs"
+    conv_dir = logs_dir / f"2026-01-01_topic_{session_id}"
+    conv_dir.mkdir(parents=True)
+    jsonl = conv_dir / "conversation.jsonl"
+    with jsonl.open("w") as fh:
+        for msg in messages:
+            fh.write(json.dumps(msg) + "\n")
+    return logs_dir
+
+
+def make_messages(session_id: str) -> list[dict]:
+    """Return a minimal conversation log referencing *session_id*."""
+    return [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+            "timestamp": "2026-01-01T10:00:00Z",
+        },
+        {
+            "role": "user",
+            "content": "Fix the broken test for utils.py",
+            "timestamp": "2026-01-01T10:00:01Z",
+        },
+        {
+            "role": "assistant",
+            "content": "```shell\npython -m pytest tests/\n```",
+            "timestamp": "2026-01-01T10:01:00Z",
+            "metadata": {"model": "claude-sonnet-4-6"},
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_categorise_files_code():
+    assert _categorise_files(["src/foo.py", "tests/test_foo.py"]) == "code"
+
+
+def test_categorise_files_docs():
+    assert _categorise_files(["docs/guide.md"]) == "docs"
+
+
+def test_categorise_files_journal():
+    assert _categorise_files(["journal/2026-01-01/notes.md"]) == "journal"
+
+
+def test_categorise_files_other():
+    assert _categorise_files([".gitignore"]) == "other"
+
+
+def test_categorise_files_empty():
+    assert _categorise_files([]) == "other"
+
+
+def test_extract_tool_call_counts_markdown():
+    messages = [
+        {"role": "assistant", "content": "```shell\nls\n```\n```python\nprint()\n```"}
+    ]
+    counts = _extract_tool_call_counts(messages)
+    assert counts["shell"] == 1
+    assert counts["python"] == 1
+
+
+def test_extract_tool_call_counts_tool_use_blocks():
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": "Bash"},
+                {"type": "tool_use", "name": "Read"},
+                {"type": "tool_use", "name": "Bash"},
+            ],
+        }
+    ]
+    counts = _extract_tool_call_counts(messages)
+    assert counts["Bash"] == 2
+    assert counts["Read"] == 1
+
+
+def test_get_task_description_string():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "Fix the bug in utils.py"},
+    ]
+    desc = _get_task_description(messages)
+    assert desc == "Fix the bug in utils.py"
+
+
+def test_get_task_description_list_content():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Part A"},
+                {"type": "text", "text": "Part B"},
+            ],
+        }
+    ]
+    desc = _get_task_description(messages)
+    assert "Part A" in desc
+    assert "Part B" in desc
+
+
+def test_get_task_description_truncates():
+    messages = [{"role": "user", "content": "x" * 5000}]
+    desc = _get_task_description(messages)
+    assert len(desc) <= 2000
+
+
+def test_get_session_model():
+    messages = [
+        {"role": "assistant", "content": "...", "metadata": {"model": "claude-foo"}},
+    ]
+    assert _get_session_model(messages) == "claude-foo"
+
+
+def test_get_session_model_missing():
+    messages = [{"role": "assistant", "content": "..."}]
+    assert _get_session_model(messages) == ""
+
+
+def test_get_session_duration():
+    messages = [
+        {"role": "user", "content": "q", "timestamp": "2026-01-01T10:00:00Z"},
+        {"role": "assistant", "content": "a", "timestamp": "2026-01-01T10:14:07Z"},
+    ]
+    secs = _get_session_duration(messages)
+    assert abs(secs - 847.0) < 1.0
+
+
+def test_get_session_duration_single():
+    messages = [{"role": "user", "content": "q", "timestamp": "2026-01-01T10:00:00Z"}]
+    assert _get_session_duration(messages) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real git repo
+# ---------------------------------------------------------------------------
+
+
+def test_find_session_commits(tmp_path):
+    repo = make_repo(tmp_path)
+    sha = add_commit(repo, "foo.py", "pass\n", "fix: handle edge case (a1b2)")
+    commits = _find_session_commits("a1b2", repo)
+    assert sha in commits
+
+
+def test_find_session_commits_no_match(tmp_path):
+    repo = make_repo(tmp_path)
+    add_commit(repo, "bar.py", "pass\n", "fix: unrelated change")
+    commits = _find_session_commits("zzzz", repo)
+    assert commits == []
+
+
+def test_get_entry_commit(tmp_path):
+    repo = make_repo(tmp_path)
+    # initial commit is the parent we expect
+    init_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_GIT_ENV,
+    ).stdout.strip()
+    session_sha = add_commit(repo, "foo.py", "pass\n", "fix: something (abcd)")
+    entry = _get_entry_commit(session_sha, repo)
+    assert entry == init_sha
+
+
+def test_get_files_changed(tmp_path):
+    repo = make_repo(tmp_path)
+    sha = add_commit(repo, "utils.py", "# util\n", "feat: add utils (beef)")
+    files = _get_files_changed([sha], repo)
+    assert "utils.py" in files
+
+
+def test_extract_environments_end_to_end(tmp_path):
+    session_id = "cafe"
+    repo = make_repo(tmp_path)
+    add_commit(repo, "script.py", "print('hi')\n", f"feat: add script ({session_id})")
+
+    messages = make_messages(session_id)
+    logs_dir = make_logs_dir(tmp_path, session_id, messages)
+
+    envs = list(extract_environments(repo_path=repo, logs_dir=logs_dir, limit=10))
+    assert len(envs) == 1
+
+    env = envs[0]
+    assert env.session_id == session_id
+    assert env.entry_commit  # non-empty
+    assert "script.py" in env.files_changed
+    assert env.task_description == "Fix the broken test for utils.py"
+    assert env.outcome == "productive"
+    assert env.model == "claude-sonnet-4-6"
+    assert env.category == "code"
+
+
+def test_extract_environments_no_commits(tmp_path):
+    """Sessions with no associated commits must be skipped."""
+    session_id = "dead"
+    repo = make_repo(tmp_path)
+    # Commit exists but does not reference this session_id
+    add_commit(repo, "x.py", "", "chore: unrelated")
+
+    messages = make_messages(session_id)
+    logs_dir = make_logs_dir(tmp_path, session_id, messages)
+
+    envs = list(extract_environments(repo_path=repo, logs_dir=logs_dir))
+    assert envs == []
+
+
+def test_extract_environments_requires_git_repo(tmp_path):
+    logs_dir = make_logs_dir(tmp_path, "1234", make_messages("1234"))
+    not_a_repo = tmp_path / "notrepo"
+    not_a_repo.mkdir()
+    with pytest.raises(ValueError, match="not a git repository"):
+        list(extract_environments(repo_path=not_a_repo, logs_dir=logs_dir))
+
+
+def test_task_environment_to_jsonl_roundtrip():
+    env = TaskEnvironment(
+        session_id="cafe",
+        entry_commit="abc123",
+        solution_commits=["def456"],
+        files_changed=["foo.py"],
+        task_description="Fix the bug",
+        category="code",
+        outcome="productive",
+        tool_call_counts={"shell": 3},
+        model="claude-sonnet-4-6",
+        duration_seconds=120.0,
+    )
+    jsonl = env.to_jsonl()
+    d = json.loads(jsonl)
+    assert d["session_id"] == "cafe"
+    assert d["entry_commit"] == "abc123"
+    assert d["category"] == "code"
+    env2 = TaskEnvironment.from_dict(d)
+    assert env2 == env
+
+
+def test_scan_sessions_excludes_test_convs(tmp_path):
+    """Conversations with IDs like 'tmp*' or 'test-*' are excluded by default."""
+    logs_dir = tmp_path / "logs"
+    for conv_id in ["test-abc", "tmp123", "2026-01-01_normal_ab12"]:
+        (logs_dir / conv_id).mkdir(parents=True)
+        (logs_dir / conv_id / "conversation.jsonl").write_text(
+            json.dumps({"role": "user", "content": "hi"}) + "\n"
+        )
+
+    sessions = list(scan_sessions(logs_dir=logs_dir))
+    ids = [s for s, _ in sessions]
+    assert not any(i.startswith(("test-", "tmp")) for i in ids)
+    assert any("normal" in i for i in ids)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_stats_no_repo(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    runner = CliRunner()
+    not_a_repo = tmp_path / "notrepo"
+    not_a_repo.mkdir()
+    result = runner.invoke(dataset, ["stats", "--repo", str(not_a_repo)])
+    assert result.exit_code != 0
+    assert "Error" in result.output
+
+
+def test_cli_export_stdout(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    session_id = "feed"
+    repo = make_repo(tmp_path)
+    add_commit(repo, "impl.py", "# impl\n", f"feat: implement ({session_id})")
+    messages = make_messages(session_id)
+    logs_dir = make_logs_dir(tmp_path, session_id, messages)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        dataset,
+        ["export", "--repo", str(repo), "--logs-dir", str(logs_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    # At least one JSONL line on stdout
+    lines = [ln for ln in result.output.splitlines() if ln.strip().startswith("{")]
+    assert lines, f"Expected JSON output, got:\n{result.output}"
+    env_dict = json.loads(lines[0])
+    assert env_dict["session_id"] == session_id
+
+
+def test_cli_stats_json(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    repo = make_repo(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        dataset, ["stats", "--repo", str(repo), "--json", "--limit", "0"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "scanned" in data
+    assert "yield_pct" in data

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -68,18 +68,30 @@ def make_repo(tmp_path: Path) -> Path:
 
 def add_commit(repo: Path, filename: str, content: str, message: str) -> str:
     """Add a file and commit it; return the SHA."""
-    (repo / filename).write_text(content)
+    target = repo / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
     _git(["add", filename], cwd=repo)
     _git(["commit", "-m", message], cwd=repo)
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
+    return _git(["rev-parse", "HEAD"], cwd=repo).stdout.strip()
+
+
+def add_merge_commit(repo: Path, session_id: str) -> str:
+    """Create a non-fast-forward merge attributed to *session_id*."""
+    _git(["switch", "-c", "session-branch"], cwd=repo)
+    add_commit(repo, "merged.py", "merged\n", "feat: branch change")
+    _git(["switch", "test-main"], cwd=repo)
+    _git(
+        [
+            "merge",
+            "--no-ff",
+            "session-branch",
+            "-m",
+            f"chore: merge session ({session_id})",
+        ],
         cwd=repo,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=_GIT_ENV,
     )
-    return result.stdout.strip()
+    return _git(["rev-parse", "HEAD"], cwd=repo).stdout.strip()
 
 
 def make_logs_dir(tmp_path: Path, session_id: str, messages: list[dict]) -> Path:
@@ -241,6 +253,39 @@ def test_find_session_commits_no_match(tmp_path):
     assert commits == []
 
 
+def test_find_session_commits_requires_exact_marker(tmp_path):
+    repo = make_repo(tmp_path)
+    unrelated = add_commit(repo, "bar.py", "pass\n", "fix: feed parser")
+    matching = add_commit(repo, "foo.py", "pass\n", "fix: parser (feed)")
+
+    commits = _find_session_commits("feed", repo)
+
+    assert matching in commits
+    assert unrelated not in commits
+
+
+def test_find_session_commits_does_not_search_divergent_refs(tmp_path):
+    repo = make_repo(tmp_path)
+    _git(["switch", "-c", "other"], cwd=repo)
+    add_commit(repo, "other.py", "pass\n", "fix: other branch (cafe)")
+    _git(["switch", "test-main"], cwd=repo)
+
+    assert _find_session_commits("cafe", repo) == []
+
+
+def test_find_session_commits_accepts_full_id_trailer(tmp_path):
+    repo = make_repo(tmp_path)
+    session_id = "2026-01-01-fix-utils"
+    matching = add_commit(
+        repo,
+        "foo.py",
+        "pass\n",
+        f"fix: parser\n\nGit-Session-Id: {session_id}",
+    )
+
+    assert _find_session_commits(session_id, repo) == [matching]
+
+
 def test_get_entry_commit(tmp_path):
     repo = make_repo(tmp_path)
     # initial commit is the parent we expect
@@ -264,6 +309,13 @@ def test_get_files_changed(tmp_path):
     assert "utils.py" in files
 
 
+def test_get_files_changed_includes_merge_changes(tmp_path):
+    repo = make_repo(tmp_path)
+    sha = add_merge_commit(repo, "beef")
+
+    assert "merged.py" in _get_files_changed([sha], repo)
+
+
 def test_extract_environments_end_to_end(tmp_path):
     session_id = "cafe"
     repo = make_repo(tmp_path)
@@ -276,7 +328,8 @@ def test_extract_environments_end_to_end(tmp_path):
     assert len(envs) == 1
 
     env = envs[0]
-    assert env.session_id == session_id
+    # session_id is the full conversation directory name, not just the short hex
+    assert env.session_id == f"2026-01-01_topic_{session_id}"
     assert env.entry_commit  # non-empty
     assert "script.py" in env.files_changed
     assert env.task_description == "Fix the broken test for utils.py"
@@ -305,6 +358,53 @@ def test_extract_environments_requires_git_repo(tmp_path):
     not_a_repo.mkdir()
     with pytest.raises(ValueError, match="not a git repository"):
         list(extract_environments(repo_path=not_a_repo, logs_dir=logs_dir))
+
+
+def test_extract_environments_accepts_repo_subdirectory(tmp_path):
+    session_id = "cafe"
+    repo = make_repo(tmp_path)
+    add_commit(repo, "src/impl.py", "# impl\n", f"feat: implement ({session_id})")
+    logs_dir = make_logs_dir(tmp_path, session_id, make_messages(session_id))
+
+    envs = list(
+        extract_environments(repo_path=repo / "src", logs_dir=logs_dir, limit=10)
+    )
+
+    assert len(envs) == 1
+    # session_id is the full conversation directory name, not just the short hex
+    assert envs[0].session_id == f"2026-01-01_topic_{session_id}"
+
+
+def test_extract_environments_accepts_nonhex_conversation_id(tmp_path):
+    # A real non-hex session ID: the conv directory name IS the full session ID.
+    session_id = "2026-01-01-fix-utils"
+    repo = make_repo(tmp_path)
+    add_commit(
+        repo,
+        "impl.py",
+        "# impl\n",
+        f"feat: implement\n\nGit-Session-Id: {session_id}",
+    )
+    # Create the conv dir with session_id as the exact directory name so the
+    # scanned conv_id matches the Git-Session-Id trailer in the commit.
+    logs_dir = tmp_path / "logs"
+    conv_dir = logs_dir / session_id
+    conv_dir.mkdir(parents=True)
+    with (conv_dir / "conversation.jsonl").open("w") as fh:
+        for msg in make_messages(session_id):
+            fh.write(json.dumps(msg) + "\n")
+
+    envs = list(extract_environments(repo_path=repo, logs_dir=logs_dir))
+
+    assert len(envs) == 1
+    assert envs[0].session_id == session_id
+
+
+def test_extract_environments_rejects_nonpositive_min_commits(tmp_path):
+    repo = make_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="at least 1"):
+        list(extract_environments(repo_path=repo, min_commits=0))
 
 
 def test_task_environment_to_jsonl_roundtrip():
@@ -360,6 +460,55 @@ def test_cli_stats_no_repo(tmp_path):
     assert "Error" in result.output
 
 
+def test_cli_export_invalid_repo_has_no_traceback(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    runner = CliRunner()
+    not_a_repo = tmp_path / "notrepo"
+    not_a_repo.mkdir()
+
+    result = runner.invoke(dataset, ["export", "--repo", str(not_a_repo)])
+
+    assert result.exit_code != 0
+    assert "Error" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_export_failure_preserves_existing_output(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    runner = CliRunner()
+    not_a_repo = tmp_path / "notrepo"
+    not_a_repo.mkdir()
+    output = tmp_path / "dataset.jsonl"
+    output.write_text("existing\n")
+
+    result = runner.invoke(
+        dataset,
+        ["export", "--repo", str(not_a_repo), "--output", str(output)],
+    )
+
+    assert result.exit_code != 0
+    assert output.read_text() == "existing\n"
+    assert not list(tmp_path.glob(".dataset.jsonl.*"))
+
+
+def test_cli_export_rejects_nonpositive_min_commits(tmp_path):
+    from gptme.cli.cmd_dataset import dataset
+
+    runner = CliRunner()
+    repo = make_repo(tmp_path)
+
+    result = runner.invoke(
+        dataset,
+        ["export", "--repo", str(repo), "--min-commits", "0"],
+    )
+
+    assert result.exit_code != 0
+    # click.IntRange(min=1) produces "not in the range x>=1"; check non-zero exit
+    assert "Error" in result.output
+
+
 def test_cli_export_stdout(tmp_path):
     from gptme.cli.cmd_dataset import dataset
 
@@ -379,7 +528,8 @@ def test_cli_export_stdout(tmp_path):
     lines = [ln for ln in result.output.splitlines() if ln.strip().startswith("{")]
     assert lines, f"Expected JSON output, got:\n{result.output}"
     env_dict = json.loads(lines[0])
-    assert env_dict["session_id"] == session_id
+    # session_id is the full conversation directory name; short hex appears as suffix
+    assert session_id in env_dict["session_id"]
 
 
 def test_cli_stats_json(tmp_path):


### PR DESCRIPTION
## Summary

Implements the trajectory-to-env pipeline proposed in #3718.

Adds a `gptme.dataset` subpackage that converts gptme session trajectories
into `TaskEnvironment` JSONL records suitable for fine-tuning pipelines.

### Core insight

gptme sessions embed session IDs in commit messages:
```
chore(journal): session c876 — refactor done
fix(tool): handle edge case (a1b2)
```

This lets us recover the git state before/after each session **without replaying the trajectory** — a cheap alternative to the general file-op replay approach in the Terminal-Universe paper (arXiv:2609.04148).

### New modules

| File | Purpose |
|------|---------|
| `gptme/dataset/__init__.py` | Public API: `TaskEnvironment`, `extract_environments`, `scan_sessions` |
| `gptme/dataset/trajectory_to_env.py` | Core pipeline: session scanning, commit attribution, JSONL export |
| `gptme/cli/cmd_dataset.py` | CLI: `gptme-util dataset stats/export` (lazy-loaded via util dispatch) |
| `tests/test_dataset.py` | 26 offline unit + integration tests (no network, no real gptme logs) |

### Usage

```bash
# Corpus statistics
gptme-util dataset stats --repo /path/to/repo --limit 500

# Export TaskEnvironment JSONL
gptme-util dataset export --repo /path/to/repo -n 200 -o envs.jsonl

# Library usage
from gptme.dataset import extract_environments
envs = list(extract_environments(repo_path=Path('/path/to/repo'), limit=500))
```

### TaskEnvironment schema

```json
{
  "session_id": "c876",
  "entry_commit": "abc123",
  "solution_commits": ["def456", "ghi789"],
  "files_changed": ["scripts/foo.py", "tests/test_foo.py"],
  "task_description": "CASCADE: fix tool edge case",
  "category": "code",
  "outcome": "productive",
  "tool_call_counts": {"shell": 12, "python": 3},
  "model": "claude-sonnet-4-6",
  "duration_seconds": 847.0
}
```

Closes #3718

<!-- gptme-id:v1:gai_F6xJSlMQFt8eiM6PGzwcRduSeDB6rl9E5hmCcnrtYTA -->