### PR TITLE
fix(onboard): detect OAuth subscription providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         poetry install -E all
 
     - name: Install playwright
-      run: poetry run playwright install chromium
+      run: poetry run playwright install chromium-headless-shell
 
     - name: Run tests (without API keys, including slow)
       env:
@@ -311,7 +311,7 @@ jobs:
         poetry install -E all
 
     - name: Install playwright
-      run: poetry run playwright install chromium
+      run: poetry run playwright install chromium-headless-shell
 
     - name: Run API tests only
       uses: nick-fields/retry@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         poetry install -E all
 
     - name: Install playwright
-      run: poetry run playwright install chromium-headless-shell
+      run: poetry run playwright install chromium
 
     - name: Run tests (without API keys, including slow)
       env:
@@ -311,7 +311,7 @@ jobs:
         poetry install -E all
 
     - name: Install playwright
-      run: poetry run playwright install chromium-headless-shell
+      run: poetry run playwright install chromium
 
     - name: Run API tests only
       uses: nick-fields/retry@v4

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -68,8 +68,10 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
         for provider, source in list_available_providers():
             if provider in OAUTH_PROVIDERS:
                 results[provider] = (True, source)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(
+            "OAuth credential check failed: %s — run `gptme auth` to re-authenticate", e
+        )
 
     # Also check config file for API keys and configured model
     try:
@@ -359,10 +361,10 @@ def _run_wizard(check_only: bool = False) -> int:
             model = Prompt.ask("Default model", default=default_model)
         else:
             model = Prompt.ask("Default model (e.g. provider/model-name)")
-        if "/" in model:
+        if "/" in model and model.split("/", 1)[0] == selected:
             break
         console.print(
-            "[red]Model must be in provider/model format (e.g. openai/gpt-4o).[/red]"
+            f"[red]Model must be in {selected}/model format (e.g. {selected}/MODEL-NAME).[/red]"
         )
 
     # Create config

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -362,7 +362,12 @@ def _run_wizard(check_only: bool = False) -> int:
         else:
             model = Prompt.ask("Default model (e.g. provider/model-name)")
         provider, separator, model_name = model.partition("/")
-        if separator and provider == selected and model_name:
+        if (
+            separator
+            and provider == selected
+            and model_name
+            and not model_name.endswith("/")
+        ):
             break
         console.print(
             f"[red]Model must start with {selected}/ followed by a model name (e.g. {selected}/MODEL-NAME).[/red]"

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -362,10 +362,10 @@ def _run_wizard(check_only: bool = False) -> int:
         else:
             model = Prompt.ask("Default model (e.g. provider/model-name)")
         provider, separator, model_name = model.partition("/")
-        if separator and provider == selected and model_name and "/" not in model_name:
+        if separator and provider == selected and model_name:
             break
         console.print(
-            f"[red]Model must be in {selected}/model format (e.g. {selected}/MODEL-NAME).[/red]"
+            f"[red]Model must start with {selected}/ followed by a model name (e.g. {selected}/MODEL-NAME).[/red]"
         )
 
     # Create config

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -62,10 +62,14 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
             results[provider] = (False, None)
 
     # OAuth providers have no API key; use the same token-file detection as the
-    # runtime and ``gptme-doctor``.
-    for provider, source in list_available_providers():
-        if provider in OAUTH_PROVIDERS:
-            results[provider] = (True, source)
+    # runtime and ``gptme-doctor``. Credential/config errors must not discard
+    # providers already detected from the environment.
+    try:
+        for provider, source in list_available_providers():
+            if provider in OAUTH_PROVIDERS:
+                results[provider] = (True, source)
+    except Exception:
+        pass
 
     # Also check config file for API keys and configured model
     try:

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -19,8 +19,9 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from ..config import config_path
+from ..llm import list_available_providers
 from ..llm.models import PROVIDERS, BuiltinProvider, get_recommended_model
-from ..llm.validate import PROVIDER_DOCS, validate_api_key
+from ..llm.validate import OAUTH_PROVIDERS, PROVIDER_DOCS, validate_api_key
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -60,6 +61,12 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
         else:
             results[provider] = (False, None)
 
+    # OAuth providers have no API key; use the same token-file detection as the
+    # runtime and ``gptme-doctor``.
+    for provider, source in list_available_providers():
+        if provider in OAUTH_PROVIDERS:
+            results[provider] = (True, source)
+
     # Also check config file for API keys and configured model
     try:
         from ..config import get_config
@@ -92,6 +99,12 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
 
 def _test_provider(provider: str) -> tuple[bool, str]:
     """Test if a provider is working (checks env vars and config file)."""
+    if provider in OAUTH_PROVIDERS:
+        available = {name for name, _ in list_available_providers()}
+        if provider in available:
+            return True, "OAuth credentials found (not validated during onboarding)"
+        return False, f"Not authenticated (run gptme auth {provider})"
+
     env_var = PROVIDER_ENV_VARS.get(provider)
     if not env_var:
         return False, f"Unknown provider: {provider}"

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -104,7 +104,10 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
 def _test_provider(provider: str) -> tuple[bool, str]:
     """Test if a provider is working (checks env vars and config file)."""
     if provider in OAUTH_PROVIDERS:
-        available = {name for name, _ in list_available_providers()}
+        try:
+            available = {name for name, _ in list_available_providers()}
+        except Exception:
+            available = set()
         if provider in available:
             return True, "OAuth credentials found (not validated during onboarding)"
         return False, f"Not authenticated (run gptme auth {provider})"
@@ -315,7 +318,14 @@ def _run_wizard(check_only: bool = False) -> int:
             rec_model = get_recommended_model(cast(BuiltinProvider, selected))
             default_model = f"{selected}/{rec_model}"
         except ValueError:
-            # Provider doesn't have a recommended model configured
+            # OAuth/subscription providers may have no builtin recommended model.
+            # Prompt the user to supply the model in provider/model form.
+            if selected in OAUTH_PROVIDERS:
+                console.print(
+                    f"[dim]Note: {selected} requires specifying a model.  "
+                    f"Enter it as [bold]{selected}/MODEL-NAME[/bold] "
+                    f"(e.g. {selected}/grok-3).[/dim]"
+                )
             default_model = selected
     else:
         default_model = selected

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -20,7 +20,7 @@ from rich.table import Table
 
 from ..config import config_path
 from ..llm import list_available_providers
-from ..llm.models import PROVIDERS, BuiltinProvider, get_recommended_model
+from ..llm.models import MODELS, PROVIDERS, BuiltinProvider, get_recommended_model
 from ..llm.validate import OAUTH_PROVIDERS, PROVIDER_DOCS, validate_api_key
 
 logger = logging.getLogger(__name__)
@@ -156,6 +156,29 @@ def _show_provider_status(providers: dict[str, tuple[bool, str | None]]) -> None
         table.add_row(provider, status, preview_text, docs_url)
 
     console.print(table)
+
+
+def _get_default_model(provider: str) -> str:
+    """Return a valid default model string for the given provider.
+
+    For providers with a builtin recommended model, returns ``provider/model``.
+    For OAuth/subscription providers that have no builtin recommendation, falls
+    back to the first model listed in the static ``MODELS`` dict so the default
+    is always a fully-qualified ``provider/model`` string rather than the bare
+    provider name (which fails at startup).
+    """
+    if provider in PROVIDERS:
+        try:
+            rec = get_recommended_model(cast(BuiltinProvider, provider))
+            return f"{provider}/{rec}"
+        except ValueError:
+            pass
+    # Fallback: first model in the static MODELS dict, if any.
+    # MODELS keys are Literal types; cast provider str to avoid the mypy overload mismatch.
+    provider_models = list(MODELS.get(cast(BuiltinProvider, provider), {}).keys())
+    if provider_models:
+        return f"{provider}/{provider_models[0]}"
+    return provider
 
 
 def _select_provider(providers: dict[str, tuple[bool, str | None]]) -> str | None:
@@ -317,22 +340,14 @@ def _run_wizard(check_only: bool = False) -> int:
     console.print("\n[bold]Step 4: Create configuration[/bold]")
 
     # Ask for model preference
-    if selected in PROVIDERS:
-        try:
-            rec_model = get_recommended_model(cast(BuiltinProvider, selected))
-            default_model = f"{selected}/{rec_model}"
-        except ValueError:
-            # OAuth/subscription providers may have no builtin recommended model.
-            # Prompt the user to supply the model in provider/model form.
-            if selected in OAUTH_PROVIDERS:
-                console.print(
-                    f"[dim]Note: {selected} requires specifying a model.  "
-                    f"Enter it as [bold]{selected}/MODEL-NAME[/bold] "
-                    f"(e.g. {selected}/grok-3).[/dim]"
-                )
-            default_model = selected
-    else:
-        default_model = selected
+    default_model = _get_default_model(selected)
+    if selected in OAUTH_PROVIDERS:
+        # Show a hint for OAuth providers so the user knows the required format.
+        console.print(
+            f"[dim]Note: {selected} requires specifying a model.  "
+            f"Enter it as [bold]{selected}/MODEL-NAME[/bold] "
+            f"(e.g. {default_model}).[/dim]"
+        )
     model = Prompt.ask("Default model", default=default_model)
 
     # Create config

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -139,7 +139,11 @@ def _show_provider_status(providers: dict[str, tuple[bool, str | None]]) -> None
     table.add_column("Key Preview")
     table.add_column("Docs")
 
-    for provider in PROVIDERS:
+    # Show all builtin providers plus any additional (e.g. OAuth) providers
+    # detected in `providers` that aren't in the builtin list, so a
+    # configured OAuth provider isn't silently omitted from the table.
+    all_providers = list(PROVIDERS) + [p for p in providers if p not in PROVIDERS]
+    for provider in all_providers:
         has_key, preview = providers.get(provider, (False, None))
         if has_key:
             status = "✅ Configured"

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -166,6 +166,10 @@ def _get_default_model(provider: str) -> str:
     back to the first model listed in the static ``MODELS`` dict so the default
     is always a fully-qualified ``provider/model`` string rather than the bare
     provider name (which fails at startup).
+
+    Returns an empty string if no default model can be determined.
+    Callers must treat an empty return as "no default available" and require
+    the user to supply a full ``provider/model`` string explicitly.
     """
     if provider in PROVIDERS:
         try:
@@ -178,7 +182,9 @@ def _get_default_model(provider: str) -> str:
     provider_models = list(MODELS.get(cast(BuiltinProvider, provider), {}).keys())
     if provider_models:
         return f"{provider}/{provider_models[0]}"
-    return provider
+    # No default known — returning the bare provider name would produce an invalid
+    # config (runtime requires provider/model).  Let the caller ask the user.
+    return ""
 
 
 def _select_provider(providers: dict[str, tuple[bool, str | None]]) -> str | None:
@@ -343,12 +349,21 @@ def _run_wizard(check_only: bool = False) -> int:
     default_model = _get_default_model(selected)
     if selected in OAUTH_PROVIDERS:
         # Show a hint for OAuth providers so the user knows the required format.
+        example = f" (e.g. {default_model})" if default_model else ""
         console.print(
             f"[dim]Note: {selected} requires specifying a model.  "
-            f"Enter it as [bold]{selected}/MODEL-NAME[/bold] "
-            f"(e.g. {default_model}).[/dim]"
+            f"Enter it as [bold]{selected}/MODEL-NAME[/bold]{example}.[/dim]"
         )
-    model = Prompt.ask("Default model", default=default_model)
+    while True:
+        if default_model:
+            model = Prompt.ask("Default model", default=default_model)
+        else:
+            model = Prompt.ask("Default model (e.g. provider/model-name)")
+        if "/" in model:
+            break
+        console.print(
+            "[red]Model must be in provider/model format (e.g. openai/gpt-4o).[/red]"
+        )
 
     # Create config
     config_created = _create_config(selected, model)

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -361,7 +361,8 @@ def _run_wizard(check_only: bool = False) -> int:
             model = Prompt.ask("Default model", default=default_model)
         else:
             model = Prompt.ask("Default model (e.g. provider/model-name)")
-        if "/" in model and model.split("/", 1)[0] == selected:
+        provider, separator, model_name = model.partition("/")
+        if separator and provider == selected and model_name and "/" not in model_name:
             break
         console.print(
             f"[red]Model must be in {selected}/model format (e.g. {selected}/MODEL-NAME).[/red]"

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -108,8 +108,13 @@ def _test_provider(provider: str) -> tuple[bool, str]:
     if provider in OAUTH_PROVIDERS:
         try:
             available = {name for name, _ in list_available_providers()}
-        except Exception:
-            available = set()
+        except Exception as e:
+            logger.warning(
+                "OAuth credential check failed: %s — run `gptme auth %s` to re-authenticate",
+                e,
+                provider,
+            )
+            return False, f"Could not read OAuth credentials: {e}"
         if provider in available:
             return True, "OAuth credentials found (not validated during onboarding)"
         return False, f"Not authenticated (run gptme auth {provider})"

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -68,7 +68,7 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
         for provider, source in list_available_providers():
             if provider in OAUTH_PROVIDERS:
                 results[provider] = (True, source)
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.warning(
             "OAuth credential check failed: %s — run `gptme auth` to re-authenticate", e
         )
@@ -108,7 +108,7 @@ def _test_provider(provider: str) -> tuple[bool, str]:
     if provider in OAUTH_PROVIDERS:
         try:
             available = {name for name, _ in list_available_providers()}
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning(
                 "OAuth credential check failed: %s — run `gptme auth %s` to re-authenticate",
                 e,

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -128,6 +128,24 @@ class TestDetectProviders:
 
         assert providers["openai"][0]
 
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        side_effect=RuntimeError("token file corrupted"),
+    )
+    def test_oauth_lookup_failure_logs_warning(self, _mock_providers, caplog):
+        """OAuth credential lookup failures emit a warning rather than silently passing."""
+        import logging
+
+        with (
+            caplog.at_level(logging.WARNING, logger="gptme.cli.onboard"),
+            patch("gptme.config.get_config", return_value=_mock_empty_config()),
+        ):
+            _detect_providers()
+
+        messages = " ".join(r.message for r in caplog.records)
+        assert "OAuth credential check failed" in messages
+        assert "gptme auth" in messages
+
 
 class TestTestProvider:
     """Test provider connectivity testing."""

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -3,7 +3,12 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from gptme.cli.onboard import _detect_providers, _show_provider_status, _test_provider
+from gptme.cli.onboard import (
+    _detect_providers,
+    _get_default_model,
+    _show_provider_status,
+    _test_provider,
+)
 
 
 def _mock_empty_config():
@@ -191,3 +196,29 @@ class TestShowProviderStatus:
         out = capsys.readouterr().out
         assert "openai-subscription" in out
         assert "Configured" in out
+
+
+class TestGetDefaultModel:
+    """Test _get_default_model returns a valid full model string."""
+
+    def test_known_provider_returns_recommended(self):
+        """Providers with a builtin recommendation return provider/model."""
+        result = _get_default_model("openai")
+        assert result.startswith("openai/"), result
+        assert "/" in result
+
+    def test_grok_subscription_returns_valid_model(self):
+        """grok-subscription has no builtin recommended model; must fall back to
+        the first model in the static MODELS dict (e.g. grok-4.6) rather than
+        returning the bare provider name, which fails at startup."""
+        result = _get_default_model("grok-subscription")
+        assert result.startswith("grok-subscription/"), result
+        assert result != "grok-subscription", (
+            "_get_default_model must never return the bare provider name"
+        )
+
+    def test_openai_subscription_returns_valid_model(self):
+        """openai-subscription should similarly return a qualified default."""
+        result = _get_default_model("openai-subscription")
+        assert result.startswith("openai-subscription/"), result
+        assert result != "openai-subscription"

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -3,7 +3,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from gptme.cli.onboard import _detect_providers, _test_provider
+from gptme.cli.onboard import _detect_providers, _show_provider_status, _test_provider
 
 
 def _mock_empty_config():
@@ -172,3 +172,22 @@ class TestTestProvider:
 
         assert not is_valid
         assert "Not authenticated" in message
+
+
+class TestShowProviderStatus:
+    """Test the provider status table."""
+
+    def test_shows_configured_oauth_provider_not_in_builtins(self, capsys):
+        """An OAuth provider detected as configured is shown, even though it's
+        not in the builtin PROVIDERS list (regression: it was previously
+        omitted, so --check could report "1 provider(s) configured" while the
+        visible table showed everything as not configured)."""
+        providers: dict[str, tuple[bool, str | None]] = {
+            "openai-subscription": (True, "oauth")
+        }
+
+        _show_provider_status(providers)
+
+        out = capsys.readouterr().out
+        assert "openai-subscription" in out
+        assert "Configured" in out

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -260,13 +260,24 @@ class TestModelValidation:
     def _is_valid_model(self, model: str, selected: str = "openai") -> bool:
         """Replicate the wizard's partition-based validation predicate."""
         provider, separator, model_name = model.partition("/")
-        return bool(separator and provider == selected and model_name)
+        return bool(
+            separator
+            and provider == selected
+            and model_name
+            and not model_name.endswith("/")
+        )
 
     def test_trailing_slash_rejected(self):
         """'openai/' must be rejected — empty model segment after the slash."""
         assert not self._is_valid_model("openai/"), (
             "trailing slash with no model name must not pass validation"
         )
+
+    def test_nested_trailing_slash_rejected(self):
+        """'openrouter/deepseek/' must be rejected — empty final component."""
+        assert not self._is_valid_model(
+            "openrouter/deepseek/", selected="openrouter"
+        ), "nested trailing slash must be rejected — empty final component"
 
     def test_valid_model_accepted(self):
         """'openai/gpt-4o' and similar well-formed strings must pass."""

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -161,3 +161,14 @@ class TestTestProvider:
 
         assert not is_valid
         assert message == "Not authenticated (run gptme auth openai-subscription)"
+
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        side_effect=ValueError("malformed credentials"),
+    )
+    def test_oauth_lookup_failure_in_test_provider(self, _mock_providers):
+        """Credential lookup failure in _test_provider returns (False, message)."""
+        is_valid, message = _test_provider("openai-subscription")
+
+        assert not is_valid
+        assert "Not authenticated" in message

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -103,6 +103,26 @@ class TestDetectProviders:
 
         assert providers["openai-subscription"] == (True, "oauth")
 
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        side_effect=ValueError("malformed credentials"),
+    )
+    def test_detect_preserves_env_fallback_when_oauth_lookup_fails(
+        self, _mock_providers
+    ):
+        """Credential lookup failures do not discard environment detection."""
+        with (
+            patch.dict(
+                os.environ,
+                {"OPENAI_API_KEY": "sk-test1234567890abcdef"},
+                clear=True,
+            ),
+            patch("gptme.config.get_config", return_value=_mock_empty_config()),
+        ):
+            providers = _detect_providers()
+
+        assert providers["openai"][0]
+
 
 class TestTestProvider:
     """Test provider connectivity testing."""

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -92,6 +92,17 @@ class TestDetectProviders:
                 assert preview is not None
                 assert "model:" in preview
 
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        return_value=[("openai-subscription", "oauth")],
+    )
+    def test_detect_with_oauth(self, _mock_providers):
+        """Test detection finds subscription providers with OAuth credentials."""
+        with patch("gptme.config.get_config", return_value=_mock_empty_config()):
+            providers = _detect_providers()
+
+        assert providers["openai-subscription"] == (True, "oauth")
+
 
 class TestTestProvider:
     """Test provider connectivity testing."""
@@ -111,3 +122,22 @@ class TestTestProvider:
                 is_valid, error = _test_provider("openai")
                 assert not is_valid
                 assert "No API key found" in error
+
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        return_value=[("openai-subscription", "oauth")],
+    )
+    def test_oauth_credentials_found(self, _mock_providers):
+        """Subscription credentials are accepted without an API-key validation call."""
+        is_valid, message = _test_provider("openai-subscription")
+
+        assert is_valid
+        assert "OAuth credentials found" in message
+
+    @patch("gptme.cli.onboard.list_available_providers", return_value=[])
+    def test_oauth_credentials_missing(self, _mock_providers):
+        """Missing subscription credentials give the provider-specific auth command."""
+        is_valid, message = _test_provider("openai-subscription")
+
+        assert not is_valid
+        assert message == "Not authenticated (run gptme auth openai-subscription)"

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -222,3 +222,15 @@ class TestGetDefaultModel:
         result = _get_default_model("openai-subscription")
         assert result.startswith("openai-subscription/"), result
         assert result != "openai-subscription"
+
+    def test_unknown_provider_returns_empty_not_bare_name(self):
+        """A provider with no entry in MODELS must return '' not the bare name.
+
+        The bare provider name is not a valid model string (runtime requires
+        ``provider/model``).  The caller is responsible for prompting the user.
+        """
+        result = _get_default_model("unknown-future-provider")
+        assert result == "", (
+            "_get_default_model must return '' for unknown providers, "
+            f"not the bare name; got {result!r}"
+        )

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -260,9 +260,7 @@ class TestModelValidation:
     def _is_valid_model(self, model: str, selected: str = "openai") -> bool:
         """Replicate the wizard's partition-based validation predicate."""
         provider, separator, model_name = model.partition("/")
-        return bool(
-            separator and provider == selected and model_name and "/" not in model_name
-        )
+        return bool(separator and provider == selected and model_name)
 
     def test_trailing_slash_rejected(self):
         """'openai/' must be rejected — empty model segment after the slash."""
@@ -274,6 +272,15 @@ class TestModelValidation:
         """'openai/gpt-4o' and similar well-formed strings must pass."""
         assert self._is_valid_model("openai/gpt-4o")
         assert self._is_valid_model("openai/gpt-3.5-turbo")
+
+    def test_nested_model_accepted(self):
+        """Nested slash identifiers like openrouter/deepseek/deepseek-v4-pro must pass."""
+        assert self._is_valid_model(
+            "openrouter/deepseek/deepseek-v4-pro", selected="openrouter"
+        ), "OpenRouter nested model identifiers must be accepted"
+        assert self._is_valid_model(
+            "requesty/openai/gpt-4o-mini", selected="requesty"
+        ), "Requesty nested model identifiers must be accepted"
 
     def test_bare_provider_rejected(self):
         """Bare provider name without a slash must be rejected."""

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -252,3 +252,37 @@ class TestGetDefaultModel:
             "_get_default_model must return '' for unknown providers, "
             f"not the bare name; got {result!r}"
         )
+
+
+class TestModelValidation:
+    """Test model string validation used in the wizard input loop."""
+
+    def _is_valid_model(self, model: str, selected: str = "openai") -> bool:
+        """Replicate the wizard's partition-based validation predicate."""
+        provider, separator, model_name = model.partition("/")
+        return bool(
+            separator and provider == selected and model_name and "/" not in model_name
+        )
+
+    def test_trailing_slash_rejected(self):
+        """'openai/' must be rejected — empty model segment after the slash."""
+        assert not self._is_valid_model("openai/"), (
+            "trailing slash with no model name must not pass validation"
+        )
+
+    def test_valid_model_accepted(self):
+        """'openai/gpt-4o' and similar well-formed strings must pass."""
+        assert self._is_valid_model("openai/gpt-4o")
+        assert self._is_valid_model("openai/gpt-3.5-turbo")
+
+    def test_bare_provider_rejected(self):
+        """Bare provider name without a slash must be rejected."""
+        assert not self._is_valid_model("openai")
+
+    def test_wrong_provider_rejected(self):
+        """A valid model string for the *wrong* provider must be rejected."""
+        assert not self._is_valid_model("anthropic/claude-3", selected="openai")
+
+    def test_leading_slash_rejected(self):
+        """/gpt-4o (no provider) must be rejected."""
+        assert not self._is_valid_model("/gpt-4o")

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from gptme.cli.onboard import (
     _detect_providers,
     _get_default_model,
@@ -130,7 +132,7 @@ class TestDetectProviders:
 
     @patch(
         "gptme.cli.onboard.list_available_providers",
-        side_effect=RuntimeError("token file corrupted"),
+        side_effect=OSError("permission denied"),
     )
     def test_oauth_lookup_failure_logs_warning(self, _mock_providers, caplog):
         """OAuth credential lookup failures emit a warning rather than silently passing."""
@@ -145,6 +147,18 @@ class TestDetectProviders:
         messages = " ".join(r.message for r in caplog.records)
         assert "OAuth credential check failed" in messages
         assert "gptme auth" in messages
+
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        side_effect=RuntimeError("token file corrupted"),
+    )
+    def test_unexpected_oauth_lookup_error_propagates(self, _mock_providers):
+        """Programming errors in credential enumeration are not swallowed."""
+        with (
+            patch("gptme.config.get_config", return_value=_mock_empty_config()),
+            pytest.raises(RuntimeError, match="token file corrupted"),
+        ):
+            _detect_providers()
 
 
 class TestTestProvider:
@@ -203,6 +217,15 @@ class TestTestProvider:
         messages = " ".join(r.message for r in caplog.records)
         assert "OAuth credential check failed" in messages
         assert "gptme auth openai-subscription" in messages
+
+    @patch(
+        "gptme.cli.onboard.list_available_providers",
+        side_effect=RuntimeError("token file corrupted"),
+    )
+    def test_unexpected_oauth_error_in_test_provider_propagates(self, _mock_providers):
+        """Programming errors in _test_provider OAuth lookup are not swallowed."""
+        with pytest.raises(RuntimeError, match="token file corrupted"):
+            _test_provider("openai-subscription")
 
 
 class TestShowProviderStatus:

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -189,12 +189,20 @@ class TestTestProvider:
         "gptme.cli.onboard.list_available_providers",
         side_effect=ValueError("malformed credentials"),
     )
-    def test_oauth_lookup_failure_in_test_provider(self, _mock_providers):
-        """Credential lookup failure in _test_provider returns (False, message)."""
-        is_valid, message = _test_provider("openai-subscription")
+    def test_oauth_lookup_failure_in_test_provider(self, _mock_providers, caplog):
+        """Lookup failure is distinct from missing credentials and is logged."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="gptme.cli.onboard"):
+            is_valid, message = _test_provider("openai-subscription")
 
         assert not is_valid
-        assert "Not authenticated" in message
+        assert "Could not read OAuth credentials" in message
+        assert "malformed credentials" in message
+        assert "Not authenticated" not in message
+        messages = " ".join(r.message for r in caplog.records)
+        assert "OAuth credential check failed" in messages
+        assert "gptme auth openai-subscription" in messages
 
 
 class TestShowProviderStatus:


### PR DESCRIPTION
## Problem

`gptme-onboard --check` reports `openai-subscription` and `grok-subscription` as not configured even when their OAuth token files exist. On an OAuth-only install it exits 1 with “No API keys detected”, despite the runtime and `gptme-doctor` recognizing the credentials.

## Fix

- Reuse `list_available_providers()` for OAuth detection, matching runtime/doctor behavior.
- Treat detected OAuth credentials as configured without trying API-key validation.
- Give the provider-specific `gptme auth <provider>` hint when credentials are absent.

## Verification

- `poetry run pytest tests/test_onboard.py -q` — 24 passed
- `ruff check gptme/cli/onboard.py tests/test_onboard.py`
- `ruff format --check gptme/cli/onboard.py tests/test_onboard.py`
- Reproduced `gptme-onboard --check` before the patch with an OAuth-only temp HOME: exit 1 / not configured. After the patch: exit 0 / `openai-subscription` configured.

**2026-09-07 trim**: dropped a smuggled `.github/workflows/test.yml` hunk (`playwright install chromium` → `chromium-headless-shell`) — a sensitive CI-path change with no relation to onboarding. Reverted cleanly; the diff is now just `gptme/cli/onboard.py` and `tests/test_onboard.py`.
