### PR TITLE
fix: decode editable install file URLs

### DIFF
--- a/gptme/info.py
+++ b/gptme/info.py
@@ -15,6 +15,7 @@ import shutil
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.request import url2pathname
 
 from .__version__ import __version__
 from .dirs import get_logs_dir
@@ -57,6 +58,13 @@ _INTERNAL_EXTRAS = {"all", "eval", "pyinstaller"}
 
 # Cache for parsed extras
 _EXTRAS_CACHE: list[ExtraInfo] | None = None
+
+
+def _file_url_to_path(url: str) -> str | None:
+    """Convert an absolute ``file://`` URL from package metadata to a path."""
+    if not url.startswith("file://"):
+        return None
+    return url2pathname(url[7:])
 
 
 def _load_toml_data(pyproject_path: Path) -> dict:
@@ -156,8 +164,8 @@ def _parse_extras_from_metadata() -> list[ExtraInfo]:
                 dir_info = url_data.get("dir_info", {})
                 if dir_info.get("editable"):
                     src_url = url_data.get("url", "")
-                    if src_url.startswith("file://"):
-                        src_dir = Path(src_url[7:])
+                    if src_path := _file_url_to_path(src_url):
+                        src_dir = Path(src_path)
                         pyproject = src_dir / "pyproject.toml"
                         if pyproject.exists():
                             return _parse_extras_from_pyproject(pyproject)
@@ -266,8 +274,7 @@ def get_install_info() -> InstallInfo:
                 data = json.loads(direct_url_text)
                 editable = data.get("dir_info", {}).get("editable", False)
                 url = data.get("url", "")
-                if url.startswith("file://"):
-                    path = url[7:]  # Strip file://
+                path = _file_url_to_path(url)
         except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError):
             pass
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -453,10 +453,12 @@ class TestGetInstallInfo:
         assert info.path == "/home/user/dev/gptme"
 
     @patch("gptme.info.importlib.metadata.distribution")
-    def test_editable_install_decodes_file_url(self, mock_dist_fn):
+    def test_editable_install_decodes_file_url(self, mock_dist_fn, tmp_path):
+        source_dir = tmp_path / "gptme checkout"
+        source_dir.mkdir()
         url_json = json.dumps(
             {
-                "url": "file:///home/user/dev/gptme%20checkout",
+                "url": source_dir.as_uri(),
                 "dir_info": {"editable": True},
             }
         )
@@ -466,7 +468,7 @@ class TestGetInstallInfo:
 
         info = get_install_info()
 
-        assert info.path == "/home/user/dev/gptme checkout"
+        assert info.path == str(source_dir)
 
     @patch("gptme.info.importlib.metadata.distribution")
     def test_path_distribution_not_editable(self, mock_dist_fn):

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -230,6 +230,29 @@ class TestParseExtrasFromMetadata:
         assert result == []
 
     @patch("gptme.info.importlib.metadata.distribution")
+    def test_editable_fallback_decodes_file_url(self, mock_dist, tmp_path):
+        source_dir = tmp_path / "gptme checkout"
+        source_dir.mkdir()
+        (source_dir / "pyproject.toml").write_text(
+            '[project.optional-dependencies]\nbrowser = ["playwright"]\n',
+            encoding="utf-8",
+        )
+        dist = self._make_mock_dist(extras=[], requires=[])
+        dist.read_text.return_value = json.dumps(
+            {
+                "url": source_dir.as_uri(),
+                "dir_info": {"editable": True},
+            }
+        )
+        mock_dist.return_value = dist
+
+        result = _parse_extras_from_metadata()
+
+        assert [(extra.name, extra.packages) for extra in result] == [
+            ("browser", ["playwright"])
+        ]
+
+    @patch("gptme.info.importlib.metadata.distribution")
     def test_none_extras(self, mock_dist):
         dist = MagicMock()
         dist.metadata = MagicMock()
@@ -428,6 +451,22 @@ class TestGetInstallInfo:
         info = get_install_info()
         assert info.editable is True
         assert info.path == "/home/user/dev/gptme"
+
+    @patch("gptme.info.importlib.metadata.distribution")
+    def test_editable_install_decodes_file_url(self, mock_dist_fn):
+        url_json = json.dumps(
+            {
+                "url": "file:///home/user/dev/gptme%20checkout",
+                "dir_info": {"editable": True},
+            }
+        )
+        mock_dist_fn.return_value = self._mock_dist(
+            installer="uv", direct_url_json=url_json
+        )
+
+        info = get_install_info()
+
+        assert info.path == "/home/user/dev/gptme checkout"
 
     @patch("gptme.info.importlib.metadata.distribution")
     def test_path_distribution_not_editable(self, mock_dist_fn):


### PR DESCRIPTION
## Summary

Editable-install metadata stores source locations as `file://` URLs. Reading the URL by slicing off the scheme leaves percent escapes such as `%20` in the reported path and can prevent `pyproject.toml` discovery.

Convert local file URLs with `url2pathname` in both install-info and extras-detection paths.

## Testing

- Added regression tests for decoded install reporting and editable-source extras discovery when the checkout path contains an encoded space.
- `pytest --noconftest tests/test_info.py::TestParseExtrasFromMetadata::test_editable_fallback_decodes_file_url tests/test_info.py::TestGetInstallInfo::test_editable_install_decodes_file_url -q`
- Ruff check, formatting check, and `compileall` on both changed files.