### PR TITLE
feat(tools): add deterministic claim verification

### DIFF
--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -1,0 +1,547 @@
+"""Deterministically verify factual claims before acting."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import cast
+
+from ..message import Message
+from .base import Parameter, ToolFormat, ToolFunction, ToolSpec, ToolUse
+
+PROCESS_VERIFICATION_ENV = "GPTME_VERIFY_ALLOW_PROCESS"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+TEST_TIMEOUT_SECONDS = 60.0
+MAX_FILE_BYTES = 2_000_000
+MAX_OUTPUT_CHARS = 4000
+CLAIM_TYPES = (
+    "file_exists",
+    "file_not_exists",
+    "contains",
+    "not_contains",
+    "shell",
+    "env_var",
+    "test_passes",
+    "test_fails",
+)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    ok: bool
+    claim_type: str
+    target: str
+    expected: str | None = None
+    actual: str | None = None
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    def __str__(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+def _result(
+    ok: bool,
+    claim_type: str,
+    target: str,
+    reason: str,
+    *,
+    expected: str | None = None,
+    actual: str | None = None,
+) -> VerificationResult:
+    return VerificationResult(ok, claim_type, target, expected, actual, reason)
+
+
+def _display_path(path: str) -> str:
+    return str(Path(path).expanduser().resolve(strict=False))
+
+
+def verify_file_exists(path: str) -> VerificationResult:
+    """Verify that a filesystem path exists."""
+    if not path:
+        return _result(False, "file_exists", "", "path is required")
+    display = _display_path(path)
+    ok = Path(path).expanduser().exists()
+    reason = f"path exists: {display}" if ok else f"path does not exist: {display}"
+    return _result(ok, "file_exists", path, reason, actual=display)
+
+
+def verify_file_not_exists(path: str) -> VerificationResult:
+    """Verify that a filesystem path does not exist."""
+    if not path:
+        return _result(False, "file_not_exists", "", "path is required")
+    display = _display_path(path)
+    ok = not Path(path).expanduser().exists()
+    reason = f"path is absent: {display}" if ok else f"path exists: {display}"
+    return _result(ok, "file_not_exists", path, reason, actual=display)
+
+
+def _read_text(
+    path: str, claim_type: str
+) -> tuple[str | None, VerificationResult | None]:
+    if not path:
+        return None, _result(False, claim_type, "", "path is required")
+
+    candidate = Path(path).expanduser()
+    display = _display_path(path)
+    if not candidate.exists():
+        return None, _result(
+            False, claim_type, path, f"path does not exist: {display}", actual=display
+        )
+    if not candidate.is_file():
+        return None, _result(
+            False, claim_type, path, f"path is not a file: {display}", actual=display
+        )
+
+    try:
+        size = candidate.stat().st_size
+        if size > MAX_FILE_BYTES:
+            return None, _result(
+                False,
+                claim_type,
+                path,
+                f"file is too large to scan ({size} bytes, max {MAX_FILE_BYTES})",
+                actual=f"{size} bytes",
+            )
+        return candidate.read_text(encoding="utf-8"), None
+    except UnicodeDecodeError:
+        return None, _result(False, claim_type, path, "file is not valid UTF-8 text")
+    except OSError as exc:
+        return None, _result(False, claim_type, path, f"could not read file: {exc}")
+
+
+def _match_line(text: str, match: re.Match[str]) -> str:
+    line_no = text.count("\n", 0, match.start()) + 1
+    line_start = text.rfind("\n", 0, match.start()) + 1
+    line_end = text.find("\n", match.end())
+    line = text[line_start : len(text) if line_end == -1 else line_end].strip()
+    return f"line {line_no}: {line[:197] + '...' if len(line) > 200 else line}"
+
+
+def _verify_pattern(
+    path: str,
+    pattern: str,
+    *,
+    claim_type: str,
+    want_found: bool,
+) -> VerificationResult:
+    if not pattern:
+        return _result(False, claim_type, path, "pattern is required")
+
+    text, error = _read_text(path, claim_type)
+    if error is not None:
+        return error
+    assert text is not None
+
+    try:
+        match = re.search(pattern, text, flags=re.MULTILINE)
+    except re.error as exc:
+        return _result(
+            False,
+            claim_type,
+            path,
+            f"invalid regex pattern: {exc}",
+            expected=pattern,
+        )
+
+    found = match is not None
+    ok = found is want_found
+    actual = _match_line(text, match) if match else "not found"
+    reason = "pattern was found" if found else "pattern was not found"
+    return _result(ok, claim_type, path, reason, expected=pattern, actual=actual)
+
+
+def verify_contains(path: str, pattern: str) -> VerificationResult:
+    """Verify that a UTF-8 text file contains a regex pattern."""
+    return _verify_pattern(path, pattern, claim_type="contains", want_found=True)
+
+
+def verify_not_contains(path: str, pattern: str) -> VerificationResult:
+    """Verify that a UTF-8 text file does not contain a regex pattern."""
+    return _verify_pattern(path, pattern, claim_type="not_contains", want_found=False)
+
+
+def _process_verification_allowed() -> bool:
+    if os.environ.get(PROCESS_VERIFICATION_ENV, "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
+    try:
+        from . import has_tool
+    except Exception:
+        return False
+    return has_tool("shell")
+
+
+def _timeout(value: str | float | int | None, default: float) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.1, min(parsed, 300.0))
+
+
+def _short(value: str) -> str:
+    value = value.strip()
+    if len(value) <= MAX_OUTPUT_CHARS:
+        return value
+    return value[: MAX_OUTPUT_CHARS - 15] + "\n...[truncated]"
+
+
+def _process_output(result: subprocess.CompletedProcess[str]) -> str:
+    parts = [_short(result.stdout or "")]
+    if result.stderr:
+        parts.append(f"stderr:\n{_short(result.stderr)}")
+    return "\n".join(part for part in parts if part) or "<no output>"
+
+
+def _run_process(
+    args: list[str],
+    *,
+    claim_type: str,
+    target: str,
+    timeout: float,
+    expected: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str] | None, VerificationResult | None]:
+    if not _process_verification_allowed():
+        return None, _result(
+            False,
+            claim_type,
+            target,
+            f"process checks require the shell tool or {PROCESS_VERIFICATION_ENV}=1",
+            expected=expected,
+        )
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, check=False, timeout=timeout
+        ), None
+    except FileNotFoundError as exc:
+        return None, _result(
+            False, claim_type, target, f"executable not found: {exc.filename}"
+        )
+    except subprocess.TimeoutExpired:
+        return None, _result(
+            False, claim_type, target, f"command timed out after {timeout:g}s"
+        )
+    except OSError as exc:
+        return None, _result(False, claim_type, target, f"could not run command: {exc}")
+
+
+def verify_shell(
+    command: str,
+    expected: str | None = None,
+    timeout: str | float | int | None = None,
+) -> VerificationResult:
+    """Verify that a process command exits 0 and optionally prints expected text."""
+    if not command:
+        return _result(False, "shell", "", "command is required")
+    try:
+        args = shlex.split(command)
+    except ValueError as exc:
+        return _result(
+            False,
+            "shell",
+            command,
+            f"could not parse command: {exc}",
+            expected=expected,
+        )
+    if not args:
+        return _result(False, "shell", command, "command is empty", expected=expected)
+
+    proc, error = _run_process(
+        args,
+        claim_type="shell",
+        target=command,
+        timeout=_timeout(timeout, DEFAULT_TIMEOUT_SECONDS),
+        expected=expected,
+    )
+    if error is not None:
+        return error
+    assert proc is not None
+
+    actual = _process_output(proc)
+    if proc.returncode != 0:
+        return _result(
+            False,
+            "shell",
+            command,
+            f"command exited {proc.returncode}",
+            expected=expected,
+            actual=actual,
+        )
+    if expected is not None and expected not in proc.stdout:
+        return _result(
+            False,
+            "shell",
+            command,
+            "expected text was not present in stdout",
+            expected=expected,
+            actual=actual,
+        )
+    return _result(
+        True, "shell", command, "command exited 0", expected=expected, actual=actual
+    )
+
+
+def verify_env_var(name: str, expected: str | None = None) -> VerificationResult:
+    """Verify that an environment variable is set, optionally to an exact value."""
+    if not name:
+        return _result(False, "env_var", "", "environment variable name is required")
+    if name not in os.environ:
+        return _result(
+            False,
+            "env_var",
+            name,
+            "environment variable is not set",
+            expected=expected,
+            actual="<unset>",
+        )
+    if expected is not None and os.environ[name] != expected:
+        return _result(
+            False,
+            "env_var",
+            name,
+            "environment variable is set but does not match expected value",
+            expected=expected,
+            actual="<set but different>",
+        )
+    return _result(
+        True,
+        "env_var",
+        name,
+        "environment variable is set",
+        expected=expected,
+        actual="<set>",
+    )
+
+
+def _verify_pytest(
+    test_spec: str,
+    claim_type: str,
+    timeout: str | float | int | None,
+) -> VerificationResult:
+    if not test_spec:
+        return _result(False, claim_type, "", "test_spec is required")
+    if test_spec.startswith("-"):
+        return _result(
+            False, claim_type, test_spec, "test_spec must not start with '-'"
+        )
+
+    proc, error = _run_process(
+        [sys.executable, "-m", "pytest", test_spec],
+        claim_type=claim_type,
+        target=test_spec,
+        timeout=_timeout(timeout, TEST_TIMEOUT_SECONDS),
+    )
+    if error is not None:
+        return error
+    assert proc is not None
+
+    actual = f"exit_code={proc.returncode}\n{_process_output(proc)}"
+    if claim_type == "test_passes":
+        reason = "pytest passed" if proc.returncode == 0 else "pytest did not pass"
+        return _result(
+            proc.returncode == 0, claim_type, test_spec, reason, actual=actual
+        )
+    if proc.returncode == 1:
+        return _result(
+            True, claim_type, test_spec, "pytest failed as expected", actual=actual
+        )
+    reason = (
+        "pytest passed unexpectedly"
+        if proc.returncode == 0
+        else f"pytest exited {proc.returncode}, not the expected failure code 1"
+    )
+    return _result(False, claim_type, test_spec, reason, actual=actual)
+
+
+def verify_test_passes(
+    test_spec: str, timeout: str | float | int | None = None
+) -> VerificationResult:
+    """Verify that a pytest test spec passes."""
+    return _verify_pytest(test_spec, "test_passes", timeout)
+
+
+def verify_test_fails(
+    test_spec: str, timeout: str | float | int | None = None
+) -> VerificationResult:
+    """Verify that a pytest test spec fails with pytest exit code 1."""
+    return _verify_pytest(test_spec, "test_fails", timeout)
+
+
+def verify_claim(
+    claim_type: str,
+    target: str | None = None,
+    expected: str | None = None,
+    pattern: str | None = None,
+    command: str | None = None,
+    name: str | None = None,
+    timeout: str | float | int | None = None,
+) -> VerificationResult:
+    """Dispatch a deterministic claim verification by type."""
+    kind = claim_type.strip()
+    if kind == "file_exists":
+        return verify_file_exists(target or "")
+    if kind == "file_not_exists":
+        return verify_file_not_exists(target or "")
+    if kind == "contains":
+        return verify_contains(
+            target or "", pattern if pattern is not None else expected or ""
+        )
+    if kind == "not_contains":
+        return verify_not_contains(
+            target or "", pattern if pattern is not None else expected or ""
+        )
+    if kind == "shell":
+        return verify_shell(command or target or "", expected=expected, timeout=timeout)
+    if kind == "env_var":
+        return verify_env_var(name or target or "", expected=expected)
+    if kind == "test_passes":
+        return verify_test_passes(target or "", timeout=timeout)
+    if kind == "test_fails":
+        return verify_test_fails(target or "", timeout=timeout)
+    return _result(
+        False,
+        kind or "unknown",
+        target or command or name or "",
+        f"unknown claim_type: {kind}",
+    )
+
+
+def _extract_values(
+    code: str | None, args: list[str] | None, kwargs: dict[str, str] | None
+) -> dict[str, str]:
+    if kwargs:
+        return dict(kwargs)
+    if args:
+        return {
+            "type": args[0],
+            **({"target": args[1]} if len(args) >= 2 else {}),
+            **({"expected": " ".join(args[2:])} if len(args) >= 3 else {}),
+        }
+    if not code or not code.strip():
+        return {}
+
+    stripped = code.strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        return {str(key): str(value) for key, value in parsed.items()}
+
+    values: dict[str, str] = {}
+    for raw_line in stripped.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        delimiter = ":" if ":" in line else "=" if "=" in line else None
+        if delimiter:
+            key, value = line.split(delimiter, 1)
+            values[key.strip()] = value.strip()
+    return values
+
+
+def execute_verify_claim(
+    code: str | None, args: list[str] | None, kwargs: dict[str, str] | None
+) -> Message:
+    values = _extract_values(code, args, kwargs)
+    result = verify_claim(
+        claim_type=values.get("claim_type") or values.get("type") or "",
+        target=values.get("target"),
+        expected=values.get("expected"),
+        pattern=values.get("pattern"),
+        command=values.get("command"),
+        name=values.get("name"),
+        timeout=values.get("timeout"),
+    )
+    return Message("system", str(result))
+
+
+def examples(tool_format: str) -> str:
+    output_format = cast(ToolFormat, tool_format)
+    file_call = ToolUse(
+        "verify", [], "type: file_exists\ntarget: gptme/tools/bash.py"
+    ).to_output(output_format)
+    shell_call = ToolUse(
+        "verify",
+        [],
+        "type: shell\ncommand: git branch --show-current\nexpected: master",
+    ).to_output(output_format)
+    return f"""
+> User: Verify that a file exists before patching it
+> Assistant:
+{file_call}
+> System: {{ "ok": true, "claim_type": "file_exists" }}
+
+> User: Verify the current branch
+> Assistant:
+{shell_call}
+> System: {{ "ok": true, "claim_type": "shell" }}
+""".strip()
+
+
+_PARAMS = [
+    Parameter(
+        "type",
+        'Literal["file_exists", "file_not_exists", "contains", "not_contains", '
+        '"shell", "env_var", "test_passes", "test_fails"]',
+        "Claim type to verify.",
+        required=True,
+    ),
+    Parameter("target", "string", "Path, env var name, command, or pytest spec."),
+    Parameter("pattern", "string", "Regex for contains/not_contains checks."),
+    Parameter("expected", "string", "Expected stdout text or env var value."),
+    Parameter("command", "string", "Read-only process command for shell checks."),
+    Parameter("name", "string", "Environment variable name for env_var checks."),
+    Parameter("timeout", "number", "Process timeout in seconds, capped at 300."),
+]
+
+
+tool = ToolSpec(
+    name="verify_claim",
+    desc="Deterministically verify factual claims before taking action",
+    instructions=f"""
+Use before risky actions when a factual premise might be stale or hallucinated.
+Prefer native claim types over shell checks.
+
+Claim types: {", ".join(CLAIM_TYPES)}.
+For contains/not_contains, set target to a UTF-8 text file and pattern to a regex.
+For env_var, set name or target; actual values are never echoed.
+For shell, set command; expected is optional stdout text.
+For test_passes/test_fails, set target to a pytest test spec.
+
+Process checks only run when the shell tool is loaded or
+{PROCESS_VERIFICATION_ENV}=1 is set, so verify_claim cannot widen a restricted
+session's execution capability.
+""".strip(),
+    instructions_format={
+        "tool": (
+            "Verify a factual premise. Required: type. Optional: target, pattern, "
+            "expected, command, name, timeout. Claim types: "
+            + ", ".join(CLAIM_TYPES)
+            + f". Process checks require shell or {PROCESS_VERIFICATION_ENV}=1."
+        )
+    },
+    examples=examples,
+    functions=[ToolFunction.from_callable(verify_claim)],
+    execute=execute_verify_claim,
+    block_types=["verify"],
+    parameters=_PARAMS,
+    hints=frozenset({"read-only"}),
+)
+
+__doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -345,7 +345,13 @@ def _run_process(
                 subprocess.TimeoutExpired,
             ):
                 proc.kill()
-            proc.communicate()
+            # Drain the pipes with a short timeout so a still-alive process
+            # cannot block the caller indefinitely if termination failed.
+            try:
+                proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
             return None, _result(
                 False, claim_type, target, f"command timed out after {timeout:g}s"
             )

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -347,11 +347,23 @@ def _run_process(
                 proc.kill()
             # Drain the pipes with a short timeout so a still-alive process
             # cannot block the caller indefinitely if termination failed.
+            # proc.communicate() blocks until stdin/stdout/stderr hit EOF, which
+            # a surviving descendant that inherited the pipe write-ends can
+            # delay indefinitely, so it must never be the unbounded fallback.
             try:
                 proc.communicate(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
-                proc.communicate()
+                # Wait for the direct child only — wait() is bounded and returns
+                # once the child exits, unlike communicate() which waits for pipe
+                # EOF. If the child is still alive after the grace window, close
+                # the pipes so the caller cannot be blocked regardless.
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    for stream in (proc.stdout, proc.stderr):
+                        if stream is not None:
+                            stream.close()
             return None, _result(
                 False, claim_type, target, f"command timed out after {timeout:g}s"
             )

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -16,8 +18,10 @@ from ..message import Message
 from .base import Parameter, ToolFormat, ToolFunction, ToolSpec, ToolUse
 
 PROCESS_VERIFICATION_ENV = "GPTME_VERIFY_ALLOW_PROCESS"
+_READ_ROOT_ENV = "GPTME_READ_ROOT"
 DEFAULT_TIMEOUT_SECONDS = 30.0
 TEST_TIMEOUT_SECONDS = 60.0
+REGEX_TIMEOUT_SECONDS = 5.0
 MAX_FILE_BYTES = 2_000_000
 MAX_OUTPUT_CHARS = 4000
 CLAIM_TYPES = (
@@ -84,25 +88,69 @@ def verify_file_not_exists(path: str) -> VerificationResult:
     return _result(ok, "file_not_exists", path, reason, actual=display)
 
 
+def _check_path_containment(
+    resolved: Path, claim_type: str, raw: str
+) -> VerificationResult | None:
+    """Return an error result if resolved is outside the permitted read root."""
+    read_root_val = os.environ.get(_READ_ROOT_ENV)
+    if read_root_val:
+        read_root = Path(read_root_val)
+        if not read_root.is_absolute():
+            return _result(
+                False,
+                claim_type,
+                raw,
+                f"{_READ_ROOT_ENV} must be an absolute path: {read_root_val!r}",
+            )
+        try:
+            resolved.relative_to(read_root)
+        except ValueError:
+            return _result(
+                False,
+                claim_type,
+                raw,
+                f"path traversal denied: {resolved} is outside read root {read_root}",
+            )
+    elif not resolved.is_absolute():
+        # Relative paths must stay within cwd
+        cwd = Path.cwd().resolve()
+        try:
+            resolved.relative_to(cwd)
+        except ValueError:
+            return _result(
+                False,
+                claim_type,
+                raw,
+                f"path traversal denied: {resolved} is outside current directory {cwd}",
+            )
+    return None
+
+
 def _read_text(
     path: str, claim_type: str
 ) -> tuple[str | None, VerificationResult | None]:
     if not path:
         return None, _result(False, claim_type, "", "path is required")
 
-    candidate = Path(path).expanduser()
-    display = _display_path(path)
-    if not candidate.exists():
+    expanded = Path(path).expanduser()
+    resolved = expanded.resolve()
+    display = str(resolved)
+
+    containment_error = _check_path_containment(resolved, claim_type, path)
+    if containment_error is not None:
+        return None, containment_error
+
+    if not resolved.exists():
         return None, _result(
             False, claim_type, path, f"path does not exist: {display}", actual=display
         )
-    if not candidate.is_file():
+    if not resolved.is_file():
         return None, _result(
             False, claim_type, path, f"path is not a file: {display}", actual=display
         )
 
     try:
-        size = candidate.stat().st_size
+        size = resolved.stat().st_size
         if size > MAX_FILE_BYTES:
             return None, _result(
                 False,
@@ -111,7 +159,7 @@ def _read_text(
                 f"file is too large to scan ({size} bytes, max {MAX_FILE_BYTES})",
                 actual=f"{size} bytes",
             )
-        return candidate.read_text(encoding="utf-8"), None
+        return resolved.read_text(encoding="utf-8"), None
     except UnicodeDecodeError:
         return None, _result(False, claim_type, path, "file is not valid UTF-8 text")
     except OSError as exc:
@@ -142,7 +190,19 @@ def _verify_pattern(
     assert text is not None
 
     try:
-        match = re.search(pattern, text, flags=re.MULTILINE)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(re.search, pattern, text, re.MULTILINE)
+            try:
+                match = future.result(timeout=REGEX_TIMEOUT_SECONDS)
+            except concurrent.futures.TimeoutError:
+                return _result(
+                    False,
+                    claim_type,
+                    path,
+                    f"regex match timed out after {REGEX_TIMEOUT_SECONDS:g}s "
+                    f"(pattern may cause catastrophic backtracking)",
+                    expected=pattern,
+                )
     except re.error as exc:
         return _result(
             False,
@@ -225,16 +285,29 @@ def _run_process(
             expected=expected,
         )
     try:
-        return subprocess.run(
-            args, capture_output=True, text=True, check=False, timeout=timeout
-        ), None
+        proc = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,  # own process group so timeout kills all descendants
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            # Kill the entire process group to clean up descendants
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                proc.kill()
+            proc.communicate()
+            return None, _result(
+                False, claim_type, target, f"command timed out after {timeout:g}s"
+            )
+        return subprocess.CompletedProcess(args, proc.returncode, stdout, stderr), None
     except FileNotFoundError as exc:
         return None, _result(
             False, claim_type, target, f"executable not found: {exc.filename}"
-        )
-    except subprocess.TimeoutExpired:
-        return None, _result(
-            False, claim_type, target, f"command timed out after {timeout:g}s"
         )
     except OSError as exc:
         return None, _result(False, claim_type, target, f"could not run command: {exc}")
@@ -282,12 +355,12 @@ def verify_shell(
             expected=expected,
             actual=actual,
         )
-    if expected is not None and expected not in proc.stdout:
+    if expected is not None and expected not in actual:
         return _result(
             False,
             "shell",
             command,
-            "expected text was not present in stdout",
+            "expected text was not present in output",
             expected=expected,
             actual=actual,
         )
@@ -515,18 +588,27 @@ tool = ToolSpec(
     name="verify_claim",
     desc="Deterministically verify factual claims before taking action",
     instructions=f"""
-Use before risky actions when a factual premise might be stale or hallucinated.
-Prefer native claim types over shell checks.
+Use this tool before taking risky actions when a premise might be stale or wrong.
+A failed verification is a signal to re-investigate, not to proceed anyway.
 
-Claim types: {", ".join(CLAIM_TYPES)}.
-For contains/not_contains, set target to a UTF-8 text file and pattern to a regex.
-For env_var, set name or target; actual values are never echoed.
-For shell, set command; expected is optional stdout text.
-For test_passes/test_fails, set target to a pytest test spec.
+**When to use it**
+- Before patching a file: verify it exists and contains the symbol you expect.
+- Before running a build step: verify environment variables and tool availability.
+- After shipping a change: verify the test that previously failed now passes.
 
-Process checks only run when the shell tool is loaded or
-{PROCESS_VERIFICATION_ENV}=1 is set, so verify_claim cannot widen a restricted
-session's execution capability.
+**Pick the narrowest claim type**
+- Prefer `file_exists` / `contains` / `env_var` over `shell` — they have no
+  process-spawning overhead and work in restricted sessions.
+- Use `shell` only when no native type covers the check; keep commands read-only.
+- Use `test_passes` / `test_fails` to gate on a specific pytest outcome.
+- Process checks (`shell`, `test_passes`, `test_fails`) require the shell tool
+  or {PROCESS_VERIFICATION_ENV}=1 — they will not silently widen a restricted
+  session.
+
+**Acting on results**
+- `ok: true` — proceed with confidence; the premise is confirmed.
+- `ok: false` — stop; re-read `reason` and `actual` to understand what changed,
+  then repair the state before retrying the action.
 """.strip(),
     instructions_format={
         "tool": (

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -72,8 +72,12 @@ def verify_file_exists(path: str) -> VerificationResult:
     """Verify that a filesystem path exists."""
     if not path:
         return _result(False, "file_exists", "", "path is required")
-    display = _display_path(path)
-    ok = Path(path).expanduser().exists()
+    resolved = Path(path).expanduser().resolve(strict=False)
+    containment_error = _check_path_containment(resolved, "file_exists", path)
+    if containment_error is not None:
+        return containment_error
+    display = str(resolved)
+    ok = resolved.exists()
     reason = f"path exists: {display}" if ok else f"path does not exist: {display}"
     return _result(ok, "file_exists", path, reason, actual=display)
 
@@ -82,8 +86,12 @@ def verify_file_not_exists(path: str) -> VerificationResult:
     """Verify that a filesystem path does not exist."""
     if not path:
         return _result(False, "file_not_exists", "", "path is required")
-    display = _display_path(path)
-    ok = not Path(path).expanduser().exists()
+    resolved = Path(path).expanduser().resolve(strict=False)
+    containment_error = _check_path_containment(resolved, "file_not_exists", path)
+    if containment_error is not None:
+        return containment_error
+    display = str(resolved)
+    ok = not resolved.exists()
     reason = f"path is absent: {display}" if ok else f"path exists: {display}"
     return _result(ok, "file_not_exists", path, reason, actual=display)
 
@@ -189,21 +197,24 @@ def _verify_pattern(
         return error
     assert text is not None
 
+    # Run regex in a separate thread so we can enforce a wall-clock timeout.
+    # shutdown(wait=False) ensures a catastrophic match doesn't block the caller.
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(re.search, pattern, text, re.MULTILINE)
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(re.search, pattern, text, re.MULTILINE)
-            try:
-                match = future.result(timeout=REGEX_TIMEOUT_SECONDS)
-            except concurrent.futures.TimeoutError:
-                return _result(
-                    False,
-                    claim_type,
-                    path,
-                    f"regex match timed out after {REGEX_TIMEOUT_SECONDS:g}s "
-                    f"(pattern may cause catastrophic backtracking)",
-                    expected=pattern,
-                )
+        match = future.result(timeout=REGEX_TIMEOUT_SECONDS)
+    except concurrent.futures.TimeoutError:
+        executor.shutdown(wait=False)
+        return _result(
+            False,
+            claim_type,
+            path,
+            f"regex match timed out after {REGEX_TIMEOUT_SECONDS:g}s "
+            f"(pattern may cause catastrophic backtracking)",
+            expected=pattern,
+        )
     except re.error as exc:
+        executor.shutdown(wait=False)
         return _result(
             False,
             claim_type,
@@ -211,6 +222,7 @@ def _verify_pattern(
             f"invalid regex pattern: {exc}",
             expected=pattern,
         )
+    executor.shutdown(wait=False)
 
     found = match is not None
     ok = found is want_found
@@ -297,7 +309,11 @@ def _run_process(
         except subprocess.TimeoutExpired:
             # Kill the entire process group to clean up descendants
             try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                pgid = os.getpgid(proc.pid)
+                os.killpg(pgid, signal.SIGKILL)
+            except AttributeError:
+                # os.getpgid/os.killpg not available on Windows
+                proc.kill()
             except (ProcessLookupError, OSError):
                 proc.kill()
             proc.communicate()
@@ -355,12 +371,12 @@ def verify_shell(
             expected=expected,
             actual=actual,
         )
-    if expected is not None and expected not in actual:
+    if expected is not None and expected not in (proc.stdout or ""):
         return _result(
             False,
             "shell",
             command,
-            "expected text was not present in output",
+            "expected text was not present in stdout",
             expected=expected,
             actual=actual,
         )

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import json
+import multiprocessing
 import os
 import re
 import shlex
@@ -119,8 +119,10 @@ def _check_path_containment(
                 raw,
                 f"path traversal denied: {resolved} is outside read root {read_root}",
             )
-    elif not resolved.is_absolute():
-        # Relative paths must stay within cwd
+    elif not Path(raw).is_absolute():
+        # A relative input that resolves outside cwd is a traversal attempt
+        # (e.g. "../../etc/passwd"). Check the ORIGINAL raw input — not `resolved`,
+        # which is always absolute — so explicit absolute paths are still allowed.
         cwd = Path.cwd().resolve()
         try:
             resolved.relative_to(cwd)
@@ -174,12 +176,19 @@ def _read_text(
         return None, _result(False, claim_type, path, f"could not read file: {exc}")
 
 
-def _match_line(text: str, match: re.Match[str]) -> str:
-    line_no = text.count("\n", 0, match.start()) + 1
-    line_start = text.rfind("\n", 0, match.start()) + 1
-    line_end = text.find("\n", match.end())
+def _match_line(text: str, start: int, end: int) -> str:
+    line_no = text.count("\n", 0, start) + 1
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
     line = text[line_start : len(text) if line_end == -1 else line_end].strip()
     return f"line {line_no}: {line[:197] + '...' if len(line) > 200 else line}"
+
+
+def _regex_search_span(args: tuple[str, str, int]) -> tuple[int, int] | None:
+    """Run re.search in a subprocess worker; returns span or None (picklable)."""
+    pattern, text, flags = args
+    match = re.search(pattern, text, flags)
+    return (match.start(), match.end()) if match else None
 
 
 def _verify_pattern(
@@ -197,36 +206,44 @@ def _verify_pattern(
         return error
     assert text is not None
 
-    # Run regex in a separate thread so we can enforce a wall-clock timeout.
-    # shutdown(wait=False) ensures a catastrophic match doesn't block the caller.
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(re.search, pattern, text, re.MULTILINE)
+    # Validate the pattern before spawning a worker to catch re.error cheaply.
     try:
-        match = future.result(timeout=REGEX_TIMEOUT_SECONDS)
-    except concurrent.futures.TimeoutError:
-        executor.shutdown(wait=False)
-        return _result(
-            False,
-            claim_type,
-            path,
-            f"regex match timed out after {REGEX_TIMEOUT_SECONDS:g}s "
-            f"(pattern may cause catastrophic backtracking)",
-            expected=pattern,
-        )
+        re.compile(pattern)
     except re.error as exc:
-        executor.shutdown(wait=False)
         return _result(
-            False,
-            claim_type,
-            path,
-            f"invalid regex pattern: {exc}",
-            expected=pattern,
+            False, claim_type, path, f"invalid regex pattern: {exc}", expected=pattern
         )
-    executor.shutdown(wait=False)
 
-    found = match is not None
+    # Run regex in a subprocess so we can terminate a catastrophic match.
+    # A thread cannot be interrupted mid-re.search; a process can be killed.
+    ctx = multiprocessing.get_context("fork" if sys.platform != "win32" else "spawn")
+    with ctx.Pool(processes=1) as pool:
+        async_result = pool.apply_async(
+            _regex_search_span, ((pattern, text, re.MULTILINE),)
+        )
+        try:
+            span = async_result.get(timeout=REGEX_TIMEOUT_SECONDS)
+        except multiprocessing.TimeoutError:
+            pool.terminate()
+            pool.join()
+            return _result(
+                False,
+                claim_type,
+                path,
+                f"regex match timed out after {REGEX_TIMEOUT_SECONDS:g}s "
+                f"(pattern may cause catastrophic backtracking)",
+                expected=pattern,
+            )
+        except Exception as exc:
+            pool.terminate()
+            pool.join()
+            return _result(
+                False, claim_type, path, f"regex error: {exc}", expected=pattern
+            )
+
+    found = span is not None
     ok = found is want_found
-    actual = _match_line(text, match) if match else "not found"
+    actual = _match_line(text, span[0], span[1]) if span is not None else "not found"
     reason = "pattern was found" if found else "pattern was not found"
     return _result(ok, claim_type, path, reason, expected=pattern, actual=actual)
 
@@ -307,14 +324,26 @@ def _run_process(
         try:
             stdout, stderr = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            # Kill the entire process group to clean up descendants
+            # Kill the entire process tree to clean up descendants.
             try:
-                pgid = os.getpgid(proc.pid)
-                os.killpg(pgid, signal.SIGKILL)
-            except AttributeError:
-                # os.getpgid/os.killpg not available on Windows
-                proc.kill()
-            except (ProcessLookupError, OSError):
+                if sys.platform == "win32":
+                    # taskkill /F /T kills the process and all its descendants.
+                    subprocess.run(
+                        ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=5,
+                        check=False,
+                    )
+                else:
+                    pgid = os.getpgid(proc.pid)
+                    os.killpg(pgid, signal.SIGKILL)
+            except (
+                OSError,
+                ProcessLookupError,
+                FileNotFoundError,
+                subprocess.TimeoutExpired,
+            ):
                 proc.kill()
             proc.communicate()
             return None, _result(

--- a/gptme/tools/verify.py
+++ b/gptme/tools/verify.py
@@ -588,27 +588,15 @@ tool = ToolSpec(
     name="verify_claim",
     desc="Deterministically verify factual claims before taking action",
     instructions=f"""
-Use this tool before taking risky actions when a premise might be stale or wrong.
+Use before taking risky actions when a premise might be stale or wrong.
 A failed verification is a signal to re-investigate, not to proceed anyway.
 
-**When to use it**
-- Before patching a file: verify it exists and contains the symbol you expect.
-- Before running a build step: verify environment variables and tool availability.
-- After shipping a change: verify the test that previously failed now passes.
+Prefer `file_exists`/`contains`/`env_var` over `shell` (no process overhead).
+Use `shell` only when no native type covers it; keep commands read-only.
+Use `test_passes`/`test_fails` to gate on a specific pytest outcome.
+Process checks require {PROCESS_VERIFICATION_ENV}=1 or the shell tool.
 
-**Pick the narrowest claim type**
-- Prefer `file_exists` / `contains` / `env_var` over `shell` — they have no
-  process-spawning overhead and work in restricted sessions.
-- Use `shell` only when no native type covers the check; keep commands read-only.
-- Use `test_passes` / `test_fails` to gate on a specific pytest outcome.
-- Process checks (`shell`, `test_passes`, `test_fails`) require the shell tool
-  or {PROCESS_VERIFICATION_ENV}=1 — they will not silently widen a restricted
-  session.
-
-**Acting on results**
-- `ok: true` — proceed with confidence; the premise is confirmed.
-- `ok: false` — stop; re-read `reason` and `actual` to understand what changed,
-  then repair the state before retrying the action.
+`ok: true` — proceed. `ok: false` — stop; re-read `reason` and `actual`.
 """.strip(),
     instructions_format={
         "tool": (

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -25,8 +25,8 @@ def test_get_prompt_full():
 
     # TODO: lower this significantly by selectively removing examples from the full prompt
     # Note: Ceiling bumped to 8100 to accommodate memory tool instructions
-    # Note: verify_claim tool added ~320 tokens (2026-09-05)
-    assert 500 < len_tokens(combined_content, "gpt-4") < 8500 + user_config_size
+    # Note: verify_claim tool added ~320 tokens (2026-09-05); ceiling bumped to 8600
+    assert 500 < len_tokens(combined_content, "gpt-4") < 8600 + user_config_size
 
 
 def test_get_prompt_short():
@@ -36,7 +36,8 @@ def test_get_prompt_short():
 
     # TODO: make the short prompt shorter
     # Note: prompt size grows with new tools/features; bump ceiling as needed
-    assert 400 < len_tokens(combined_content, "gpt-4") < 4500 + user_config_size
+    # Note: verify_claim tool added tokens; ceiling bumped to 4700
+    assert 400 < len_tokens(combined_content, "gpt-4") < 4700 + user_config_size
 
 
 def test_get_prompt_custom():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -25,7 +25,8 @@ def test_get_prompt_full():
 
     # TODO: lower this significantly by selectively removing examples from the full prompt
     # Note: Ceiling bumped to 8100 to accommodate memory tool instructions
-    assert 500 < len_tokens(combined_content, "gpt-4") < 8100 + user_config_size
+    # Note: verify_claim tool added ~320 tokens (2026-09-05)
+    assert 500 < len_tokens(combined_content, "gpt-4") < 8500 + user_config_size
 
 
 def test_get_prompt_short():

--- a/tests/test_tools_verify.py
+++ b/tests/test_tools_verify.py
@@ -1,0 +1,175 @@
+"""Tests for the verify_claim tool."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING
+
+from gptme.tools import clear_tools, get_available_tools, set_tools
+from gptme.tools.base import ToolSpec
+from gptme.tools.verify import (
+    PROCESS_VERIFICATION_ENV,
+    execute_verify_claim,
+    tool,
+    verify_claim,
+    verify_contains,
+    verify_env_var,
+    verify_file_exists,
+    verify_file_not_exists,
+    verify_not_contains,
+    verify_shell,
+    verify_test_fails,
+    verify_test_passes,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_verify_tool_is_discoverable() -> None:
+    available = get_available_tools(include_mcp=False)
+
+    assert tool in available
+    assert any(candidate.name == "verify_claim" for candidate in available)
+
+
+def test_verify_file_exists_branches(tmp_path: Path) -> None:
+    present = tmp_path / "present.txt"
+    missing = tmp_path / "missing.txt"
+    present.write_text("ok\n", encoding="utf-8")
+
+    assert verify_file_exists(str(present)).ok is True
+    assert verify_file_exists(str(missing)).ok is False
+    assert verify_file_not_exists(str(missing)).ok is True
+    assert verify_file_not_exists(str(present)).ok is False
+
+
+def test_verify_contains_branches(tmp_path: Path) -> None:
+    path = tmp_path / "sample.txt"
+    path.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    found = verify_contains(str(path), "alp.a")
+    missing = verify_contains(str(path), "gamma")
+    absent = verify_not_contains(str(path), "gamma")
+    present = verify_not_contains(str(path), "beta")
+
+    assert found.ok is True
+    assert found.actual == "line 1: alpha"
+    assert missing.ok is False
+    assert absent.ok is True
+    assert present.ok is False
+    assert present.actual == "line 2: beta"
+
+
+def test_verify_contains_reports_invalid_regex(tmp_path: Path) -> None:
+    path = tmp_path / "sample.txt"
+    path.write_text("alpha\n", encoding="utf-8")
+
+    result = verify_contains(str(path), "[")
+
+    assert result.ok is False
+    assert "invalid regex pattern" in result.reason
+
+
+def test_verify_env_var_does_not_leak_actual_value(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VERIFY_TEST_SECRET", "actual-secret")
+
+    present = verify_env_var("GPTME_VERIFY_TEST_SECRET")
+    mismatch = verify_env_var("GPTME_VERIFY_TEST_SECRET", expected="expected-secret")
+    missing = verify_env_var("GPTME_VERIFY_TEST_MISSING")
+
+    assert present.ok is True
+    assert present.actual == "<set>"
+    assert mismatch.ok is False
+    assert mismatch.actual == "<set but different>"
+    assert "actual-secret" not in str(mismatch)
+    assert missing.ok is False
+    assert missing.actual == "<unset>"
+
+
+def test_process_checks_require_shell_tool_or_env_opt_in(monkeypatch) -> None:
+    clear_tools()
+    monkeypatch.delenv(PROCESS_VERIFICATION_ENV, raising=False)
+
+    result = verify_shell("echo hello")
+
+    assert result.ok is False
+    assert "process checks require" in result.reason
+
+
+def test_process_checks_allowed_when_shell_tool_loaded(monkeypatch) -> None:
+    clear_tools()
+    monkeypatch.delenv(PROCESS_VERIFICATION_ENV, raising=False)
+    set_tools([ToolSpec(name="shell", desc="Run shell commands")])
+
+    command = f"{sys.executable} -c \"print('ready')\""
+    result = verify_shell(command, expected="ready")
+
+    assert result.ok is True
+    assert result.actual == "ready"
+
+
+def test_verify_shell_expected_stdout_mismatch(monkeypatch) -> None:
+    monkeypatch.setenv(PROCESS_VERIFICATION_ENV, "1")
+    command = f"{sys.executable} -c \"print('ready')\""
+
+    result = verify_shell(command, expected="missing")
+
+    assert result.ok is False
+    assert result.reason == "expected text was not present in stdout"
+    assert result.actual == "ready"
+
+
+def test_verify_pytest_passes_and_fails(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv(PROCESS_VERIFICATION_ENV, "1")
+    passing = tmp_path / "test_passing.py"
+    failing = tmp_path / "test_failing.py"
+    passing.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    failing.write_text("def test_bad():\n    assert False\n", encoding="utf-8")
+
+    assert verify_test_passes(str(passing)).ok is True
+    assert verify_test_fails(str(failing)).ok is True
+    assert verify_test_passes(str(failing)).ok is False
+    assert verify_test_fails(str(passing)).ok is False
+
+
+def test_verify_claim_dispatches_alias_fields(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VERIFY_ALIAS_ENV", "yes")
+    path = tmp_path / "sample.txt"
+    path.write_text("needle\n", encoding="utf-8")
+
+    assert verify_claim("contains", target=str(path), expected="needle").ok is True
+    assert verify_claim("env_var", target="GPTME_VERIFY_ALIAS_ENV").ok is True
+    assert verify_claim("unknown", target=str(path)).ok is False
+
+
+def test_execute_verify_claim_returns_json(tmp_path: Path) -> None:
+    path = tmp_path / "sample.txt"
+    path.write_text("needle\n", encoding="utf-8")
+
+    message = execute_verify_claim(
+        None,
+        None,
+        {"type": "file_exists", "target": str(path)},
+    )
+    payload = json.loads(message.content)
+
+    assert message.role == "system"
+    assert payload["ok"] is True
+    assert payload["claim_type"] == "file_exists"
+
+
+def test_execute_verify_claim_parses_key_value_block(tmp_path: Path) -> None:
+    path = tmp_path / "sample.txt"
+    path.write_text("needle\n", encoding="utf-8")
+
+    message = execute_verify_claim(
+        f"type: contains\ntarget: {path}\npattern: needle",
+        None,
+        None,
+    )
+    payload = json.loads(message.content)
+
+    assert payload["ok"] is True
+    assert payload["claim_type"] == "contains"

--- a/tests/test_tools_verify.py
+++ b/tests/test_tools_verify.py
@@ -117,7 +117,7 @@ def test_verify_shell_expected_stdout_mismatch(monkeypatch) -> None:
     result = verify_shell(command, expected="missing")
 
     assert result.ok is False
-    assert result.reason == "expected text was not present in output"
+    assert result.reason == "expected text was not present in stdout"
     assert "ready" in (result.actual or "")
 
 

--- a/tests/test_tools_verify.py
+++ b/tests/test_tools_verify.py
@@ -117,8 +117,8 @@ def test_verify_shell_expected_stdout_mismatch(monkeypatch) -> None:
     result = verify_shell(command, expected="missing")
 
     assert result.ok is False
-    assert result.reason == "expected text was not present in stdout"
-    assert result.actual == "ready"
+    assert result.reason == "expected text was not present in output"
+    assert "ready" in (result.actual or "")
 
 
 def test_verify_pytest_passes_and_fails(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_tools_verify.py
+++ b/tests/test_tools_verify.py
@@ -62,6 +62,16 @@ def test_verify_contains_branches(tmp_path: Path) -> None:
     assert present.actual == "line 2: beta"
 
 
+def test_path_traversal_via_relative_is_denied(tmp_path: Path, monkeypatch) -> None:
+    # A relative path that resolves outside cwd must be blocked even though
+    # `resolved` is always absolute — the old `elif not resolved.is_absolute()`
+    # was unreachable. This test ensures the fix holds.
+    monkeypatch.chdir(tmp_path)
+    result = verify_file_exists("../../etc/passwd")
+    assert result.ok is False
+    assert "path traversal denied" in result.reason
+
+
 def test_verify_contains_reports_invalid_regex(tmp_path: Path) -> None:
     path = tmp_path / "sample.txt"
     path.write_text("alpha\n", encoding="utf-8")

--- a/tests/test_tools_verify.py
+++ b/tests/test_tools_verify.py
@@ -183,3 +183,63 @@ def test_execute_verify_claim_parses_key_value_block(tmp_path: Path) -> None:
 
     assert payload["ok"] is True
     assert payload["claim_type"] == "contains"
+
+
+def test_run_process_timeout_cleanup_is_bounded(monkeypatch) -> None:
+    """Timeout cleanup must never fall through to an unbounded communicate().
+
+    Regression guard for the Greptile P1: when the first bounded communicate()
+    times out (a surviving descendant retains the pipe write-ends, so EOF never
+    arrives), the cleanup must not call communicate() with no timeout, which
+    would block the caller indefinitely. It should bound every wait and close
+    the pipes instead.
+    """
+    import subprocess
+    from types import SimpleNamespace
+
+    from gptme.tools import verify as verify_mod
+
+    monkeypatch.setenv(PROCESS_VERIFICATION_ENV, "1")
+
+    calls: list[tuple] = []
+
+    class FakeProc:
+        pid = 12345
+        returncode = None
+        stdout = SimpleNamespace(close=lambda: calls.append(("close_stdout", None)))
+        stderr = SimpleNamespace(close=lambda: calls.append(("close_stderr", None)))
+
+        def communicate(self, timeout=None):
+            calls.append(("communicate", timeout))
+            raise subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+        def kill(self):
+            calls.append(("kill", None))
+
+        def wait(self, timeout=None):
+            calls.append(("wait", timeout))
+            raise subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+    def fake_popen(*args, **kwargs):
+        calls.append(("popen", None))
+        return FakeProc()
+
+    monkeypatch.setattr(verify_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        verify_mod.subprocess, "TimeoutExpired", subprocess.TimeoutExpired
+    )
+
+    result = verify_mod.verify_shell("sleep 10", timeout=0.1)
+
+    assert result.ok is False
+    assert "timed out" in result.reason
+    # Every communicate()/wait() on the proc must carry an explicit timeout.
+    for name, arg in calls:
+        if name in ("communicate", "wait"):
+            assert arg is not None, f"unbounded {name}() with no timeout in {calls}"
+    # The unbounded fallback communicate() must never be reached.
+    assert not any(name == "communicate" and arg is None for name, arg in calls)
+    # Cleanup should close the pipe streams once waits are exhausted.
+    assert ("close_stdout", None) in calls
+    assert ("close_stderr", None) in calls
+    # (monkeypatch restores the module-level Popen automatically after the test.)


### PR DESCRIPTION
## Summary
- add an explicit `verify_claim` tool for deterministic premise checks
- support file existence, regex contains/not_contains, env var, shell, and pytest pass/fail claims
- gate process-based checks behind an already-loaded shell tool or `GPTME_VERIFY_ALLOW_PROCESS=1` so restricted sessions are not widened accidentally
- add focused coverage for success/failure branches, discovery, JSON output, and env value redaction

## Tests
- `env -u VIRTUAL_ENV uv run python -m pytest tests/test_tools_verify.py -q`
- `env -u VIRTUAL_ENV uv run ruff check gptme/tools/verify.py tests/test_tools_verify.py`
- `env -u VIRTUAL_ENV uv run mypy gptme/tools/verify.py tests/test_tools_verify.py`
- `env -u VIRTUAL_ENV make lint`

Full `env -u VIRTUAL_ENV make typecheck` currently fails in this fresh worktree because optional dependencies/stubs are missing from the local Poetry env (`prometheus_client`, `torch`, `transformers`, `sentence_transformers`, `sphinx`, `pypdf`, `textual`, `flask_compress`, `werkzeug`). The touched files pass targeted mypy.