### PR TITLE
fix(cli): handle capabilities output write errors

### DIFF
--- a/gptme/cli/cmd_capabilities.py
+++ b/gptme/cli/cmd_capabilities.py
@@ -74,6 +74,11 @@ def capabilities(
 
     text = render(snapshot, fmt, show_all=show_all)
     if output:
-        output.write_text(text, encoding="utf-8")
+        try:
+            output.write_text(text, encoding="utf-8")
+        except OSError as exc:
+            raise click.ClickException(
+                f"Unable to write capabilities output to {output}: {exc.strerror}"
+            ) from exc
     else:
         click.echo(text, nl=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ import gptme.cli.main as cli
 import gptme.constants
 import gptme.tools.browser
 from gptme.__version__ import __version__
+from gptme.cli.cmd_capabilities import capabilities
 from gptme.message import Message
 from gptme.tools import ToolUse
 
@@ -154,6 +155,20 @@ def test_help_no_external_subcommands_section_when_none_installed(
     result = runner.invoke(cli.main, ["--help"])
     assert result.exit_code == 0
     assert "Installed external subcommands" not in result.output
+
+
+def test_capabilities_output_missing_parent_exits_cleanly(tmp_path: Path):
+    """A bad --output path should print a clean CLI error, not a traceback."""
+    runner = CliRunner()
+    out = tmp_path / "missing" / "capabilities.txt"
+
+    result = runner.invoke(capabilities, ["--output", str(out)])
+
+    assert result.exit_code != 0
+    combined_output = result.output + (result.stderr or "")
+    assert "Unable to write capabilities output" in combined_output
+    assert "Traceback" not in combined_output
+    assert "FileNotFoundError" not in combined_output
 
 
 def test_version(runner: CliRunner):


### PR DESCRIPTION
## Problem

Dogfooding the `gptme capabilities --output PATH` CLI surface found a raw traceback when the output path's parent directory does not exist:

```text
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/nonexistent-dir/out.json'
```

This is a CLI bad-input boundary bug: a user-facing command should report a clean error, not a Python traceback.

## Fix

Wrap the `Path.write_text()` call for `--output` in `click.ClickException`, preserving the concrete path and OS error string while using Click's normal error formatting.

## Verification

- `uv run -- python -m pytest tests/test_cli.py::test_capabilities_output_missing_parent_exits_cleanly -q`
- `uv run ruff check gptme/cli/cmd_capabilities.py tests/test_cli.py`
- `uv run ruff format --check gptme/cli/cmd_capabilities.py tests/test_cli.py`
- Manual repro now exits non-zero with no traceback:
  `uv run gptme capabilities --output /tmp/nonexistent-dir/out.json`

Part of the dogfood fresh gptme product surface sweep.
