### PR TITLE
fix(security): strip repo-local execution sinks from git inspection commands

### DIFF
--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -10,7 +10,7 @@ from ..dirs import get_cc_memory_file
 from ..message import Message
 from ..util.context import md_codeblock
 from ..util.context_dedup import _content_hash
-from ..util.git_cmd import GIT_CMD
+from ..util.git_cmd import git_inspect_cmd
 from ..util.tree import get_tree_output
 from . import AGENT_FILES, DEFAULT_CONTEXT_FILES, _loaded_agent_files_var
 from .context_cmd import get_project_context_cmd_output
@@ -73,7 +73,7 @@ def _get_git_status(workspace: Path) -> str | None:
     try:
         # Check if in a git repo
         result = subprocess.run(
-            [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
+            [*git_inspect_cmd(), "rev-parse", "--is-inside-work-tree"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -85,7 +85,7 @@ def _get_git_status(workspace: Path) -> str | None:
 
         # Get current branch
         branch_result = subprocess.run(
-            [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
+            [*git_inspect_cmd(), "rev-parse", "--abbrev-ref", "HEAD"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -98,7 +98,7 @@ def _get_git_status(workspace: Path) -> str | None:
 
         # Get short status (modified/untracked files)
         status_result = subprocess.run(
-            [GIT_CMD, "status", "--short"],
+            [*git_inspect_cmd(), "status", "--short"],
             check=False,
             cwd=workspace,
             capture_output=True,

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -28,7 +28,7 @@ from .gh import (
     parse_github_url,
     transform_github_url,
 )
-from .git_cmd import GIT_CMD
+from .git_cmd import git_inspect_cmd
 from .uri import URI
 
 logger = logging.getLogger(__name__)
@@ -336,7 +336,7 @@ def git_branch() -> str | None:
     if shutil.which("git"):
         try:
             branch = subprocess.run(
-                [GIT_CMD, "rev-parse", "--abbrev-ref", "HEAD"],
+                [*git_inspect_cmd(), "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -397,7 +397,7 @@ def git_status() -> str | None:
     """Get git status if in a repository."""
     try:
         git_status = subprocess.run(
-            [GIT_CMD, "status"],
+            [*git_inspect_cmd(), "status"],
             capture_output=True,
             text=True,
             check=True,
@@ -459,7 +459,7 @@ def get_changed_files() -> list[Path]:
     """Returns a list of changed files based on git diff."""
     try:
         p = subprocess.run(
-            [GIT_CMD, "diff", "--name-only", "HEAD"],
+            [*git_inspect_cmd(), "diff", "--name-only", "HEAD"],
             capture_output=True,
             text=True,
             check=True,
@@ -817,7 +817,13 @@ def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
     try:
         # Try git ls-files first (respects .gitignore, lists tracked + untracked)
         result = subprocess.run(
-            [GIT_CMD, "ls-files", "--cached", "--others", "--exclude-standard"],
+            [
+                *git_inspect_cmd(),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            ],
             cwd=path,
             capture_output=True,
             text=True,

--- a/gptme/util/git_cmd.py
+++ b/gptme/util/git_cmd.py
@@ -36,3 +36,36 @@ def _resolve_git_cmd() -> str:
 
 
 GIT_CMD: str = _resolve_git_cmd()
+
+# Repository-local execution sinks that fire during index refresh:
+# core.fsmonitor (FS event hook), core.sshCommand (used by some transports
+# during ls-files), diff.external (external diff tool), core.hooksPath
+# (pre-commit / post-checkout hooks).  Setting them to empty / /dev/null
+# suppresses execution without affecting the output of read-only commands.
+_INSPECT_SAFE_FLAGS: list[str] = [
+    "-c",
+    "core.fsmonitor=",
+    "-c",
+    "core.sshCommand=cat",
+    "-c",
+    "diff.external=",
+    "-c",
+    "core.hooksPath=/dev/null",
+]
+
+
+def git_inspect_cmd() -> list[str]:
+    """Return a git invocation prefix that strips repo-local execution sinks.
+
+    Use this instead of ``[GIT_CMD]`` for read-only context-gathering calls
+    (``git status``, ``git diff --name-only``, ``git ls-files``).  Write paths
+    and trusted-workspace hooks (commit, push) should keep using ``GIT_CMD``
+    directly so legitimate user hooks are not suppressed.
+
+    Defends against the GitSpawn class of attack (Manifold Security, 2026-09-01):
+    a repository delivered as a directory (zip, USB, shared folder) may carry a
+    ``.git/config`` that sets ``core.fsmonitor`` or similar to an attacker
+    payload; index-refresh triggered by ``git status`` executes that payload
+    before any approval prompt.
+    """
+    return [GIT_CMD, *_INSPECT_SAFE_FLAGS]

--- a/gptme/util/tree.py
+++ b/gptme/util/tree.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 
 from ..config import get_config
-from .git_cmd import GIT_CMD
+from .git_cmd import git_inspect_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
     in_git_repo = False
     try:
         result = subprocess.run(
-            [GIT_CMD, "rev-parse", "--is-inside-work-tree"],
+            [*git_inspect_cmd(), "rev-parse", "--is-inside-work-tree"],
             check=False,
             cwd=workspace,
             capture_output=True,
@@ -39,7 +39,7 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
 
     # git and tree --gitignore require a git repo; ls works anywhere
     git_methods: dict[TreeMethod, list[str]] = {
-        "git": [GIT_CMD, "ls-files", "--exclude-standard"],
+        "git": [*git_inspect_cmd(), "ls-files", "--exclude-standard"],
         "tree": ["tree", "-fi", "--gitignore", "."],
     }
     non_git_methods: dict[TreeMethod, list[str]] = {

--- a/tests/test_git_cmd_resolver.py
+++ b/tests/test_git_cmd_resolver.py
@@ -1,8 +1,10 @@
-"""Tests for the Git executable resolver (hardening against Windows CWD hijack)."""
+"""Tests for the Git executable resolver (hardening against CWD hijack and GitSpawn)."""
 
 import importlib
 import os
+import platform
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -95,3 +97,137 @@ def test_git_cmd_cwd_filtered_from_path():
         ) != os.path.normcase(os.path.abspath(cwd)), (
             f"GIT_CMD={result!r} still points into CWD after filtering"
         )
+
+
+# ---------------------------------------------------------------------------
+# GitSpawn hardening — repo-local execution sink suppression
+# ---------------------------------------------------------------------------
+
+
+def test_git_inspect_cmd_structure():
+    """git_inspect_cmd() returns a list with GIT_CMD and all four sink-suppression flags."""
+    from gptme.util.git_cmd import GIT_CMD, git_inspect_cmd
+
+    cmd = git_inspect_cmd()
+    assert isinstance(cmd, list)
+    assert len(cmd) >= 1
+    assert cmd[0] == GIT_CMD
+
+    joined = " ".join(cmd)
+    for sink in (
+        "core.fsmonitor=",
+        "core.sshCommand=",
+        "diff.external=",
+        "core.hooksPath=",
+    ):
+        assert sink in joined, f"git_inspect_cmd() is missing -{sink!r} suppression"
+
+
+def _find_real_git() -> str | None:
+    """Locate the real git binary, skipping any local wrapper at ~/bin/git."""
+    import os
+
+    # Skip any directory that resolves to $HOME/bin — those may hold wrapper scripts.
+    home_bin = os.path.expanduser("~/bin")
+    safe_path = os.pathsep.join(
+        d for d in os.get_exec_path() if os.path.abspath(d) != os.path.abspath(home_bin)
+    )
+    return shutil.which("git", path=safe_path)
+
+
+_REAL_GIT = _find_real_git()
+
+
+@pytest.mark.skipif(
+    _REAL_GIT is None,
+    reason="real git binary not available outside ~/bin",
+)
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="fsmonitor shell-script test is Unix-only",
+)
+def test_git_inspect_cmd_suppresses_fsmonitor(tmp_path):
+    """git_inspect_cmd() flags prevent core.fsmonitor from firing during inspection.
+
+    Regression guard for the GitSpawn attack class (Manifold Security, 2026-09-01):
+    a repository-local core.fsmonitor hook can be set to an arbitrary command that
+    executes when git refreshes its index (triggered by git status / git ls-files).
+    git_inspect_cmd() passes -c core.fsmonitor= to disable it.
+
+    Uses the real git binary (not any ~/bin wrapper) so the test is pure and does
+    not depend on wrapper behaviour.
+    """
+    from gptme.util.git_cmd import _INSPECT_SAFE_FLAGS
+
+    assert _REAL_GIT is not None  # for type-checker
+    real_git = _REAL_GIT
+
+    # Isolated HOME keeps gpg-sign, global hooks, and other user config out of the test.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    git_env = {**os.environ, "HOME": str(fake_home), "GIT_CONFIG_NOSYSTEM": "1"}
+
+    repo = tmp_path / "testrepo"
+    repo.mkdir()
+    marker = tmp_path / "fsmonitor_fired"
+    fsmonitor_script = tmp_path / "fsmonitor.sh"
+    fsmonitor_script.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    fsmonitor_script.chmod(0o755)
+
+    # Set up a minimal git repo using the real git binary (no wrappers)
+    for cmd in [
+        [real_git, "init", str(repo)],
+        [real_git, "-C", str(repo), "config", "user.email", "test@example.com"],
+        [real_git, "-C", str(repo), "config", "user.name", "Test"],
+    ]:
+        subprocess.run(cmd, check=True, capture_output=True, env=git_env)
+    (repo / "file.txt").write_text("hello")
+    subprocess.run(
+        [real_git, "-C", str(repo), "add", "."],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+    subprocess.run(
+        [real_git, "-C", str(repo), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+
+    # Plant the fsmonitor hook in the repo's local config
+    subprocess.run(
+        [real_git, "-C", str(repo), "config", "core.fsmonitor", str(fsmonitor_script)],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+
+    # Baseline: bare git DOES fire the hook (validates the test setup is sound)
+    marker.unlink(missing_ok=True)
+    subprocess.run(
+        [real_git, "status", "--short"],
+        cwd=repo,
+        capture_output=True,
+        timeout=5,
+        env=git_env,
+        check=False,
+    )
+    if not marker.exists():
+        pytest.skip(
+            "core.fsmonitor did not fire with bare git on this platform — test setup inconclusive"
+        )
+
+    # With sink-suppression flags the hook must NOT fire
+    marker.unlink(missing_ok=True)
+    subprocess.run(
+        [real_git, *_INSPECT_SAFE_FLAGS, "status", "--short"],
+        cwd=repo,
+        capture_output=True,
+        timeout=5,
+        env=git_env,
+        check=False,
+    )
+    assert not marker.exists(), (
+        "core.fsmonitor fired despite -c core.fsmonitor= flag — sink suppression is broken"
+    )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,6 +1,14 @@
 from gptme.util.git_cmd import GIT_CMD
 
 
+def _is_git_cmd(cmd: list, subcommand: str) -> bool:
+    """Check if cmd is a git invocation with the given subcommand.
+
+    Accounts for -c flag prefixes inserted by git_inspect_cmd().
+    """
+    return isinstance(cmd, list) and cmd[0] == GIT_CMD and subcommand in cmd
+
+
 def test_get_tree_output_different_methods(tmp_path, monkeypatch):
     """Test that get_tree_output works with different tree methods."""
     from typing import cast
@@ -17,7 +25,7 @@ def test_get_tree_output_different_methods(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -40,11 +48,7 @@ def test_get_tree_output_different_methods(tmp_path, monkeypatch):
                 "tree" in cmd for cmd in called_commands if isinstance(cmd, list)
             )
         elif method == "git":
-            assert any(
-                cmd[:2] == [GIT_CMD, "ls-files"]
-                for cmd in called_commands
-                if isinstance(cmd, list)
-            )
+            assert any(_is_git_cmd(cmd, "ls-files") for cmd in called_commands)
         elif method == "ls":
             assert any(
                 cmd[:2] == ["ls", "-R"]
@@ -77,7 +81,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -86,7 +90,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
             return subprocess.CompletedProcess(
                 args[0], returncode=127, stdout="", stderr="tree: command not found"
             )
-        if isinstance(args[0], list) and args[0][:2] == [GIT_CMD, "ls-files"]:
+        if _is_git_cmd(args[0], "ls-files"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="file1.txt\nfile2.txt", stderr=""
             )
@@ -100,10 +104,7 @@ def test_get_tree_output_fallback_when_tree_missing(tmp_path, monkeypatch):
 
     # Verify git ls-files was called after tree failed
     assert any(isinstance(cmd, list) and cmd[0] == "tree" for cmd in called_commands)
-    assert any(
-        isinstance(cmd, list) and cmd[:2] == [GIT_CMD, "ls-files"]
-        for cmd in called_commands
-    )
+    assert any(_is_git_cmd(cmd, "ls-files") for cmd in called_commands)
 
 
 def test_get_tree_output_not_git_repo(tmp_path, monkeypatch):
@@ -120,7 +121,7 @@ def test_get_tree_output_not_git_repo(tmp_path, monkeypatch):
 
     def mock_run(*args, **kwargs):
         called_commands.append(args[0])
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=1, stdout="", stderr="not a git repository"
             )
@@ -139,10 +140,7 @@ def test_get_tree_output_not_git_repo(tmp_path, monkeypatch):
     assert any(
         isinstance(cmd, list) and cmd[:2] == ["ls", "-R"] for cmd in called_commands
     )
-    assert not any(
-        isinstance(cmd, list) and cmd[:2] == [GIT_CMD, "ls-files"]
-        for cmd in called_commands
-    )
+    assert not any(_is_git_cmd(cmd, "ls-files") for cmd in called_commands)
 
 
 def test_get_tree_output_command_fails(tmp_path, monkeypatch):
@@ -156,7 +154,7 @@ def test_get_tree_output_command_fails(tmp_path, monkeypatch):
     import subprocess
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -182,7 +180,7 @@ def test_get_tree_output_too_long(tmp_path, monkeypatch):
     import subprocess
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )
@@ -213,7 +211,7 @@ def test_get_tree_output_success(tmp_path, monkeypatch):
     expected_output = "file1.txt\nfile2.txt\nsrc/main.py"
 
     def mock_run(*args, **kwargs):
-        if args[0][:2] == [GIT_CMD, "rev-parse"]:
+        if _is_git_cmd(args[0], "rev-parse"):
             return subprocess.CompletedProcess(
                 args[0], returncode=0, stdout="true", stderr=""
             )


### PR DESCRIPTION
## Summary

Defends against the **GitSpawn** attack class ([Manifold Security, 2026-09-01](https://www.manifold.security/blog/ai-coding-agents-git-hijack)):

- A repository delivered as a directory (zip, USB, shared folder) can carry a `.git/config` that sets `core.fsmonitor`, `diff.external`, `core.sshCommand`, or `core.hooksPath` to an attacker payload.
- When gptme runs `git status` / `git ls-files` to gather workspace context, git refreshes its index and fires those hooks — **before any approval prompt**.
- The existing PATH-hijack fix (gptme#3266, absolute `GIT_CMD`) does **not** cover repo-local config.

## Changes

**New helper** `git_inspect_cmd()` in `gptme/util/git_cmd.py` prepends four `-c` flags to neutralise the known sinks without changing command output:

```python
[GIT_CMD,
 "-c", "core.fsmonitor=",
 "-c", "core.sshCommand=cat",
 "-c", "diff.external=",
 "-c", "core.hooksPath=/dev/null",
]
```

**Updated** three context-gathering paths to use `git_inspect_cmd()` instead of bare `GIT_CMD`:
- `gptme/prompts/workspace.py` — `git status --short`, `rev-parse`
- `gptme/util/context.py` — `git status`, `git diff --name-only HEAD`, `git ls-files`, `rev-parse`
- `gptme/util/tree.py` — `git ls-files`, `rev-parse`

Write-path calls (commit, push, etc.) intentionally keep using bare `GIT_CMD` so legitimate user commit hooks are not suppressed.

**Two new regression tests** in `tests/test_git_cmd_resolver.py`:
- `test_git_inspect_cmd_structure` — verifies all four sink-suppression flags are present
- `test_git_inspect_cmd_suppresses_fsmonitor` — creates a repo with `core.fsmonitor` set to a marker-writing script, confirms the marker is NOT written when using the inspect flags (uses isolated `HOME`/`GIT_CONFIG_NOSYSTEM` to avoid gpg-sign and other global hooks)

## Test plan

- [x] `tests/test_git_cmd_resolver.py` — all 5 tests pass locally (2 Windows-only tests skip as expected)
- [x] Pre-commit hooks (ruff, mypy, prek) pass
- [ ] CI green