### PR TITLE
fix(webui): navigate before server response in new-chat flow

### DIFF
--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -70,6 +70,7 @@ describe('useConversation', () => {
           closeEventStream,
           getConversation: jest.fn(),
           getChatConfig,
+          waitForConversationCreation: jest.fn().mockResolvedValue(undefined),
         }) as any,
       isConnected$: observable(true),
     } as any);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -182,6 +182,9 @@ export function useConversation(conversationId: string, serverId?: string) {
           // and the model selector is stuck on its loading skeleton for the
           // whole life of every newly created conversation.
           try {
+            // Gate on any in-flight background server creation before fetching
+            // config: the config endpoint returns 404 until the PUT completes.
+            await api.waitForConversationCreation(conversationId);
             const chatConfig = await api.getChatConfig(conversationId);
             if (!cancelled) updateConversation(conversationId, { chatConfig });
           } catch (error) {

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -846,7 +846,12 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     const client = new ApiClient('http://127.0.0.1:5700');
     client.setConnected(true);
 
-    await client.createConversationWithPlaceholder('hello', { workspace: '.' });
+    const conversationId = await client.createConversationWithPlaceholder('hello', {
+      workspace: '.',
+    });
+    // Server creation runs in background; await it explicitly so the fetch
+    // mock has been called before we inspect its arguments.
+    await client.waitForConversationCreation(conversationId);
 
     const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
     const body = JSON.parse(request.body as string);
@@ -864,7 +869,8 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     const client = new ApiClient('http://127.0.0.1:5700');
     client.setConnected(true);
 
-    await client.createConversationWithPlaceholder('hello');
+    const conversationId = await client.createConversationWithPlaceholder('hello');
+    await client.waitForConversationCreation(conversationId);
 
     const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
     const body = JSON.parse(request.body as string);
@@ -882,7 +888,7 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     client.setConnected(true);
 
     await client.createConversationWithPlaceholder('hello', { workspace: '.' });
-
+    // initConversation is called synchronously, so no need to await server creation here
     const [, initData] = (conversationsStore.initConversation as jest.Mock).mock.calls[0];
     expect(initData.workspace).toBe('@log');
   });
@@ -897,9 +903,10 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     const client = new ApiClient('http://127.0.0.1:5700');
     client.setConnected(true);
 
-    await client.createConversationWithPlaceholder('hello', {
+    const conversationId = await client.createConversationWithPlaceholder('hello', {
       workspace: '/workspace/project',
     });
+    await client.waitForConversationCreation(conversationId);
 
     const request = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
     const body = JSON.parse(request.body as string);
@@ -919,8 +926,60 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     await client.createConversationWithPlaceholder('hello', {
       workspace: '/home/user/project',
     });
-
+    // initConversation is called synchronously, so no need to await server creation here
     const [, initData] = (conversationsStore.initConversation as jest.Mock).mock.calls[0];
     expect(initData.workspace).toBe('/home/user/project');
+  });
+
+  it('returns the conversation ID before the server responds (no-block navigation)', async () => {
+    // Verify the core UX fix: createConversationWithPlaceholder must return the
+    // conversation ID before the server fetch resolves so that the UI can navigate
+    // to the chat page without waiting for the server round-trip.
+    // The server call starts in the background; the returned promise resolves
+    // immediately with the local ID so the caller can navigate.
+    let fetchResolve!: () => void;
+    let fetchWasCalled = false;
+    global.fetch = jest.fn().mockImplementation(() => {
+      fetchWasCalled = true;
+      return new Promise<Response>((res) => {
+        fetchResolve = () =>
+          res({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: 'ok', session_id: 'session-1' }),
+          } as Response);
+      });
+    });
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    // createConversationWithPlaceholder MUST resolve (return the ID) before the
+    // server fetch promise resolves.  We don't resolve fetchResolve until after
+    // we have the ID, proving navigation can happen without waiting for the server.
+    const idPromise = client.createConversationWithPlaceholder('hello');
+
+    // initConversation is synchronous — must be called before any await.
+    expect(conversationsStore.initConversation).toHaveBeenCalledTimes(1);
+
+    // The idPromise should resolve immediately (before we resolve the fetch).
+    // We collect the ID without resolving the server response first.
+    let conversationId = '';
+    let idResolved = false;
+    idPromise.then((id) => {
+      conversationId = id;
+      idResolved = true;
+    });
+
+    // Flush microtasks — idPromise should be resolved by now.
+    await Promise.resolve();
+    expect(idResolved).toBe(true);
+    expect(conversationId).toMatch(/^chat-/);
+    expect(fetchWasCalled).toBe(true); // fetch started in background
+
+    // Now let the server respond and verify the pending creation settles.
+    fetchResolve();
+    await client.waitForConversationCreation(conversationId);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -325,6 +325,24 @@ export class ApiClient {
   private authCookieSetAt: number | null = null;
   private authCookiePromise: Promise<void> | null = null;
   private _probeNonce = 0;
+  // Tracks in-flight server-side conversation creation so subscribeToEvents
+  // can await server readiness before opening the SSE stream.  This lets
+  // createConversationWithPlaceholder return (and the UI navigate) immediately
+  // while the REST call still completes in the background.
+  private pendingServerCreations = new Map<string, Promise<void>>();
+
+  /**
+   * Resolves when the background server-side creation for a given conversation
+   * is complete (or immediately if no creation is in flight).  Useful for tests
+   * that need to assert on server request details after calling
+   * createConversationWithPlaceholder.
+   */
+  async waitForConversationCreation(conversationId: string): Promise<void> {
+    const pending = this.pendingServerCreations.get(conversationId);
+    if (pending) {
+      await pending;
+    }
+  }
 
   constructor(baseUrl: string = getApiBaseUrl(), authHeader: string | null = null) {
     this.baseUrl = baseUrl;
@@ -721,6 +739,26 @@ export class ApiClient {
     reconnectAttempt = 0
   ): Promise<void> {
     const maxReconnects = 5;
+
+    // If this conversation was just created via createConversationWithPlaceholder,
+    // wait for the background server-side creation to finish before opening the
+    // SSE stream.  Without this the EventSource would hit a 404 because the
+    // conversation doesn't exist on the server yet.
+    const pendingCreation = this.pendingServerCreations.get(conversationId);
+    if (pendingCreation) {
+      // Remove before awaiting: reconnect attempts skip this branch because
+      // the same settled promise resolves immediately anyway.
+      this.pendingServerCreations.delete(conversationId);
+      try {
+        await pendingCreation;
+      } catch (error) {
+        console.error('[ApiClient] Background server creation failed:', error);
+        callbacks.onError(
+          error instanceof Error ? error.message : 'Failed to create conversation on server'
+        );
+        return;
+      }
+    }
 
     // Close any existing event stream for this conversation
     this.closeEventStream(conversationId);
@@ -1302,42 +1340,51 @@ export class ApiClient {
       setTopP(conversationId, options.topP);
     }
 
-    if (options?.pendingFiles?.length) {
-      // When files are attached: create an empty conversation first (no message yet),
-      // upload files, then send ONE complete message with file paths.
-      // This avoids the duplicate-message bug where createConversation sent msg_no_files
-      // and sendMessage sent a second copy of msg_with_files.
-      await this.createConversation(conversationId, [], {
-        chat: {
-          model: options?.model,
-          stream: options?.stream,
-          workspace: requestWorkspace(options?.workspace),
-        },
-      });
-      try {
-        const uploadResult = await this.uploadFiles(conversationId, options.pendingFiles);
-        const filePaths = uploadResult.files.map((f) => f.path);
-        await this.sendMessage(conversationId, { ...message, files: filePaths });
-      } catch (error) {
-        console.error('[API] Failed to upload pending files:', error);
-        // Fall back: send original message without files
-        await this.sendMessage(conversationId, message);
+    // Fire server-side creation in the background so the caller can navigate
+    // immediately without waiting for the round-trip.  subscribeToEvents
+    // awaits this promise before opening the SSE stream, preserving the
+    // invariant that the conversation exists on the server before any event
+    // subscription is attempted.
+    const serverCreation = (async () => {
+      if (options?.pendingFiles?.length) {
+        // When files are attached: create an empty conversation first (no message yet),
+        // upload files, then send ONE complete message with file paths.
+        // This avoids the duplicate-message bug where createConversation sent msg_no_files
+        // and sendMessage sent a second copy of msg_with_files.
+        await this.createConversation(conversationId, [], {
+          chat: {
+            model: options?.model,
+            stream: options?.stream,
+            workspace: requestWorkspace(options?.workspace),
+          },
+        });
+        try {
+          const uploadResult = await this.uploadFiles(conversationId, options.pendingFiles);
+          const filePaths = uploadResult.files.map((f) => f.path);
+          await this.sendMessage(conversationId, { ...message, files: filePaths });
+        } catch (error) {
+          console.error('[API] Failed to upload pending files:', error);
+          // Fall back: send original message without files
+          await this.sendMessage(conversationId, message);
+        }
+      } else {
+        // No files: create conversation with the initial message.
+        // useConversation will call step() after subscribing (needsInitialStep: true above).
+        await this.createConversation(conversationId, [message], {
+          chat: {
+            model: options?.model,
+            stream: options?.stream,
+            workspace: requestWorkspace(options?.workspace),
+          },
+        });
       }
-    } else {
-      // No files: create conversation with the initial message.
-      // useConversation will call step() after subscribing (needsInitialStep: true above).
-      await this.createConversation(conversationId, [message], {
-        chat: {
-          model: options?.model,
-          stream: options?.stream,
-          workspace: requestWorkspace(options?.workspace),
-        },
-      });
-    }
+    })();
+
+    this.pendingServerCreations.set(conversationId, serverCreation);
 
     // NOTE: step() is NOT called here — useConversation calls it after subscribing to SSE.
 
-    // Return ID immediately after server creation
+    // Return the ID immediately; server creation runs concurrently.
     return conversationId;
   }
 

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -746,9 +746,9 @@ export class ApiClient {
     // conversation doesn't exist on the server yet.
     const pendingCreation = this.pendingServerCreations.get(conversationId);
     if (pendingCreation) {
-      // Remove before awaiting: reconnect attempts skip this branch because
-      // the same settled promise resolves immediately anyway.
-      this.pendingServerCreations.delete(conversationId);
+      // Keep the promise in the map until it settles so that concurrent
+      // subscribers (e.g. navigate away and back while creation is pending)
+      // also wait on it instead of bypassing the gate.
       try {
         await pendingCreation;
       } catch (error) {
@@ -757,6 +757,10 @@ export class ApiClient {
           error instanceof Error ? error.message : 'Failed to create conversation on server'
         );
         return;
+      } finally {
+        // Delete after settling (success or failure) so no further subscriber
+        // can block on a stale entry.
+        this.pendingServerCreations.delete(conversationId);
       }
     }
 
@@ -1379,6 +1383,14 @@ export class ApiClient {
         });
       }
     })();
+
+    // Attach a catch handler so that if no subscriber ever calls
+    // subscribeToEvents, an abandoned rejection doesn't become an
+    // UnhandledPromiseRejection and the map entry is cleaned up.
+    serverCreation.catch((error) => {
+      console.warn('[ApiClient] Background server creation failed (no subscriber):', error);
+      this.pendingServerCreations.delete(conversationId);
+    });
 
     this.pendingServerCreations.set(conversationId, serverCreation);
 

--- a/webui/src/utils/demoApiClient.ts
+++ b/webui/src/utils/demoApiClient.ts
@@ -407,6 +407,9 @@ export function createDemoApiClient(baseUrl: string = DEMO_BASE_URL): IApiClient
     deleteSession: async () => {},
     getExternalSession: async () => notImpl('getExternalSession'),
     steerExternalSession: async () => notImpl('steerExternalSession'),
+    // Demo conversations are created synchronously in-memory, so there is never
+    // a background server creation in flight.
+    waitForConversationCreation: async () => {},
   };
 
   return client;


### PR DESCRIPTION
## Problem

When a user submits a new chat message from the welcome screen, the UI shows too many visible "microsteps" before the conversation is fully loaded (feedback: gptme/gptme-cloud#895):

1. Welcome page stays while server creates the conversation
2. Page transitions to chat
3. User message appears
4. AI loading indicator starts

The culprit: `createConversationWithPlaceholder` **awaited** the server `PUT /api/v2/conversations/:id` before returning, so `navigate()` in WelcomeView could only fire after the round-trip completed (~200–500 ms of blocked-looking UI).

The comment in WelcomeView already said *"Navigate immediately — server-side creation happens in background"* but the `await` contradicted it.

## Fix

- **Background server creation**: wrap the REST call in an immediately-invoked async function and store the resulting `Promise<void>` in a new `ApiClient.pendingServerCreations` Map keyed by conversation ID.
- **Return ID immediately**: `createConversationWithPlaceholder` returns the conversation ID as soon as the local store is hydrated — the caller can `navigate()` on the very next tick.
- **SSE gating**: `subscribeToEvents` (called by `useConversation` after navigation) awaits the pending creation promise before opening the EventSource, preserving the invariant that the conversation exists on the server before any SSE subscription.
- **Test helper**: `waitForConversationCreation(id)` lets tests synchronise with the background creation without accessing private state.
- **Demo client**: `waitForConversationCreation` is a no-op (demo conversations are in-memory).

## Result

User clicks send → immediately sees the chat page with their message → AI indicator starts.  No intermediate "submitting" pause on the welcome page.