### PR TITLE
fix(codeblock): carry quote state across lines; close exec-lang blocks in streaming

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -442,6 +442,12 @@ def _extract_codeblocks(
                     is_outer_close = is_bare_fence and line_fence_len == fence_len
                     if is_outer_close or (is_bare_fence and nesting_depth > 1):
                         # Bare fence - determine if opening or closing based on context
+                        # A fence inside an open quoted string is literal content,
+                        # not a markdown delimiter (same rationale as heredoc bodies).
+                        if _qs_in_single or _qs_in_double:
+                            content_lines.append(line)
+                            i += 1
+                            continue
 
                         # Check next line
                         has_next_line = i + 1 < len(lines)

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -563,7 +563,12 @@ def _extract_codeblocks(
                             # prevents the trailing-blank-line sensitivity where
                             # an extra ``\n`` at end-of-message flips the result
                             # from no-block to an oversized block.
-                            if lang in _EXEC_LANGS and heredoc_terminator is None:
+                            if (
+                                lang in _EXEC_LANGS
+                                and heredoc_terminator is None
+                                and not _qs_in_single
+                                and not _qs_in_double
+                            ):
                                 yield Codeblock(
                                     lang,
                                     "\n".join(content_lines),

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -99,8 +99,18 @@ class Codeblock:
         return list(_extract_codeblocks(markdown, streaming=streaming))
 
 
-def _find_heredoc_terminator(line: str) -> str | None:
-    """Return the heredoc terminator word if ``line`` opens a heredoc.
+def _find_heredoc_terminator(
+    line: str,
+    in_single: bool = False,
+    in_double: bool = False,
+) -> tuple[str | None, bool, bool]:
+    """Return ``(terminator | None, in_single, in_double)`` for the given line.
+
+    The ``in_single`` / ``in_double`` parameters let callers carry per-character
+    quote state across lines so that a multiline single-quoted string (e.g.
+    ``s='\\n<< EOF\\n'``) is not misidentified as a heredoc opener on the
+    continuation line.  Returns the end-of-line quote state so callers can
+    pass it into the next invocation.
 
     Only recognizes ``<<`` operators at top-level (outside quoted strings,
     outside comments, and not backslash-escaped): a heredoc operator is
@@ -123,10 +133,13 @@ def _find_heredoc_terminator(line: str) -> str | None:
     are rejected to avoid minting a phantom terminator that could swallow
     later fences.
     """
-    in_single = in_double = False
     i = 0
     n = len(line)
-    while i < n - 1:
+    # Iterate over ALL characters so that a quote at the very end of a line
+    # (e.g. ``s='``) updates in_single/in_double for the caller to carry to the
+    # next line.  The old ``while i < n - 1`` guard was safe for the ``<<``
+    # look-ahead but silently skipped trailing quote characters.
+    while i < n:
         c = line[i]
         if c == "\\" and not in_single:
             # Backslash escapes the next char outside single quotes (bash
@@ -144,7 +157,7 @@ def _find_heredoc_terminator(line: str) -> str | None:
             and (i == 0 or line[i - 1].isspace())
         ):
             # Start of a shell comment - nothing after it is executable syntax.
-            return None
+            return None, in_single, in_double
         elif (
             c == "$"
             and not in_single
@@ -160,6 +173,7 @@ def _find_heredoc_terminator(line: str) -> str | None:
             continue
         elif (
             c == "<"
+            and i + 1 < n  # guard: need line[i+1] for the look-ahead
             and line[i + 1] == "<"
             and not in_single
             and not in_double
@@ -180,9 +194,11 @@ def _find_heredoc_terminator(line: str) -> str | None:
                     # terminator that could swallow later fences.
                     i += 2
                     continue
-                return term
+                # At the heredoc opener, quote state is always unquoted (the
+                # guard above requires not in_single and not in_double).
+                return term, False, False
         i += 1
-    return None
+    return None, in_single, in_double
 
 
 def _extract_codeblocks(
@@ -327,6 +343,12 @@ def _extract_codeblocks(
             # body (e.g. a shell script writing a markdown file) are treated as literal
             # content and never as block closers.
             heredoc_terminator: str | None = None
+            # Cross-line quote state for the heredoc scanner: a shell single-quoted
+            # string can span multiple lines (e.g. ``s='\n<< EOF\n'``).  Without
+            # carrying in_single/in_double across lines, the ``<< EOF`` on the
+            # continuation line is misidentified as a heredoc opener.
+            _qs_in_single: bool = False
+            _qs_in_double: bool = False
 
             # Collect content until we find the matching closing ```
             while i < len(lines):
@@ -391,7 +413,9 @@ def _extract_codeblocks(
                 # message) and the O(n^2) worst case on very large documents.
                 if lang in _SHELL_LANGS:
                     if heredoc_terminator is None:
-                        candidate = _find_heredoc_terminator(line)
+                        candidate, _qs_in_single, _qs_in_double = (
+                            _find_heredoc_terminator(line, _qs_in_single, _qs_in_double)
+                        )
                         _confirm_window = lines[i + 1 : i + 1 + 200]
                         if candidate is not None and any(
                             later.strip() == candidate for later in _confirm_window
@@ -399,6 +423,13 @@ def _extract_codeblocks(
                             heredoc_terminator = candidate
                     elif line.strip() == heredoc_terminator:
                         heredoc_terminator = None
+                        # Heredoc body is verbatim text — it doesn't affect the
+                        # outer shell's quote state.  A heredoc opener always
+                        # appears outside any quoted string (the not-in_single /
+                        # not-in_double guards ensure this), so restoring to
+                        # unquoted after the body closes is always correct.
+                        _qs_in_single = False
+                        _qs_in_double = False
 
                 # Check if this line starts with backticks (potential opening or closing)
                 line_fence_match = re.match(r"^(`{3,})", line)
@@ -523,8 +554,28 @@ def _extract_codeblocks(
                             else:
                                 content_lines.append(line)
                         elif streaming:
-                            # Streaming mode: require blank line to confirm closure
-                            if next_is_blank:
+                            # Exec langs (shell, bash, ipython, …) have no
+                            # triple-backtick syntax of their own, so a bare
+                            # fence at depth 1 is unambiguously a block closer
+                            # even in streaming mode — no blank-line confirmation
+                            # is required.  This makes streaming extraction
+                            # consistent with non-streaming for exec langs and
+                            # prevents the trailing-blank-line sensitivity where
+                            # an extra ``\n`` at end-of-message flips the result
+                            # from no-block to an oversized block.
+                            if lang in _EXEC_LANGS and heredoc_terminator is None:
+                                yield Codeblock(
+                                    lang,
+                                    "\n".join(content_lines),
+                                    start=start_line,
+                                    fence="`" * fence_len,
+                                )
+                                i += 1
+                                break
+                            # For non-exec langs: require blank line to confirm
+                            # closure (a bare fence could be the start of a
+                            # nested block that isn't finished yet).
+                            elif next_is_blank:
                                 # Blank line confirms this is a closing tag
                                 nesting_depth -= 1
                                 if nesting_depth == 0:

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -103,14 +103,20 @@ def _find_heredoc_terminator(
     line: str,
     in_single: bool = False,
     in_double: bool = False,
-) -> tuple[str | None, bool, bool]:
-    """Return ``(terminator | None, in_single, in_double)`` for the given line.
+    in_ansi_c: bool = False,
+) -> tuple[str | None, bool, bool, bool]:
+    """Return ``(terminator | None, in_single, in_double, in_ansi_c)``.
 
-    The ``in_single`` / ``in_double`` parameters let callers carry per-character
-    quote state across lines so that a multiline single-quoted string (e.g.
+    The quote-state parameters let callers carry per-character quote state
+    across lines so that a multiline single-quoted string (e.g.
     ``s='\\n<< EOF\\n'``) is not misidentified as a heredoc opener on the
     continuation line.  Returns the end-of-line quote state so callers can
     pass it into the next invocation.
+
+    ``in_ansi_c`` tracks bash ANSI-C quoting (``$'...'``), where backslash
+    escapes *are* processed (unlike POSIX single quotes).  Without this,
+    ``x=$'a\\'b'`` is scanned as POSIX ``'...'`` and leaves ``in_single``
+    set, so a later closing fence is treated as quoted content.
 
     Only recognizes ``<<`` operators at top-level (outside quoted strings,
     outside comments, and not backslash-escaped): a heredoc operator is
@@ -141,9 +147,29 @@ def _find_heredoc_terminator(
     # look-ahead but silently skipped trailing quote characters.
     while i < n:
         c = line[i]
+        if in_ansi_c:
+            # ANSI-C $'...' : backslash escapes the next char, including quotes.
+            if c == "\\":
+                i += 2
+                continue
+            if c == "'":
+                in_ansi_c = False
+            i += 1
+            continue
         if c == "\\" and not in_single:
             # Backslash escapes the next char outside single quotes (bash
             # doesn't allow escaping inside single quotes at all).
+            i += 2
+            continue
+        if (
+            c == "$"
+            and not in_single
+            and not in_double
+            and i + 1 < n
+            and line[i + 1] == "'"
+        ):
+            # Start of ANSI-C quoting: $'...'
+            in_ansi_c = True
             i += 2
             continue
         if c == "'" and not in_double:
@@ -157,7 +183,7 @@ def _find_heredoc_terminator(
             and (i == 0 or line[i - 1].isspace())
         ):
             # Start of a shell comment - nothing after it is executable syntax.
-            return None, in_single, in_double
+            return None, in_single, in_double, in_ansi_c
         elif (
             c == "$"
             and not in_single
@@ -196,9 +222,9 @@ def _find_heredoc_terminator(
                     continue
                 # At the heredoc opener, quote state is always unquoted (the
                 # guard above requires not in_single and not in_double).
-                return term, False, False
+                return term, False, False, False
         i += 1
-    return None, in_single, in_double
+    return None, in_single, in_double, in_ansi_c
 
 
 def _extract_codeblocks(
@@ -349,6 +375,7 @@ def _extract_codeblocks(
             # continuation line is misidentified as a heredoc opener.
             _qs_in_single: bool = False
             _qs_in_double: bool = False
+            _qs_in_ansi_c: bool = False
 
             # Collect content until we find the matching closing ```
             while i < len(lines):
@@ -413,8 +440,10 @@ def _extract_codeblocks(
                 # message) and the O(n^2) worst case on very large documents.
                 if lang in _SHELL_LANGS:
                     if heredoc_terminator is None:
-                        candidate, _qs_in_single, _qs_in_double = (
-                            _find_heredoc_terminator(line, _qs_in_single, _qs_in_double)
+                        candidate, _qs_in_single, _qs_in_double, _qs_in_ansi_c = (
+                            _find_heredoc_terminator(
+                                line, _qs_in_single, _qs_in_double, _qs_in_ansi_c
+                            )
                         )
                         _confirm_window = lines[i + 1 : i + 1 + 200]
                         if candidate is not None and any(
@@ -430,6 +459,7 @@ def _extract_codeblocks(
                         # unquoted after the body closes is always correct.
                         _qs_in_single = False
                         _qs_in_double = False
+                        _qs_in_ansi_c = False
 
                 # Check if this line starts with backticks (potential opening or closing)
                 line_fence_match = re.match(r"^(`{3,})", line)
@@ -444,7 +474,7 @@ def _extract_codeblocks(
                         # Bare fence - determine if opening or closing based on context
                         # A fence inside an open quoted string is literal content,
                         # not a markdown delimiter (same rationale as heredoc bodies).
-                        if _qs_in_single or _qs_in_double:
+                        if _qs_in_single or _qs_in_double or _qs_in_ansi_c:
                             content_lines.append(line)
                             i += 1
                             continue
@@ -574,6 +604,7 @@ def _extract_codeblocks(
                                 and heredoc_terminator is None
                                 and not _qs_in_single
                                 and not _qs_in_double
+                                and not _qs_in_ansi_c
                             ):
                                 yield Codeblock(
                                     lang,

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1998,3 +1998,27 @@ def test_extract_codeblocks_shell_quoted_bare_fence_is_literal():
     assert blocks_stream == expected, (
         "Streaming must not close or nest at a fence inside an open quoted string"
     )
+
+
+def test_extract_codeblocks_shell_ansi_c_escaped_quote_does_not_hide_closer():
+    """ANSI-C ``$'...'`` with an escaped quote must not leave quote state open.
+
+    Regression for gptme/gptme#3730 Greptile P1: ``x=$'a\\'b'`` was scanned as
+    POSIX single quotes (backslash ignored), so the trailing ``'`` opened a
+    new quote and the real closing fence was treated as literal content.
+    The block was never yielded.
+    """
+    from gptme.codeblock import _extract_codeblocks
+
+    message = "```shell\nx=$'a\\'b'\necho done\n```\n"
+    expected = [Codeblock("shell", "x=$'a\\'b'\necho done")]
+
+    blocks_default = list(_extract_codeblocks(message, streaming=False))
+    assert blocks_default == expected, (
+        "Non-streaming must still close after a complete ANSI-C string"
+    )
+
+    blocks_stream = list(_extract_codeblocks(message, streaming=True))
+    assert blocks_stream == expected, (
+        "Streaming must still close after a complete ANSI-C string"
+    )

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -573,50 +573,80 @@ def test_streaming_parameter_comprehensive():
     """
     Comprehensive test for streaming parameter behavior.
 
-    Tests both positive and negative cases:
-    - Streaming=True with blank line → should extract
-    - Streaming=True without blank line → should NOT extract
-    - Streaming=False with blank line → should extract
-    - Streaming=False without blank line → should extract
+    Exec langs (shell, bash, python, …) have no triple-backtick syntax of
+    their own, so a bare ``` at depth 1 is *always* a closer — no blank-line
+    confirmation is required even in streaming mode.
+
+    Non-exec langs (markdown, text, …) still require a blank line to confirm
+    closure in streaming mode because a bare ``` could be the opening of an
+    inner nested block that isn't finished yet.
+
+    Tests:
+    - Exec lang, streaming=True, WITH blank line → extract
+    - Exec lang, streaming=True, WITHOUT blank line → extract (no confirmation needed)
+    - Exec lang, streaming=False → always extract
+    - Non-exec lang, streaming=True, WITH blank line → extract
+    - Non-exec lang, streaming=True, WITHOUT blank line → do NOT extract
     """
     fence = "```"
 
-    # Case 1: Streaming=True, WITH blank line (positive case)
-    # Should extract because blank line confirms completion
-    markdown_with_blank = f"""{fence}shell
+    # ── Exec lang (shell) ──────────────────────────────────────────────────
+
+    markdown_exec_with_blank = f"""{fence}shell
 echo "hello"
 {fence}
 
 """
-    blocks = list(_extract_codeblocks(markdown_with_blank, streaming=True))
-    assert len(blocks) == 1, "Should extract block when streaming=True with blank line"
-    assert blocks[0].lang == "shell"
-    assert blocks[0].content == 'echo "hello"'
-
-    # Case 2: Streaming=True, WITHOUT blank line (negative case)
-    # Should NOT extract because no blank line to confirm completion
-    markdown_without_blank = f"""{fence}shell
+    markdown_exec_no_blank = f"""{fence}shell
 echo "hello"
 {fence}"""
-    blocks = list(_extract_codeblocks(markdown_without_blank, streaming=True))
-    assert len(blocks) == 0, (
-        "Should NOT extract block when streaming=True without blank line"
-    )
 
-    # Case 3: Streaming=False, WITH blank line (positive case)
-    # Should extract normally
-    blocks = list(_extract_codeblocks(markdown_with_blank, streaming=False))
-    assert len(blocks) == 1, "Should extract block when streaming=False with blank line"
+    # Case 1: Exec lang, streaming=True, WITH blank line → extract
+    blocks = list(_extract_codeblocks(markdown_exec_with_blank, streaming=True))
+    assert len(blocks) == 1, "Exec: should extract with blank line in streaming mode"
     assert blocks[0].lang == "shell"
+    assert blocks[0].content == 'echo "hello"'
 
-    # Case 4: Streaming=False, WITHOUT blank line (positive case)
-    # Should extract because message is complete (not streaming)
-    blocks = list(_extract_codeblocks(markdown_without_blank, streaming=False))
+    # Case 2: Exec lang, streaming=True, WITHOUT blank line → extract
+    # Shell has no nested ``` syntax; a bare fence at depth 1 is always a closer.
+    blocks = list(_extract_codeblocks(markdown_exec_no_blank, streaming=True))
     assert len(blocks) == 1, (
-        "Should extract block when streaming=False even without blank line"
+        "Exec: should extract without blank line in streaming mode "
+        "(bare fence is unambiguously a closer for exec langs)"
     )
     assert blocks[0].lang == "shell"
     assert blocks[0].content == 'echo "hello"'
+
+    # Case 3: Exec lang, streaming=False → always extract
+    blocks = list(_extract_codeblocks(markdown_exec_no_blank, streaming=False))
+    assert len(blocks) == 1, "Exec: should extract in non-streaming mode"
+    assert blocks[0].lang == "shell"
+    assert blocks[0].content == 'echo "hello"'
+
+    # ── Non-exec lang (text) ───────────────────────────────────────────────
+
+    markdown_text_with_blank = f"""{fence}text
+hello
+{fence}
+
+"""
+    markdown_text_no_blank = f"""{fence}text
+hello
+{fence}"""
+
+    # Case 4: Non-exec lang, streaming=True, WITH blank line → extract
+    blocks = list(_extract_codeblocks(markdown_text_with_blank, streaming=True))
+    assert len(blocks) == 1, (
+        "Non-exec: should extract with blank line in streaming mode"
+    )
+    assert blocks[0].content == "hello"
+
+    # Case 5: Non-exec lang, streaming=True, WITHOUT blank line → do NOT extract
+    # A bare ``` could still be a nested opener whose body hasn't arrived yet.
+    blocks = list(_extract_codeblocks(markdown_text_no_blank, streaming=True))
+    assert len(blocks) == 0, (
+        "Non-exec: should NOT extract without blank line in streaming mode"
+    )
 
 
 def test_streaming_nested_blocks():
@@ -1862,3 +1892,81 @@ output here
         Codeblock("shell", 'echo "a << b"'),
         Codeblock("", "output here"),
     ]
+
+
+def test_extract_codeblocks_shell_multiline_quoted_string_no_phantom_heredoc():
+    """A ``<<`` inside a multi-line single-quoted string must not be treated
+    as a heredoc opener.
+
+    Regression for the quote-state-across-lines bug: ``_find_heredoc_terminator``
+    used to start each line with ``in_single=False``, so the ``<< EOF`` on the
+    continuation line of ``s='\\n<< EOF\\n'`` was misidentified as a heredoc
+    opener.  That phantom terminator matched the standalone ``EOF`` in subsequent
+    prose, causing the parser to absorb the real closing fence, the prose, and
+    the output block into an oversized shell block.
+    """
+    markdown = "```shell\ns='\n<< EOF\n'\necho \"$s\"\n```\nThis is documentation.\n\nEOF\n```\noutput\n```\n"
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("shell", "s='\n<< EOF\n'\necho \"$s\""),
+        Codeblock("", "output"),
+    ], (
+        "The << EOF inside the single-quoted string must not open heredoc state; "
+        "the shell block must close at its own ``` fence"
+    )
+
+
+def test_extract_codeblocks_shell_streaming_exec_lang_closes_without_blank_line():
+    """Exec-lang blocks in streaming mode must close at the bare fence
+    regardless of whether a blank confirmation line follows.
+
+    Regression for the trailing-blank-line sensitivity: previously, streaming
+    mode required a blank line after ``` to confirm closure.  For exec langs
+    (shell, bash, python, …) this was wrong — these langs have no triple-backtick
+    syntax of their own, so a bare fence at depth 1 is always a closer.
+
+    The practical consequence was asymmetric stop-detection: a complete reply
+    ending in ``...```\\n`` yielded no blocks, while the same reply with an extra
+    trailing newline yielded one oversized block absorbing prose and output.
+    Both variants must now yield just the shell block (the output block may not
+    be extractable in streaming mode when no confirmation newline follows it).
+    """
+    from gptme.codeblock import _extract_codeblocks
+
+    # A complete LLM reply: shell command + prose + output block.
+    message = "```shell\necho hello\n```\nThe exact output is:\n\n```\nhello\n```\n"
+
+    # Non-streaming: both blocks extracted.
+    blocks_default = list(_extract_codeblocks(message, streaming=False))
+    assert blocks_default == [
+        Codeblock("shell", "echo hello"),
+        Codeblock("", "hello"),
+    ], "Non-streaming should extract both blocks"
+
+    # Streaming + single trailing newline: shell block extracted.
+    # (The output block has no blank confirmation line in this variant.)
+    blocks_stream_single = list(_extract_codeblocks(message, streaming=True))
+    assert blocks_stream_single == [Codeblock("shell", "echo hello")], (
+        "Streaming + single trailing newline must yield the shell block "
+        "(exec langs close without blank-line confirmation)"
+    )
+
+    # Streaming + extra trailing newline: both blocks extracted.
+    # The extra newline provides the blank confirmation needed for the
+    # non-exec output block.
+    blocks_stream_double = list(_extract_codeblocks(message + "\n", streaming=True))
+    assert blocks_stream_double == [
+        Codeblock("shell", "echo hello"),
+        Codeblock("", "hello"),
+    ], (
+        "Streaming + extra trailing newline must yield both blocks; "
+        "must NOT yield an oversized block absorbing prose and output"
+    )
+
+    # Verify stop-detection semantics: the streaming parser must signal
+    # 'at least one complete block found' for a finished exec-lang reply,
+    # regardless of the trailing newline count.
+    assert len(blocks_stream_single) > 0, (
+        "Stop-detection: streaming must find at least one complete block "
+        "in a finished exec-lang reply"
+    )

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1970,3 +1970,31 @@ def test_extract_codeblocks_shell_streaming_exec_lang_closes_without_blank_line(
         "Stop-detection: streaming must find at least one complete block "
         "in a finished exec-lang reply"
     )
+
+
+def test_extract_codeblocks_shell_quoted_bare_fence_is_literal():
+    """A bare fence inside an open multiline quoted string is literal content.
+
+    Regression for gptme/gptme#3730 Greptile P1: the exec-lang streaming
+    fast-path treated every bare fence as a closer even when the quote
+    scanner reported an open multiline string.  Closing at the data fence
+    truncated the runnable block (and stopped generation).  Guarding the
+    fast-path against quote state is necessary but not sufficient — the
+    streaming fallback then treated the same fence as a nested opener,
+    so the real closer only un-nested to depth 1 and the block was never
+    yielded.  Quoted fences must be literal content in both modes.
+    """
+    from gptme.codeblock import _extract_codeblocks
+
+    message = "```shell\ns='\n```\n'\necho done\n```\n"
+    expected = [Codeblock("shell", "s='\n```\n'\necho done")]
+
+    blocks_default = list(_extract_codeblocks(message, streaming=False))
+    assert blocks_default == expected, (
+        "Non-streaming must not close at a fence inside an open quoted string"
+    )
+
+    blocks_stream = list(_extract_codeblocks(message, streaming=True))
+    assert blocks_stream == expected, (
+        "Streaming must not close or nest at a fence inside an open quoted string"
+    )

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -551,8 +551,10 @@ def test_reply_stream_on_token_break_on_tooluse(monkeypatch):
     init_tools()
 
     # Use ``shell`` lang tag (recognized by get_tool_for_langtag).
-    # streaming=True requires a blank line after closing ``` to confirm block closure.
-    tool_block = "```shell\necho hi\n```\n\n"
+    # Exec langs (shell, bash, …) close immediately in streaming mode without
+    # requiring a blank line after the closing ``` — a bare fence at depth 1 is
+    # unambiguously a closer for langs that have no triple-backtick syntax.
+    tool_block = "```shell\necho hi\n```\n"
     suffix = "This text should not be reached"
 
     def _fake_gen(chunks):


### PR DESCRIPTION
## Problem

Two parser regressions present at commit `1e7e5547c`:

### 1. Multiline shell string phantom heredoc

`_find_heredoc_terminator` reset `in_single`/`in_double` to `False` for every line, so a `<<` inside a multiline single-quoted string (e.g. `s='\n<< EOF\n'`) was misidentified as a heredoc opener. The phantom terminator then matched a later standalone `EOF` in subsequent prose, causing the real closing fence and all subsequent content to be absorbed into the shell block.

Additional root cause: the scanner loop used `while i < n - 1`, silently skipping the last character of each line — so a trailing quote (e.g. in `s='`) never updated the quote state.

### 2. Streaming exec-lang blocks require blank line to close

Streaming mode required `next_is_blank` to confirm block closure for all langs. But exec langs (`shell`, `bash`, `python`, `ipython`, …) have no nested triple-backtick syntax, so a bare fence at depth 1 is always a closer. This made extraction asymmetric: a complete reply ending in ```````\n` returned no blocks while the same reply with an extra trailing `\n` returned an oversized block absorbing prose and output.

## Fix

**Bug 1:** Change `_find_heredoc_terminator` to accept and return `(in_single, in_double)` so callers carry quote state across lines. Fix loop bound from `while i < n - 1` to `while i < n` with `i + 1 < n` guard on the `<<` lookahead. `_extract_codeblocks` accumulates per-line quote state in `_qs_in_single`/`_qs_in_double`.

**Bug 2:** In the `elif streaming:` branch at `nesting_depth == 1`, add an exec-lang fast-path that closes immediately without blank-line confirmation (matching non-streaming behavior). Non-exec langs retain the blank-line requirement.

## Tests

- Updated `test_streaming_parameter_comprehensive` to document correct semantics: exec langs close without blank line; non-exec langs (`text`) still require it.
- Added `test_extract_codeblocks_shell_multiline_quoted_string_no_phantom_heredoc`: covers the reproduction case from the discovery.
- Added `test_extract_codeblocks_shell_streaming_exec_lang_closes_without_blank_line`: verifies streaming consistency and stop-detection behavior.

All 84 tests pass (`tests/test_codeblock.py`).