### PR TITLE
fix(telemetry): keep startup diagnostics out of JSON stdout

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -1155,6 +1155,12 @@ def main(
                 interactive = False
                 no_confirm = True
                 auto_switched_noninteractive = True
+                # Reconfigure logging to stderr: the handler was set up before
+                # the auto-switch (when interactive was True, stderr=False), so
+                # it still points at stdout.  Re-init with stderr=True so that
+                # subsequent logger.info calls (e.g. from init_telemetry) don't
+                # contaminate JSON stdout.
+                init_logging(verbose, stderr=True)
 
     # add prompts to prompt-toolkit history
     for prompt in prompts:

--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -598,11 +598,8 @@ def init_telemetry(
         otel_attributes_logger = logging.getLogger("opentelemetry.attributes")
         otel_attributes_logger.addFilter(notgiven_filter)
 
-        # Import console for user-visible messages
-        from . import console  # fmt: skip
-
-        # Log to console so users know telemetry is active
-        console.log(f"Using OTLP to send metrics and traces to {otlp_endpoint}")
+        # Respect the CLI's stderr routing so JSON stdout stays machine-readable.
+        logger.info("Using OTLP to send metrics and traces to %s", otlp_endpoint)
 
     except Exception as e:
         logger.error(f"Failed to initialize telemetry: {e}")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -24,8 +24,8 @@ def test_get_prompt_full():
     combined_content = "\n\n".join(msg.content for msg in prompt_msgs)
 
     # TODO: lower this significantly by selectively removing examples from the full prompt
-    # Note: Ceiling bumped to 8100 to accommodate memory tool instructions
-    assert 500 < len_tokens(combined_content, "gpt-4") < 8100 + user_config_size
+    # Note: Ceiling bumped to 8250 to accommodate memory read+write tool instructions
+    assert 500 < len_tokens(combined_content, "gpt-4") < 8250 + user_config_size
 
 
 def test_get_prompt_short():

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,9 +1,12 @@
 """Tests for telemetry functionality."""
 
 import importlib.util
+import json
 import logging
+import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +34,66 @@ def test_telemetry_imports_lazy():
         "assert not leaked, f'opentelemetry eagerly imported: {leaked[:5]}'"
     )
     subprocess.check_call([sys.executable, "-c", code])
+
+
+@pytest.mark.skipif(
+    not _has_telemetry_deps(),
+    reason="Requires telemetry dependencies (opentelemetry, prometheus_client)",
+)
+def test_telemetry_startup_preserves_json_stdout():
+    """Startup runs before chat selects JSON output; diagnostics belong on stderr."""
+    for dependency in (
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        "opentelemetry.instrumentation.flask",
+        "opentelemetry.instrumentation.requests",
+        "opentelemetry.instrumentation.openai",
+        "opentelemetry.instrumentation.anthropic",
+        "opentelemetry.instrumentation.threading",
+    ):
+        pytest.importorskip(dependency)
+    code = """
+from unittest.mock import patch
+from gptme.init import init_logging
+from gptme.message import Message, print_msg, set_output_format
+from gptme.util._telemetry import init_telemetry, is_telemetry_enabled, shutdown_telemetry
+
+init_logging(False, stderr=True)
+with (
+    patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export"),
+    patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter.export"),
+):
+    init_telemetry(
+        enable_flask_instrumentation=False,
+        enable_requests_instrumentation=False,
+        enable_openai_instrumentation=False,
+        enable_anthropic_instrumentation=False,
+        interactive=False,
+    )
+    assert is_telemetry_enabled()
+    set_output_format("json")
+    print_msg(Message("assistant", "review complete"))
+    shutdown_telemetry()
+"""
+    # A separate process isolates OpenTelemetry's global providers and threads.
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=Path(__file__).resolve().parents[1],
+        env={
+            **os.environ,
+            "GPTME_TELEMETRY_ENABLED": "true",
+            "OTLP_ENDPOINT": "http://localhost:4318",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    events = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(events) == 1
+    assert events[0]["role"] == "assistant"
+    assert events[0]["content"] == "review complete"
+    assert "Using OTLP" in result.stderr
 
 
 def test_calculate_llm_cost_resolves_anthropic_short_alias():

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -96,6 +96,74 @@ with (
     assert "Using OTLP" in result.stderr
 
 
+@pytest.mark.skipif(
+    not _has_telemetry_deps(),
+    reason="Requires telemetry dependencies (opentelemetry, prometheus_client)",
+)
+def test_telemetry_startup_preserves_json_stdout_after_auto_switch():
+    """Auto-switched noninteractive path must not contaminate JSON stdout either.
+
+    When stdin is not a TTY and prompts are supplied, the CLI initially
+    configures logging for stdout (interactive mode), then auto-switches to
+    noninteractive and re-inits logging to stderr.  Telemetry is initialised
+    after that re-init, so its INFO banner must also land on stderr.
+    """
+    for dependency in (
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        "opentelemetry.instrumentation.flask",
+        "opentelemetry.instrumentation.requests",
+        "opentelemetry.instrumentation.openai",
+        "opentelemetry.instrumentation.anthropic",
+        "opentelemetry.instrumentation.threading",
+    ):
+        pytest.importorskip(dependency)
+    code = """
+from unittest.mock import patch
+from gptme.init import init_logging
+from gptme.message import Message, print_msg, set_output_format
+from gptme.util._telemetry import init_telemetry, is_telemetry_enabled, shutdown_telemetry
+
+# Simulate the CLI's interactive startup (stderr=False routes logs to stdout).
+init_logging(False, stderr=False)
+# Simulate the auto-switch: stdin not a TTY + prompts supplied.
+init_logging(False, stderr=True)
+with (
+    patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export"),
+    patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter.export"),
+):
+    init_telemetry(
+        enable_flask_instrumentation=False,
+        enable_requests_instrumentation=False,
+        enable_openai_instrumentation=False,
+        enable_anthropic_instrumentation=False,
+        interactive=False,
+    )
+    assert is_telemetry_enabled()
+    set_output_format("json")
+    print_msg(Message("assistant", "review complete"))
+    shutdown_telemetry()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=Path(__file__).resolve().parents[1],
+        env={
+            **os.environ,
+            "GPTME_TELEMETRY_ENABLED": "true",
+            "OTLP_ENDPOINT": "http://localhost:4318",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    events = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(events) == 1
+    assert events[0]["role"] == "assistant"
+    assert events[0]["content"] == "review complete"
+    assert "Using OTLP" in result.stderr
+
+
 def test_calculate_llm_cost_resolves_anthropic_short_alias():
     """Anthropic short aliases should use Anthropic pricing metadata."""
     from gptme.telemetry import _calculate_llm_cost


### PR DESCRIPTION
With telemetry enabled, `gptme --non-interactive --output-format json` writes the plain-text `Using OTLP...` startup banner before its JSON events. This breaks JSONL consumers: a live `gptme-util review pr` session emitted valid findings but rejected the whole child output because its first line was not JSON.

Send the startup diagnostic through the configured logger, which the CLI routes to stderr in noninteractive mode. Telemetry remains enabled and the review parser remains strict. Checking JSON mode at the banner would be too late: telemetry initializes before `chat()` selects that mode.

Validation: a subprocess regression exercises real telemetry initialization followed by JSON message output, with network export mocked. It failed on the banner before the fix and now passes. All 47 telemetry/JSON-output tests pass; scoped typecheck with the hooks' `--ignore-missing-imports` setting, commit hooks, and pre-PR quality gate pass. The plain scoped typecheck only reported four missing optional dependency imports in this test environment.

**Live-reviewer validation (2026-09-08, session 0942):** the production `ai-review.py --engine agent` replay on gptme/gptme#3731 failed twice on the installed gptme 0.32.1 (`session produced no valid findings block`, the child's first stdout line was the OTLP banner). Re-running the identical command with `gptme-util` built from master plus this branch produced a valid artifact (score 5/5, 0 findings, 3 of 8 turns). Evidence: `state/ai-review-probes/0942/` in ErikBjare/bob. Prompt-ceiling bump in `tests/test_prompts.py` is already on master and will collapse on merge.

**Why the existing setup was insufficient, and what the change does not touch.** `gptme-util review pr` and every other `--output-format json` consumer read the child's stdout as strict JSONL; `console.log` writes to stdout unconditionally, so with telemetry enabled the first stdout line was prose and the whole review was discarded. The diff changes only how the one startup line is emitted (`logger.info` instead of `console.log`) and re-initialises the logging handler to stderr after the noninteractive auto-switch. The OTLP exporter, tracer/meter providers, instrumentation, and `shutdown_telemetry` are untouched. The unit test mocks the network export so CI needs no collector; the end-to-end run above was not mocked: it ran with `GPTME_TELEMETRY_ENABLED=true` against the real collector at Bob's `OTLP_ENDPOINT`, telemetry initialised (banner on stderr), and the review completed.