### PR TITLE
feat(memory): gptme.memory package + gptme-util memory CLI (layered roots, CC-compatible)

### DIFF
--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -1,0 +1,198 @@
+"""gptme-util memory — cross-harness memory store CLI.
+
+Entries are Claude Code compatible markdown files (``name``, ``description``,
+``metadata.type`` frontmatter) read from an ordered list of roots and written
+to one scope. Any harness can wrap these commands: Claude Code through hooks,
+Codex through an AGENTS.md snippet, gptme through the ``memory`` tool.
+
+See gptme/gptme#3734 for the design.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+import click
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _clean(value: str) -> str:
+    return _CONTROL_CHARS_RE.sub("", value)
+
+
+def _store():
+    from ..memory import MemoryStore  # fmt: skip
+
+    return MemoryStore.from_workspace()
+
+
+@click.group("memory")
+def memory():
+    """Cross-harness memory store: CC-compatible entries, layered roots."""
+
+
+@memory.command("roots")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def memory_roots(as_json: bool):
+    """Show the resolved memory roots, nearest layer first."""
+    store = _store()
+    if as_json:
+        click.echo(
+            json.dumps(
+                [
+                    {"scope": r.scope, "path": str(r.path), "exists": r.exists}
+                    for r in store.roots
+                ],
+                indent=2,
+            )
+        )
+        return
+    for r in store.roots:
+        marker = "" if r.exists else "  (missing)"
+        click.echo(f"{r.scope:8s} {r.path}{marker}")
+
+
+@memory.command("list")
+@click.option("--type", "type_", help="Only entries of this type.")
+@click.option(
+    "--scope", help="Only entries from this root (project, cc, agent, user, explicit)."
+)
+@click.option(
+    "--status", help="Only entries with this status (living, superseded, historical)."
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def memory_list(
+    type_: str | None, scope: str | None, status: str | None, as_json: bool
+):
+    """List entries across all roots (nearest root wins on name collision)."""
+    store = _store()
+    entries = store.entries(type=type_, status=status, scope=scope)
+    if as_json:
+        click.echo(json.dumps([e.to_dict() for e in entries], indent=2, default=str))
+    else:
+        for e in entries:
+            click.echo(f"{e.type:10s} {e.name}  — {_clean(e.description)}")
+    if store.errors:
+        click.echo(
+            f"({len(store.errors)} file(s) skipped: not memory entries)", err=True
+        )
+
+
+@memory.command("show")
+@click.argument("name")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output as JSON (frontmatter fields + body).",
+)
+def memory_show(name: str, as_json: bool):
+    """Print one entry by name."""
+    entry = _store().get(name)
+    if entry is None:
+        click.echo(f"Error: no memory entry named {name!r}", err=True)
+        sys.exit(1)
+    if as_json:
+        click.echo(
+            json.dumps({**entry.to_dict(), "body": entry.body}, indent=2, default=str)
+        )
+    else:
+        click.echo(entry.to_markdown(), nl=False)
+
+
+@memory.command("save")
+@click.argument("name")
+@click.argument("description")
+@click.option(
+    "--type",
+    "type_",
+    default="general",
+    show_default=True,
+    help="Entry type (user, feedback, project, reference, general, …).",
+)
+@click.option(
+    "--scope", help="Root to write to (default: project when present, else cc)."
+)
+@click.option("--title", help="Index link text (defaults to the name).")
+@click.option(
+    "--body-file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Read the body from this file instead of stdin.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Print the saved entry as JSON.")
+def memory_save(
+    name: str,
+    description: str,
+    type_: str,
+    scope: str | None,
+    title: str | None,
+    body_file: str | None,
+    as_json: bool,
+):
+    """Save an entry. The body is read from --body-file or from stdin when piped.
+
+    Example:
+
+    \b
+        gptme-util memory save prefer-short-answers \\
+          "User prefers short, direct answers." --type feedback < body.md
+    """
+    if body_file:
+        with open(body_file, encoding="utf-8") as f:
+            body = f.read()
+    elif not sys.stdin.isatty():
+        body = sys.stdin.read()
+    else:
+        body = ""
+    store = _store()
+    try:
+        path = store.save(name, description, body, type=type_, scope=scope, title=title)
+    except (KeyError, OSError) as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        entry = store.get(name)
+        click.echo(
+            json.dumps(
+                entry.to_dict() if entry else {"path": str(path)}, indent=2, default=str
+            )
+        )
+    else:
+        click.echo(f"Saved memory to {path}")
+
+
+@memory.command("index")
+@click.option("--scope", help="Root whose index to generate (default: the write root).")
+@click.option("--write", is_flag=True, help="Write MEMORY.md instead of printing it.")
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Exit 1 when MEMORY.md differs from the regenerated index.",
+)
+@click.option("--budget", type=int, help="Cap the index at this many bytes.")
+def memory_index(scope: str | None, write: bool, check: bool, budget: int | None):
+    """Generate the always-on index (living entries grouped by type).
+
+    Prints to stdout by default so a hand-curated MEMORY.md is never
+    overwritten by accident; pass --write to replace it, --check to verify.
+    """
+    store = _store()
+    try:
+        if check:
+            ok = store.check_index(scope, budget=budget)
+            click.echo(f"{store.index_path(scope)}: {'up to date' if ok else 'DRIFT'}")
+            sys.exit(0 if ok else 1)
+        if write:
+            path = store.write_index(scope, budget=budget)
+            click.echo(f"Wrote {path}")
+            return
+        root = store.root(scope)
+        click.echo(
+            store.render_index(store.entries(scope=root.scope), budget=budget), nl=False
+        )
+    except KeyError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -16,11 +16,16 @@ import sys
 
 import click
 
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+# C0/C1 controls. ``keep_newlines`` still drops ESC/CSI but preserves \t and \n
+# so markdown bodies and generated indexes stay readable.
+_ALL_CONTROLS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+_UNSAFE_CONTROLS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
 
-def _clean(value: str) -> str:
-    return _CONTROL_CHARS_RE.sub("", value)
+def _clean(value: str, *, keep_newlines: bool = False) -> str:
+    """Strip terminal controls from untrusted memory text."""
+    pattern = _UNSAFE_CONTROLS_RE if keep_newlines else _ALL_CONTROLS_RE
+    return pattern.sub("", value)
 
 
 def _store():
@@ -74,7 +79,9 @@ def memory_list(
         click.echo(json.dumps([e.to_dict() for e in entries], indent=2, default=str))
     else:
         for e in entries:
-            click.echo(f"{e.type:10s} {e.name}  — {_clean(e.description)}")
+            click.echo(
+                f"{_clean(e.type):10s} {_clean(e.name)}  — {_clean(e.description)}"
+            )
     if store.errors:
         click.echo(
             f"({len(store.errors)} file(s) skipped: not memory entries)", err=True
@@ -100,7 +107,7 @@ def memory_show(name: str, as_json: bool):
             json.dumps({**entry.to_dict(), "body": entry.body}, indent=2, default=str)
         )
     else:
-        click.echo(entry.to_markdown(), nl=False)
+        click.echo(_clean(entry.to_markdown(), keep_newlines=True), nl=False)
 
 
 @memory.command("save")
@@ -172,7 +179,11 @@ def memory_save(
     is_flag=True,
     help="Exit 1 when MEMORY.md differs from the regenerated index.",
 )
-@click.option("--budget", type=int, help="Cap the index at this many bytes.")
+@click.option(
+    "--budget",
+    type=click.IntRange(min=1),
+    help="Cap the index at this many bytes.",
+)
 def memory_index(scope: str | None, write: bool, check: bool, budget: int | None):
     """Generate the always-on index (living entries grouped by type).
 
@@ -189,10 +200,13 @@ def memory_index(scope: str | None, write: bool, check: bool, budget: int | None
             path = store.write_index(scope, budget=budget)
             click.echo(f"Wrote {path}")
             return
-        root = store.root(scope)
         click.echo(
-            store.render_index(store.entries(scope=root.scope), budget=budget), nl=False
+            _clean(
+                store.render_index(store.index_entries(scope), budget=budget),
+                keep_newlines=True,
+            ),
+            nl=False,
         )
-    except KeyError as e:
+    except (KeyError, ValueError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -16,10 +16,10 @@ import sys
 
 import click
 
-# C0/C1 controls. ``keep_newlines`` still drops ESC/CSI but preserves \t and \n
-# so markdown bodies and generated indexes stay readable.
+# C0/C1 controls. ``keep_newlines`` still drops ESC/CSI/CR (CR overwrites the
+# current terminal line) but preserves \t and \n so markdown stays readable.
 _ALL_CONTROLS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
-_UNSAFE_CONTROLS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_UNSAFE_CONTROLS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
 
 def _clean(value: str, *, keep_newlines: bool = False) -> str:

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -58,6 +58,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
     "hooks": (".cmd_hooks", "hooks"),
     "knowledge": (".cmd_knowledge", "knowledge"),
     "mcp": (".cmd_mcp", "mcp"),
+    "memory": (".cmd_memory", "memory"),
     "resume": (".cmd_resume", "resume"),
     # Unified review group (gptme#3442): ``gptme-util review watch``
     "review": (".cmd_review", "review"),

--- a/gptme/memory/__init__.py
+++ b/gptme/memory/__init__.py
@@ -1,0 +1,21 @@
+"""Cross-harness memory store: CC-compatible markdown entries with layered roots.
+
+This package imports nothing from gptme core except :mod:`gptme.dirs`, so it
+can be extracted into a standalone ``gptme-memory`` package (sibling of
+``gptme-rag``) as a file move. See gptme/gptme#3734.
+"""
+
+from .roots import MemoryRoot, resolve_roots
+from .schema import MemoryEntry, MemoryParseError, parse_entry, slugify
+from .store import MemoryStore, update_index_line
+
+__all__ = [
+    "MemoryEntry",
+    "MemoryParseError",
+    "MemoryRoot",
+    "MemoryStore",
+    "parse_entry",
+    "resolve_roots",
+    "slugify",
+    "update_index_line",
+]

--- a/gptme/memory/roots.py
+++ b/gptme/memory/roots.py
@@ -1,0 +1,97 @@
+"""Memory root resolution: an ordered list of layers, nearest first.
+
+Order (see gptme/gptme#3734, "layers, not a third store"):
+
+1. ``explicit`` — ``GPTME_MEMORY_DIRS`` (colon-separated); when set it replaces
+   every other layer.
+2. ``project`` — ``<workspace>/memory/`` when it exists.
+3. ``cc`` — Claude Code's ``~/.claude/projects/<hash>/memory/``. Always
+   present so CC-native memories are never invisible; written only when it is
+   the only writable layer.
+4. ``agent`` — ``$GPTME_AGENT_WORKSPACE/memory/`` when set: an agent's brain
+   while it works in another repository.
+5. ``user`` — ``<config dir>/memory/``, shared across every workspace.
+
+Roots that resolve to the same directory are collapsed onto the first scope
+that named them (for an agent working in its own brain, ``project`` and ``cc``
+are one directory).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from ..dirs import get_cc_memory_dir, get_config_dir, get_workspace
+
+ENV_DIRS = "GPTME_MEMORY_DIRS"
+ENV_AGENT_WORKSPACE = "GPTME_AGENT_WORKSPACE"
+SCOPES = ("explicit", "project", "cc", "agent", "user")
+
+
+@dataclass(frozen=True)
+class MemoryRoot:
+    scope: str
+    path: Path
+
+    @property
+    def exists(self) -> bool:
+        return self.path.is_dir()
+
+
+def resolve_roots(
+    workspace: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    config_dir: Path | None = None,
+) -> list[MemoryRoot]:
+    env = os.environ if env is None else env
+    explicit = env.get(ENV_DIRS, "").strip()
+    if explicit:
+        return _dedupe(
+            MemoryRoot("explicit", Path(p).expanduser())
+            for p in explicit.split(os.pathsep)
+            if p.strip()
+        )
+
+    ws = (workspace or get_workspace()).resolve()
+    candidates: list[MemoryRoot] = []
+    project = ws / "memory"
+    if project.is_dir():
+        candidates.append(MemoryRoot("project", project))
+    candidates.append(MemoryRoot("cc", get_cc_memory_dir(ws)))
+    agent_ws = env.get(ENV_AGENT_WORKSPACE, "").strip()
+    if agent_ws:
+        agent = Path(agent_ws).expanduser() / "memory"
+        if agent.is_dir():
+            candidates.append(MemoryRoot("agent", agent))
+    candidates.append(MemoryRoot("user", (config_dir or get_config_dir()) / "memory"))
+    return _dedupe(candidates)
+
+
+def default_write_root(roots: list[MemoryRoot]) -> MemoryRoot:
+    """The scope ``save`` targets when none is given: explicit or project, else cc."""
+    for scope in ("explicit", "project", "cc"):
+        for r in roots:
+            if r.scope == scope:
+                return r
+    if roots:
+        return roots[0]
+    raise KeyError("no memory roots resolved")
+
+
+def _dedupe(roots) -> list[MemoryRoot]:
+    out: list[MemoryRoot] = []
+    seen: set[Path] = set()
+    for r in roots:
+        key = r.path.resolve()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(r)
+    return out

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -1,0 +1,244 @@
+"""Memory entry schema: markdown body + YAML frontmatter, Claude Code compatible.
+
+The Claude Code fields (``name``, ``description``, ``metadata.type``,
+``metadata.originSessionId``) are read and written exactly as CC writes them,
+so CC's built-in memory feature keeps working on the same files. Every other
+field is additive and optional.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import yaml
+
+DEFAULT_TYPE = "general"
+DEFAULT_STATUS = "living"
+STATUSES = ("living", "superseded", "historical")
+# Types in the order the generated index groups them; unknown types follow alphabetically.
+TYPE_ORDER = ("user", "feedback", "project", "reference", "general")
+
+_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*\r?\n?", re.DOTALL)
+_KV_RE = re.compile(
+    r"^(?P<indent> *)(?P<key>[A-Za-z_][A-Za-z0-9_-]*):[ \t]*(?P<value>.*)$"
+)
+
+
+class MemoryParseError(ValueError):
+    """Raised when a file is not a memory entry (no or unusable frontmatter)."""
+
+
+def slugify(name: str) -> str:
+    """Convert a name to a safe filename slug (``My Fact!`` → ``my-fact``)."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")
+    return slug or "memory"
+
+
+def is_index_file(path: Path) -> bool:
+    """``MEMORY.md`` and its siblings (``MEMORY-archive.md``) are indexes, not entries."""
+    return path.name.upper().startswith("MEMORY")
+
+
+@dataclass
+class MemoryEntry:
+    name: str
+    description: str = ""
+    type: str = DEFAULT_TYPE
+    body: str = ""
+    title: str | None = None
+    status: str = DEFAULT_STATUS
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: str | None = None
+    provenance: dict[str, Any] = field(default_factory=dict)
+    confidence: float | None = None
+    keywords: list[str] = field(default_factory=list)
+    recheck: str | None = None
+    # The CC ``metadata`` block verbatim (minus ``type``, which is lifted to ``type``).
+    metadata: dict[str, Any] = field(default_factory=dict)
+    path: Path | None = None
+    scope: str | None = None
+
+    @property
+    def filename(self) -> str:
+        return self.path.name if self.path is not None else f"{self.name}.md"
+
+    @property
+    def index_title(self) -> str:
+        """Link text for the index line: the title when set, else the name."""
+        return self.title or self.name
+
+    @property
+    def is_living(self) -> bool:
+        return self.status == DEFAULT_STATUS
+
+    def index_line(self) -> str:
+        return f"- [{self.index_title}]({self.filename}) — {self.description}"
+
+    def to_markdown(self) -> str:
+        """Render frontmatter + body. Field order is fixed so diffs stay small."""
+        lines = ["---", f"name: {self.name}"]
+        if self.title:
+            lines.append(f"title: {_quote(self.title)}")
+        lines.append(f"description: {_quote(self.description)}")
+        meta: dict[str, Any] = {"type": self.type, **self.metadata}
+        lines.append("metadata:")
+        lines.append(_dump_block(meta, indent=2))
+        if self.status != DEFAULT_STATUS:
+            lines.append(f"status: {self.status}")
+        optional: dict[str, Any] = {}
+        if self.supersedes:
+            optional["supersedes"] = list(self.supersedes)
+        if self.superseded_by:
+            optional["superseded_by"] = self.superseded_by
+        if self.provenance:
+            optional["provenance"] = dict(self.provenance)
+        if self.confidence is not None:
+            optional["confidence"] = self.confidence
+        if self.keywords:
+            optional["keywords"] = list(self.keywords)
+        if self.recheck:
+            optional["recheck"] = self.recheck
+        if optional:
+            lines.append(_dump_block(optional, indent=0))
+        lines.append("---")
+        lines.append("")
+        text = "\n".join(lines) + "\n"
+        body = self.body.strip("\n")
+        return text + (body + "\n" if body else "")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "type": self.type,
+            "status": self.status,
+            "supersedes": self.supersedes,
+            "superseded_by": self.superseded_by,
+            "provenance": self.provenance,
+            "confidence": self.confidence,
+            "keywords": self.keywords,
+            "recheck": self.recheck,
+            "metadata": self.metadata,
+            "path": str(self.path) if self.path else None,
+            "scope": self.scope,
+        }
+
+
+def _quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _dump_block(data: dict[str, Any], indent: int) -> str:
+    dumped = yaml.safe_dump(data, sort_keys=False, allow_unicode=True, width=10_000)
+    pad = " " * indent
+    return "\n".join(pad + line for line in dumped.rstrip("\n").splitlines())
+
+
+def split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return ``(frontmatter, body)`` or ``None`` when the text has no frontmatter."""
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    return m.group(1), text[m.end() :]
+
+
+def _lenient_load(raw: str) -> dict[str, Any]:
+    """Line-based fallback for frontmatter that PyYAML rejects (unquoted colons etc.).
+
+    Handles top-level scalars and a one-level nested block (``metadata:``).
+    Lists and deeper nesting are dropped; ``audit`` will flag those files later.
+    """
+    data: dict[str, Any] = {}
+    current: dict[str, Any] | None = None
+    for line in raw.splitlines():
+        m = _KV_RE.match(line)
+        if not m:
+            continue
+        key, value = m.group("key"), m.group("value").strip()
+        if m.group("indent"):
+            if current is not None:
+                current[key] = value.strip("'\"")
+            continue
+        if value == "":
+            current = {}
+            data[key] = current
+        else:
+            current = None
+            data[key] = value.strip("'\"")
+    return data
+
+
+def parse_frontmatter(raw: str) -> dict[str, Any]:
+    try:
+        loaded = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return _lenient_load(raw)
+    if not isinstance(loaded, dict):
+        return _lenient_load(raw)
+    return loaded
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return [str(v) for v in value]
+
+
+def entry_from_text(
+    text: str, path: Path | None = None, scope: str | None = None
+) -> MemoryEntry:
+    parts = split_frontmatter(text)
+    if parts is None:
+        raise MemoryParseError(f"no frontmatter: {path or '<text>'}")
+    raw, body = parts
+    data = parse_frontmatter(raw)
+    if not data:
+        raise MemoryParseError(f"empty frontmatter: {path or '<text>'}")
+
+    metadata = data.get("metadata")
+    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    type_ = metadata.pop("type", None) or data.get("type") or DEFAULT_TYPE
+
+    name = data.get("name") or (path.stem if path is not None else None)
+    if not name:
+        raise MemoryParseError(f"entry has no name: {path or '<text>'}")
+
+    confidence = data.get("confidence")
+    try:
+        confidence = float(confidence) if confidence is not None else None
+    except (TypeError, ValueError):
+        confidence = None
+
+    provenance = data.get("provenance")
+    status = str(data.get("status") or DEFAULT_STATUS)
+
+    return MemoryEntry(
+        name=str(name),
+        description=str(data.get("description") or "").strip(),
+        type=str(type_),
+        body=body.strip("\n"),
+        title=str(data["title"]) if data.get("title") else None,
+        status=status if status in STATUSES else DEFAULT_STATUS,
+        supersedes=_as_list(data.get("supersedes")),
+        superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
+        provenance=dict(provenance) if isinstance(provenance, dict) else {},
+        confidence=confidence,
+        keywords=_as_list(data.get("keywords")),
+        recheck=str(data["recheck"]) if data.get("recheck") else None,
+        metadata=metadata,
+        path=path,
+        scope=scope,
+    )
+
+
+def parse_entry(path: Path, scope: str | None = None) -> MemoryEntry:
+    """Parse one memory file. Raises :class:`MemoryParseError` for non-entries."""
+    return entry_from_text(path.read_text(encoding="utf-8"), path=path, scope=scope)

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -1,0 +1,243 @@
+"""Layered memory store: union reads across roots, scoped writes, index generation."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+from .roots import MemoryRoot, default_write_root, resolve_roots
+from .schema import (
+    DEFAULT_TYPE,
+    TYPE_ORDER,
+    MemoryEntry,
+    MemoryParseError,
+    is_index_file,
+    parse_entry,
+    slugify,
+)
+
+logger = logging.getLogger(__name__)
+
+INDEX_FILENAME = "MEMORY.md"
+INDEX_HEADER = "# Persistent Memory"
+
+try:
+    import fcntl as _fcntl
+
+    def _lock_exclusive(f) -> None:
+        _fcntl.flock(f, _fcntl.LOCK_EX)
+
+    def _unlock(f) -> None:
+        _fcntl.flock(f, _fcntl.LOCK_UN)
+
+except ImportError:  # Windows: no flock, best effort
+
+    def _lock_exclusive(f) -> None:
+        pass
+
+    def _unlock(f) -> None:
+        pass
+
+
+def update_index_line(memory_dir: Path, entry: MemoryEntry) -> None:
+    """Upsert one ``- [title](file) — description`` line in ``MEMORY.md``.
+
+    This is the Claude Code convention: append a pointer line, never rewrite
+    the whole index. It is what ``save`` does so a hand-curated index is never
+    clobbered; full regeneration is the explicit ``index --write`` path.
+
+    The file name is the key, so renaming an entry's title updates the same
+    line instead of adding a duplicate. An exclusive lock serialises
+    concurrent writers.
+    """
+    index_path = memory_dir / INDEX_FILENAME
+    line = entry.index_line()
+    pattern = rf"^- \[[^\]]*\]\({re.escape(entry.filename)}\).*$"
+    with open(index_path, "a+", encoding="utf-8") as f:
+        _lock_exclusive(f)
+        try:
+            f.seek(0)
+            content = f.read()
+            if not content:
+                new_content = f"{INDEX_HEADER}\n\n{line}\n"
+            elif re.search(pattern, content, re.MULTILINE):
+                new_content = re.sub(
+                    pattern, lambda _: line, content, flags=re.MULTILINE
+                )
+            else:
+                if not content.endswith("\n"):
+                    content += "\n"
+                new_content = content + line + "\n"
+            f.seek(0)
+            f.truncate()
+            f.write(new_content)
+        finally:
+            _unlock(f)
+
+
+class MemoryStore:
+    """Reads union every root (nearest layer wins on name); writes target one scope."""
+
+    def __init__(self, roots: Iterable[MemoryRoot]):
+        self.roots = list(roots)
+        self.errors: list[tuple[Path, str]] = []
+
+    @classmethod
+    def from_workspace(
+        cls, workspace: Path | None = None, **kwargs: Any
+    ) -> MemoryStore:
+        return cls(resolve_roots(workspace, **kwargs))
+
+    # -- reads -------------------------------------------------------------
+
+    def root(self, scope: str | None) -> MemoryRoot:
+        if scope is None:
+            return default_write_root(self.roots)
+        for r in self.roots:
+            if r.scope == scope:
+                return r
+        available = ", ".join(r.scope for r in self.roots) or "none"
+        raise KeyError(f"no memory root for scope {scope!r} (available: {available})")
+
+    def entries(
+        self,
+        *,
+        type: str | None = None,
+        status: str | None = None,
+        scope: str | None = None,
+    ) -> list[MemoryEntry]:
+        self.errors = []
+        seen: dict[str, MemoryEntry] = {}
+        for r in self.roots:
+            if scope is not None and r.scope != scope:
+                continue
+            if not r.path.is_dir():
+                continue
+            for path in sorted(r.path.glob("*.md")):
+                if is_index_file(path):
+                    continue
+                try:
+                    entry = parse_entry(path, scope=r.scope)
+                except (MemoryParseError, OSError, UnicodeDecodeError) as e:
+                    self.errors.append((path, str(e)))
+                    continue
+                seen.setdefault(entry.name, entry)  # nearest root wins
+        out = list(seen.values())
+        if type is not None:
+            out = [e for e in out if e.type == type]
+        if status is not None:
+            out = [e for e in out if e.status == status]
+        return sorted(out, key=lambda e: e.name)
+
+    def get(self, name: str, scope: str | None = None) -> MemoryEntry | None:
+        wanted = {name, slugify(name)}
+        for e in self.entries(scope=scope):
+            if e.name in wanted or e.path is not None and e.path.stem in wanted:
+                return e
+        return None
+
+    # -- writes ------------------------------------------------------------
+
+    def save(
+        self,
+        name: str,
+        description: str,
+        body: str = "",
+        *,
+        type: str = DEFAULT_TYPE,
+        scope: str | None = None,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Path:
+        """Write ``<slug>.md`` into the scope's root and upsert its index line."""
+        root = self.root(scope)
+        root.path.mkdir(parents=True, exist_ok=True)
+        entry = MemoryEntry(
+            name=slugify(name),
+            description=description.strip(),
+            type=type,
+            body=body,
+            title=title,
+            metadata=dict(metadata or {}),
+            scope=root.scope,
+        )
+        entry.path = root.path / entry.filename
+        entry.path.write_text(entry.to_markdown(), encoding="utf-8")
+        update_index_line(root.path, entry)
+        logger.debug("saved memory %s to %s", entry.name, entry.path)
+        return entry.path
+
+    # -- index -------------------------------------------------------------
+
+    @staticmethod
+    def render_index(
+        entries: Iterable[MemoryEntry], *, budget: int | None = None
+    ) -> str:
+        """Generate the always-on index: living entries grouped by type, one line each.
+
+        ``budget`` caps the output in bytes; entries past the budget are
+        replaced by one trailing line naming how many were omitted, so the
+        output is deterministic for a given entry set.
+        """
+        living = [e for e in entries if e.is_living]
+        groups: dict[str, list[MemoryEntry]] = {}
+        for e in living:
+            groups.setdefault(e.type, []).append(e)
+        order = [t for t in TYPE_ORDER if t in groups] + sorted(
+            t for t in groups if t not in TYPE_ORDER
+        )
+        lines = [INDEX_HEADER, ""]
+        size = len("\n".join(lines).encode()) + 1
+        omitted = 0
+        for t in order:
+            header = f"## {t.capitalize()}"
+            block = [header] + [
+                e.index_line() for e in sorted(groups[t], key=lambda e: e.name)
+            ]
+            for i, line in enumerate(block):
+                cost = len(line.encode()) + 1
+                if budget is not None and size + cost > budget - 64:
+                    omitted += len(block) - i
+                    if i == 0:
+                        omitted -= 1  # the header is not an entry
+                    break
+                lines.append(line)
+                size += cost
+            else:
+                lines.append("")
+                size += 1
+                continue
+            break
+        if omitted:
+            lines.append("")
+            lines.append(f"- … {omitted} more entries omitted (budget {budget} bytes)")
+        while lines and lines[-1] == "":
+            lines.pop()
+        return "\n".join(lines) + "\n"
+
+    def index_path(self, scope: str | None = None) -> Path:
+        return self.root(scope).path / INDEX_FILENAME
+
+    def write_index(
+        self, scope: str | None = None, *, budget: int | None = None
+    ) -> Path:
+        root = self.root(scope)
+        text = self.render_index(self.entries(scope=root.scope), budget=budget)
+        root.path.mkdir(parents=True, exist_ok=True)
+        path = root.path / INDEX_FILENAME
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def check_index(
+        self, scope: str | None = None, *, budget: int | None = None
+    ) -> bool:
+        """True when the on-disk index equals the regenerated one byte for byte."""
+        root = self.root(scope)
+        path = root.path / INDEX_FILENAME
+        expected = self.render_index(self.entries(scope=root.scope), budget=budget)
+        return path.is_file() and path.read_text(encoding="utf-8") == expected

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -104,18 +104,10 @@ class MemoryStore:
         available = ", ".join(r.scope for r in self.roots) or "none"
         raise KeyError(f"no memory root for scope {scope!r} (available: {available})")
 
-    def entries(
-        self,
-        *,
-        type: str | None = None,
-        status: str | None = None,
-        scope: str | None = None,
-    ) -> list[MemoryEntry]:
+    def _entries_from_roots(self, roots: Iterable[MemoryRoot]) -> list[MemoryEntry]:
         self.errors = []
         seen: dict[str, MemoryEntry] = {}
-        for r in self.roots:
-            if scope is not None and r.scope != scope:
-                continue
+        for r in roots:
             if not r.path.is_dir():
                 continue
             for path in sorted(r.path.glob("*.md")):
@@ -127,12 +119,34 @@ class MemoryStore:
                     self.errors.append((path, str(e)))
                     continue
                 seen.setdefault(entry.name, entry)  # nearest root wins
-        out = list(seen.values())
+        return list(seen.values())
+
+    def entries(
+        self,
+        *,
+        type: str | None = None,
+        status: str | None = None,
+        scope: str | None = None,
+    ) -> list[MemoryEntry]:
+        if scope is None:
+            roots = self.roots
+        else:
+            roots = [r for r in self.roots if r.scope == scope]
+        out = self._entries_from_roots(roots)
         if type is not None:
             out = [e for e in out if e.type == type]
         if status is not None:
             out = [e for e in out if e.status == status]
         return sorted(out, key=lambda e: e.name)
+
+    def index_entries(self, scope: str | None = None) -> list[MemoryEntry]:
+        """Entries that belong in the index of one physical root.
+
+        ``entries(scope=...)`` unions every root with that scope name, which
+        would put later-directory filenames into the first directory's
+        ``MEMORY.md``. Index generation is always per-directory.
+        """
+        return self._entries_from_roots([self.root(scope)])
 
     def get(self, name: str, scope: str | None = None) -> MemoryEntry | None:
         wanted = {name, slugify(name)}
@@ -180,10 +194,14 @@ class MemoryStore:
     ) -> str:
         """Generate the always-on index: living entries grouped by type, one line each.
 
-        ``budget`` caps the output in bytes; entries past the budget are
-        replaced by one trailing line naming how many were omitted, so the
-        output is deterministic for a given entry set.
+        ``budget`` caps the output in bytes. Entries that do not fit — including
+        every later type group — are replaced by one trailing line naming how
+        many were omitted. The marker is included in the cap, so the returned
+        text never exceeds ``budget``.
         """
+        if budget is not None and budget <= 0:
+            raise ValueError(f"budget {budget} is too small for the index header")
+
         living = [e for e in entries if e.is_living]
         groups: dict[str, list[MemoryEntry]] = {}
         for e in living:
@@ -191,34 +209,49 @@ class MemoryStore:
         order = [t for t in TYPE_ORDER if t in groups] + sorted(
             t for t in groups if t not in TYPE_ORDER
         )
-        lines = [INDEX_HEADER, ""]
-        size = len("\n".join(lines).encode()) + 1
-        omitted = 0
-        for t in order:
-            header = f"## {t.capitalize()}"
-            block = [header] + [
-                e.index_line() for e in sorted(groups[t], key=lambda e: e.name)
-            ]
-            for i, line in enumerate(block):
-                cost = len(line.encode()) + 1
-                if budget is not None and size + cost > budget - 64:
-                    omitted += len(block) - i
-                    if i == 0:
-                        omitted -= 1  # the header is not an entry
+        grouped: list[tuple[str, list[str]]] = [
+            (
+                f"## {t.capitalize()}",
+                [e.index_line() for e in sorted(groups[t], key=lambda e: e.name)],
+            )
+            for t in order
+        ]
+        total = sum(len(lines) for _, lines in grouped)
+
+        def build(n_entries: int) -> str:
+            omitted = total - n_entries
+            lines = [INDEX_HEADER, ""]
+            remaining = n_entries
+            for header, entry_lines in grouped:
+                if remaining <= 0:
                     break
-                lines.append(line)
-                size += cost
-            else:
+                take = min(len(entry_lines), remaining)
+                lines.append(header)
+                lines.extend(entry_lines[:take])
                 lines.append("")
-                size += 1
-                continue
-            break
-        if omitted:
-            lines.append("")
-            lines.append(f"- … {omitted} more entries omitted (budget {budget} bytes)")
-        while lines and lines[-1] == "":
-            lines.pop()
-        return "\n".join(lines) + "\n"
+                remaining -= take
+            while lines and lines[-1] == "":
+                lines.pop()
+            if omitted:
+                lines.extend(
+                    [
+                        "",
+                        f"- … {omitted} more entries omitted (budget {budget} bytes)",
+                    ]
+                )
+            return "\n".join(lines) + "\n"
+
+        if budget is None:
+            return build(total)
+
+        n = total
+        while True:
+            text = build(n)
+            if len(text.encode()) <= budget:
+                return text
+            if n == 0:
+                raise ValueError(f"budget {budget} is too small for the index header")
+            n -= 1
 
     def index_path(self, scope: str | None = None) -> Path:
         return self.root(scope).path / INDEX_FILENAME
@@ -227,7 +260,7 @@ class MemoryStore:
         self, scope: str | None = None, *, budget: int | None = None
     ) -> Path:
         root = self.root(scope)
-        text = self.render_index(self.entries(scope=root.scope), budget=budget)
+        text = self.render_index(self.index_entries(scope), budget=budget)
         root.path.mkdir(parents=True, exist_ok=True)
         path = root.path / INDEX_FILENAME
         path.write_text(text, encoding="utf-8")
@@ -237,7 +270,6 @@ class MemoryStore:
         self, scope: str | None = None, *, budget: int | None = None
     ) -> bool:
         """True when the on-disk index equals the regenerated one byte for byte."""
-        root = self.root(scope)
-        path = root.path / INDEX_FILENAME
-        expected = self.render_index(self.entries(scope=root.scope), budget=budget)
+        path = self.root(scope).path / INDEX_FILENAME
+        expected = self.render_index(self.index_entries(scope), budget=budget)
         return path.is_file() and path.read_text(encoding="utf-8") == expected

--- a/gptme/tools/memory.py
+++ b/gptme/tools/memory.py
@@ -17,32 +17,14 @@ Usage:
 """
 
 import logging
-import re
 from collections.abc import Generator
 from pathlib import Path
 
 from ..dirs import get_cc_memory_dir, get_workspace
+from ..memory import MemoryEntry, MemoryRoot, MemoryStore, slugify, update_index_line
 from ..message import Message
 from ..util.ask_execute import execute_with_confirmation
 from .base import ToolSpec, ToolUse
-
-try:
-    import fcntl as _fcntl
-
-    def _lock_exclusive(f) -> None:
-        _fcntl.flock(f, _fcntl.LOCK_EX)
-
-    def _unlock(f) -> None:
-        _fcntl.flock(f, _fcntl.LOCK_UN)
-
-except ImportError:
-    # Windows: no flock — skip locking (best-effort)
-    def _lock_exclusive(f) -> None:
-        pass
-
-    def _unlock(f) -> None:
-        pass
-
 
 logger = logging.getLogger(__name__)
 
@@ -75,53 +57,19 @@ def examples(tool_format):
 """.strip()
 
 
-def _slugify(name: str) -> str:
-    """Convert a name to a safe filename slug."""
-    slug = name.lower().strip()
-    slug = re.sub(r"[^a-z0-9]+", "-", slug)
-    slug = slug.strip("-")
-    return slug or "memory"
+# Kept as module-level names for callers and tests; the implementation lives
+# in gptme.memory so gptme-util and other harnesses share it.
+_slugify = slugify
 
 
 def _update_memory_index(
     memory_dir: Path, slug: str, filename: str, description: str
 ) -> None:
-    """Add or update an entry in MEMORY.md.
-
-    Uses the slug (not the raw name) as the index key so that distinct names
-    that normalise to the same slug always update the same single entry rather
-    than creating duplicate lines pointing at the same file.
-
-    An exclusive file lock serialises concurrent index updates so that parallel
-    sessions cannot race and silently drop each other's entries.
-    """
-    index_path = memory_dir / "MEMORY.md"
-    entry = f"- [{slug}]({filename}) — {description}\n"
-
-    # Open 'a+': creates when absent, positions at EOF, allows read+write.
-    with open(index_path, "a+", encoding="utf-8") as f:
-        _lock_exclusive(f)
-        try:
-            f.seek(0)
-            content = f.read()
-            if not content:
-                new_content = f"# Persistent Memory\n\n{entry}"
-            else:
-                pattern = rf"^- \[{re.escape(slug)}\]\({re.escape(filename)}\).*$"
-                if re.search(pattern, content, re.MULTILINE):
-                    replacement = entry.rstrip()
-                    new_content = re.sub(
-                        pattern, lambda _: replacement, content, flags=re.MULTILINE
-                    )
-                else:
-                    if not content.endswith("\n"):
-                        content += "\n"
-                    new_content = content + entry
-            f.seek(0)
-            f.truncate()
-            f.write(new_content)
-        finally:
-            _unlock(f)
+    """Add or update an entry line in MEMORY.md (delegates to gptme.memory)."""
+    update_index_line(
+        memory_dir,
+        MemoryEntry(name=slug, description=description, path=memory_dir / filename),
+    )
 
 
 def save_memory(name: str, content: str, workspace: Path | None = None) -> str:
@@ -138,26 +86,12 @@ def save_memory(name: str, content: str, workspace: Path | None = None) -> str:
     if workspace is None:
         workspace = get_workspace()
 
-    memory_dir = get_cc_memory_dir(workspace)
-    memory_dir.mkdir(parents=True, exist_ok=True)
-
-    slug = _slugify(name)
-    filename = f"{slug}.md"
-    file_path = memory_dir / filename
-
     lines = content.strip().splitlines()
     description = lines[0].strip() if lines else name
     body = "\n".join(lines[1:]).strip() if len(lines) > 1 else content.strip()
 
-    safe_desc = description.replace("\\", "\\\\").replace('"', '\\"')
-    frontmatter = f'---\nname: {slug}\ndescription: "{safe_desc}"\nmetadata:\n  type: general\n---\n\n'
-    file_path.write_text(frontmatter + body + "\n", encoding="utf-8")
-
-    # Use slug as the index key so colliding names update the same entry.
-    _update_memory_index(memory_dir, slug, filename, description)
-
-    logger.debug(f"Saved memory '{name}' to {file_path}")
-    return str(file_path)
+    store = MemoryStore([MemoryRoot("cc", get_cc_memory_dir(workspace))])
+    return str(store.save(name, description, body))
 
 
 def execute_memory(
@@ -190,7 +124,7 @@ def execute_memory(
     ) -> Path:
         ws = get_workspace()
         mem_dir = get_cc_memory_dir(ws)
-        return mem_dir / f"{_slugify(name)}.md"
+        return mem_dir / f"{slugify(name)}.md"
 
     def _do_save(
         save_content: str, path: Path | None

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,284 @@
+"""Tests for gptme.memory: schema round-trip, layered roots, store, index, CLI."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import main as util_main
+from gptme.memory import (
+    MemoryEntry,
+    MemoryParseError,
+    MemoryRoot,
+    MemoryStore,
+    parse_entry,
+    resolve_roots,
+    slugify,
+)
+from gptme.memory.roots import default_write_root
+from gptme.memory.schema import entry_from_text
+
+CC_FILE = """---
+name: prefer-short-answers
+description: "User prefers short, direct answers."
+metadata:
+  type: feedback
+  originSessionId: abc-123
+---
+
+Erik said so on 2026-09-07.
+"""
+
+
+def _write(dir_: Path, name: str, text: str) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    p = dir_ / f"{name}.md"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestSchema:
+    def test_parse_cc_file(self, tmp_path):
+        e = parse_entry(_write(tmp_path, "prefer-short-answers", CC_FILE))
+        assert e.name == "prefer-short-answers"
+        assert e.type == "feedback"
+        assert e.description == "User prefers short, direct answers."
+        assert e.metadata == {"originSessionId": "abc-123"}
+        assert e.body == "Erik said so on 2026-09-07."
+        assert e.is_living
+
+    def test_render_round_trip(self):
+        e = entry_from_text(CC_FILE)
+        again = entry_from_text(e.to_markdown())
+        assert again.to_dict() == e.to_dict()
+        assert again.body == e.body
+        # CC fields keep their exact shape
+        assert (
+            "metadata:\n  type: feedback\n  originSessionId: abc-123" in e.to_markdown()
+        )
+
+    def test_optional_fields_round_trip(self):
+        e = MemoryEntry(
+            name="x",
+            description="d",
+            type="project",
+            title="X the thing",
+            status="superseded",
+            superseded_by="y",
+            supersedes=["w"],
+            provenance={"session": "b831", "source": "knowledge/design/a.md"},
+            confidence=0.9,
+            keywords=["pacing floor", "fable window"],
+            recheck="2026-09-28",
+            body="body",
+        )
+        again = entry_from_text(e.to_markdown())
+        assert again.to_dict() == e.to_dict()
+        assert again.index_line() == "- [X the thing](x.md) — d"
+
+    def test_top_level_type_and_lenient_yaml(self, tmp_path):
+        # Unquoted colon makes PyYAML fail; the lenient parser still yields an entry.
+        text = "---\nname: odd\ndescription: note: this has a colon\ntype: reference\n---\nbody\n"
+        e = parse_entry(_write(tmp_path, "odd", text))
+        assert e.type == "reference"
+        assert "colon" in e.description
+
+    def test_no_frontmatter_raises(self, tmp_path):
+        with pytest.raises(MemoryParseError):
+            parse_entry(_write(tmp_path, "plain", "# Just a heading\n"))
+
+    def test_name_falls_back_to_stem(self, tmp_path):
+        e = parse_entry(_write(tmp_path, "from-stem", "---\ndescription: d\n---\n"))
+        assert e.name == "from-stem"
+
+    def test_slugify(self):
+        assert slugify("My Cool Fact!") == "my-cool-fact"
+        assert slugify("") == "memory"
+
+
+class TestRoots:
+    def test_explicit_env_overrides_everything(self, tmp_path):
+        a, b = tmp_path / "a", tmp_path / "b"
+        roots = resolve_roots(tmp_path, env={"GPTME_MEMORY_DIRS": f"{a}:{b}"})
+        assert [r.scope for r in roots] == ["explicit", "explicit"]
+        assert [r.path for r in roots] == [a, b]
+
+    def test_layer_order(self, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        (ws / "memory").mkdir(parents=True)
+        agent = tmp_path / "brain"
+        (agent / "memory").mkdir(parents=True)
+        cfg = tmp_path / "cfg"
+        monkeypatch.setattr(
+            "gptme.memory.roots.get_cc_memory_dir", lambda _ws: tmp_path / "cc"
+        )
+        roots = resolve_roots(
+            ws, env={"GPTME_AGENT_WORKSPACE": str(agent)}, config_dir=cfg
+        )
+        assert [r.scope for r in roots] == ["project", "cc", "agent", "user"]
+        assert roots[0].path == ws / "memory"
+        assert roots[3].path == cfg / "memory"
+        assert default_write_root(roots).scope == "project"
+
+    def test_same_dir_collapses_onto_first_scope(self, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        (ws / "memory").mkdir(parents=True)
+        monkeypatch.setattr(
+            "gptme.memory.roots.get_cc_memory_dir", lambda _ws: ws / "memory"
+        )
+        roots = resolve_roots(ws, env={}, config_dir=tmp_path / "cfg")
+        assert [r.scope for r in roots] == ["project", "user"]
+
+    def test_cc_is_default_write_root_without_project_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "gptme.memory.roots.get_cc_memory_dir", lambda _ws: tmp_path / "cc"
+        )
+        roots = resolve_roots(tmp_path / "ws", env={}, config_dir=tmp_path / "cfg")
+        assert default_write_root(roots).scope == "cc"
+
+
+class TestStore:
+    def _store(self, tmp_path) -> MemoryStore:
+        return MemoryStore(
+            [
+                MemoryRoot("project", tmp_path / "project"),
+                MemoryRoot("user", tmp_path / "user"),
+            ]
+        )
+
+    def test_union_and_nearest_wins(self, tmp_path):
+        _write(
+            tmp_path / "project",
+            "shared",
+            "---\nname: shared\ndescription: near\n---\n",
+        )
+        _write(
+            tmp_path / "user", "shared", "---\nname: shared\ndescription: far\n---\n"
+        )
+        _write(
+            tmp_path / "user",
+            "only-user",
+            "---\nname: only-user\ndescription: u\n---\n",
+        )
+        entries = self._store(tmp_path).entries()
+        assert [e.name for e in entries] == ["only-user", "shared"]
+        assert entries[1].description == "near"
+        assert entries[1].scope == "project"
+
+    def test_skips_index_and_non_entries(self, tmp_path):
+        _write(tmp_path / "project", "MEMORY", "# Persistent Memory\n")
+        _write(tmp_path / "project", "MEMORY-archive", "- old\n")
+        _write(tmp_path / "project", "notes", "no frontmatter\n")
+        _write(tmp_path / "project", "real", "---\nname: real\ndescription: r\n---\n")
+        store = self._store(tmp_path)
+        assert [e.name for e in store.entries()] == ["real"]
+        assert [p.name for p, _ in store.errors] == ["notes.md"]
+
+    def test_save_writes_file_and_index_line(self, tmp_path):
+        store = self._store(tmp_path)
+        path = store.save("My Fact", "A fact.", "Detail.", type="project")
+        assert path == tmp_path / "project" / "my-fact.md"
+        text = path.read_text()
+        assert 'description: "A fact."' in text and "type: project" in text
+        index = (tmp_path / "project" / "MEMORY.md").read_text()
+        assert index.startswith("# Persistent Memory\n\n")
+        assert "- [my-fact](my-fact.md) — A fact." in index
+        # re-save updates the same line, never duplicates it
+        store.save("my fact", "Changed.", type="project")
+        index = (tmp_path / "project" / "MEMORY.md").read_text()
+        assert index.count("my-fact.md") == 1 and "Changed." in index
+
+    def test_save_to_scope_and_unknown_scope(self, tmp_path):
+        store = self._store(tmp_path)
+        assert store.save("u", "d", scope="user").parent == tmp_path / "user"
+        with pytest.raises(KeyError):
+            store.save("u", "d", scope="agent")
+
+    def test_index_groups_by_type_and_is_byte_stable(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("b-proj", "B", type="project")
+        store.save("a-proj", "A", type="project")
+        store.save("fb", "F", type="feedback")
+        store.save("custom", "C", type="decision")
+        _write(
+            tmp_path / "project",
+            "old",
+            "---\nname: old\ndescription: gone\nstatus: historical\n---\n",
+        )
+        assert not store.check_index()
+        store.write_index()
+        text = (tmp_path / "project" / "MEMORY.md").read_text()
+        assert text == (
+            "# Persistent Memory\n\n"
+            "## Feedback\n- [fb](fb.md) — F\n\n"
+            "## Project\n- [a-proj](a-proj.md) — A\n- [b-proj](b-proj.md) — B\n\n"
+            "## Decision\n- [custom](custom.md) — C\n"
+        )
+        assert "gone" not in text
+        assert store.check_index()
+
+    def test_index_budget_omits_deterministically(self, tmp_path):
+        store = self._store(tmp_path)
+        for i in range(20):
+            store.save(f"e{i:02d}", "x" * 40, type="project")
+        full = store.render_index(store.entries())
+        small = store.render_index(store.entries(), budget=400)
+        assert len(small.encode()) <= 400
+        assert "more entries omitted" in small
+        assert small == store.render_index(store.entries(), budget=400)
+        assert len(full.encode()) > 400
+
+
+class TestCli:
+    @pytest.fixture
+    def env(self, tmp_path, monkeypatch):
+        root = tmp_path / "mem"
+        monkeypatch.setenv("GPTME_MEMORY_DIRS", str(root))
+        return root
+
+    def test_save_list_show_index(self, env):
+        runner = CliRunner()
+        r = runner.invoke(
+            util_main,
+            ["memory", "save", "pref", "Short answers.", "--type", "feedback"],
+            input="Body text.\n",
+        )
+        assert r.exit_code == 0, r.output
+        assert (env / "pref.md").exists()
+
+        r = runner.invoke(util_main, ["memory", "list", "--type", "feedback"])
+        assert r.exit_code == 0 and "pref" in r.output
+
+        r = runner.invoke(util_main, ["memory", "show", "pref", "--json"])
+        assert r.exit_code == 0 and '"body": "Body text."' in r.output
+
+        r = runner.invoke(util_main, ["memory", "show", "nope"])
+        assert r.exit_code == 1
+
+        r = runner.invoke(util_main, ["memory", "index", "--check"])
+        assert r.exit_code == 1 and "DRIFT" in r.output
+        r = runner.invoke(util_main, ["memory", "index", "--write"])
+        assert r.exit_code == 0
+        r = runner.invoke(util_main, ["memory", "index", "--check"])
+        assert r.exit_code == 0, r.output
+
+    def test_roots(self, env):
+        r = CliRunner().invoke(util_main, ["memory", "roots"])
+        assert r.exit_code == 0 and "explicit" in r.output and "(missing)" in r.output
+
+
+@pytest.mark.skipif(
+    not Path("/home/bob/bob/memory").is_dir(), reason="Bob's memory dir not present"
+)
+def test_bob_memory_dir_round_trip(tmp_path):
+    """Real-world corpus: every CC-written entry parses and the index is byte-stable."""
+    import shutil
+
+    copy = tmp_path / "memory"
+    shutil.copytree("/home/bob/bob/memory", copy)
+    store = MemoryStore([MemoryRoot("explicit", copy)])
+    entries = store.entries()
+    assert len(entries) >= 400
+    assert all(e.description for e in entries[:50])
+    store.write_index()
+    assert store.check_index()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -294,17 +294,20 @@ class TestCli:
         _write(
             env,
             "unsafe",
-            '---\nname: unsafe\ndescription: "red \u001b[31mtext\u001b[0m"\n---\n\nline 1\nline 2\n',
+            '---\nname: unsafe\ndescription: "red \u001b[31mtext\u001b[0m"\n---\n\nline 1\r\nline 2\n',
         )
         runner = CliRunner()
         shown = runner.invoke(util_main, ["memory", "show", "unsafe"])
         assert shown.exit_code == 0
         assert "\x1b" not in shown.output
+        assert "\r" not in shown.output
         assert "line 1\nline 2" in shown.output
         listed = runner.invoke(util_main, ["memory", "list"])
         assert "\x1b" not in listed.output
+        assert "\r" not in listed.output
         indexed = runner.invoke(util_main, ["memory", "index"])
         assert "\x1b" not in indexed.output
+        assert "\r" not in indexed.output
 
     def test_index_budget_cli_rejects_non_positive(self, env):
         r = CliRunner().invoke(util_main, ["memory", "index", "--budget", "0"])

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -228,6 +228,34 @@ class TestStore:
         assert small == store.render_index(store.entries(), budget=400)
         assert len(full.encode()) > 400
 
+    def test_index_budget_counts_entries_in_later_groups(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("first", "x" * 80, type="feedback")
+        store.save("second", "x" * 80, type="project")
+        text = store.render_index(store.entries(), budget=130)
+        assert len(text.encode()) <= 130
+        assert "2 more entries omitted" in text
+
+    def test_index_budget_too_small_raises(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("first", "x" * 80, type="feedback")
+        with pytest.raises(ValueError, match="too small"):
+            store.render_index(store.entries(), budget=1)
+        with pytest.raises(ValueError, match="too small"):
+            store.render_index(store.entries(), budget=0)
+
+    def test_index_uses_only_selected_physical_root(self, tmp_path):
+        first, second = tmp_path / "first", tmp_path / "second"
+        _write(first, "one", "---\nname: one\ndescription: first\n---\n")
+        _write(second, "two", "---\nname: two\ndescription: second\n---\n")
+        store = MemoryStore(
+            [MemoryRoot("explicit", first), MemoryRoot("explicit", second)]
+        )
+        store.write_index("explicit")
+        text = (first / "MEMORY.md").read_text()
+        assert "one.md" in text
+        assert "two.md" not in text
+
 
 class TestCli:
     @pytest.fixture
@@ -261,6 +289,26 @@ class TestCli:
         assert r.exit_code == 0
         r = runner.invoke(util_main, ["memory", "index", "--check"])
         assert r.exit_code == 0, r.output
+
+    def test_human_output_strips_controls_but_preserves_lines(self, env):
+        _write(
+            env,
+            "unsafe",
+            '---\nname: unsafe\ndescription: "red \u001b[31mtext\u001b[0m"\n---\n\nline 1\nline 2\n',
+        )
+        runner = CliRunner()
+        shown = runner.invoke(util_main, ["memory", "show", "unsafe"])
+        assert shown.exit_code == 0
+        assert "\x1b" not in shown.output
+        assert "line 1\nline 2" in shown.output
+        listed = runner.invoke(util_main, ["memory", "list"])
+        assert "\x1b" not in listed.output
+        indexed = runner.invoke(util_main, ["memory", "index"])
+        assert "\x1b" not in indexed.output
+
+    def test_index_budget_cli_rejects_non_positive(self, env):
+        r = CliRunner().invoke(util_main, ["memory", "index", "--budget", "0"])
+        assert r.exit_code != 0
 
     def test_roots(self, env):
         r = CliRunner().invoke(util_main, ["memory", "roots"])


### PR DESCRIPTION
Phase 1 of #3734 — one memory/knowledge CLI with layered roots that any harness can wrap. Design and inventory are in the issue.

## What

- **`gptme/memory/`** — a package that imports nothing from core except `gptme.dirs`, so extracting it to a `gptme-memory` sibling of gptme-rag later is a file move.
  - `schema.py`: `MemoryEntry` dataclass. The Claude Code fields (`name`, `description`, `metadata.type`, `metadata.originSessionId`) are read and written exactly as CC writes them, so CC's own memory feature keeps working on the same files. Additive optional fields: `title`, `status` (living/superseded/historical), `supersedes`, `superseded_by`, `provenance`, `confidence`, `keywords`, `recheck`. PyYAML with a lenient line-parser fallback for frontmatter PyYAML rejects (unquoted colons in descriptions are common in real CC-written files).
  - `roots.py`: ordered layers `GPTME_MEMORY_DIRS` (explicit) → `<workspace>/memory/` (project) → `~/.claude/projects/<hash>/memory/` (cc) → `$GPTME_AGENT_WORKSPACE/memory/` (agent) → `<config>/memory/` (user). Same-directory layers collapse onto the first scope. This is the answer to #3728's "layer/include both" comment and to the "agent's brain memories while working in another repo" case.
  - `store.py`: `MemoryStore` — union reads (nearest root wins on name), scoped writes, `render_index` (living entries grouped by type, deterministic byte budget), `write_index`/`check_index`.
- **`gptme-util memory`** lazy subgroup: `roots`, `list`, `show`, `save`, `index`. `index` prints by default; `--write` replaces `MEMORY.md`, `--check` exits 1 on drift. A hand-curated index is never overwritten by accident.
- **`tools/memory.py`** now delegates to the package. `save` still upserts a single CC-style `- [title](file) — description` line under flock, so incremental CC-compatible behavior is unchanged (existing `test_memory_tool.py` passes untouched).

## Verified

- 49 tests: `tests/test_memory_store.py` (new, 24) + `tests/test_memory_tool.py` (existing, unchanged).
- Round-trip on a real 417-file Claude Code memory dir (Bob's brain): 404 entries parse (the rest are index files and notes without frontmatter, reported on stderr, never fatal); `index --write` then `index --check` is byte-stable.
- ruff, mypy clean on the new files.

## Not in this PR (later phases of #3734)

`recall` (ambient), `match` (triggered, lesson-matcher integration), `supersede`/`audit`, `migrate-knowledge-jsonl` (folding `gptme-util knowledge`), the CC hook and Codex AGENTS.md wrappers in docs, and switching `prompts/workspace.py` to the generated index.