### PR TITLE
fix: reduce lesson/hidden-message log spam in TUI

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -678,7 +678,9 @@ def print_msg(
             logger.exception("Error printing message")
             print(s)
         shown += 1
-    if skipped_hidden:
+    # Only show the skip notice when printing a multi-message log (e.g. /log),
+    # not when a single appended message happens to be hidden (spammy mid-reply).
+    if skipped_hidden and len(msgs) > 1:
         console.print(
             f"[dim]Skipped {skipped_hidden} hidden system messages (/log --hidden to show)[/]"
         )

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -412,7 +412,9 @@ def auto_include_lessons_hook(
 
         titles = [str(match.lesson.title) for match in new_matches]
         titles_list = "\n".join(f"- {title}" for title in titles)
-        logger.info(f"Auto-included {len(new_matches)} lessons:\n{titles_list}")
+        # debug-level: session-end stats (session_end_lessons_hook) report this
+        # in the right place; info-level spam here fires mid-reply at hook time.
+        logger.debug(f"Auto-included {len(new_matches)} lessons:\n{titles_list}")
 
         yield lesson_msg
 


### PR DESCRIPTION
Two small UX fixes for spammy/misleading log output during interactive sessions:

1. **"Skipped N hidden system messages" notice** — `LogManager.append()` prints every appended message; when a hidden system message (e.g. lesson injection) was appended, the skip notice printed even though nothing was shown. The notice now only prints when printing a multi-message log (like `/log`), not for single appended hidden messages.

2. **"Auto-included N lessons" mid-reply** — the lessons hook logged at INFO level at hook time, which can fire mid-reply at an arbitrary point. Downgraded to DEBUG; the session-end stats hook (`session_end_lessons_hook`) already reports lesson matches in the right place.

Also renames the `# Instructions` heading in `.cursor/rules/cursor-tools.mdc` context (not included here) — that was a local config fix, separate from core.

## Testing
- `tests/test_lessons*.py`: 416 passed
- Pre-existing failures in `TestJSONOutputIntegration` confirmed on clean master (unrelated)