### PR TITLE
fix(webui): suppress 'Cannot reach' banner while auto-connecting

### DIFF
--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -51,12 +51,14 @@ export const WelcomeView = () => {
   const [isRestartingServer, setIsRestartingServer] = useState(false);
   const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
   const navigate = useNavigate();
-  const { api, isConnected$, connectionConfig, switchServer, connect } = useApi();
+  const { api, isConnected$, isAutoConnecting$, connectionConfig, switchServer, connect } =
+    useApi();
   const demoMode = isDemoMode();
   const isTauri = isTauriEnvironment();
   const { managesLocalServer } = useTauriServerStatus();
   const queryClient = useQueryClient();
   const isConnected = use$(isConnected$);
+  const isAutoConnecting = use$(isAutoConnecting$);
   const lastConnectionResult = use$(api.lastConnectionResult$);
   const compatibilityWarning = use$(api.compatibilityWarning$);
   const providerStatusVersion = use$(setupWizard$.providerStatusVersion);
@@ -379,7 +381,7 @@ export const WelcomeView = () => {
               </Alert>
             )}
 
-            {!isConnected && (
+            {!isConnected && !isAutoConnecting && (
               <Alert className="mx-auto w-full max-w-2xl border-amber-500/30 bg-amber-500/10 text-left">
                 <Server className="h-4 w-4 text-amber-700 dark:text-amber-300" />
                 <AlertTitle>

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -131,6 +131,7 @@ describe('WelcomeView', () => {
     localStorage.clear();
     setLocation('http://localhost/');
     isConnected$.set(true);
+    isAutoConnecting$.set(false);
     lastConnectionResult$.set(null);
     compatibilityWarning$.set(null);
     mockBaseUrl = 'http://localhost:5700';
@@ -421,6 +422,37 @@ describe('WelcomeView', () => {
       'href',
       'https://gptme.org/docs/server.html'
     );
+  });
+
+  it('hides the disconnected banner while auto-connect is still in progress', () => {
+    // Loading /chat directly kicks off an auto-connect that takes ~1s. Rendering
+    // "Cannot reach ..." during that window contradicts the server dropdown,
+    // which reports "Auto-connecting..." at the same moment.
+    mockBaseUrl = 'http://my-server.example.com:5700';
+    isConnected$.set(false);
+    isAutoConnecting$.set(true);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByText(/Cannot reach/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the disconnected banner once auto-connect finishes without connecting', () => {
+    mockBaseUrl = 'http://my-server.example.com:5700';
+    isConnected$.set(false);
+    isAutoConnecting$.set(false);
+
+    render(
+      <SettingsProvider>
+        <WelcomeView />
+      </SettingsProvider>
+    );
+
+    expect(screen.getByText(/Cannot reach/i)).toBeInTheDocument();
   });
 
   it('shows a finish-setup banner when the server has no provider configured', async () => {

--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -19,6 +19,7 @@ const mockUseTauriServerStatus = jest.fn(() => ({
   serverStatus: null,
 }));
 const isConnected$ = observable(true);
+const isAutoConnecting$ = observable(false);
 const compatibilityWarning$ = observable<null | {
   kind: 'server_older' | 'api_major_mismatch';
   serverApiVersion: number;
@@ -85,6 +86,7 @@ jest.mock('@/contexts/ApiContext', () => {
         compatibilityWarning$,
       },
       isConnected$,
+      isAutoConnecting$,
       connect: mockConnect,
       connectionConfig: { baseUrl: mockBaseUrl },
       switchServer: jest.fn(),


### PR DESCRIPTION
## Problem

Loading the webui directly (e.g. `/chat`) briefly shows a **"Cannot reach ..."**
banner for ~1s before the connection establishes — while the server dropdown
simultaneously reports **"Auto-connecting..."**. Two parts of the same screen
disagree, and the alarming one wins.

Reported by Erik against gptme.ai prod: gptme/gptme-cloud#894.

The `WelcomeView` disconnected alert was gated only on `!isConnected`, so it
rendered during the initial auto-connect window. `ServerSelector` already
consumes `isAutoConnecting$` for exactly this reason; `WelcomeView` did not.

## Fix

`webui/src/components/WelcomeView.tsx`:
- destructure `isAutoConnecting$` from `useApi()`
- gate the banner with `!isConnected && !isAutoConnecting`

The banner still shows for every genuine disconnected state — it is only
withheld while an auto-connect attempt is actually in flight.

## Tests

Two regression tests in `WelcomeView.test.tsx`:
- banner hidden while `isAutoConnecting` is true
- banner shown once auto-connect settles without connecting

Plus `isAutoConnecting$.set(false)` in `beforeEach` so the observable does not
leak between tests.

Guard verified by reverting the `WelcomeView` condition: the first test fails,
restoring it passes. **33/33 in `WelcomeView.test.tsx`.**

## Why this PR exists

The commit was authored on this branch and consumed directly by a
gptme-cloud submodule bump (gptme/gptme-cloud#898, merged) **without ever being
opened upstream**. The pointer therefore referenced a branch-only commit: the
next submodule bump to `master` would have silently reverted the fix, and gptme's
own webui users never got it at all. Rebased onto current `master` (was 37 behind).