### PR TITLE
feat(memory): add cross-harness lexical recall

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    acp
    lessons
    skills
+   memory
 
 .. toctree::
    :maxdepth: 2

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -1,0 +1,66 @@
+Cross-harness memory
+====================
+
+``gptme-util memory`` provides one local, Markdown-based memory store that can
+be shared by gptme, Claude Code, Codex, and other agent harnesses. Entries use
+Claude Code-compatible frontmatter and are read from layered roots (project,
+Claude Code, agent, and user); the nearest entry wins when names collide.
+
+Inspect and write memory
+------------------------
+
+.. code-block:: console
+
+   $ gptme-util memory roots
+   $ gptme-util memory list
+   $ gptme-util memory show prefer-short-answers
+   $ gptme-util memory save prefer-short-answers \
+       "User prefers short, direct answers." --type feedback < details.md
+   $ gptme-util memory index
+
+``index`` prints by default. Pass ``--write`` only when you want to replace the
+selected root's ``MEMORY.md`` with a generated index.
+
+Recall
+------
+
+Recall searches all living entries across the layered roots:
+
+.. code-block:: console
+
+   $ gptme-util memory recall "How should private code be reviewed?" -k 3
+   $ gptme-util memory recall "exact identifier" --format json
+
+With ``gptme-rag`` and its ``lexical`` extra installed, ``--backend auto`` uses
+its TF-IDF index. A minimal gptme installation falls back to a stdlib
+token-overlap scorer. Output always reports the backend that actually ran; use
+``--backend tfidf`` when fallback would be unacceptable.
+
+Claude Code hook
+----------------
+
+Add the command below to a ``UserPromptSubmit`` hook in
+``.claude/settings.json``. It reads Claude Code's JSON event from stdin and
+returns a valid ``additionalContext`` response:
+
+.. code-block:: json
+
+   {
+     "hooks": {
+       "UserPromptSubmit": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "gptme-util memory recall --prompt - --format hook-json",
+               "timeout": 20
+             }
+           ]
+         }
+       ]
+     }
+   }
+
+The hook is read-only and returns empty ``additionalContext`` when there is no
+relevant memory. Keep the executable on Claude Code's hook ``PATH``; if the
+workspace uses an isolated environment, call its absolute ``gptme-util`` path.

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from typing import Literal
 
 import click
 
@@ -169,6 +170,100 @@ def memory_save(
         )
     else:
         click.echo(f"Saved memory to {path}")
+
+
+def _read_recall_prompt(prompt: str | None) -> str:
+    if prompt == "-":
+        raw = sys.stdin.read()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+        if isinstance(payload, dict):
+            value = payload.get("prompt")
+            return value if isinstance(value, str) else ""
+        return ""
+    if prompt is not None:
+        return prompt
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise click.UsageError("provide QUERY or --prompt - to read stdin")
+
+
+@memory.command("recall")
+@click.argument("query", required=False)
+@click.option(
+    "--prompt",
+    help="Prompt text, or '-' to read a Claude Code hook payload/plain text from stdin.",
+)
+@click.option(
+    "-k",
+    "--limit",
+    type=click.IntRange(min=1),
+    default=3,
+    show_default=True,
+    help="Maximum number of entries to return.",
+)
+@click.option(
+    "--backend",
+    type=click.Choice(["auto", "tfidf", "overlap"]),
+    default="auto",
+    show_default=True,
+    help="Retrieval backend; auto falls back to token overlap.",
+)
+@click.option(
+    "--format",
+    "format_",
+    type=click.Choice(["text", "json", "hook-json"]),
+    default="text",
+    show_default=True,
+    help="Output format. hook-json is a Claude Code UserPromptSubmit response.",
+)
+@click.option(
+    "--body-chars",
+    type=click.IntRange(min=1),
+    default=1200,
+    show_default=True,
+    help="Maximum body characters to inject per text result.",
+)
+def memory_recall(
+    query: str | None,
+    prompt: str | None,
+    limit: int,
+    backend: Literal["auto", "tfidf", "overlap"],
+    format_: str,
+    body_chars: int,
+):
+    """Recall relevant entries from every layered memory root."""
+    from ..memory import RecallBackendUnavailable, recall, render_recall
+
+    if query is not None and prompt is not None:
+        raise click.UsageError("use either QUERY or --prompt, not both")
+    prompt_text = _read_recall_prompt(prompt if prompt is not None else query)
+    try:
+        result = recall(_store(), prompt_text, limit=limit, backend=backend)
+    except (RecallBackendUnavailable, ValueError) as e:
+        raise click.ClickException(str(e)) from e
+
+    if format_ == "json":
+        click.echo(json.dumps(result.to_dict(), indent=2, default=str))
+        return
+
+    rendered = _clean(render_recall(result, body_chars=body_chars), keep_newlines=True)
+    if format_ == "hook-json":
+        click.echo(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "additionalContext": rendered,
+                    }
+                }
+            )
+        )
+        return
+    if rendered:
+        click.echo(rendered)
 
 
 @memory.command("index")

--- a/gptme/memory/__init__.py
+++ b/gptme/memory/__init__.py
@@ -5,6 +5,13 @@ can be extracted into a standalone ``gptme-memory`` package (sibling of
 ``gptme-rag``) as a file move. See gptme/gptme#3734.
 """
 
+from .recall import (
+    RecallBackendUnavailable,
+    RecallHit,
+    RecallResult,
+    recall,
+    render_recall,
+)
 from .roots import MemoryRoot, resolve_roots
 from .schema import MemoryEntry, MemoryParseError, parse_entry, slugify
 from .store import MemoryStore, update_index_line
@@ -14,7 +21,12 @@ __all__ = [
     "MemoryParseError",
     "MemoryRoot",
     "MemoryStore",
+    "RecallBackendUnavailable",
+    "RecallHit",
+    "RecallResult",
     "parse_entry",
+    "recall",
+    "render_recall",
     "resolve_roots",
     "slugify",
     "update_index_line",

--- a/gptme/memory/recall.py
+++ b/gptme/memory/recall.py
@@ -227,7 +227,10 @@ def render_recall(result: RecallResult, *, body_chars: int = DEFAULT_BODY_CHARS)
         summary = re.sub(r"\s+", " ", entry.body.strip() or entry.description)
         if summary:
             if len(summary) > body_chars:
-                summary = summary[: body_chars - 3].rstrip() + "..."
+                if body_chars <= 3:
+                    summary = summary[:body_chars]
+                else:
+                    summary = summary[: body_chars - 3].rstrip() + "..."
             lines.append(f"  {summary}")
     lines.append("</memory_relevant_entries>")
     return "\n".join(lines)

--- a/gptme/memory/recall.py
+++ b/gptme/memory/recall.py
@@ -1,0 +1,233 @@
+"""Lexical recall over a :class:`~gptme.memory.store.MemoryStore`.
+
+The optional gptme-rag TF-IDF backend is preferred when installed. A small
+stdlib token-overlap scorer keeps ``gptme-util memory recall`` useful in a
+minimal gptme installation and makes the fallback explicit in every result.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from .schema import MemoryEntry
+    from .store import MemoryStore
+
+RecallBackend = Literal["auto", "tfidf", "overlap"]
+DEFAULT_BODY_CHARS = 1200
+STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "can",
+        "do",
+        "for",
+        "from",
+        "has",
+        "have",
+        "how",
+        "i",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "me",
+        "my",
+        "of",
+        "on",
+        "or",
+        "our",
+        "that",
+        "the",
+        "their",
+        "them",
+        "this",
+        "to",
+        "use",
+        "when",
+        "with",
+        "you",
+        "your",
+    }
+)
+
+
+class RecallBackendUnavailable(ImportError):
+    """Raised when a caller forces a recall backend that is not installed."""
+
+
+@dataclass(frozen=True)
+class RecallHit:
+    """One ranked memory entry."""
+
+    entry: MemoryEntry
+    score: float
+    matched_terms: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self.entry.to_dict(),
+            "score": self.score,
+            "matched_terms": self.matched_terms,
+            "body": self.entry.body,
+        }
+
+
+@dataclass(frozen=True)
+class RecallResult:
+    """Ranked hits plus the backend that actually produced them."""
+
+    backend: Literal["tfidf", "overlap"]
+    hits: list[RecallHit]
+
+    def to_dict(self) -> dict[str, object]:
+        return {"backend": self.backend, "hits": [hit.to_dict() for hit in self.hits]}
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", text.lower())
+        if len(token) >= 3 and token not in STOPWORDS
+    }
+
+
+def _entry_text(entry: MemoryEntry) -> str:
+    return "\n".join(
+        part
+        for part in (
+            entry.name.replace("-", " ").replace("_", " "),
+            entry.title or "",
+            entry.description,
+            " ".join(entry.keywords),
+            entry.body,
+        )
+        if part
+    )
+
+
+def _recall_overlap(
+    entries: list[MemoryEntry], query: str, limit: int
+) -> list[RecallHit]:
+    query_tokens = _tokens(query)
+    if len(query_tokens) < 2:
+        return []
+
+    hits: list[RecallHit] = []
+    for entry in entries:
+        matched = sorted(query_tokens & _tokens(_entry_text(entry)))
+        if len(matched) < 2:
+            continue
+        score = round(len(matched) / len(query_tokens), 4)
+        hits.append(RecallHit(entry=entry, score=score, matched_terms=matched[:5]))
+    return sorted(hits, key=lambda hit: (-hit.score, hit.entry.name))[:limit]
+
+
+def _install_hint() -> str:
+    return "install gptme-rag[lexical] or use --backend overlap"
+
+
+def _recall_tfidf(
+    entries: list[MemoryEntry], query: str, limit: int
+) -> list[RecallHit]:
+    try:
+        from gptme_rag.indexing.document import Document
+        from gptme_rag.lexical import TfidfIndex
+    except ImportError as exc:
+        raise RecallBackendUnavailable(
+            f"gptme-rag lexical retrieval is unavailable; {_install_hint()}"
+        ) from exc
+
+    documents = [
+        Document(
+            content=_entry_text(entry),
+            metadata={"memory_entry": entry},
+            source_path=entry.path,
+            doc_id=entry.name,
+        )
+        for entry in entries
+    ]
+    try:
+        index = TfidfIndex(relevance_floor=0.05)
+        index.index(documents)
+        ranked = index.search(query, n_results=limit)
+    except ImportError as exc:
+        raise RecallBackendUnavailable(
+            f"gptme-rag lexical retrieval is unavailable; {_install_hint()}"
+        ) from exc
+
+    return [
+        RecallHit(
+            entry=hit.document.metadata["memory_entry"],
+            score=float(hit.score),
+            matched_terms=[],
+        )
+        for hit in ranked
+    ]
+
+
+def recall(
+    store: MemoryStore,
+    query: str,
+    *,
+    limit: int = 3,
+    backend: RecallBackend = "auto",
+) -> RecallResult:
+    """Recall living entries across every layered root.
+
+    ``auto`` prefers gptme-rag's TF-IDF backend and falls back to the built-in
+    overlap scorer only when the optional backend is unavailable. A forced
+    ``tfidf`` request fails instead of silently changing semantics.
+    """
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    query = query.strip()
+    entries = store.entries(status="living")
+
+    if backend in {"auto", "tfidf"}:
+        try:
+            return RecallResult(
+                backend="tfidf", hits=_recall_tfidf(entries, query, limit)
+            )
+        except RecallBackendUnavailable:
+            if backend == "tfidf":
+                raise
+
+    return RecallResult(backend="overlap", hits=_recall_overlap(entries, query, limit))
+
+
+def render_recall(result: RecallResult, *, body_chars: int = DEFAULT_BODY_CHARS) -> str:
+    """Render bounded context suitable for injection into another harness."""
+    if body_chars <= 0:
+        raise ValueError("body_chars must be positive")
+    if not result.hits:
+        return ""
+    lines = [
+        "<memory_relevant_entries>",
+        f"## Relevant Memory (backend={result.backend})",
+    ]
+    for hit in result.hits:
+        entry = hit.entry
+        lines.append(
+            f"- [{entry.type}] {entry.name} "
+            f"(score {hit.score:.3f}, scope {entry.scope or 'unknown'})"
+        )
+        if hit.matched_terms:
+            lines.append(f"  Match: {', '.join(hit.matched_terms)}")
+        summary = re.sub(r"\s+", " ", entry.body.strip() or entry.description)
+        if summary:
+            if len(summary) > body_chars:
+                summary = summary[: body_chars - 3].rstrip() + "..."
+            lines.append(f"  {summary}")
+    lines.append("</memory_relevant_entries>")
+    return "\n".join(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,6 +381,10 @@ module = "gptme_sessions.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "gptme_rag.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["docx", "magic"]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,10 +388,6 @@ ignore_missing_imports = true
 module = ["docx", "magic"]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "gptme_rag.*"
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,6 +388,10 @@ ignore_missing_imports = true
 module = ["docx", "magic"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "gptme_rag.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -393,6 +393,20 @@ class TestRecall:
         assert "line one xxxxxxxx..." in rendered
         assert "line one\n" not in rendered
 
+    def test_render_tiny_body_chars_does_not_bypass_bound(self, tmp_path):
+        store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+        self._entry(tmp_path, "one", "Useful memory", "line one\n" + "x" * 80)
+        result = recall(store, "one useful memory", backend="overlap")
+        for body_chars in (1, 2, 3):
+            tiny = render_recall(result, body_chars=body_chars)
+            body_line = next(
+                line
+                for line in tiny.splitlines()
+                if line.startswith("  ") and not line.startswith("  Match:")
+            )
+            assert len(body_line[2:]) <= body_chars
+            assert "x" * 10 not in tiny
+
 
 class TestCli:
     @pytest.fixture

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,5 +1,6 @@
 """Tests for gptme.memory: schema round-trip, layered roots, store, index, CLI."""
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -11,10 +12,14 @@ from gptme.memory import (
     MemoryParseError,
     MemoryRoot,
     MemoryStore,
+    RecallBackendUnavailable,
     parse_entry,
+    recall,
+    render_recall,
     resolve_roots,
     slugify,
 )
+from gptme.memory.recall import RecallHit
 from gptme.memory.roots import default_write_root
 from gptme.memory.schema import entry_from_text
 
@@ -257,6 +262,138 @@ class TestStore:
         assert "two.md" not in text
 
 
+class TestRecall:
+    @staticmethod
+    def _entry(
+        root: Path,
+        name: str,
+        description: str,
+        body: str = "",
+        *,
+        status: str = "living",
+    ) -> MemoryEntry:
+        path = _write(
+            root,
+            name,
+            "---\n"
+            f"name: {name}\n"
+            f'description: "{description}"\n'
+            f"status: {status}\n"
+            "---\n"
+            f"{body}\n",
+        )
+        return parse_entry(path, scope="explicit")
+
+    def test_overlap_fallback_ranks_all_layered_roots(self, tmp_path, monkeypatch):
+        near = tmp_path / "near"
+        far = tmp_path / "far"
+        self._entry(
+            near,
+            "openrouter-guardrail",
+            "OpenRouter guardrail blocks Anthropic model IDs",
+            "Use another provider when Anthropic requests return 404.",
+        )
+        self._entry(
+            far,
+            "slot-refresh",
+            "Refresh dead Claude subscription slots",
+            "An invalid_grant means the slot needs login.",
+        )
+        self._entry(
+            far,
+            "old-guardrail",
+            "OpenRouter guardrail historical note",
+            status="superseded",
+        )
+        store = MemoryStore([MemoryRoot("explicit", near), MemoryRoot("user", far)])
+
+        def unavailable(*_args, **_kwargs):
+            raise RecallBackendUnavailable("gptme-rag unavailable")
+
+        recall_module = importlib.import_module("gptme.memory.recall")
+        monkeypatch.setattr(recall_module, "_recall_tfidf", unavailable)
+        result = recall(
+            store,
+            "Why are Anthropic model requests blocked by the OpenRouter guardrail?",
+            limit=3,
+        )
+        assert result.backend == "overlap"
+        assert [hit.entry.name for hit in result.hits] == ["openrouter-guardrail"]
+        assert result.hits[0].matched_terms == [
+            "anthropic",
+            "guardrail",
+            "model",
+            "openrouter",
+            "requests",
+        ]
+
+        second = recall(
+            store,
+            "The Claude slot says invalid grant and needs login refresh",
+            backend="overlap",
+        )
+        assert [hit.entry.name for hit in second.hits] == ["slot-refresh"]
+        assert second.hits[0].entry.scope == "user"
+
+    def test_auto_prefers_tfidf_when_available(self, tmp_path, monkeypatch):
+        entry = self._entry(tmp_path, "one", "One useful memory")
+        store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+        expected = [RecallHit(entry=entry, score=0.42, matched_terms=[])]
+        recall_module = importlib.import_module("gptme.memory.recall")
+        monkeypatch.setattr(
+            recall_module,
+            "_recall_tfidf",
+            lambda entries, query, limit: expected,
+        )
+        result = recall(store, "useful memory", backend="auto")
+        assert result.backend == "tfidf"
+        assert result.hits == expected
+
+    def test_real_tfidf_backend_when_optional_package_is_installed(self, tmp_path):
+        pytest.importorskip("gptme_rag.lexical")
+        store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+        self._entry(
+            tmp_path,
+            "guardrail",
+            "OpenRouter guardrail blocks Anthropic models",
+            "The account returns a provider-specific 404.",
+        )
+        self._entry(
+            tmp_path,
+            "database",
+            "PostgreSQL migration procedure",
+            "Back up the database before applying migrations.",
+        )
+        result = recall(
+            store,
+            "Why does the OpenRouter Anthropic guardrail return 404?",
+            backend="tfidf",
+        )
+        assert result.backend == "tfidf"
+        assert [hit.entry.name for hit in result.hits] == ["guardrail"]
+        assert result.hits[0].score > 0
+
+    def test_forced_tfidf_does_not_silently_fallback(self, tmp_path, monkeypatch):
+        store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+        self._entry(tmp_path, "one", "One useful memory")
+
+        def unavailable(*_args, **_kwargs):
+            raise RecallBackendUnavailable("install gptme-rag[lexical]")
+
+        recall_module = importlib.import_module("gptme.memory.recall")
+        monkeypatch.setattr(recall_module, "_recall_tfidf", unavailable)
+        with pytest.raises(RecallBackendUnavailable, match="gptme-rag"):
+            recall(store, "useful memory", backend="tfidf")
+
+    def test_render_bounds_and_flattens_entry_body(self, tmp_path):
+        store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+        self._entry(tmp_path, "one", "Useful memory", "line one\n" + "x" * 80)
+        result = recall(store, "one useful memory", backend="overlap")
+        rendered = render_recall(result, body_chars=20)
+        assert "line one xxxxxxxx..." in rendered
+        assert "line one\n" not in rendered
+
+
 class TestCli:
     @pytest.fixture
     def env(self, tmp_path, monkeypatch):
@@ -312,6 +449,56 @@ class TestCli:
     def test_index_budget_cli_rejects_non_positive(self, env):
         r = CliRunner().invoke(util_main, ["memory", "index", "--budget", "0"])
         assert r.exit_code != 0
+
+    def test_recall_hook_json_reads_claude_payload(self, env):
+        _write(
+            env,
+            "provider-policy",
+            "---\n"
+            "name: provider-policy\n"
+            'description: "Keep private code off training providers"\n'
+            "metadata:\n"
+            "  type: feedback\n"
+            "---\n"
+            "Route sensitive review through a private provider.\n",
+        )
+        result = CliRunner().invoke(
+            util_main,
+            [
+                "memory",
+                "recall",
+                "--prompt",
+                "-",
+                "--backend",
+                "overlap",
+                "--format",
+                "hook-json",
+            ],
+            input='{"prompt":"Which provider should review private sensitive code?"}',
+        )
+        assert result.exit_code == 0, result.output
+        payload = __import__("json").loads(result.output)
+        hook = payload["hookSpecificOutput"]
+        assert hook["hookEventName"] == "UserPromptSubmit"
+        assert "provider-policy" in hook["additionalContext"]
+        assert "backend=overlap" in hook["additionalContext"]
+
+    def test_recall_json_discloses_backend_and_empty_results(self, env):
+        result = CliRunner().invoke(
+            util_main,
+            [
+                "memory",
+                "recall",
+                "no matching signal here",
+                "--backend",
+                "overlap",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = __import__("json").loads(result.output)
+        assert payload == {"backend": "overlap", "hits": []}
 
     def test_roots(self, env):
         r = CliRunner().invoke(util_main, ["memory", "roots"])


### PR DESCRIPTION
## What

Adds Phase 2.1 of gptme/gptme#3734:

- `gptme-util memory recall` searches living entries across every layered root
- `auto` prefers `gptme-rag`'s `TfidfIndex`; minimal installs fall back to deterministic token overlap and disclose the backend
- text, JSON, and Claude Code `UserPromptSubmit` hook JSON formats
- bounded injected bodies and a documented Claude Code hook wrapper

## Why

Memory already has one CC-compatible substrate. This gives every harness the same read path instead of carrying a harness-local scorer.

## Verification

- 32 focused memory tests pass, including the real `gptme-rag` TF-IDF backend and fallback path
- ruff clean and formatted
- mypy clean for the new recall and CLI modules
- all scoped pre-commit hooks pass
- Sphinx parses and renders `docs/memory.rst`; the full docs build reaches completion but reports two unrelated pre-existing optional-Flask/undefined-label warnings

Part of gptme/gptme#3734 (does not close it; later phases remain).