### PR TITLE
test(webui): exercise live auto-connect banner transition

### DIFF
--- a/webui/src/components/__tests__/WelcomeView.test.tsx
+++ b/webui/src/components/__tests__/WelcomeView.test.tsx
@@ -441,10 +441,13 @@ describe('WelcomeView', () => {
     expect(screen.queryByText(/Cannot reach/i)).not.toBeInTheDocument();
   });
 
-  it('shows the disconnected banner once auto-connect finishes without connecting', () => {
+  it('shows the disconnected banner once auto-connect finishes without connecting', async () => {
+    // Mount during the in-flight window, then flip the observable so the
+    // banner appears via the live true→false transition — not a pre-settled
+    // render that would still pass if WelcomeView stopped reacting.
     mockBaseUrl = 'http://my-server.example.com:5700';
     isConnected$.set(false);
-    isAutoConnecting$.set(false);
+    isAutoConnecting$.set(true);
 
     render(
       <SettingsProvider>
@@ -452,7 +455,13 @@ describe('WelcomeView', () => {
       </SettingsProvider>
     );
 
-    expect(screen.getByText(/Cannot reach/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Cannot reach/i)).not.toBeInTheDocument();
+
+    act(() => {
+      isAutoConnecting$.set(false);
+    });
+
+    expect(await screen.findByText(/Cannot reach/i)).toBeInTheDocument();
   });
 
   it('shows a finish-setup banner when the server has no provider configured', async () => {


### PR DESCRIPTION
Follow-up to gptme/gptme#3739 (merged `b3b4501d4`) — closes the Greptile 4/5 finding on that PR.

## Problem

Greptile flagged that the `shows the disconnected banner once auto-connect finishes
without connecting` test did not exercise the transition its name describes. It set
`isAutoConnecting$` to `false` **before** render, so it only asserted a pre-settled
static state. That assertion passes whether or not `WelcomeView` actually subscribes
to the observable — it cannot detect a regression that drops reactivity.

The fix commit was authored while #3739 was in flight and Erik squash-merged before
it landed, so it stayed on the leftover branch and never reached `master`. Cherry-picked
here onto current master.

## Change

Test-only. Mount during the in-flight window (`isAutoConnecting$ = true`), assert the
banner is suppressed, then flip the observable and assert the banner appears via the
live `true → false` transition.

## Verification

- `npm test -- src/components/__tests__/WelcomeView.test.tsx` — **33/33 passing**
- **Mutation-tested**: changing `use$(isAutoConnecting$)` to `isAutoConnecting$.peek()`
  in `WelcomeView.tsx` (dropping reactivity, keeping the same gate) fails **this test
  and only this test** — 1 failed, 32 passed. The old static version passed under that
  mutation, which is exactly the gap Greptile identified.
- `prettier --check` and `eslint` clean on the changed file.