### PR TITLE
fix(webui): repair dead conversations-list invalidation after create/delete/import

### DIFF
--- a/webui/src/components/DeleteConversationConfirmationDialog.tsx
+++ b/webui/src/components/DeleteConversationConfirmationDialog.tsx
@@ -12,8 +12,8 @@ import { Loader2 } from 'lucide-react';
 import { useApi } from '@/contexts/ApiContext';
 import { conversations$, selectedConversation$ } from '@/stores/conversations';
 import { useQueryClient } from '@tanstack/react-query';
-import { use$ } from '@legendapp/state/react';
 import { demoConversations } from '@/democonversations';
+import { conversationsQueryKey } from '@/hooks/useConversationsInfiniteQuery';
 
 interface Props {
   conversationName: string;
@@ -31,9 +31,8 @@ export function DeleteConversationConfirmationDialog({
   onOpenChange,
   onDelete,
 }: Props) {
-  const { api, connectionConfig, isConnected$ } = useApi();
+  const { api, connectionConfig } = useApi();
   const queryClient = useQueryClient();
-  const isConnected = use$(isConnected$);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -57,7 +56,7 @@ export function DeleteConversationConfirmationDialog({
     }
     conversations$.delete(conversationName);
     queryClient.invalidateQueries({
-      queryKey: ['conversations', connectionConfig.baseUrl, isConnected],
+      queryKey: conversationsQueryKey(connectionConfig.baseUrl),
     });
     selectedConversation$.set(demoConversations[0].name);
 

--- a/webui/src/components/UnifiedSidebar.tsx
+++ b/webui/src/components/UnifiedSidebar.tsx
@@ -29,6 +29,7 @@ import type { ChangeEvent, FC } from 'react';
 import { use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
 import { useState, useMemo, useRef, useCallback } from 'react';
+import { conversationsQueryKey } from '@/hooks/useConversationsInfiniteQuery';
 
 // Simplified task display component for sidebar
 const TaskListItem: FC<{ task: Task; isSelected: boolean; onClick: () => void }> = ({
@@ -246,7 +247,7 @@ export const UnifiedSidebar: FC<Props> = ({
         });
 
         await queryClient.invalidateQueries({
-          queryKey: ['conversations', connectionConfig.baseUrl, isConnected],
+          queryKey: conversationsQueryKey(connectionConfig.baseUrl),
         });
 
         toast.success(

--- a/webui/src/components/WelcomeView.tsx
+++ b/webui/src/components/WelcomeView.tsx
@@ -28,6 +28,7 @@ import { appRoute, chatRoute } from '@/utils/routes';
 import { isTauriEnvironment, invokeTauri } from '@/utils/tauri';
 import { formatUnknownError } from '@/utils/errors';
 import { useTauriServerStatus } from '@/hooks/useTauriServerStatus';
+import { conversationsQueryKey } from '@/hooks/useConversationsInfiniteQuery';
 
 const DEFAULT_LOCAL_SERVER_URLS = new Set(['http://127.0.0.1:5700', 'http://localhost:5700']);
 
@@ -121,7 +122,7 @@ export const WelcomeView = () => {
 
       // Invalidate conversations query to refresh the list (async, don't block)
       queryClient.invalidateQueries({
-        queryKey: ['conversations', connectionConfig.baseUrl, isConnected$.get()],
+        queryKey: conversationsQueryKey(connectionConfig.baseUrl),
       });
     } catch (error) {
       // This only catches synchronous errors (e.g., local state issues)

--- a/webui/src/hooks/__tests__/conversationsQueryKey.test.ts
+++ b/webui/src/hooks/__tests__/conversationsQueryKey.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { QueryClient } from '@tanstack/react-query';
+import { conversationsQueryKey } from '../useConversationsInfiniteQuery';
+
+const BASE_URL = 'http://localhost:5700';
+
+const seedConversationsQuery = (client: QueryClient) => {
+  client.setQueryData(conversationsQueryKey(BASE_URL), {
+    pages: [{ conversations: [], nextCursor: undefined }],
+    pageParams: [undefined],
+  });
+};
+
+const isInvalidated = (client: QueryClient) =>
+  client.getQueryState(conversationsQueryKey(BASE_URL))?.isInvalidated ?? false;
+
+describe('conversationsQueryKey', () => {
+  it('matches the conversations list query when used for invalidation', async () => {
+    const client = new QueryClient();
+    seedConversationsQuery(client);
+
+    await client.invalidateQueries({ queryKey: conversationsQueryKey(BASE_URL) });
+
+    expect(isInvalidated(client)).toBe(true);
+  });
+
+  it('does not match when callers append extra key segments', async () => {
+    // Regression guard: invalidateQueries matches by key *prefix*, so the old
+    // `['conversations', baseUrl, isConnected]` call sites silently matched
+    // nothing after the query key dropped its isConnected segment — the
+    // sidebar list was never refreshed after create/delete/import.
+    const client = new QueryClient();
+    seedConversationsQuery(client);
+
+    await client.invalidateQueries({ queryKey: ['conversations', BASE_URL, true] });
+
+    expect(isInvalidated(client)).toBe(false);
+  });
+
+  it('is stable for the same base URL and distinct across servers', () => {
+    expect(conversationsQueryKey(BASE_URL)).toEqual(conversationsQueryKey(BASE_URL));
+    expect(conversationsQueryKey(BASE_URL)).not.toEqual(
+      conversationsQueryKey('http://localhost:5701')
+    );
+  });
+});
+
+describe('conversations invalidation call sites', () => {
+  const srcDir = join(__dirname, '../..');
+
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return entry.name === '__tests__' ? [] : walk(full);
+      return /\.tsx?$/.test(entry.name) ? [full] : [];
+    });
+
+  it('never inlines a conversations query key with extra segments', () => {
+    // An inline `['conversations', baseUrl, somethingElse]` is longer than the
+    // real query key, so prefix matching makes the invalidation a silent no-op.
+    const offenders = walk(srcDir).filter((file) =>
+      /queryKey:\s*\['conversations',[^\]]+\]/.test(readFileSync(file, 'utf8'))
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/webui/src/hooks/useConversationsInfiniteQuery.ts
+++ b/webui/src/hooks/useConversationsInfiniteQuery.ts
@@ -3,6 +3,16 @@ import { useApi } from '@/contexts/ApiContext';
 import { use$ } from '@legendapp/state/react';
 import type { ConversationSummary } from '@/types/conversation';
 
+/**
+ * Canonical query key for the conversations list.
+ *
+ * Callers that invalidate the list MUST use this instead of an inline array:
+ * `invalidateQueries` matches by key *prefix*, so an extra trailing element
+ * (e.g. the old `isConnected` flag) silently matches nothing and the list is
+ * never refreshed.
+ */
+export const conversationsQueryKey = (baseUrl: string) => ['conversations', baseUrl] as const;
+
 export function useConversationsInfiniteQuery(enabled: boolean = true) {
   const { api, connectionConfig } = useApi();
   const isConnected = use$(api.isConnected$);
@@ -12,7 +22,7 @@ export function useConversationsInfiniteQuery(enabled: boolean = true) {
     // isConnected flips from false→true on auto-connect. The `enabled` flag
     // already controls when the query fires. staleTime=30s prevents redundant
     // refetches within a fresh window (common during auto-connect handshake).
-    queryKey: ['conversations', connectionConfig.baseUrl],
+    queryKey: conversationsQueryKey(connectionConfig.baseUrl),
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
       try {
         return await api.getConversationsPaginated(pageParam, 50);


### PR DESCRIPTION
## Problem

`useConversationsInfiniteQuery` keys the conversations list as
`['conversations', baseUrl]` — the trailing `isConnected` segment was
deliberately dropped in #2860 ("Remove isConnected from queryKey to avoid a
second query identity"). Three call sites were never updated and still invalidate
with the old three-element key:

- `WelcomeView.tsx` — after creating a new chat
- `DeleteConversationConfirmationDialog.tsx` — after deleting a conversation
- `UnifiedSidebar.tsx` — after importing/restoring a conversation

`invalidateQueries` matches by key **prefix**: a filter key *longer* than the
query key matches nothing. All three invalidations have been silent no-ops, so
the sidebar list is not refreshed after any of those actions (it only catches up
on the next `staleTime` expiry or unrelated refetch).

Found while verifying gptme/gptme-cloud#895 (Erik's in-app feedback on the
new-chat flow, of which #3729 fixed the navigation latency half).

## Fix

- Export `conversationsQueryKey(baseUrl)` from the hook as the single source of
  truth, and use it in the hook and all three call sites.
- Drop the now-unused `isConnected` read in the delete dialog.

## Tests

`webui/src/hooks/__tests__/conversationsQueryKey.test.ts`:

- Real `QueryClient`: the shared key invalidates a seeded conversations query;
  a key with an extra segment does **not** (encodes the prefix-matching rule
  that caused this bug).
- Static guard: no source file inlines a longer `['conversations', ...]`
  invalidation key. Verified red on the pre-fix tree (flags `WelcomeView.tsx`),
  green after.

## Verification

- `npx jest src/hooks/__tests__ src/components/__tests__/WelcomeView.test.tsx src/components/__tests__/UnifiedSidebar.test.tsx` — 64 passed
- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `npx eslint` on all touched files — clean

## Visual changes

No screenshot needed — no rendered output, CSS, layout, or user-visible text was
changed. The modifications to `WelcomeView.tsx`, `UnifiedSidebar.tsx`, and
`DeleteConversationConfirmationDialog.tsx` are purely data/logic changes (replacing
inline `['conversations', baseUrl, isConnected]` array literals with the exported
`conversationsQueryKey(baseUrl)` call in `invalidateQueries`).
