### PR TITLE
fix(webui): pre-set generating state on new-chat placeholder to collapse microsteps

### DIFF
--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -25,6 +25,7 @@ describe('useConversation', () => {
   const mockedUseApi = useApi as jest.MockedFunction<typeof useApi>;
   const subscribeToEvents = jest.fn().mockResolvedValue(undefined);
   const step = jest.fn().mockResolvedValue(undefined);
+  const interruptGenerationApi = jest.fn().mockResolvedValue(undefined);
   const closeEventStream = jest.fn();
   const getChatConfig = jest.fn().mockResolvedValue(null);
   let eventHandlers:
@@ -39,7 +40,8 @@ describe('useConversation', () => {
       eventHandlers = handlers;
       return Promise.resolve();
     });
-    step.mockClear();
+    step.mockReset().mockResolvedValue(undefined);
+    interruptGenerationApi.mockReset().mockResolvedValue(undefined);
     closeEventStream.mockClear();
     getChatConfig.mockReset().mockResolvedValue(null);
 
@@ -67,6 +69,7 @@ describe('useConversation', () => {
         ({
           subscribeToEvents,
           step,
+          interruptGeneration: interruptGenerationApi,
           closeEventStream,
           getConversation: jest.fn(),
           getChatConfig,
@@ -148,5 +151,50 @@ describe('useConversation', () => {
         'initialStepStream'
       )
     ).toBe(false);
+  });
+
+  it('honors Stop before the SSE session exists by cancelling the pending initial step', async () => {
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+
+    expect(conversations$.get('chat-placeholder')?.needsInitialStep.get()).toBe(false);
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+    expect(interruptGenerationApi).toHaveBeenCalledWith('chat-placeholder');
+
+    await act(async () => {
+      eventHandlers?.onConnected?.();
+      await Promise.resolve();
+    });
+
+    expect(step).not.toHaveBeenCalled();
+  });
+
+  it('clears generating when the initial step request fails', async () => {
+    step.mockRejectedValueOnce(new Error('step failed'));
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      eventHandlers?.onConnected?.();
+    });
+
+    await waitFor(() => {
+      expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+    });
+    expect(step).toHaveBeenCalled();
   });
 });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -31,6 +31,7 @@ describe('useConversation', () => {
   let eventHandlers:
     | {
         onConnected?: () => void;
+        onMessageStart?: () => void;
       }
     | undefined;
 
@@ -176,6 +177,35 @@ describe('useConversation', () => {
     });
 
     expect(step).not.toHaveBeenCalled();
+  });
+
+  it('hides Stop even after onConnected already consumed the pending initial step', async () => {
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      eventHandlers?.onConnected?.();
+      await Promise.resolve();
+    });
+    expect(step).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+
+    await act(async () => {
+      eventHandlers?.onMessageStart?.();
+    });
+
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+    expect(interruptGenerationApi).toHaveBeenCalledTimes(2);
   });
 
   it('clears generating when the initial step request fails', async () => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -424,26 +424,29 @@ export function useConversation(conversationId: string, serverId?: string) {
             },
             onConnected: () => {
               // Check if this conversation needs initial step (was created from WelcomeView)
-              // This fixes the race condition where step() was called before subscription
-              const needsStep = conversation$?.needsInitialStep?.get();
-              if (needsStep) {
-                const initialStepStream = conversation$?.initialStepStream?.get();
-                clearInitialStepState(conversationId);
-                api
-                  .step(
-                    conversationId,
-                    undefined,
-                    initialStepStream ?? true,
-                    'main',
-                    maxTokens,
-                    temperature,
-                    topP
-                  )
-                  .catch((error) => {
-                    console.error('[useConversation] Error triggering initial step:', error);
-                    toastStepStartError(toast, error);
-                  });
+              // This fixes the race condition where step() was called before subscription.
+              // Re-read immediately before stepping so a Stop click during the handshake
+              // (which clears needsInitialStep) is honored instead of starting generation.
+              if (!conversation$?.needsInitialStep?.get()) {
+                return;
               }
+              const initialStepStream = conversation$?.initialStepStream?.get();
+              clearInitialStepState(conversationId);
+              api
+                .step(
+                  conversationId,
+                  undefined,
+                  initialStepStream ?? true,
+                  'main',
+                  maxTokens,
+                  temperature,
+                  topP
+                )
+                .catch((error) => {
+                  console.error('[useConversation] Error triggering initial step:', error);
+                  setGenerating(conversationId, false);
+                  toastStepStartError(toast, error);
+                });
             },
             onConnectionState: (state) => {
               switch (state.status) {
@@ -491,6 +494,7 @@ export function useConversation(conversationId: string, serverId?: string) {
           })
           .catch((err) => {
             console.error('[useConversation] Failed to subscribe to events:', err);
+            setGenerating(conversationId, false);
             toast({
               variant: 'destructive',
               title: 'Error',
@@ -661,6 +665,13 @@ export function useConversation(conversationId: string, serverId?: string) {
   };
 
   const interruptGeneration = async () => {
+    // Stop before the initial step starts: drop the optimistic generating
+    // state and cancel the pending step so onConnected cannot start it.
+    if (conversation$?.needsInitialStep?.get()) {
+      clearInitialStepState(conversationId);
+      setGenerating(conversationId, false);
+    }
+
     try {
       await api.interruptGeneration(conversationId);
     } catch (error) {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -53,6 +53,9 @@ export function useConversation(conversationId: string, serverId?: string) {
   const topP = use$(() => conversation$?.topP.get());
 
   const messageJustCompleted = useRef(false);
+  // Stop during the new-chat handshake: onConnected / onMessageStart must not
+  // restart generation after the user already cancelled the pending initial step.
+  const stopRequestedRef = useRef(false);
   const loadingOlderMessagesRef = useRef(false);
   const isLoadingOlderMessages$ = useObservable(false);
   const isLoadingOlderMessages = use$(isLoadingOlderMessages$);
@@ -220,6 +223,13 @@ export function useConversation(conversationId: string, serverId?: string) {
         api
           .subscribeToEvents(conversationId, {
             onMessageStart: () => {
+              if (stopRequestedRef.current) {
+                // Handshake started generation after Stop. Keep the UI stopped
+                // and interrupt now that a session is likely present.
+                setGenerating(conversationId, false);
+                void api.interruptGeneration(conversationId);
+                return;
+              }
               setGenerating(conversationId, true);
               setExecutingTool(conversationId, null, null); // Clear executing tool when starting new generation
               messageJustCompleted.current = false;
@@ -426,8 +436,8 @@ export function useConversation(conversationId: string, serverId?: string) {
               // Check if this conversation needs initial step (was created from WelcomeView)
               // This fixes the race condition where step() was called before subscription.
               // Re-read immediately before stepping so a Stop click during the handshake
-              // (which clears needsInitialStep) is honored instead of starting generation.
-              if (!conversation$?.needsInitialStep?.get()) {
+              // (which clears needsInitialStep / stopRequestedRef) is honored.
+              if (stopRequestedRef.current || !conversation$?.needsInitialStep?.get()) {
                 return;
               }
               const initialStepStream = conversation$?.initialStepStream?.get();
@@ -527,6 +537,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     if (!conversation$) {
       throw new Error('Conversation not initialized');
     }
+    stopRequestedRef.current = false;
 
     // Clear any pending or executing tool when sending a new message
     const pendingTool = conversation$?.pendingTool.get();
@@ -665,12 +676,13 @@ export function useConversation(conversationId: string, serverId?: string) {
   };
 
   const interruptGeneration = async () => {
-    // Stop before the initial step starts: drop the optimistic generating
-    // state and cancel the pending step so onConnected cannot start it.
-    if (conversation$?.needsInitialStep?.get()) {
-      clearInitialStepState(conversationId);
-      setGenerating(conversationId, false);
-    }
+    // Unconditional local cancel. Stop must hide immediately even if
+    // onConnected already consumed needsInitialStep and step() is in flight
+    // without a session id yet. The API interrupt is best-effort and no-ops
+    // until a session exists.
+    stopRequestedRef.current = true;
+    clearInitialStepState(conversationId);
+    setGenerating(conversationId, false);
 
     try {
       await api.interruptGeneration(conversationId);

--- a/webui/src/utils/__tests__/api.test.ts
+++ b/webui/src/utils/__tests__/api.test.ts
@@ -5,6 +5,7 @@ jest.mock('@/utils/connectionConfig', () => ({
 }));
 jest.mock('@/stores/conversations', () => ({
   initConversation: jest.fn(),
+  setGenerating: jest.fn(),
   setMaxTokens: jest.fn(),
   setTemperature: jest.fn(),
   setTopP: jest.fn(),
@@ -825,6 +826,7 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
       configurable: true,
     });
     (conversationsStore.initConversation as jest.Mock).mockClear();
+    (conversationsStore.setGenerating as jest.Mock).mockClear();
     (conversationsStore.setMaxTokens as jest.Mock).mockClear();
     (conversationsStore.setTemperature as jest.Mock).mockClear();
     (conversationsStore.setTopP as jest.Mock).mockClear();
@@ -981,5 +983,70 @@ describe('createConversationWithPlaceholder workspace defaults', () => {
     fetchResolve();
     await client.waitForConversationCreation(conversationId);
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('pre-sets generating so Stop is visible before the SSE handshake', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok', session_id: 'session-1' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    const conversationId = await client.createConversationWithPlaceholder('hello');
+
+    expect(conversationsStore.setGenerating).toHaveBeenCalledWith(conversationId, true);
+  });
+});
+
+describe('ApiClient interruptGeneration', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: { ...originalCrypto, randomUUID: jest.fn(() => 'test-client-id') },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'crypto', { value: originalCrypto, configurable: true });
+    jest.restoreAllMocks();
+  });
+
+  it('posts interrupt when a session id exists', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok' }),
+    } as Response);
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+    client.sessions$.set('conv-1', 'session-1');
+
+    await client.interruptGeneration('conv-1');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:5700/api/v2/conversations/conv-1/interrupt',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ session_id: 'session-1' }),
+      })
+    );
+  });
+
+  it('no-ops without error when no session id exists yet', async () => {
+    global.fetch = jest.fn();
+
+    const client = new ApiClient('http://127.0.0.1:5700');
+    client.setConnected(true);
+
+    await expect(client.interruptGeneration('conv-1')).resolves.toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -1340,10 +1340,12 @@ export class ApiClient {
       },
       { needsInitialStep: true, initialStepStream: options?.stream }
     );
-    // Pre-set generating state so the stop-button appears the moment the chat page renders,
-    // collapsing the "user message appears" and "response starts indicating" into one visual
-    // event instead of two. onMessageStart will re-set it (no-op); onError/onInterrupted
-    // will clear it on failure as they do for any other generation.
+    // Pre-set generating so Stop appears with the first chat render, collapsing
+    // "message appears" and "response starts indicating" into one visual event.
+    // Stop before the SSE session exists cancels this pending initial step
+    // (useConversation.interruptGeneration). A rejected initial step() also
+    // clears the flag. onMessageStart re-sets it (no-op); onError/onInterrupted
+    // remain the SSE failure/interrupt paths.
     setGenerating(conversationId, true);
     if (options?.maxTokens !== undefined) {
       setMaxTokens(conversationId, options.maxTokens);
@@ -1704,7 +1706,9 @@ export class ApiClient {
       const sessionId: string | undefined = this.sessions$.get(logfile).get();
 
       if (!sessionId) {
-        throw new ApiClientError('Session ID not found for conversation', 404);
+        // Stop clicked before the SSE handshake supplied a session. Nothing to
+        // interrupt on the server; the caller cancels any pending local initial-step.
+        return;
       }
 
       await this.fetchJson<{ status: string }>(

--- a/webui/src/utils/api.ts
+++ b/webui/src/utils/api.ts
@@ -18,7 +18,13 @@ import { getApiBaseUrl } from '@/utils/connectionConfig';
 import { isLocalUrl, withLocalAddressSpace } from '@/utils/addressSpace';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
-import { initConversation, setMaxTokens, setTemperature, setTopP } from '@/stores/conversations';
+import {
+  initConversation,
+  setGenerating,
+  setMaxTokens,
+  setTemperature,
+  setTopP,
+} from '@/stores/conversations';
 
 // Add DOM types
 type RequestInit = globalThis.RequestInit;
@@ -1334,6 +1340,11 @@ export class ApiClient {
       },
       { needsInitialStep: true, initialStepStream: options?.stream }
     );
+    // Pre-set generating state so the stop-button appears the moment the chat page renders,
+    // collapsing the "user message appears" and "response starts indicating" into one visual
+    // event instead of two. onMessageStart will re-set it (no-op); onError/onInterrupted
+    // will clear it on failure as they do for any other generation.
+    setGenerating(conversationId, true);
     if (options?.maxTokens !== undefined) {
       setMaxTokens(conversationId, options.maxTokens);
     }


### PR DESCRIPTION
## Problem

When starting a new chat from `WelcomeView`, the user sees two sequential visible events:

1. **Chat page renders** — user message appears, no generating indicator (`isGenerating=false`)
2. **A moment later** — SSE connects → `step()` called → `onMessageStart` fires → `isGenerating=true` → red Stop button appears

This gap (200–500ms for SSE connection + step handshake) makes the new-chat flow feel laggy — Erik reported it as "too many visible microsteps" in gptme/gptme-cloud#895.

## Fix

Pre-set `isGenerating=true` immediately after `initConversation()` in `createConversationWithPlaceholder()`. The Stop button appears alongside the user message in one visual event instead of two.

**Lifecycle safety:**
- `onMessageStart` re-sets `isGenerating=true` (no-op, already true)
- `onError` clears it on step failure (existing handler, unchanged)
- `onInterrupted` clears it on interrupt (existing handler, unchanged)
- SSE connection failure: stop button stays visible until the disconnect banner appears — acceptable trade-off given the rare failure path

## Context

The first two microsteps were already fixed:
- "chat inbox clears" → gptme/gptme#3742 (dead conversations-list invalidation)
- "page changes to the chat" → gptme/gptme#3729 (removed `await` before `navigate()`)

This PR fixes the remaining two ("message appears", "response starts indicating").

Closes gptme/gptme-cloud#895