### PR TITLE
fix(webui): clear stop flag before edit/rerun/regenerate

### DIFF
--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -363,4 +363,62 @@ describe('useConversation', () => {
     expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
     expect(interruptGenerationApi).toHaveBeenCalledTimes(2);
   });
+
+  it('re-interrupts after a successful rerunTools that raced with Stop', async () => {
+    conversations$.get('chat-placeholder')?.data.log.set([
+      {
+        role: 'user',
+        content: 'What is gptme?',
+        timestamp: '2026-06-07T00:00:00.000Z',
+      },
+      {
+        role: 'assistant',
+        content: 'An agent.',
+        timestamp: '2026-06-07T00:00:01.000Z',
+      },
+    ]);
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    // Hold rerunTools itself open. Unlike the truncation-request race, a
+    // successful rerun can start auto-confirm execution before it returns.
+    let resolveRerun: (value: { status: string; tool_ids: string[] }) => void = () => {};
+    rerunTools.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRerun = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    let pending: Promise<unknown> | undefined;
+    act(() => {
+      // Last message: skip truncation and go straight to rerunTools.
+      pending = result.current.rerunFromMessage(1);
+    });
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+
+    await act(async () => {
+      resolveRerun({ status: 'ok', tool_ids: ['tool-1'] });
+      await pending;
+    });
+
+    await act(async () => {
+      eventHandlers?.onMessageStart?.();
+    });
+
+    expect(step).not.toHaveBeenCalled();
+    expect(rerunTools).toHaveBeenCalledTimes(1);
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+    // 1: user Stop while rerunTools is in flight
+    // 2: post-success re-interrupt of the execution rerun started
+    // 3: late onMessageStart still sees the stop flag
+    expect(interruptGenerationApi).toHaveBeenCalledTimes(3);
+  });
 });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -356,7 +356,10 @@ describe('useConversation', () => {
       eventHandlers?.onMessageStart?.();
     });
 
-    // The Stop is newer than the request, so onMessageStart must not resume.
+    // The Stop is newer than the request: do not start generation, and do
+    // not let a late onMessageStart resume it.
+    expect(step).not.toHaveBeenCalled();
+    expect(rerunTools).not.toHaveBeenCalled();
     expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
     expect(interruptGenerationApi).toHaveBeenCalledTimes(2);
   });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -26,6 +26,8 @@ describe('useConversation', () => {
   const subscribeToEvents = jest.fn().mockResolvedValue(undefined);
   const step = jest.fn().mockResolvedValue(undefined);
   const interruptGenerationApi = jest.fn().mockResolvedValue(undefined);
+  const editMessageApi = jest.fn();
+  const rerunTools = jest.fn().mockResolvedValue(undefined);
   const closeEventStream = jest.fn();
   const getChatConfig = jest.fn().mockResolvedValue(null);
   let eventHandlers:
@@ -43,6 +45,8 @@ describe('useConversation', () => {
     });
     step.mockReset().mockResolvedValue(undefined);
     interruptGenerationApi.mockReset().mockResolvedValue(undefined);
+    editMessageApi.mockReset().mockResolvedValue({ log: [], branches: {} });
+    rerunTools.mockReset().mockResolvedValue(undefined);
     closeEventStream.mockClear();
     getChatConfig.mockReset().mockResolvedValue(null);
 
@@ -71,6 +75,8 @@ describe('useConversation', () => {
           subscribeToEvents,
           step,
           interruptGeneration: interruptGenerationApi,
+          editMessage: editMessageApi,
+          rerunTools,
           closeEventStream,
           getConversation: jest.fn(),
           getChatConfig,
@@ -226,5 +232,64 @@ describe('useConversation', () => {
       expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
     });
     expect(step).toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'edit with truncation',
+      async (result: { current: ReturnType<typeof useConversation> }) => {
+        await result.current.editMessage(0, 'What is gptme?', true);
+      },
+    ],
+    [
+      'rerun',
+      async (result: { current: ReturnType<typeof useConversation> }) => {
+        rerunTools.mockRejectedValueOnce(new Error('no tools'));
+        await result.current.rerunFromMessage(0);
+      },
+    ],
+    [
+      'regenerate',
+      async (result: { current: ReturnType<typeof useConversation> }) => {
+        conversations$.get('chat-placeholder')?.data.log.set([
+          {
+            role: 'user',
+            content: 'What is gptme?',
+            timestamp: '2026-06-07T00:00:00.000Z',
+          },
+          {
+            role: 'assistant',
+            content: 'An agent.',
+            timestamp: '2026-06-07T00:00:01.000Z',
+          },
+        ]);
+        await result.current.regenerateMessage(1);
+      },
+    ],
+  ])('does not interrupt a later %s after Stop', async (_label, startGeneration) => {
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+
+    await act(async () => {
+      await startGeneration(result);
+    });
+    expect(step).toHaveBeenCalled();
+
+    await act(async () => {
+      eventHandlers?.onMessageStart?.();
+    });
+
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(true);
+    expect(interruptGenerationApi).toHaveBeenCalledTimes(1);
   });
 });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -421,4 +421,65 @@ describe('useConversation', () => {
     // 3: late onMessageStart still sees the stop flag
     expect(interruptGenerationApi).toHaveBeenCalledTimes(3);
   });
+
+  it('re-interrupts leftover rerun tools before a later action that started in flight', async () => {
+    conversations$.get('chat-placeholder')?.data.log.set([
+      {
+        role: 'user',
+        content: 'What is gptme?',
+        timestamp: '2026-06-07T00:00:00.000Z',
+      },
+      {
+        role: 'assistant',
+        content: 'An agent.',
+        timestamp: '2026-06-07T00:00:01.000Z',
+      },
+    ]);
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    let resolveRerun: (value: { status: string; tool_ids: string[] }) => void = () => {};
+    rerunTools.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRerun = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    let pendingRerun: Promise<unknown> | undefined;
+    act(() => {
+      pendingRerun = result.current.rerunFromMessage(1);
+    });
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+
+    let pendingEdit: Promise<unknown> | undefined;
+    act(() => {
+      pendingEdit = result.current.editMessage(0, 'What is gptme?', true);
+    });
+
+    await act(async () => {
+      resolveRerun({ status: 'ok', tool_ids: ['tool-1'] });
+      await pendingRerun;
+      await pendingEdit;
+    });
+
+    await act(async () => {
+      eventHandlers?.onMessageStart?.();
+    });
+
+    expect(rerunTools).toHaveBeenCalledTimes(1);
+    expect(step).toHaveBeenCalledTimes(1);
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(true);
+    // 1: user Stop while rerunTools is in flight
+    // 2: old rerun re-interrupts leftover auto-confirm tools before the edit steps
+    // Late onMessageStart belongs to the edit, so it must not interrupt again.
+    expect(interruptGenerationApi).toHaveBeenCalledTimes(2);
+  });
 });

--- a/webui/src/hooks/__tests__/useConversation.test.tsx
+++ b/webui/src/hooks/__tests__/useConversation.test.tsx
@@ -292,4 +292,72 @@ describe('useConversation', () => {
     expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(true);
     expect(interruptGenerationApi).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    [
+      'edit-with-truncation',
+      (result: { current: ReturnType<typeof useConversation> }) =>
+        result.current.editMessage(0, 'What is gptme?', true),
+    ],
+    [
+      'rerun-of-a-non-last-message',
+      (result: { current: ReturnType<typeof useConversation> }) =>
+        result.current.rerunFromMessage(0),
+    ],
+    [
+      'regenerate',
+      (result: { current: ReturnType<typeof useConversation> }) =>
+        result.current.regenerateMessage(1),
+    ],
+  ])('honors a Stop pressed while the %s request is in flight', async (_label, startGeneration) => {
+    conversations$.get('chat-placeholder')?.data.log.set([
+      {
+        role: 'user',
+        content: 'What is gptme?',
+        timestamp: '2026-06-07T00:00:00.000Z',
+      },
+      {
+        role: 'assistant',
+        content: 'An agent.',
+        timestamp: '2026-06-07T00:00:01.000Z',
+      },
+    ]);
+    conversations$.get('chat-placeholder')?.isGenerating.set(true);
+
+    // Hold the truncation request open so Stop lands while it is in flight.
+    let resolveEdit: (value: { log: []; branches: Record<string, never> }) => void = () => {};
+    editMessageApi.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveEdit = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useConversation('chat-placeholder'));
+
+    await waitFor(() => {
+      expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+    });
+
+    let pending: Promise<unknown> | undefined;
+    act(() => {
+      pending = startGeneration(result);
+    });
+
+    await act(async () => {
+      await result.current.interruptGeneration();
+    });
+
+    await act(async () => {
+      resolveEdit({ log: [], branches: {} });
+      await pending;
+    });
+
+    await act(async () => {
+      eventHandlers?.onMessageStart?.();
+    });
+
+    // The Stop is newer than the request, so onMessageStart must not resume.
+    expect(conversations$.get('chat-placeholder')?.isGenerating.get()).toBe(false);
+    expect(interruptGenerationApi).toHaveBeenCalledTimes(2);
+  });
 });

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -533,11 +533,18 @@ export function useConversation(conversationId: string, serverId?: string) {
     };
   }, [conversationId, isConnected, api, conversation$, toast, retryNonce]);
 
+  const beginGeneration = () => {
+    // A new user-initiated generation supersedes any prior Stop. Without this,
+    // onMessageStart treats the next edit/rerun/regenerate as part of the
+    // cancelled request and immediately interrupts it.
+    stopRequestedRef.current = false;
+  };
+
   const sendMessage = async ({ message, options }: { message: string; options?: ChatOptions }) => {
     if (!conversation$) {
       throw new Error('Conversation not initialized');
     }
-    stopRequestedRef.current = false;
+    beginGeneration();
 
     // Clear any pending or executing tool when sending a new message
     const pendingTool = conversation$?.pendingTool.get();
@@ -730,6 +737,7 @@ export function useConversation(conversationId: string, serverId?: string) {
 
       // After truncation, trigger re-generation
       if (truncate) {
+        beginGeneration();
         await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
@@ -770,6 +778,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       }
       // Re-run tools from the (now last) assistant message
       // This parses tool uses and sets them as pending, without calling the LLM
+      beginGeneration();
       try {
         await api.rerunTools(conversationId);
       } catch {
@@ -791,6 +800,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     if (prevIndex < 0) return;
 
     try {
+      beginGeneration();
       const result = await api.editMessage(conversationId, prevIndex, undefined, true);
       replaceLog(conversationId, result.log);
       if (result.branches) {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -56,6 +56,8 @@ export function useConversation(conversationId: string, serverId?: string) {
   // Stop during the new-chat handshake: onConnected / onMessageStart must not
   // restart generation after the user already cancelled the pending initial step.
   const stopRequestedRef = useRef(false);
+  const generationEpochRef = useRef(0);
+  const generationChainRef = useRef<Promise<void> | null>(null);
   const loadingOlderMessagesRef = useRef(false);
   const isLoadingOlderMessages$ = useObservable(false);
   const isLoadingOlderMessages = use$(isLoadingOlderMessages$);
@@ -540,87 +542,126 @@ export function useConversation(conversationId: string, serverId?: string) {
   // Call this BEFORE the first await of the path, never after. Clearing the
   // flag once a request is already in flight would also swallow a *newer* Stop
   // the user pressed while waiting for that request.
+  //
+  // Epoch + chain: a later action may call this while an older rerunTools() is
+  // still in flight. That clear is current user intent, but the older request
+  // must still re-interrupt leftover auto-confirm tools before the newer path
+  // starts its first API call. The chain serializes those paths so the
+  // re-interrupt cannot kill the new generation.
   const beginGeneration = () => {
+    generationEpochRef.current += 1;
     stopRequestedRef.current = false;
+    return generationEpochRef.current;
+  };
+
+  const generationIsStale = (epoch: number) =>
+    stopRequestedRef.current || generationEpochRef.current !== epoch;
+
+  const runGeneration = async (work: (epoch: number) => Promise<void>) => {
+    const epoch = beginGeneration();
+    const previous = generationChainRef.current;
+    let release: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    generationChainRef.current = current;
+    try {
+      // Only yield when another generation is actually in flight. Awaiting an
+      // already-resolved tail would let Stop land before this path's first
+      // API call — a different race than the one we serialize.
+      if (previous) {
+        await previous.catch(() => undefined);
+      }
+      if (generationIsStale(epoch)) return;
+      await work(epoch);
+    } finally {
+      release();
+      if (generationChainRef.current === current) {
+        generationChainRef.current = null;
+      }
+    }
   };
 
   const sendMessage = async ({ message, options }: { message: string; options?: ChatOptions }) => {
     if (!conversation$) {
       throw new Error('Conversation not initialized');
     }
-    beginGeneration();
 
-    // Clear any pending or executing tool when sending a new message
-    const pendingTool = conversation$?.pendingTool.get();
-    const executingTool = conversation$?.executingTool.get();
-    if (pendingTool) {
-      setPendingTool(conversationId, null, null);
-    }
-    if (executingTool) {
-      setExecutingTool(conversationId, null, null);
-    }
+    await runGeneration(async (epoch) => {
+      // Clear any pending or executing tool when sending a new message
+      const pendingTool = conversation$?.pendingTool.get();
+      const executingTool = conversation$?.executingTool.get();
+      if (pendingTool) {
+        setPendingTool(conversationId, null, null);
+      }
+      if (executingTool) {
+        setExecutingTool(conversationId, null, null);
+      }
 
-    // Upload pending files first if any
-    let filePaths = options?.files || [];
-    if (options?.pendingFiles?.length) {
+      // Upload pending files first if any
+      let filePaths = options?.files || [];
+      if (options?.pendingFiles?.length) {
+        try {
+          const uploadResult = await api.uploadFiles(conversationId, options.pendingFiles);
+          filePaths = [...filePaths, ...uploadResult.files.map((f) => f.path)];
+        } catch (error) {
+          console.error('[useConversation] File upload failed:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Upload failed',
+            description: 'Failed to upload attached files',
+          });
+          // Continue sending the message without files
+        }
+      }
+
+      // Create user message with pending status
+      const userMessage: Message = {
+        role: 'user',
+        content: message,
+        timestamp: new Date().toISOString(),
+        ...(filePaths.length > 0 ? { files: filePaths } : {}),
+        _status: 'pending',
+      };
+
+      // Add message to conversation (optimistic)
+      addMessage(conversationId, userMessage);
+
       try {
-        const uploadResult = await api.uploadFiles(conversationId, options.pendingFiles);
-        filePaths = [...filePaths, ...uploadResult.files.map((f) => f.path)];
+        // Send the message
+        await api.sendMessage(conversationId, userMessage);
+        setMessageStatus(conversationId, userMessage.timestamp!, 'sent');
+
+        if (generationIsStale(epoch)) return;
+
+        // Start generation
+        await api.step(
+          conversationId,
+          options?.model,
+          options?.stream,
+          'main',
+          options?.maxTokens,
+          options?.temperature,
+          options?.topP
+        );
+        // Store generation params in conversation state so regenerate/rerun paths can use them
+        setMaxTokens(conversationId, options?.maxTokens);
+        setTemperature(conversationId, options?.temperature);
+        setTopP(conversationId, options?.topP);
       } catch (error) {
-        console.error('[useConversation] File upload failed:', error);
+        console.error('Error sending message:', error);
+        const { title, description } = getApiErrorPresentation(error, {
+          fallbackTitle: 'Failed to send',
+          fallbackDescription: 'Failed to send message',
+        });
+        setMessageStatus(conversationId, userMessage.timestamp!, 'failed', description);
         toast({
           variant: 'destructive',
-          title: 'Upload failed',
-          description: 'Failed to upload attached files',
+          title,
+          description,
         });
-        // Continue sending the message without files
       }
-    }
-
-    // Create user message with pending status
-    const userMessage: Message = {
-      role: 'user',
-      content: message,
-      timestamp: new Date().toISOString(),
-      ...(filePaths.length > 0 ? { files: filePaths } : {}),
-      _status: 'pending',
-    };
-
-    // Add message to conversation (optimistic)
-    addMessage(conversationId, userMessage);
-
-    try {
-      // Send the message
-      await api.sendMessage(conversationId, userMessage);
-      setMessageStatus(conversationId, userMessage.timestamp!, 'sent');
-
-      // Start generation
-      await api.step(
-        conversationId,
-        options?.model,
-        options?.stream,
-        'main',
-        options?.maxTokens,
-        options?.temperature,
-        options?.topP
-      );
-      // Store generation params in conversation state so regenerate/rerun paths can use them
-      setMaxTokens(conversationId, options?.maxTokens);
-      setTemperature(conversationId, options?.temperature);
-      setTopP(conversationId, options?.topP);
-    } catch (error) {
-      console.error('Error sending message:', error);
-      const { title, description } = getApiErrorPresentation(error, {
-        fallbackTitle: 'Failed to send',
-        fallbackDescription: 'Failed to send message',
-      });
-      setMessageStatus(conversationId, userMessage.timestamp!, 'failed', description);
-      toast({
-        variant: 'destructive',
-        title,
-        description,
-      });
-    }
+    });
   };
 
   const confirmTool = async (
@@ -724,34 +765,41 @@ export function useConversation(conversationId: string, serverId?: string) {
     files?: string[],
     pendingFiles?: File[]
   ) => {
-    // A truncating edit re-generates, so it owns the stop flag from here on.
-    if (truncate) beginGeneration();
-    try {
-      // Upload any new files first, then merge with existing file paths
-      let allFiles = files;
-      if (pendingFiles?.length) {
-        const uploadResult = await api.uploadFiles(conversationId, pendingFiles);
-        const newPaths = uploadResult.files.map((f) => f.path);
-        allFiles = [...(files || []), ...newPaths];
-      }
-      const result = await api.editMessage(conversationId, index, content, truncate, allFiles);
-      // Use API response directly (SSE event may also arrive, but this is immediate)
-      replaceLog(conversationId, result.log);
-      if (result.branches) {
-        updateBranches(conversationId, result.branches);
-      }
+    const applyEdit = async (epoch?: number) => {
+      try {
+        // Upload any new files first, then merge with existing file paths
+        let allFiles = files;
+        if (pendingFiles?.length) {
+          const uploadResult = await api.uploadFiles(conversationId, pendingFiles);
+          const newPaths = uploadResult.files.map((f) => f.path);
+          allFiles = [...(files || []), ...newPaths];
+        }
+        const result = await api.editMessage(conversationId, index, content, truncate, allFiles);
+        // Use API response directly (SSE event may also arrive, but this is immediate)
+        replaceLog(conversationId, result.log);
+        if (result.branches) {
+          updateBranches(conversationId, result.branches);
+        }
 
-      // After truncation, trigger re-generation unless Stop landed while
-      // the edit request was in flight.
-      if (truncate) {
-        if (stopRequestedRef.current) return;
-        await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
+        // After truncation, trigger re-generation unless Stop landed while
+        // the edit request was in flight, or a newer action superseded it.
+        if (truncate) {
+          if (epoch === undefined || generationIsStale(epoch)) return;
+          await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
+        }
+      } catch (error) {
+        console.error('Error editing message:', error);
+        const errorMsg = error instanceof Error ? error.message : 'Failed to edit message';
+        toast({ variant: 'destructive', title: 'Edit failed', description: errorMsg });
       }
-    } catch (error) {
-      console.error('Error editing message:', error);
-      const errorMsg = error instanceof Error ? error.message : 'Failed to edit message';
-      toast({ variant: 'destructive', title: 'Edit failed', description: errorMsg });
+    };
+
+    // A truncating edit re-generates, so it owns the stop flag from here on.
+    if (truncate) {
+      await runGeneration(applyEdit);
+      return;
     }
+    await applyEdit();
   };
 
   const deleteMessage = async (index: number) => {
@@ -770,46 +818,49 @@ export function useConversation(conversationId: string, serverId?: string) {
 
   const rerunFromMessage = async (index: number) => {
     if (!conversation$) return;
-    const log = conversation$.data.log.get();
-    const localIndex = index - conversation$.logOffset.get();
-    const isLastMessage = localIndex === log.length - 1;
+    const conv$ = conversation$;
 
-    beginGeneration();
-    try {
-      if (!isLastMessage) {
-        // Truncate after this message (creates backup branch)
-        const result = await api.editMessage(conversationId, index, undefined, true);
-        replaceLog(conversationId, result.log);
-        if (result.branches) {
-          updateBranches(conversationId, result.branches);
-        }
-      }
-      if (stopRequestedRef.current) return;
-      // Re-run tools from the (now last) assistant message
-      // This parses tool uses and sets them as pending, without calling the LLM.
-      // Auto-confirm tools can start executing on the server before this
-      // request returns, so a Stop that lands in-flight may interrupt nothing.
+    await runGeneration(async (epoch) => {
+      const log = conv$.data.log.get();
+      const localIndex = index - conv$.logOffset.get();
+      const isLastMessage = localIndex === log.length - 1;
+
       try {
-        await api.rerunTools(conversationId);
-        if (stopRequestedRef.current) {
-          setGenerating(conversationId, false);
-          try {
-            await api.interruptGeneration(conversationId);
-          } catch (error) {
-            console.error('Error interrupting generation after Stop raced with rerun:', error);
+        if (!isLastMessage) {
+          // Truncate after this message (creates backup branch)
+          const result = await api.editMessage(conversationId, index, undefined, true);
+          replaceLog(conversationId, result.log);
+          if (result.branches) {
+            updateBranches(conversationId, result.branches);
           }
-          return;
         }
-      } catch {
-        // No tools found — fall back to step() (regenerate)
-        if (stopRequestedRef.current) return;
-        await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
+        if (generationIsStale(epoch)) return;
+        // Re-run tools from the (now last) assistant message
+        // This parses tool uses and sets them as pending, without calling the LLM.
+        // Auto-confirm tools can start executing on the server before this
+        // request returns, so a Stop that lands in-flight may interrupt nothing.
+        try {
+          await api.rerunTools(conversationId);
+          if (generationIsStale(epoch)) {
+            setGenerating(conversationId, false);
+            try {
+              await api.interruptGeneration(conversationId);
+            } catch (error) {
+              console.error('Error interrupting generation after Stop raced with rerun:', error);
+            }
+            return;
+          }
+        } catch {
+          // No tools found — fall back to step() (regenerate)
+          if (generationIsStale(epoch)) return;
+          await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
+        }
+      } catch (error) {
+        console.error('Error re-running from message:', error);
+        const errorMsg = error instanceof Error ? error.message : 'Failed to re-run';
+        toast({ variant: 'destructive', title: 'Re-run failed', description: errorMsg });
       }
-    } catch (error) {
-      console.error('Error re-running from message:', error);
-      const errorMsg = error instanceof Error ? error.message : 'Failed to re-run';
-      toast({ variant: 'destructive', title: 'Re-run failed', description: errorMsg });
-    }
+    });
   };
 
   const regenerateMessage = async (index: number) => {
@@ -819,20 +870,21 @@ export function useConversation(conversationId: string, serverId?: string) {
     const prevIndex = index - 1;
     if (prevIndex < 0) return;
 
-    try {
-      beginGeneration();
-      const result = await api.editMessage(conversationId, prevIndex, undefined, true);
-      replaceLog(conversationId, result.log);
-      if (result.branches) {
-        updateBranches(conversationId, result.branches);
+    await runGeneration(async (epoch) => {
+      try {
+        const result = await api.editMessage(conversationId, prevIndex, undefined, true);
+        replaceLog(conversationId, result.log);
+        if (result.branches) {
+          updateBranches(conversationId, result.branches);
+        }
+        if (generationIsStale(epoch)) return;
+        await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
+      } catch (error) {
+        console.error('Error regenerating message:', error);
+        const errorMsg = error instanceof Error ? error.message : 'Failed to regenerate';
+        toast({ variant: 'destructive', title: 'Regenerate failed', description: errorMsg });
       }
-      if (stopRequestedRef.current) return;
-      await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
-    } catch (error) {
-      console.error('Error regenerating message:', error);
-      const errorMsg = error instanceof Error ? error.message : 'Failed to regenerate';
-      toast({ variant: 'destructive', title: 'Regenerate failed', description: errorMsg });
-    }
+    });
   };
 
   const forkConversation = async (index: number) => {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -533,10 +533,14 @@ export function useConversation(conversationId: string, serverId?: string) {
     };
   }, [conversationId, isConnected, api, conversation$, toast, retryNonce]);
 
+  // A new user-initiated generation supersedes any prior Stop. Without this,
+  // onMessageStart treats the next edit/rerun/regenerate as part of the
+  // cancelled request and immediately interrupts it.
+  //
+  // Call this BEFORE the first await of the path, never after. Clearing the
+  // flag once a request is already in flight would also swallow a *newer* Stop
+  // the user pressed while waiting for that request.
   const beginGeneration = () => {
-    // A new user-initiated generation supersedes any prior Stop. Without this,
-    // onMessageStart treats the next edit/rerun/regenerate as part of the
-    // cancelled request and immediately interrupts it.
     stopRequestedRef.current = false;
   };
 
@@ -720,6 +724,8 @@ export function useConversation(conversationId: string, serverId?: string) {
     files?: string[],
     pendingFiles?: File[]
   ) => {
+    // A truncating edit re-generates, so it owns the stop flag from here on.
+    if (truncate) beginGeneration();
     try {
       // Upload any new files first, then merge with existing file paths
       let allFiles = files;
@@ -737,7 +743,6 @@ export function useConversation(conversationId: string, serverId?: string) {
 
       // After truncation, trigger re-generation
       if (truncate) {
-        beginGeneration();
         await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
@@ -767,6 +772,7 @@ export function useConversation(conversationId: string, serverId?: string) {
     const localIndex = index - conversation$.logOffset.get();
     const isLastMessage = localIndex === log.length - 1;
 
+    beginGeneration();
     try {
       if (!isLastMessage) {
         // Truncate after this message (creates backup branch)
@@ -778,7 +784,6 @@ export function useConversation(conversationId: string, serverId?: string) {
       }
       // Re-run tools from the (now last) assistant message
       // This parses tool uses and sets them as pending, without calling the LLM
-      beginGeneration();
       try {
         await api.rerunTools(conversationId);
       } catch {

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -741,8 +741,10 @@ export function useConversation(conversationId: string, serverId?: string) {
         updateBranches(conversationId, result.branches);
       }
 
-      // After truncation, trigger re-generation
+      // After truncation, trigger re-generation unless Stop landed while
+      // the edit request was in flight.
       if (truncate) {
+        if (stopRequestedRef.current) return;
         await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
@@ -782,12 +784,14 @@ export function useConversation(conversationId: string, serverId?: string) {
           updateBranches(conversationId, result.branches);
         }
       }
+      if (stopRequestedRef.current) return;
       // Re-run tools from the (now last) assistant message
       // This parses tool uses and sets them as pending, without calling the LLM
       try {
         await api.rerunTools(conversationId);
       } catch {
         // No tools found — fall back to step() (regenerate)
+        if (stopRequestedRef.current) return;
         await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
       }
     } catch (error) {
@@ -811,6 +815,7 @@ export function useConversation(conversationId: string, serverId?: string) {
       if (result.branches) {
         updateBranches(conversationId, result.branches);
       }
+      if (stopRequestedRef.current) return;
       await api.step(conversationId, undefined, true, 'main', maxTokens, temperature, topP);
     } catch (error) {
       console.error('Error regenerating message:', error);

--- a/webui/src/hooks/useConversation.ts
+++ b/webui/src/hooks/useConversation.ts
@@ -786,9 +786,20 @@ export function useConversation(conversationId: string, serverId?: string) {
       }
       if (stopRequestedRef.current) return;
       // Re-run tools from the (now last) assistant message
-      // This parses tool uses and sets them as pending, without calling the LLM
+      // This parses tool uses and sets them as pending, without calling the LLM.
+      // Auto-confirm tools can start executing on the server before this
+      // request returns, so a Stop that lands in-flight may interrupt nothing.
       try {
         await api.rerunTools(conversationId);
+        if (stopRequestedRef.current) {
+          setGenerating(conversationId, false);
+          try {
+            await api.interruptGeneration(conversationId);
+          } catch (error) {
+            console.error('Error interrupting generation after Stop raced with rerun:', error);
+          }
+          return;
+        }
       } catch {
         // No tools found — fall back to step() (regenerate)
         if (stopRequestedRef.current) return;


### PR DESCRIPTION
## Problem

#3743 landed `stopRequestedRef` so Stop during the new-chat handshake cannot restart generation. Only `sendMessage` cleared that flag. Edit-with-truncation, rerun, and regenerate start generation directly, so their next `onMessageStart` inherited the cancelled request and was immediately interrupted.

Greptile flagged this as P1 on #3743 (4/5). That PR self-merged on `bba199321` while this fix was still in the in-band review/push path.

## Fix

Share `beginGeneration()` across every user-initiated generation path (`sendMessage`, edit-with-truncate, rerun, regenerate) so a later action is not treated as part of the cancelled handshake.

Regression covers Stop followed by each of those three paths.

Follow-up to gptme/gptme#3743.
