### PR TITLE
fix: tell user how to enable disabled-by-default tools in error messa…

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -415,19 +415,23 @@ def execute_msg(
             )
             error_msg = f"Tool '{tooluse.tool}' is not available for execution."
             # If the tool is disabled by default, tell the user how to enable it (#3698).
-            # Search available (not just loaded) tools since disabled-by-default tools
-            # are not loaded unless explicitly allowlisted.
-            available = get_available_tools(include_mcp=False)
-            tool_spec = next(
-                (
-                    t
-                    for t in available
-                    if t.name == tooluse.tool or tooluse.tool in t.block_types
-                ),
-                None,
-            )
-            if tool_spec is not None and tool_spec.disabled_by_default:
-                error_msg += f" Add --tools +{tool_spec.name} to enable this tool."
+            # Guard discovery so the paired error result is always emitted even if
+            # available-tool lookup fails — this defensive branch must not break
+            # recovery or leave a structured tool_use dangling.
+            try:
+                available = get_available_tools(include_mcp=False)
+                tool_spec = next(
+                    (
+                        t
+                        for t in available
+                        if t.name == tooluse.tool or tooluse.tool in t.block_types
+                    ),
+                    None,
+                )
+                if tool_spec is not None and tool_spec.disabled_by_default:
+                    error_msg += f" Add --tools +{tool_spec.name} to enable this tool."
+            except Exception:
+                pass
             yield Message(
                 "system",
                 error_msg,

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -413,9 +413,24 @@ def execute_msg(
                 "the tool_use/tool_result pairing valid.",
                 tooluse.tool,
             )
+            error_msg = f"Tool '{tooluse.tool}' is not available for execution."
+            # If the tool is disabled by default, tell the user how to enable it (#3698).
+            # Search available (not just loaded) tools since disabled-by-default tools
+            # are not loaded unless explicitly allowlisted.
+            available = get_available_tools(include_mcp=False)
+            tool_spec = next(
+                (
+                    t
+                    for t in available
+                    if t.name == tooluse.tool or tooluse.tool in t.block_types
+                ),
+                None,
+            )
+            if tool_spec is not None and tool_spec.disabled_by_default:
+                error_msg += f" Add --tools +{tool_spec.name} to enable this tool."
             yield Message(
                 "system",
-                f"Tool '{tooluse.tool}' is not available for execution.",
+                error_msg,
                 call_id=tooluse.call_id,
             )
 

--- a/tests/test_execute_msg_defensive.py
+++ b/tests/test_execute_msg_defensive.py
@@ -10,7 +10,7 @@ intentionally left unpaired when the tool is unavailable.
 """
 
 from gptme.message import Message
-from gptme.tools import execute_msg
+from gptme.tools import clear_tools, execute_msg, init_tools
 from gptme.tools.base import set_tool_format
 
 
@@ -84,4 +84,50 @@ class TestExecuteMsgDefensive:
         assert "call-002" in call_ids, "tool_two call_id must appear in results"
         assert len(results) == 2, (
             "Each non-runnable structured tool_use needs one error result"
+        )
+
+    def test_disabled_by_default_tool_error_message_tells_how_to_enable(self):
+        """Disabled-by-default tool error should include --tools +<name> hint (#3698).
+
+        Tools like 'read' have disabled_by_default=True and are not loaded unless
+        explicitly allowlisted. When the model calls them, the error message should
+        tell the user how to enable the tool, not just say it's unavailable.
+        """
+        clear_tools()
+        set_tool_format("tool")
+        init_tools()  # Default allowlist: 'read' is NOT loaded (disabled_by_default)
+
+        call_id = "call-disabled-read"
+        content = f'@read({call_id}): {{"path": "example.txt"}}'
+        msg = Message("assistant", content)
+
+        results = list(execute_msg(msg))
+
+        assert len(results) == 1
+        assert results[0].call_id == call_id
+        assert "not available for execution" in results[0].content
+        assert "--tools +read" in results[0].content, (
+            "Error message for disabled-by-default tool should tell user how to enable it"
+        )
+
+    def test_non_disabled_tool_error_message_has_no_enable_hint(self):
+        """Non-disabled tools should NOT get the --tools +<name> hint.
+
+        The enable hint only applies to tools with disabled_by_default=True.
+        A nonexistent tool (not in the registry at all) should get a plain error.
+        """
+        clear_tools()
+        set_tool_format("tool")
+        init_tools()
+
+        call_id = "call-unknown-tool"
+        content = f'@nonexistent_tool_xyz({call_id}): {{"arg": "value"}}'
+        msg = Message("assistant", content)
+
+        results = list(execute_msg(msg))
+
+        assert len(results) == 1
+        assert "not available for execution" in results[0].content
+        assert "--tools +" not in results[0].content, (
+            "Non-disabled/nonexistent tools should not get an enable hint"
         )


### PR DESCRIPTION
## Background
Fixes #3698. When a tool with `disabled_by_default=True` (e.g. `read`) is called by the model but not loaded, the error message previously only said `Tool 'read' is not available for execution.` with no guidance on how to enable it. Users had to figure out on their own that they needed `--tools +read`.

## Changes
- In `gptme/tools/__init__.py`, the tool-not-runnable error path now checks `get_available_tools()` for a matching tool spec. If the matched tool has `disabled_by_default=True`, the error message appends `Add --tools +<name> to enable this tool.`
- Uses `get_available_tools()` instead of `get_tool()` because disabled-by-default tools are not loaded (and thus not found by `get_tool()`) unless explicitly allowlisted.
- Added two tests in `tests/test_execute_msg_defensive.py`:
  - `test_disabled_by_default_tool_error_message_tells_how_to_enable`: verifies the `--tools +read` hint appears for the `read` tool.
  - `test_non_disabled_tool_error_message_has_no_enable_hint`: verifies nonexistent/non-disabled tools get a plain error with no hint.

## Verification
- `ruff check` and `ruff format --check`: pass
- `mypy gptme/tools/__init__.py`: no issues found
- `pytest tests/test_execute_msg_defensive.py`: 6/6 passed (4 existing + 2 new)
- `pytest tests/test_tools.py tests/test_tools_request_tool_change.py`: 73 passed, 1 pre-existing Windows-only failure (`test_read_only_tool_preset_allows_read_tool` — fails on master without this change due to Windows path handling)

## Compatibility
- Backward compatible: the error message for non-disabled tools is unchanged.
- No API changes, no config changes, no breaking changes to existing callers.
- Change is limited to 2 files, +63/-2 lines.