### PR TITLE
fix(review-pr): name the offending stdout line when JSONL parsing fails

### DIFF
--- a/gptme/cli/cmd_review_pr.py
+++ b/gptme/cli/cmd_review_pr.py
@@ -848,6 +848,7 @@ def _assistant_output_from_jsonl(
             event = json.loads(line)
         except json.JSONDecodeError:
             snippet = line[:160]
+            kind = "is not valid JSONL"
             logger.warning(
                 "review pr: child stdout line %d is not JSONL "
                 "(output-format json contract broken): %r",
@@ -857,9 +858,11 @@ def _assistant_output_from_jsonl(
             if diagnostic is not None:
                 diagnostic["line"] = line_number
                 diagnostic["snippet"] = snippet
+                diagnostic["kind"] = kind
             return None
         if not isinstance(event, dict):
             snippet = line[:160]
+            kind = "is not a JSON object"
             logger.warning(
                 "review pr: child stdout line %d is not a JSON object "
                 "(output-format json contract broken): %r",
@@ -869,6 +872,7 @@ def _assistant_output_from_jsonl(
             if diagnostic is not None:
                 diagnostic["line"] = line_number
                 diagnostic["snippet"] = snippet
+                diagnostic["kind"] = kind
             return None
         saw_event = True
         if event.get("type") == "message" and event.get("role") == "assistant":
@@ -1266,9 +1270,10 @@ def review_pr(
         # Emitting an empty artifact would cause review-watch to silently treat
         # this as a clean review.  Fail loudly instead.
         if "line" in jsonl_diagnostic:
+            kind = jsonl_diagnostic.get("kind", "is not valid JSONL")
             raise SystemExit(
                 "review pr: child stdout line "
-                f"{jsonl_diagnostic['line']} is not valid JSONL "
+                f"{jsonl_diagnostic['line']} {kind} "
                 "(output-format json contract broken), so the assistant's "
                 "output could not be parsed — refusing to emit a "
                 f"clean-looking empty artifact: {jsonl_diagnostic['snippet']!r}"

--- a/gptme/cli/cmd_review_pr.py
+++ b/gptme/cli/cmd_review_pr.py
@@ -821,24 +821,54 @@ def _json_blocks(text: str) -> Iterator[object]:
         yield value
 
 
-def _assistant_output_from_jsonl(output: str) -> str | None:
+def _assistant_output_from_jsonl(
+    output: str, *, diagnostic: dict[str, object] | None = None
+) -> str | None:
     """Return assistant text from gptme's JSONL output.
 
     JSON output gives the subprocess a trust boundary: user messages contain
     untrusted PR metadata and diffs, while only assistant messages can contain
     review findings. If any non-empty line is not valid JSONL, fail closed
     rather than falling back to scanning mixed terminal output.
+
+    This strictness is deliberate and must not be relaxed to "skip bad
+    lines" — a contaminated stdout (e.g. a stray telemetry banner ahead of
+    the JSONL stream) must not be silently tolerated. What it *should* be is
+    diagnosable: on failure, the offending line is logged at WARNING with its
+    line number and a truncated snippet, and — if the caller passed a
+    ``diagnostic`` dict — the same info is written into it under ``"line"``
+    and ``"snippet"`` so the caller can surface it in its own error message.
     """
     assistant_parts: list[str] = []
     saw_event = False
-    for line in output.splitlines():
+    for line_number, line in enumerate(output.splitlines(), start=1):
         if not line.strip():
             continue
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
+            snippet = line[:160]
+            logger.warning(
+                "review pr: child stdout line %d is not JSONL "
+                "(output-format json contract broken): %r",
+                line_number,
+                snippet,
+            )
+            if diagnostic is not None:
+                diagnostic["line"] = line_number
+                diagnostic["snippet"] = snippet
             return None
         if not isinstance(event, dict):
+            snippet = line[:160]
+            logger.warning(
+                "review pr: child stdout line %d is not a JSON object "
+                "(output-format json contract broken): %r",
+                line_number,
+                snippet,
+            )
+            if diagnostic is not None:
+                diagnostic["line"] = line_number
+                diagnostic["snippet"] = snippet
             return None
         saw_event = True
         if event.get("type") == "message" and event.get("role") == "assistant":
@@ -855,14 +885,20 @@ def _extract_findings_from_output(
     output: str,
     *,
     output_marker: str = _REVIEW_OUTPUT_MARKER,
+    diagnostic: dict[str, object] | None = None,
 ) -> tuple[list[ReviewFinding] | None, int]:
     """Parse reviewer JSONL output and extract :class:`ReviewFinding` objects.
 
     Returns ``(findings, validation_error_count)`` where:
     - findings: list of extracted findings, or None if no valid JSON block found
     - validation_error_count: number of finding entries skipped due to validation errors
+
+    If ``diagnostic`` is passed, it is populated with ``"line"``/``"snippet"``
+    when ``findings is None`` because the child's stdout was not clean JSONL
+    (as opposed to being valid JSONL with no findings block) — see
+    :func:`_assistant_output_from_jsonl`.
     """
-    assistant_output = _assistant_output_from_jsonl(output)
+    assistant_output = _assistant_output_from_jsonl(output, diagnostic=diagnostic)
     if assistant_output is None:
         return None, 0
 
@@ -1212,8 +1248,11 @@ def review_pr(
     # ------------------------------------------------------------------
     # Parse findings
     # ------------------------------------------------------------------
+    jsonl_diagnostic: dict[str, object] = {}
     findings, validation_errors = _extract_findings_from_output(
-        stdout, output_marker=summary.get("output_marker", _REVIEW_OUTPUT_MARKER)
+        stdout,
+        output_marker=summary.get("output_marker", _REVIEW_OUTPUT_MARKER),
+        diagnostic=jsonl_diagnostic,
     )
     if findings is None:
         click.echo(
@@ -1226,6 +1265,14 @@ def review_pr(
         # means we cannot distinguish "nothing to fix" from a broken review.
         # Emitting an empty artifact would cause review-watch to silently treat
         # this as a clean review.  Fail loudly instead.
+        if "line" in jsonl_diagnostic:
+            raise SystemExit(
+                "review pr: child stdout line "
+                f"{jsonl_diagnostic['line']} is not valid JSONL "
+                "(output-format json contract broken), so the assistant's "
+                "output could not be parsed — refusing to emit a "
+                f"clean-looking empty artifact: {jsonl_diagnostic['snippet']!r}"
+            )
         raise SystemExit(
             "review pr: session produced no valid findings block — "
             "refusing to emit a clean-looking empty artifact"

--- a/tests/test_util_review.py
+++ b/tests/test_util_review.py
@@ -1005,6 +1005,26 @@ class TestAssistantOutputFromJsonl:
         assert result is None
         assert diagnostic["line"] == 1
         assert diagnostic["snippet"] == self._BANNER[:160]
+        assert diagnostic["kind"] == "is not valid JSONL"
+
+    def test_non_object_json_populates_diagnostic(self, caplog):
+        """Valid JSON that is not an object is labeled as shape, not syntax."""
+        from gptme.cli.cmd_review_pr import _assistant_output_from_jsonl
+
+        output = f"[]\n{self._valid_jsonl_with_findings()}\n"
+        diagnostic: dict[str, object] = {}
+
+        with caplog.at_level("WARNING", logger="gptme.cli.cmd_review_pr"):
+            result = _assistant_output_from_jsonl(output, diagnostic=diagnostic)
+
+        assert result is None
+        assert diagnostic["line"] == 1
+        assert diagnostic["snippet"] == "[]"
+        assert diagnostic["kind"] == "is not a JSON object"
+        assert any(
+            "JSON object" in record.getMessage() and "JSONL" not in record.getMessage()
+            for record in caplog.records
+        ), caplog.text
 
     def test_clean_jsonl_still_returns_assistant_text(self):
         """Without contamination, the findings-bearing JSONL still parses."""

--- a/tests/test_util_review.py
+++ b/tests/test_util_review.py
@@ -945,6 +945,80 @@ class TestArtifactMode:
 
 
 # ---------------------------------------------------------------------------
+# _assistant_output_from_jsonl (cmd_review_pr)
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantOutputFromJsonl:
+    """Failure diagnostics for ``_assistant_output_from_jsonl``.
+
+    Regression coverage for a defect that twice misdirected real review
+    sessions (gptme#3732, seen live 2026-09-07/08): the child gptme process
+    can print a plain-text banner (e.g. an OTLP telemetry notice) to stdout
+    before its JSONL stream starts. The parser must still fail closed on
+    that first bad line — the strictness is a deliberate trust boundary, not
+    a bug — but the failure must name the offending line and its content so
+    the caller doesn't read as an unexplained "no findings" result.
+    """
+
+    _BANNER = "Using OTLP to send metrics and traces to http://x"
+
+    @staticmethod
+    def _assistant_event(content: str) -> str:
+        return json.dumps({"type": "message", "role": "assistant", "content": content})
+
+    def _valid_jsonl_with_findings(self) -> str:
+        from gptme.cli.cmd_review_pr import _REVIEW_OUTPUT_MARKER
+
+        review = (
+            f"{_REVIEW_OUTPUT_MARKER}\n"
+            "```json\n"
+            '{"findings": [{"body": "a real finding"}]}\n'
+            "```\n"
+        )
+        return self._assistant_event(review)
+
+    def test_banner_before_jsonl_returns_none_and_names_the_line(self, caplog):
+        """A pre-JSONL banner fails closed, and the warning names line 1."""
+        from gptme.cli.cmd_review_pr import _assistant_output_from_jsonl
+
+        output = f"{self._BANNER}\n{self._valid_jsonl_with_findings()}\n"
+
+        with caplog.at_level("WARNING", logger="gptme.cli.cmd_review_pr"):
+            result = _assistant_output_from_jsonl(output)
+
+        assert result is None
+        assert any(
+            "line 1" in record.getMessage() and self._BANNER in record.getMessage()
+            for record in caplog.records
+        ), caplog.text
+
+    def test_banner_before_jsonl_populates_diagnostic(self):
+        """The optional diagnostic dict records the line number and snippet."""
+        from gptme.cli.cmd_review_pr import _assistant_output_from_jsonl
+
+        output = f"{self._BANNER}\n{self._valid_jsonl_with_findings()}\n"
+        diagnostic: dict[str, object] = {}
+
+        result = _assistant_output_from_jsonl(output, diagnostic=diagnostic)
+
+        assert result is None
+        assert diagnostic["line"] == 1
+        assert diagnostic["snippet"] == self._BANNER[:160]
+
+    def test_clean_jsonl_still_returns_assistant_text(self):
+        """Without contamination, the findings-bearing JSONL still parses."""
+        from gptme.cli.cmd_review_pr import _assistant_output_from_jsonl
+
+        output = f"{self._valid_jsonl_with_findings()}\n"
+
+        result = _assistant_output_from_jsonl(output)
+
+        assert result is not None
+        assert "a real finding" in result
+
+
+# ---------------------------------------------------------------------------
 # gptme-util review pr (cmd_review_pr)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_assistant_output_from_jsonl` in `gptme/cli/cmd_review_pr.py` fails closed on the first non-JSONL (or non-dict) line of a review session's stdout — a deliberate trust boundary, since only assistant-role JSON messages may contain review findings. The failure was silent: it just returned `None`, and the caller's error message ("session produced no valid findings block") read identically whether the model produced no findings or the stdout was contaminated by unrelated output. Twice in the same day (sessions 4f63 and 1238, 2026-09-07/08) a plain-text OTLP telemetry banner on line 1 of stdout discarded an otherwise perfect findings block, and the generic message misdirected both sessions into unrelated prompt-size theories.

This PR keeps the parser exactly as strict — it still fails closed on the first bad line, no skipping or tolerating contaminants — but makes the failure self-describing:

- `_assistant_output_from_jsonl` now logs a `WARNING` naming the 1-indexed line number and a truncated (160 char) snippet of the offending line, and optionally records the same info into a caller-supplied `diagnostic` dict.
- `_extract_findings_from_output` forwards that `diagnostic` dict through to its caller.
- The `review pr` command's `SystemExit` message now distinguishes "child stdout was not valid JSONL" (names the line + snippet) from "stdout was valid JSONL but had no findings block" (unchanged message).

Companion to gptme/gptme#3732, which fixes the specific OTLP banner that triggered this; this change makes the *next* stdout contaminant diagnosable without another multi-session detour.

## Tests

Added `TestAssistantOutputFromJsonl` in `tests/test_util_review.py`: a banner-then-JSONL input returns `None` and logs a warning naming line 1 with the banner snippet, the `diagnostic` dict is populated correctly, and clean JSONL with a findings block still parses. Full `tests/test_util_review.py` suite passes (153 tests). `ruff check`/`format` and `mypy` clean on the changed file.