### PR TITLE
ux: hint how to enable disabled-by-default tool in error message

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -339,6 +339,19 @@ def get_toolchain(
     return tools
 
 
+def _enable_hint_for_disabled_tool(tool_name: str) -> str:
+    """Hint how to enable a disabled-by-default tool, if we already know it.
+
+    Reads the available-tools cache only. Must not rediscover: this runs on
+    the unpaired-tool error path, which has to keep the tool_use/tool_result
+    pairing valid even when discovery would be slow or fail.
+    """
+    cached = _get_available_tools_cache() or []
+    if any(t.name == tool_name and t.disabled_by_default for t in cached):
+        return f" Add --tools +{tool_name} to enable it."
+    return ""
+
+
 @trace_function(name="tools.execute_msg", attributes={"component": "tools"})
 def execute_msg(
     msg: Message,
@@ -413,17 +426,10 @@ def execute_msg(
                 "the tool_use/tool_result pairing valid.",
                 tooluse.tool,
             )
-            error_msg = f"Tool '{tooluse.tool}' is not available for execution."
-            disabled_tool = next(
-                (
-                    t
-                    for t in get_available_tools(include_mcp=False)
-                    if t.name == tooluse.tool and t.disabled_by_default
-                ),
-                None,
+            error_msg = (
+                f"Tool '{tooluse.tool}' is not available for execution."
+                + _enable_hint_for_disabled_tool(tooluse.tool)
             )
-            if disabled_tool:
-                error_msg += f" Add --tools +{tooluse.tool} to enable it."
             yield Message(
                 "system",
                 error_msg,

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -413,9 +413,20 @@ def execute_msg(
                 "the tool_use/tool_result pairing valid.",
                 tooluse.tool,
             )
+            error_msg = f"Tool '{tooluse.tool}' is not available for execution."
+            disabled_tool = next(
+                (
+                    t
+                    for t in get_available_tools(include_mcp=False)
+                    if t.name == tooluse.tool and t.disabled_by_default
+                ),
+                None,
+            )
+            if disabled_tool:
+                error_msg += f" Add --tools +{tooluse.tool} to enable it."
             yield Message(
                 "system",
-                f"Tool '{tooluse.tool}' is not available for execution.",
+                error_msg,
                 call_id=tooluse.call_id,
             )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -117,6 +117,23 @@ def test_read_only_tool_preset_allows_read_tool(tmp_path):
     assert "hello audit mode" in results[0].content
 
 
+def test_disabled_by_default_tool_error_includes_enable_hint():
+    """Error for a disabled-by-default tool should tell the user how to enable it."""
+    clear_tools()
+    set_tool_format("tool")
+    # Init without 'read' — it's disabled_by_default and not in the allowlist
+    init_tools(allowlist=["shell"])
+
+    results = list(
+        execute_msg(Message("assistant", '@read(call-read): {"path": "x.txt"}'))
+    )
+
+    assert len(results) == 1
+    assert results[0].call_id == "call-read"
+    assert "not available for execution" in results[0].content
+    assert "--tools +read" in results[0].content
+
+
 def test_read_only_tool_preset_cannot_be_combined_with_other_tools():
     clear_tools()
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -134,6 +134,39 @@ def test_disabled_by_default_tool_error_includes_enable_hint():
     assert "--tools +read" in results[0].content
 
 
+def test_disabled_tool_hint_uses_cache_not_rediscovery(monkeypatch):
+    """Unavailable-tool errors must not rediscover tools (can raise or stall)."""
+    clear_tools()
+    set_tool_format("tool")
+    init_tools(allowlist=["shell"])
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("must not rediscover on the unavailable-tool path")
+
+    monkeypatch.setattr("gptme.tools._discover_tools", boom)
+
+    results = list(
+        execute_msg(Message("assistant", '@read(call-read): {"path": "x.txt"}'))
+    )
+
+    assert len(results) == 1
+    assert results[0].call_id == "call-read"
+    assert "--tools +read" in results[0].content
+
+
+def test_unavailable_tool_error_pairs_when_cache_empty():
+    """Structured tool_use still pairs if the available-tools cache is empty."""
+    clear_tools()
+    set_tool_format("tool")
+
+    results = list(execute_msg(Message("assistant", '@unknown(call-x): {"x": 1}')))
+
+    assert len(results) == 1
+    assert results[0].call_id == "call-x"
+    assert "not available for execution" in results[0].content
+    assert "--tools +" not in results[0].content
+
+
 def test_read_only_tool_preset_cannot_be_combined_with_other_tools():
     clear_tools()
 


### PR DESCRIPTION
## Summary

When a model calls a tool with `disabled_by_default=True` (e.g. `read`) but the user hasn't enabled it with `--tools +read`, the error message now tells them how to fix it:

**Before:**
> Tool 'read' is not available for execution.

**After:**
> Tool 'read' is not available for execution. Add --tools +read to enable it.

This resolves the UX gap described in #3698 and was the recommended good-first-issue in #3745.

## Changes

- `gptme/tools/__init__.py`: In the not-runnable error path, look up the tool in `get_available_tools()` and append the enable hint if `disabled_by_default=True`
- `tests/test_tools.py`: New test `test_disabled_by_default_tool_error_includes_enable_hint` verifying the hint appears

## Test plan

- [x] New test passes: `pytest tests/test_tools.py::test_disabled_by_default_tool_error_includes_enable_hint`
- [x] Full `tests/test_tools.py` suite: 45 passed
- [x] Pre-commit hooks pass (ruff, mypy)

Closes #3698