### PR TITLE
feat(skills): persist explicit invocation lifecycle evidence

### DIFF
--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -216,6 +216,31 @@ argument (curly braces are required for positional references to avoid
 ambiguity with literal dollar amounts like ``$100`` in skill prose).
 Use ``/skills read <name>`` to view a skill without invoking it.
 
+Invocation evidence
+~~~~~~~~~~~~~~~~~~~
+
+Explicit slash-command invocations append versioned records to
+``<conversation>/skill-events.jsonl``. Each invocation gets a UUID, carried through
+the prompt queue into message metadata as ``skill_invocation_id``. The ledger
+records skill identity, source path, invocation surface, run identity, timestamp,
+and phase. It does not record arguments or skill contents. Ambient skill matching
+and injection do not create invocation events.
+
+``started`` means the prompt was built; ``queued`` means it was admitted to the
+queue. Queue errors record ``failed`` with the exception class, without its text.
+Neither admission nor a normal turn/session hook establishes skill completion.
+The explicit ``record_skill_phase`` API accepts a later ``completed`` or ``failed``
+event from a caller with execution evidence; terminal transitions are idempotent.
+
+On CLI exit, unresolved invocations from that run become ``abandoned``. This means
+no completion evidence was recorded, and does not establish that the skill's work
+failed. Nested and resumed runs have separate UUIDs. Server/TUI terminal adapters,
+automatic completion evidence, abrupt-process recovery, cost attribution, and OTEL
+metrics remain future work; server/TUI command records currently retain the
+conversation path as their session identity. Storage failures are logged and never
+prevent skill execution. Malformed ledgers are preserved and refuse further writes
+until repaired, rather than risking duplicate terminal events.
+
 Creating Skills
 ---------------
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -3,6 +3,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable, Generator
+from contextlib import ExitStack
 from pathlib import Path
 
 from .commands import execute_cmd
@@ -94,6 +95,7 @@ def chat(
     # Save the caller's format so nested chat() calls (inline subagents) can
     # restore it on exit instead of unconditionally resetting to "text".
     _prev_output_format = get_output_format()
+    skill_lifecycle = ExitStack()
     try:
         set_output_format(output_format)
 
@@ -133,6 +135,10 @@ def chat(
         if not is_output_json() and not is_output_quiet():
             console.log(f"Using logdir: {path_with_tilde(logdir)}")
         manager = LogManager.load(logdir, initial_msgs=initial_msgs, create=True)
+
+        from .lessons.skill_events import skill_session
+
+        skill_lifecycle.enter_context(skill_session(logdir))
 
         # Note: todo replay is now handled via SESSION_START hook
 
@@ -186,6 +192,7 @@ def chat(
             for msg in session_end_msgs:
                 manager.append(msg)
     finally:
+        skill_lifecycle.close()
         # Safety-net sentinel write.  The primary writes happen inside
         # _run_chat_loop at the actual break/raise points so the window between
         # the final _drain_external_prompt_queue() call and the sentinel being

--- a/gptme/lessons/skill_commands.py
+++ b/gptme/lessons/skill_commands.py
@@ -85,6 +85,7 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
 
     def handler(ctx: CommandContext) -> Generator[Message, None, None]:
         from ..prompt_queue import queue_prompt  # fmt: skip
+        from .skill_events import record_skill_phase, start_skill_invocation
 
         # Build the prompt first; only undo the command message on success so a
         # broken skill leaves the log intact instead of silently disappearing.
@@ -94,7 +95,15 @@ def _make_skill_handler(skill: Lesson, index: LessonIndex) -> CommandHandler:
             logger.warning("Failed to build prompt for skill %r: %s", name, e)
             yield from ()
             return
-        queue_prompt(ctx.manager.logdir, content)
+        invocation_id = start_skill_invocation(ctx.manager.logdir, name, skill.path)
+        try:
+            queue_prompt(ctx.manager.logdir, content, skill_invocation_id=invocation_id)
+        except Exception as e:
+            record_skill_phase(
+                ctx.manager.logdir, invocation_id, "failed", error_type=type(e).__name__
+            )
+            raise
+        record_skill_phase(ctx.manager.logdir, invocation_id, "queued")
         # Remove the "/skill:<name>" command message from the log after queuing,
         # like built-in commands do; the queued prompt carries its own header.
         ctx.manager.undo(1, quiet=True)

--- a/gptme/lessons/skill_events.py
+++ b/gptme/lessons/skill_events.py
@@ -1,0 +1,203 @@
+"""Append-only lifecycle evidence for explicitly invoked skills.
+
+Queueing is not completion. Callers must supply terminal evidence explicitly;
+the CLI session boundary only abandons unresolved invocations from its own run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal
+from uuid import uuid4
+
+from ..logmanager.eventlog import _event_log_lock
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SkillPhase = Literal["started", "queued", "completed", "failed", "abandoned"]
+EVENTS_FILENAME = "skill-events.jsonl"
+_TERMINAL = {"completed", "failed", "abandoned"}
+_PHASES = {"started", "queued", *_TERMINAL}
+_session: ContextVar[tuple[Path, str] | None] = ContextVar(
+    "skill_session", default=None
+)
+
+
+@dataclass(frozen=True)
+class SkillEvent:
+    invocation_id: str
+    session_id: str
+    skill_name: str
+    skill_path: str
+    surface: str
+    phase: SkillPhase
+    timestamp: str
+    duration_seconds: float | None = None
+    error_type: str | None = None
+    schema_version: int = 1
+
+
+def read_skill_events(logdir: Path) -> list[SkillEvent]:
+    """Read the ledger; refuse malformed history instead of losing terminal evidence.
+
+    Writers call this under the conversation lock. Consumers should hold that
+    same lock if they need a snapshot concurrent with a writer.
+    """
+    path = logdir / EVENTS_FILENAME
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        event = SkillEvent(**json.loads(line))
+        if event.schema_version != 1 or event.phase not in _PHASES:
+            raise ValueError("Unsupported skill event schema or phase")
+        events.append(event)
+    return events
+
+
+def _append(logdir: Path, event: SkillEvent) -> None:
+    # Reuse conversation serialization, but not its compacted recovery ledger.
+    with (logdir / EVENTS_FILENAME).open("a+b") as stream:
+        # A complete JSON record may survive without its final newline. Preserve
+        # that record and append a separator instead of concatenating two objects.
+        if stream.seek(0, 2):
+            stream.seek(-1, 2)
+            if stream.read(1) != b"\n":
+                stream.write(b"\n")
+        stream.write((json.dumps(asdict(event)) + "\n").encode("utf-8"))
+
+
+def start_skill_invocation(
+    logdir: Path,
+    skill_name: str,
+    skill_path: Path,
+    *,
+    surface: str = "gptme-slash-command",
+    session_id: str | None = None,
+) -> str | None:
+    """Record a built skill prompt. Storage failures never block invocation."""
+    try:
+        current = _session.get()
+        if session_id is None:
+            session_id = (
+                current[1]
+                if current and current[0] == logdir.resolve()
+                else str(logdir.resolve())
+            )
+        event = SkillEvent(
+            invocation_id=str(uuid4()),
+            session_id=session_id,
+            skill_name=skill_name,
+            skill_path=str(skill_path.resolve()),
+            surface=surface,
+            phase="started",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+        with _event_log_lock(logdir):
+            read_skill_events(logdir)
+            _append(logdir, event)
+        return event.invocation_id
+    except (OSError, ValueError, TypeError):
+        logger.warning("Could not record skill invocation", exc_info=True)
+        return None
+
+
+def _transition(
+    logdir: Path,
+    events: list[SkillEvent],
+    invocation_id: str,
+    phase: SkillPhase,
+    error_type: str | None,
+) -> bool:
+    matching = [event for event in events if event.invocation_id == invocation_id]
+    if not matching:
+        return False
+    first, last = matching[0], matching[-1]
+    if last.phase in _TERMINAL or last.phase == phase:
+        return False
+    allowed = {"failed", "abandoned"}
+    allowed.add("queued" if last.phase == "started" else "completed")
+    if phase not in allowed:
+        return False
+    now = datetime.now(timezone.utc)
+    event = replace(
+        first,
+        phase=phase,
+        timestamp=now.isoformat(),
+        duration_seconds=(
+            max(0.0, (now - datetime.fromisoformat(first.timestamp)).total_seconds())
+            if phase in _TERMINAL
+            else None
+        ),
+        error_type=error_type,
+    )
+    _append(logdir, event)
+    events.append(event)
+    return True
+
+
+def record_skill_phase(
+    logdir: Path,
+    invocation_id: str | None,
+    phase: SkillPhase,
+    *,
+    error_type: str | None = None,
+) -> bool:
+    """Append a valid transition once, returning whether an event was written.
+
+    ``completed`` requires caller-observed completion; neither a queued prompt
+    nor a generic turn/session hook supplies that evidence.
+    """
+    if invocation_id is None:
+        return False
+    try:
+        with _event_log_lock(logdir):
+            return _transition(
+                logdir, read_skill_events(logdir), invocation_id, phase, error_type
+            )
+    except (OSError, ValueError, TypeError):
+        logger.warning("Could not record skill phase", exc_info=True)
+        return False
+
+
+def abandon_skill_invocations(logdir: Path, session_id: str) -> None:
+    """Reconcile unresolved starts from exactly one run; preserve all history."""
+    try:
+        if not (logdir / EVENTS_FILENAME).exists():
+            return
+        with _event_log_lock(logdir):
+            events = read_skill_events(logdir)
+            invocation_ids = {
+                event.invocation_id
+                for event in events
+                if event.session_id == session_id and event.phase == "started"
+            }
+            for invocation_id in invocation_ids:
+                _transition(logdir, events, invocation_id, "abandoned", None)
+    except (OSError, ValueError, TypeError):
+        logger.warning("Could not reconcile skill invocations", exc_info=True)
+
+
+@contextmanager
+def skill_session(logdir: Path) -> Iterator[str]:
+    """Give CLI invocations a run identity and reconcile them on every exit path."""
+    session_id = str(uuid4())
+    token = _session.set((logdir.resolve(), session_id))
+    try:
+        yield session_id
+    finally:
+        try:
+            abandon_skill_invocations(logdir, session_id)
+        finally:
+            _session.reset(token)

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -175,6 +175,7 @@ class MessageMetadata(TypedDict, total=False):
     # Identifies one generated startup-prompt generation. A newer generation
     # supersedes older ones in provider context while all remain on disk.
     prompt_generation: str
+    skill_invocation_id: str  # Explicit skill invocation that queued this prompt
 
 
 _TOKEN_KEYS = (

--- a/gptme/prompt_queue.py
+++ b/gptme/prompt_queue.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from .message import Message
+from .message import Message, MessageMetadata
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -50,7 +50,13 @@ def _prompt_queue_lock(logdir: Path):
                 fcntl.flock(fd, fcntl.LOCK_UN)
 
 
-def queue_prompt(logdir: Path, content: str, *, steer: bool = False) -> None:
+def queue_prompt(
+    logdir: Path,
+    content: str,
+    *,
+    steer: bool = False,
+    skill_invocation_id: str | None = None,
+) -> None:
     """Append a prompt to a conversation queue.
 
     Args:
@@ -58,6 +64,7 @@ def queue_prompt(logdir: Path, content: str, *, steer: bool = False) -> None:
             hook.  Regular (non-steer) prompts are drained between turns; steer
             prompts are drained at each STEP_PRE checkpoint so the next LLM call
             in the same turn sees them immediately.
+        skill_invocation_id: Correlate a queued skill prompt with its invocation.
     """
     queue_path = get_prompt_queue_path(logdir)
     record: dict = {
@@ -66,6 +73,8 @@ def queue_prompt(logdir: Path, content: str, *, steer: bool = False) -> None:
     }
     if steer:
         record["steer"] = True
+    if skill_invocation_id is not None:
+        record["skill_invocation_id"] = skill_invocation_id
 
     with _prompt_queue_lock(logdir), queue_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record) + "\n")
@@ -115,7 +124,11 @@ def drain_prompt_queue(logdir: Path, max_items: int | None = None) -> list[Messa
                 logger.warning("Skipping empty queued prompt in %s", queue_path)
                 continue
 
-            drained.append(Message("user", content, quiet=True))
+            metadata: MessageMetadata | None = None
+            skill_invocation_id = record.get("skill_invocation_id")
+            if isinstance(skill_invocation_id, str) and skill_invocation_id.strip():
+                metadata = {"skill_invocation_id": skill_invocation_id}
+            drained.append(Message("user", content, quiet=True, metadata=metadata))
 
         if remaining:
             queue_path.write_text("\n".join(remaining) + "\n", encoding="utf-8")

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -73,6 +73,11 @@ logger = logging.getLogger(__name__)
 MAX_INITIAL_MESSAGES = 100
 
 
+def _queued_prompt_text(item: str | Message) -> str:
+    """Return the user-visible text for a TUI-queued prompt."""
+    return item.content if isinstance(item, Message) else item
+
+
 def _summarize(content: str, maxlen: int = 80) -> str:
     """One-line summary of message content, for collapsed sections."""
     lines = content.strip().splitlines() or [""]
@@ -1041,7 +1046,7 @@ class GptmeApp(App):
         # (exclusive=True), so reusing one Context is safe, and mutations
         # (e.g. /model-style changes) persist across turns.
         self._chat_ctx = contextvars.copy_context()
-        self.prompt_queue: list[str] = []
+        self.prompt_queue: list[str | Message] = []
         self._queued_widgets: list[Widget] = []
         self.generating = False
         self.state = "idle"
@@ -1417,7 +1422,9 @@ class GptmeApp(App):
         first, *rest = drained
         self.manager.append(first)
         self._show_message(first)
-        self.prompt_queue.extend(msg.content for msg in rest)
+        # Keep drained Message objects so later batched skill prompts retain
+        # skill_invocation_id instead of being rebuilt from content strings.
+        self.prompt_queue.extend(rest)
         self._start_generation()
 
     def _rebuild_chat(self) -> None:
@@ -1428,8 +1435,13 @@ class GptmeApp(App):
         chat.remove_children()
         self._render_history()
 
-    async def _submit(self, text: str) -> None:
-        msg = Message("user", text, quiet=True)
+    async def _submit(self, prompt: str | Message) -> None:
+        if isinstance(prompt, Message):
+            msg = prompt
+            text = msg.content
+        else:
+            text = prompt
+            msg = Message("user", text, quiet=True)
         # Confirm before fetching any URLs, matching CLI behavior (TUI can't
         # use prompt_toolkit's sync dialog inside the running event loop).
         pre_confirmed_urls: list[str] | None = None
@@ -1638,18 +1650,18 @@ class GptmeApp(App):
         self._clear_tool_placeholder()
         if self._interrupt_event.is_set() and self.prompt_queue:
             # user interrupted: hand queued text back instead of auto-submitting
-            text = "\n".join(self.prompt_queue)
+            text = "\n".join(_queued_prompt_text(item) for item in self.prompt_queue)
             self.prompt_queue.clear()
             for w in self._queued_widgets:
                 w.remove()
             self._queued_widgets.clear()
             self.query_one("#input", ChatInput)._set_text(text)
         elif self.prompt_queue:
-            text = self.prompt_queue.pop(0)
+            prompt = self.prompt_queue.pop(0)
             if self._queued_widgets:
                 self._queued_widgets.pop(0).remove()
             self._set_state("idle")
-            await self._submit(text)
+            await self._submit(prompt)
             return
         self._set_state("idle")
 

--- a/tests/test_prompt_queue.py
+++ b/tests/test_prompt_queue.py
@@ -5,8 +5,14 @@ corrupted JSONL line (e.g. a half-written record left by a crash mid-append)
 must survive a drain cycle rather than being silently deleted.
 """
 
+import json
+from pathlib import Path
+
+import pytest
+
 from gptme.prompt_queue import (
     drain_prompt_queue,
+    drain_steer_prompts,
     get_prompt_queue_path,
     queue_prompt,
 )
@@ -59,3 +65,64 @@ def test_drain_preserves_malformed_line_across_drains(tmp_path):
     queue_path = get_prompt_queue_path(logdir)
     assert queue_path.exists()
     assert '{"content": "truncated' in queue_path.read_text(encoding="utf-8")
+
+
+def test_skill_invocation_metadata_roundtrip(tmp_path: Path) -> None:
+    queue_prompt(tmp_path, "skill prompt", skill_invocation_id="invocation-123")
+
+    record = json.loads(get_prompt_queue_path(tmp_path).read_text(encoding="utf-8"))
+    assert record["content"] == "skill prompt"
+    assert record["skill_invocation_id"] == "invocation-123"
+
+    (message,) = drain_prompt_queue(tmp_path)
+    assert message.content == "skill prompt"
+    assert message.role == "user"
+    assert message.quiet is True
+    assert message.metadata == {"skill_invocation_id": "invocation-123"}
+    assert message.to_dict()["metadata"] == message.metadata
+
+
+def test_prompt_without_skill_invocation_metadata(tmp_path: Path) -> None:
+    queue_prompt(tmp_path, "regular prompt")
+
+    record = json.loads(get_prompt_queue_path(tmp_path).read_text(encoding="utf-8"))
+    assert "skill_invocation_id" not in record
+
+    (message,) = drain_prompt_queue(tmp_path)
+    assert message.content == "regular prompt"
+    assert message.metadata is None
+    assert "metadata" not in message.to_dict()
+
+
+@pytest.mark.parametrize("invocation_id", [None, "", " \t", 123, True, [], {}])
+def test_drain_ignores_malformed_skill_invocation_metadata(
+    tmp_path: Path, invocation_id: object
+) -> None:
+    get_prompt_queue_path(tmp_path).write_text(
+        json.dumps({"content": "valid prompt", "skill_invocation_id": invocation_id})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    (message,) = drain_prompt_queue(tmp_path)
+    assert message.content == "valid prompt"
+    assert message.metadata is None
+    assert not get_prompt_queue_path(tmp_path).exists()
+
+
+def test_skill_invocation_metadata_survives_partial_drain(tmp_path: Path) -> None:
+    queue_prompt(tmp_path, "first prompt")
+    queue_prompt(tmp_path, "steering prompt", steer=True)
+    queue_prompt(tmp_path, "skill prompt", skill_invocation_id="invocation-123")
+
+    assert [
+        message.content for message in drain_prompt_queue(tmp_path, max_items=1)
+    ] == ["first prompt"]
+    (skill_message,) = drain_prompt_queue(tmp_path)
+    assert skill_message.content == "skill prompt"
+    assert skill_message.metadata == {"skill_invocation_id": "invocation-123"}
+
+    (steer_message,) = drain_steer_prompts(tmp_path)
+    assert steer_message.content == "steering prompt"
+    assert steer_message.metadata is None
+    assert not get_prompt_queue_path(tmp_path).exists()

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -320,6 +320,117 @@ def test_handler_undo_not_called_when_build_fails(
     # manager.undo must NOT have been called — the log stays intact so the user
     # can see the failed invocation instead of a silent disappear.
     manager.undo.assert_not_called()
+    assert not (manager.logdir / "skill-events.jsonl").exists()
+
+
+def test_skill_handler_records_admission_not_completion(skills_root: Path, manager):
+    from gptme.lessons.skill_events import read_skill_events, skill_session
+
+    skill_path = _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+    with skill_session(manager.logdir) as session_id:
+        list(handle_cmd("/skill:demo private-argument", manager))
+        events = read_skill_events(manager.logdir)
+        assert [event.phase for event in events] == ["started", "queued"]
+        assert {event.session_id for event in events} == {session_id}
+        assert {event.skill_path for event in events} == {str(skill_path)}
+        queued = drain_prompt_queue(manager.logdir)
+        assert queued[0].metadata is not None
+        assert queued[0].metadata["skill_invocation_id"] == events[0].invocation_id
+    events = read_skill_events(manager.logdir)
+    assert [event.phase for event in events] == ["started", "queued", "abandoned"]
+    assert "private-argument" not in (manager.logdir / "skill-events.jsonl").read_text()
+
+
+def test_queue_failure_records_failure_and_preserves_command(
+    skills_root: Path, manager, monkeypatch
+):
+    from gptme.lessons.skill_events import read_skill_events, skill_session
+
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+
+    def fail_queue(*args, **kwargs):
+        raise OSError("private queue error")
+
+    monkeypatch.setattr("gptme.prompt_queue.queue_prompt", fail_queue)
+    with (
+        skill_session(manager.logdir),
+        pytest.raises(OSError, match="private queue error"),
+    ):
+        list(_command_registry["skill:demo"](_ctx(manager)))
+    events = read_skill_events(manager.logdir)
+    assert [event.phase for event in events] == ["started", "failed"]
+    assert events[-1].error_type == "OSError"
+    manager.undo.assert_not_called()
+    assert (
+        "private queue error" not in (manager.logdir / "skill-events.jsonl").read_text()
+    )
+
+
+def test_ledger_failure_does_not_prevent_skill_queueing(skills_root: Path, manager):
+    _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+    (manager.logdir / "skill-events.jsonl").write_text("malformed existing history\n")
+    list(_command_registry["skill:demo"](_ctx(manager)))
+    assert len(drain_prompt_queue(manager.logdir)) == 1
+    manager.undo.assert_called_once_with(1, quiet=True)
+
+
+@pytest.mark.parametrize("exit_kind", ["normal", "error", "complete"])
+def test_chat_finalizes_only_its_own_invocations(
+    skills_root: Path, manager, monkeypatch, exit_kind: str
+):
+    import sys
+
+    from gptme.chat import chat
+    from gptme.lessons.skill_events import read_skill_events, start_skill_invocation
+    from gptme.tools.complete import SessionCompleteException
+
+    skill_path = _write_skill(skills_root, "demo", "A demo skill", DEMO_BODY)
+    register_skill_commands()
+    old_id = start_skill_invocation(
+        manager.logdir, "demo", skill_path, session_id="previous-run"
+    )
+    chat_module = sys.modules["gptme.chat"]
+    monkeypatch.chdir(skills_root)
+    monkeypatch.setattr(chat_module, "init", lambda *args: None)
+    monkeypatch.setattr(chat_module, "trigger_hook", lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_module.LogManager, "load", lambda *args, **kwargs: manager)
+
+    def run(*args, **kwargs):
+        list(handle_cmd("/skill:demo", manager))
+        if exit_kind == "error":
+            raise RuntimeError("provider failed")
+        if exit_kind == "complete":
+            raise SessionCompleteException("stuck-loop exit is not skill success")
+
+    monkeypatch.setattr(chat_module, "_run_chat_loop", run)
+
+    def invoke():
+        chat(
+            [],
+            [],
+            manager.logdir,
+            skills_root,
+            "openai/gpt-4o",
+            interactive=False,
+            tool_format="markdown",
+            output_format="quiet",
+        )
+
+    if exit_kind == "error":
+        with pytest.raises(RuntimeError, match="provider failed"):
+            invoke()
+    else:
+        invoke()
+    events = read_skill_events(manager.logdir)
+    assert [event.phase for event in events if event.invocation_id == old_id] == [
+        "started"
+    ]
+    new_events = [event for event in events if event.invocation_id != old_id]
+    assert [event.phase for event in new_events] == ["started", "queued", "abandoned"]
+    assert len({event.session_id for event in new_events}) == 1
 
 
 def test_two_pass_registration_skill_named_with_prefix(skills_root: Path, manager):

--- a/tests/test_skill_events.py
+++ b/tests/test_skill_events.py
@@ -1,0 +1,297 @@
+"""Lifecycle evidence stays append-only, scoped to a run, and non-disruptive."""
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from threading import Barrier
+from typing import cast
+
+import pytest
+
+from gptme.lessons import skill_events
+from gptme.lessons.skill_events import (
+    EVENTS_FILENAME,
+    SkillPhase,
+    abandon_skill_invocations,
+    read_skill_events,
+    record_skill_phase,
+    skill_session,
+    start_skill_invocation,
+)
+
+
+def _start(logdir: Path, *, session_id: str | None = None) -> str:
+    invocation_id = start_skill_invocation(
+        logdir, "demo", logdir / "skills" / "demo" / "SKILL.md", session_id=session_id
+    )
+    assert invocation_id is not None
+    return invocation_id
+
+
+def test_queue_is_not_completion_and_terminal_requires_valid_transition(
+    tmp_path: Path,
+) -> None:
+    invocation_id = _start(tmp_path)
+    started_bytes = (tmp_path / EVENTS_FILENAME).read_bytes()
+
+    assert not record_skill_phase(tmp_path, invocation_id, "completed")
+    assert not record_skill_phase(tmp_path, invocation_id, "started")
+    assert not record_skill_phase(tmp_path, "unknown-id", "failed")
+    assert not record_skill_phase(tmp_path, None, "failed")
+    assert not record_skill_phase(tmp_path, invocation_id, cast(SkillPhase, "unknown"))
+    assert (tmp_path / EVENTS_FILENAME).read_bytes() == started_bytes
+
+    assert record_skill_phase(tmp_path, invocation_id, "queued")
+    queued_bytes = (tmp_path / EVENTS_FILENAME).read_bytes()
+    assert queued_bytes.startswith(started_bytes)
+    assert not record_skill_phase(tmp_path, invocation_id, "queued")
+    assert not record_skill_phase(tmp_path, invocation_id, "started")
+    events = read_skill_events(tmp_path)
+    assert [event.phase for event in events] == ["started", "queued"]
+    assert all(event.duration_seconds is None for event in events)
+
+    assert record_skill_phase(tmp_path, invocation_id, "completed")
+    finished_bytes = (tmp_path / EVENTS_FILENAME).read_bytes()
+    assert finished_bytes.startswith(queued_bytes)
+    for phase in ("completed", "failed", "abandoned", "queued", "started"):
+        assert not record_skill_phase(tmp_path, invocation_id, cast(SkillPhase, phase))
+    assert (tmp_path / EVENTS_FILENAME).read_bytes() == finished_bytes
+
+    first, _, terminal = read_skill_events(tmp_path)
+    assert terminal.invocation_id == first.invocation_id == invocation_id
+    assert terminal.session_id == first.session_id == str(tmp_path.resolve())
+    assert terminal.skill_name == first.skill_name == "demo"
+    assert terminal.skill_path == first.skill_path
+    assert terminal.surface == first.surface == "gptme-slash-command"
+    assert terminal.schema_version == first.schema_version == 1
+    elapsed = (
+        datetime.fromisoformat(terminal.timestamp)
+        - datetime.fromisoformat(first.timestamp)
+    ).total_seconds()
+    assert terminal.duration_seconds == max(0.0, elapsed)
+
+
+@pytest.mark.parametrize("queued", [False, True])
+@pytest.mark.parametrize("phase", ["failed", "abandoned"])
+def test_unfinished_invocation_can_fail_or_be_abandoned(
+    tmp_path: Path, queued: bool, phase: SkillPhase
+) -> None:
+    invocation_id = _start(tmp_path)
+    if queued:
+        assert record_skill_phase(tmp_path, invocation_id, "queued")
+
+    assert record_skill_phase(tmp_path, invocation_id, phase, error_type="OSError")
+    terminal = read_skill_events(tmp_path)[-1]
+    assert terminal.phase == phase
+    assert terminal.error_type == "OSError"
+    assert terminal.duration_seconds is not None
+    assert terminal.duration_seconds >= 0
+
+
+def test_nested_same_conversation_sessions_only_abandon_their_own_invocations(
+    tmp_path: Path,
+) -> None:
+    previous_id = _start(tmp_path, session_id="previous-run")
+    assert record_skill_phase(tmp_path, previous_id, "queued")
+
+    with skill_session(tmp_path) as outer_run:
+        outer_id = _start(tmp_path)
+        with skill_session(tmp_path) as inner_run:
+            assert inner_run != outer_run
+            inner_id = _start(tmp_path)
+            assert record_skill_phase(tmp_path, inner_id, "queued")
+
+        events = read_skill_events(tmp_path)
+        assert [e.phase for e in events if e.invocation_id == inner_id] == [
+            "started",
+            "queued",
+            "abandoned",
+        ]
+        assert [e.phase for e in events if e.invocation_id == outer_id] == ["started"]
+        after_inner_id = _start(tmp_path)
+        assert read_skill_events(tmp_path)[-1].session_id == outer_run
+
+    events = read_skill_events(tmp_path)
+    for invocation_id in (outer_id, after_inner_id):
+        assert [e.phase for e in events if e.invocation_id == invocation_id] == [
+            "started",
+            "abandoned",
+        ]
+    assert [e.phase for e in events if e.invocation_id == previous_id] == [
+        "started",
+        "queued",
+    ]
+    # Reconciliation is safe to repeat and does not sweep another run's history.
+    before = (tmp_path / EVENTS_FILENAME).read_bytes()
+    abandon_skill_invocations(tmp_path, outer_run)
+    abandon_skill_invocations(tmp_path, inner_run)
+    assert (tmp_path / EVENTS_FILENAME).read_bytes() == before
+
+    outside_id = _start(tmp_path)
+    assert read_skill_events(tmp_path)[-1].invocation_id == outside_id
+    assert read_skill_events(tmp_path)[-1].session_id == str(tmp_path.resolve())
+
+
+def test_session_scope_does_not_capture_another_conversation(tmp_path: Path) -> None:
+    own_logdir = tmp_path / "own"
+    other_logdir = tmp_path / "other"
+    with skill_session(own_logdir):
+        _start(own_logdir)
+        other_id = _start(other_logdir)
+
+    own_events = read_skill_events(own_logdir)
+    assert [e.phase for e in own_events] == ["started", "abandoned"]
+    other_events = read_skill_events(other_logdir)
+    assert len(other_events) == 1
+    assert other_events[0].invocation_id == other_id
+    assert other_events[0].session_id == str(other_logdir.resolve())
+
+
+def test_session_exception_abandons_pending_but_preserves_explicit_terminal(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RuntimeError, match="provider failed"), skill_session(tmp_path):
+        finished_id = _start(tmp_path)
+        assert record_skill_phase(tmp_path, finished_id, "queued")
+        assert record_skill_phase(tmp_path, finished_id, "completed")
+        pending_id = _start(tmp_path)
+        raise RuntimeError("provider failed")
+
+    events = read_skill_events(tmp_path)
+    assert [e.phase for e in events if e.invocation_id == finished_id] == [
+        "started",
+        "queued",
+        "completed",
+    ]
+    assert [e.phase for e in events if e.invocation_id == pending_id] == [
+        "started",
+        "abandoned",
+    ]
+
+
+def test_concurrent_terminal_writers_produce_exactly_one_terminal(
+    tmp_path: Path,
+) -> None:
+    invocation_id = _start(tmp_path)
+    assert record_skill_phase(tmp_path, invocation_id, "queued")
+    gate = Barrier(3)
+
+    def finish(phase: SkillPhase) -> bool:
+        gate.wait(timeout=10)
+        return record_skill_phase(tmp_path, invocation_id, phase)
+
+    phases: tuple[SkillPhase, ...] = ("completed", "failed", "abandoned")
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        results = list(executor.map(finish, phases))
+
+    assert sum(results) == 1
+    events = read_skill_events(tmp_path)
+    assert len(events) == 3
+    assert [event.phase for event in events[:2]] == ["started", "queued"]
+    assert events[-1].phase == phases[results.index(True)]
+
+
+@pytest.mark.parametrize("corruption", ["json", "missing-fields", "schema", "phase"])
+def test_malformed_history_blocks_appends_without_rewriting_history(
+    tmp_path: Path, corruption: str
+) -> None:
+    invocation_id = _start(tmp_path, session_id="run")
+    ledger = tmp_path / EVENTS_FILENAME
+    if corruption == "json":
+        corrupt_line = '{"invocation_id":'
+    elif corruption == "missing-fields":
+        corrupt_line = '{"invocation_id":"incomplete"}'
+    else:
+        record = json.loads(ledger.read_text())
+        record["schema_version" if corruption == "schema" else "phase"] = (
+            999 if corruption == "schema" else "unknown"
+        )
+        corrupt_line = json.dumps(record)
+    with ledger.open("a") as stream:
+        stream.write(corrupt_line + "\n")
+    before = ledger.read_bytes()
+
+    with pytest.raises((ValueError, TypeError)):
+        read_skill_events(tmp_path)
+    assert not record_skill_phase(tmp_path, invocation_id, "failed")
+    assert start_skill_invocation(tmp_path, "new", tmp_path / "SKILL.md") is None
+    abandon_skill_invocations(tmp_path, "run")
+    assert ledger.read_bytes() == before
+
+
+@pytest.mark.parametrize("failure", ["append", "stat"])
+def test_storage_failure_during_close_does_not_mask_session_error_or_leak_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: str,
+) -> None:
+    def broken_append(*args: object) -> None:
+        raise OSError("disk full")
+
+    original_exists = Path.exists
+
+    def broken_exists(path: Path) -> bool:
+        if path == tmp_path / EVENTS_FILENAME:
+            raise PermissionError("conversation directory unreadable")
+        return original_exists(path)
+
+    with (
+        monkeypatch.context() as patch,
+        pytest.raises(RuntimeError, match="provider failed"),
+        skill_session(tmp_path),
+    ):
+        invocation_id = _start(tmp_path)
+        assert record_skill_phase(tmp_path, invocation_id, "queued")
+        if failure == "append":
+            patch.setattr(skill_events, "_append", broken_append)
+        else:
+            patch.setattr(Path, "exists", broken_exists)
+        raise RuntimeError("provider failed")
+
+    assert "Could not reconcile skill invocations" in caplog.text
+    assert [event.phase for event in read_skill_events(tmp_path)] == [
+        "started",
+        "queued",
+    ]
+    _start(tmp_path)
+    assert read_skill_events(tmp_path)[-1].session_id == str(tmp_path.resolve())
+
+
+def test_start_and_phase_storage_failures_are_nonfatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    invocation_id = _start(tmp_path)
+    before = (tmp_path / EVENTS_FILENAME).read_bytes()
+
+    def broken_append(*args: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(skill_events, "_append", broken_append)
+    assert start_skill_invocation(tmp_path, "new", tmp_path / "SKILL.md") is None
+    assert not record_skill_phase(tmp_path, invocation_id, "queued")
+    assert (tmp_path / EVENTS_FILENAME).read_bytes() == before
+
+
+def test_empty_session_does_not_create_telemetry_artifacts(tmp_path: Path) -> None:
+    logdir = tmp_path / "unused"
+    with skill_session(logdir):
+        pass
+    assert not logdir.exists()
+
+
+def test_complete_record_without_newline_remains_separate_on_append(
+    tmp_path: Path,
+) -> None:
+    invocation_id = start_skill_invocation(tmp_path, "demo", tmp_path / "SKILL.md")
+    ledger = tmp_path / EVENTS_FILENAME
+    original = ledger.read_bytes().rstrip(b"\n")
+    ledger.write_bytes(original)
+
+    assert record_skill_phase(tmp_path, invocation_id, "queued")
+    assert ledger.read_bytes().startswith(original + b"\n")
+    assert [event.phase for event in read_skill_events(tmp_path)] == [
+        "started",
+        "queued",
+    ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -254,9 +254,52 @@ async def test_skill_command_drains_prompt_queue_and_starts_generation(
             assert any(
                 "Do the parity thing." in w.content for w in app.query(UserMessage)
             )
+            skill_msgs = [
+                m
+                for m in manager.log
+                if m.role == "user" and "Skill invoked: /skill:parity-demo" in m.content
+            ]
+            assert skill_msgs
+            assert skill_msgs[0].metadata is not None
+            assert skill_msgs[0].metadata.get("skill_invocation_id")
     finally:
         unregister_skill_commands()
         clear_cache()
+
+
+@pytest.mark.asyncio
+async def test_batched_tui_drain_preserves_skill_invocation_metadata(
+    tmp_path, monkeypatch
+):
+    """Later drained skill prompts must keep invocation metadata in the TUI queue."""
+    from gptme.prompt_queue import queue_prompt
+
+    manager = make_manager(tmp_path)
+    app = GptmeApp(manager, workspace=tmp_path)
+    monkeypatch.setattr(app, "_start_generation", lambda: None)
+
+    queue_prompt(manager.logdir, "first prompt")
+    queue_prompt(
+        manager.logdir,
+        "skill prompt",
+        skill_invocation_id="invocation-queued-rest",
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._drain_command_queued_prompts()
+        await pilot.pause()
+
+        assert manager.log.messages[-1].content == "first prompt"
+        assert len(app.prompt_queue) == 1
+        queued = app.prompt_queue[0]
+        assert isinstance(queued, Message)
+        assert queued.content == "skill prompt"
+        assert queued.metadata == {"skill_invocation_id": "invocation-queued-rest"}
+
+        await app._generation_done()
+        skill_msg = next(m for m in manager.log if m.content == "skill prompt")
+        assert skill_msg.metadata == {"skill_invocation_id": "invocation-queued-rest"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Explicit skill commands currently leave a prompt in the conversation but no durable invocation lifecycle. This records versioned `started` and `queued` events in `skill-events.jsonl`, carries an invocation UUID through queue/message metadata, and records queue failures without storing arguments or error text.

The terminal API validates transitions and appends at most one terminal event under the existing conversation lock. CLI shutdown abandons unresolved invocations from its own run; nested and resumed runs retain separate identities. Generic turn/session hooks do not prove skill completion, so this PR does not infer success from them. Server/TUI terminal adapters, explicit execution evidence, cost attribution, and OTEL metrics remain follow-up work.

Validation: 163 focused tests passed across lifecycle, command dispatch, queue transport, chat, messages, and JSON output. Tests cover concurrent terminal writers, nested/resumed isolation, queue failure, malformed ledgers, missing final newlines, and finalizer I/O failures. Scoped pre-commit passes, including mypy. The JSON-output tests report existing OTEL thread-leak warnings. PR quality gate: 94/100; the shared `chat.py` path with #3646 concerns an independent token-display change.

No screenshot: the TUI change is metadata-only (`prompt_queue` now holds `Message` objects so `skill_invocation_id` survives batched drain). Rendered UI is unchanged.
