### PR TITLE
fix(webui): drop auth-code bootstrap gate before the connection probe

### DIFF
--- a/webui/src/contexts/ApiContext.tsx
+++ b/webui/src/contexts/ApiContext.tsx
@@ -355,6 +355,13 @@ export function ApiProvider({
       try {
         const config = await processConnectionFromHash(currentHash);
         console.log('[ApiContext] Auth code exchange successful, connecting');
+        // The exchange is the only step the UI must block on: once the token is
+        // registered, the chat shell can render while the connection probe runs
+        // in the background (isConnecting$/isConnected$ drive the indicators).
+        // Keeping the bootstrap gate up through connect() holds a blank
+        // "signing in" screen for the full probe round-trips — or many seconds
+        // against a waking instance.
+        setIsExchangingAuthCode(false);
         await connect(config);
       } catch (error) {
         console.error('[ApiContext] Auth code exchange failed:', error);

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, waitFor } from '@testing-library/react';
 import { observable } from '@legendapp/state';
 import { QueryClient } from '@tanstack/react-query';
-import { ApiProvider, shouldSkipHostedLoopbackAutoConnect } from '../ApiContext';
+import { ApiProvider, shouldSkipHostedLoopbackAutoConnect, useApi } from '../ApiContext';
 import type { ConnectionProbeResult } from '@/utils/api';
 
 const mockCheckConnection = jest.fn();
@@ -300,6 +300,69 @@ describe('ApiProvider mobile auto-connect', () => {
       },
       { timeout: 2000 }
     );
+  });
+});
+
+describe('ApiProvider auth code exchange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isConnected$.set(false);
+    lastConnectionResult$.set(null);
+    setActiveServerBaseUrl('http://127.0.0.1:5700');
+    mockGetPrimaryClient.mockReturnValue(mockClient);
+    mockGetClientForServer.mockReturnValue(mockClient);
+    mockGetActiveServer.mockReturnValue(null);
+    mockUseTauriServerStatus.mockReturnValue({
+      isLoading: false,
+      managesLocalServer: false,
+      serverStatus: null,
+    });
+    mockIsTauriEnvironment.mockReturnValue(false);
+  });
+
+  function GateProbe() {
+    const { isExchangingAuthCode } = useApi();
+    return <div data-testid="gate">{String(isExchangingAuthCode)}</div>;
+  }
+
+  it('drops the bootstrap gate after the exchange, before the connection probe finishes', async () => {
+    window.history.replaceState(null, '', '/#code=test-code');
+
+    // Connection probe that never resolves on its own — simulates the slow
+    // round-trips to a (possibly waking) instance.
+    let resolveConnection!: (value: boolean) => void;
+    mockCheckConnection.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveConnection = resolve;
+        })
+    );
+    mockProcessConnectionFromHash.mockImplementation(async () => {
+      // Real implementation cleans the code fragment from the URL.
+      window.history.replaceState(null, '', '/');
+      return {
+        baseUrl: 'https://instance.example.com',
+        authToken: 'user-token',
+        useAuthToken: true,
+      };
+    });
+
+    const queryClient = new QueryClient();
+    const { getByTestId } = render(
+      <ApiProvider queryClient={queryClient}>
+        <GateProbe />
+      </ApiProvider>
+    );
+
+    // Once connect() starts probing, the gate must already be down: the chat
+    // shell renders while the probe runs in the background.
+    await waitFor(() => {
+      expect(mockCheckConnection).toHaveBeenCalled();
+    });
+    expect(getByTestId('gate')).toHaveTextContent('false');
+
+    resolveConnection(true);
+    window.history.replaceState(null, '', '/');
   });
 });
 

--- a/webui/src/contexts/__tests__/ApiContext.test.tsx
+++ b/webui/src/contexts/__tests__/ApiContext.test.tsx
@@ -361,7 +361,12 @@ describe('ApiProvider auth code exchange', () => {
     });
     expect(getByTestId('gate')).toHaveTextContent('false');
 
+    // Let connect() run to completion before teardown so its state updates
+    // (setConnected, invalidateQueries, toast) don't fire after unmount.
     resolveConnection(true);
+    await waitFor(() => {
+      expect(mockSetConnected).toHaveBeenCalledWith(true);
+    });
     window.history.replaceState(null, '', '/');
   });
 });


### PR DESCRIPTION
## Problem

Entering chat on gptme.ai via the auth-code flow (`/chat#code=...`) shows a blank **"Connecting to your instance... Finishing secure sign-in before the chat surface loads."** screen that lingers well past the actual sign-in. Erik reports it on prod; it should be ~instant.

The bootstrap gate (`isExchangingAuthCode`) stays up through the entire sequence:

1. Code→token exchange POST to the fleet operator — **~150ms** (measured: fleet operator answers in ~120ms)
2. `connect()` → `checkConnection()`: GET `/api/v2` **then** GET `/api/v2/conversations?limit=1`, both proxied to the instance pod, each with a 3s timeout and up to 5 retries with exponential backoff
3. `queryClient.invalidateQueries()`

Step 2 is the slow part — two sequential pod round-trips on the happy path, and a retry-loop lasting many seconds when the instance is slow or waking (the `goToChat` cache-hit path in gptme-cloud never waits for readiness before navigating).

## Fix

Drop the gate as soon as the exchange completes and the token is registered. The chat shell renders immediately; the connection probe continues in the background with `isConnecting$`/`isConnected$` driving the existing connection indicators, and connect-failure toasts unchanged.

The exchange/connect concurrency this exposes already existed behind the gate: the initial-connection effect re-fires mid-`connect()` when the registry updates, and overlapping probes are serialized by the probe nonce in `ApiClient.checkConnection`.

## Test

New regression test: with a never-resolving `checkConnection`, the gate must be down by the time the probe starts. Verified it **fails** against the previous implementation and passes with this change. Full `ApiContext.test.tsx` suite passes (11/11); typecheck and lint clean (pre-existing console warnings only).