### PR TITLE
fix(cli): render native tool calls as highlighted source

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from rich import print as rprint
+from rich.text import Text
 
 from ..config import Config, get_config
 from ..constants import prompt_assistant
@@ -24,6 +25,7 @@ from ..message import (
 from ..telemetry import trace_function
 from ..tools import ToolSpec, ToolUse, get_tool_format
 from ..util import console
+from ..util.tool_display import ToolCallDisplay, ToolCodeDisplay
 from .models import (
     MODELS,
     PROVIDERS_OPENAI,
@@ -414,7 +416,11 @@ def _reply_after_hooks(
     )
     if not json_mode and not is_output_quiet():
         rprint(" " * shutil.get_terminal_size().columns, end="\r")
-        rprint(f"{prompt_assistant(agent_name)}: {response}")
+        rprint(f"{prompt_assistant(agent_name)}: ", end="")
+        display = ToolCallDisplay()
+        for part in display.feed(response):
+            rprint(part.render() if isinstance(part, ToolCodeDisplay) else part, end="")
+        rprint(Text(display.finish()))
     return Message("assistant", response, metadata=metadata)
 
 
@@ -817,6 +823,11 @@ def _reply_stream(
     # sys.stdout.flush() calls from O(chars) to O(chunks) — the main source of
     # bursty terminal rendering (gptme/gptme#2717 terminal side).
     normal_display_buffer: list[str] = []
+    tool_display = ToolCallDisplay()
+
+    def _display_normal(text: str) -> None:
+        for part in tool_display.feed(text):
+            rprint(part.render() if isinstance(part, ToolCodeDisplay) else part, end="")
 
     # Create stream wrapper to capture metadata
     stream = _stream(
@@ -911,13 +922,13 @@ def _reply_stream(
                     if normal_display_buffer:
                         # Flush buffered normal chars before the newline so the
                         # line content appears before the line ending.
-                        rprint("".join(normal_display_buffer), end="")
+                        _display_normal("".join(normal_display_buffer))
                         normal_display_buffer.clear()
                     if think_display_buffer:
                         # Emit the entire buffered line dimly in one shot.
                         rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
                         think_display_buffer.clear()
-                    rprint(char, end="")
+                    _display_normal(char)
             else:
                 # Print normal characters
                 if display_enabled:
@@ -978,7 +989,7 @@ def _reply_stream(
             # of bursty terminal rendering (per-char syscall overhead).
             if _is_chunk_end and display_enabled:
                 if normal_display_buffer:
-                    rprint("".join(normal_display_buffer), end="")
+                    _display_normal("".join(normal_display_buffer))
                     normal_display_buffer.clear()
                 sys.stdout.flush()
 
@@ -1007,7 +1018,7 @@ def _reply_stream(
         # Flush any remaining buffered chars (responses that end without a
         # trailing newline, or partial lines left after a break_on_tooluse break).
         if display_enabled and normal_display_buffer:
-            rprint("".join(normal_display_buffer), end="")
+            _display_normal("".join(normal_display_buffer))
             normal_display_buffer.clear()
         if display_enabled and think_display_buffer:
             rprint(f"[dim]{''.join(think_display_buffer)}[/dim]", end="")
@@ -1020,7 +1031,7 @@ def _reply_stream(
         # Flush any chars buffered since the last chunk boundary so the terminal
         # shows everything received before the interrupt.
         if display_enabled and normal_display_buffer:
-            rprint("".join(normal_display_buffer), end="")
+            _display_normal("".join(normal_display_buffer))
             normal_display_buffer.clear()
         # Flush partial line before the interrupt suffix so callers see the
         # content that was streamed up to the interrupt point.
@@ -1050,6 +1061,12 @@ def _reply_stream(
         # Explicitly close the underlying generator to release resources
         # This handles all exit paths: normal completion, KeyboardInterrupt, and tool break
         stream.gen.close()
+        if display_enabled:
+            if normal_display_buffer:
+                _display_normal("".join(normal_display_buffer))
+                normal_display_buffer.clear()
+            if pending := tool_display.finish():
+                rprint(Text(pending), end="")
         print_clear()
         if first_token_time:
             end_time = time.time()

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -17,6 +17,7 @@ import tomlkit
 from dateutil.parser import isoparse
 from rich.markup import escape as escape_markup
 from rich.syntax import Syntax
+from rich.text import Text
 from tomlkit._utils import escape_string
 from typing_extensions import Self
 
@@ -559,6 +560,7 @@ def format_msgs(
     """
     # Import here to avoid circular import
     from .config import get_config
+    from .util.tool_display import ToolCallDisplay, ToolCodeDisplay
 
     outputs = []
     for msg in msgs:
@@ -590,24 +592,44 @@ def format_msgs(
         else:
             multiline = len(stripped_content.split("\n")) > 1
             output += "\n" + indent * " " if multiline else ""
-            for i, block in enumerate(stripped_content.split("```")):
-                if i % 2 == 0:
-                    # Escape Rich markup in non-code-block content
-                    if highlight:
-                        block = escape_markup(block)
-                    output += textwrap.indent(block, prefix=indent * " ")
-                    continue
-                if highlight:
-                    lang = block.split("\n", 1)[0]
-                    content = block.split("\n", 1)[-1]
-                    fmt = "underline blue"
-                    block = f"[{fmt}]{lang}\n[/{fmt}]" + rich_to_str(
-                        Syntax(
-                            content.rstrip().replace("[", r"\["),
-                            lang,
-                        )
+            parts: list[str | Text | ToolCodeDisplay] = [stripped_content]
+            if terminal_projection and msg.role == "assistant":
+                display = ToolCallDisplay()
+                parts = [*display.feed(stripped_content), Text(display.finish())]
+            for part in parts:
+                if isinstance(part, ToolCodeDisplay):
+                    rendered = rich_to_str(
+                        part.render(highlight), force_terminal=highlight
                     )
-                output += f"```{block.rstrip()}\n```"
+                    output += textwrap.indent(
+                        Text.from_ansi(rendered).markup if highlight else rendered,
+                        prefix=indent * " ",
+                    )
+                    continue
+                if isinstance(part, Text):
+                    output += textwrap.indent(
+                        escape_markup(part.plain) if highlight else part.plain,
+                        prefix=indent * " ",
+                    )
+                    continue
+                for i, block in enumerate(part.split("```")):
+                    if i % 2 == 0:
+                        # Escape Rich markup in non-code-block content
+                        if highlight:
+                            block = escape_markup(block)
+                        output += textwrap.indent(block, prefix=indent * " ")
+                        continue
+                    if highlight:
+                        lang = block.split("\n", 1)[0]
+                        content = block.split("\n", 1)[-1]
+                        fmt = "underline blue"
+                        block = f"[{fmt}]{lang}\n[/{fmt}]" + rich_to_str(
+                            Syntax(
+                                content.rstrip().replace("[", r"\["),
+                                lang,
+                            )
+                        )
+                    output += f"```{block.rstrip()}\n```"
 
         status_emoji = ""
         if msg.role == "system":

--- a/gptme/util/tool_display.py
+++ b/gptme/util/tool_display.py
@@ -49,6 +49,78 @@ _EXT_LANG = {
 }
 _FENCE = re.compile(r" {0,3}(`{3,}|~{3,})(.*)")
 _PARTIAL_NATIVE = re.compile(r"@[\w.]*(?:\([\w\-:.]*\)?(?::\s*\{?)?)?")
+_JSON_KEYWORDS = ("true", "false", "null")
+
+
+def _json_prefix_viable(s: str, start: int) -> bool:
+    """True if s[start:] can still complete as a JSON object.
+
+    False means the fragment is already illegal, so this is not a live native call.
+    """
+    if start >= len(s) or s[start] != "{":
+        return False
+    in_string = False
+    escape = False
+    i = start
+    n = len(s)
+    while i < n:
+        c = s[i]
+        if escape:
+            escape = False
+            i += 1
+            continue
+        if in_string:
+            if c == "\\":
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c.isspace() or c in "{}[]:,":
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+        if c in "-0123456789":
+            i += 1
+            while i < n and s[i] in "0123456789.eE+-":
+                i += 1
+            continue
+        matched = False
+        for kw in _JSON_KEYWORDS:
+            if s.startswith(kw, i):
+                i += len(kw)
+                matched = True
+                break
+            if kw.startswith(s[i:]):
+                return True
+        if matched:
+            continue
+        return False
+    return True
+
+
+def _partial_native_hold_start(remaining: str) -> int | None:
+    """Offset in remaining to keep unemitted, or None to flush it all.
+
+    Holds a last-line partial header, and also ``@tool(id):\\n`` so a JSON object
+    that arrives on the next chunk is still recognized as part of the call.
+    """
+    last_nl = remaining.rfind("\n")
+    if last_nl < 0:
+        return 0 if _PARTIAL_NATIVE.fullmatch(remaining) else None
+    last_line = remaining[last_nl + 1 :]
+    if _PARTIAL_NATIVE.fullmatch(last_line):
+        return last_nl + 1
+    if last_line.strip() == "":
+        prev_nl = remaining.rfind("\n", 0, last_nl)
+        prev_start = prev_nl + 1
+        prev_line = remaining[prev_start:last_nl]
+        if _PARTIAL_NATIVE.fullmatch(prev_line):
+            return prev_start
+    return None
 
 
 def _skip_state(content: str) -> tuple[list[tuple[int, int]], int | None]:
@@ -198,30 +270,34 @@ class ToolCallDisplay:
         skip, _ = _skip_state(self._buf)
         while self._emitted < len(self._buf):
             match = None
+            json_end: int | None = None
             search_from = self._emitted
             while found := toolcall_re.search(self._buf, search_from):
                 skipped_until = _inside_skip(found.start(), skip)
                 if skipped_until is not None:
                     search_from = skipped_until
                     continue
+                candidate_end = find_json_end(self._buf, found.start(3))
+                if candidate_end is None and not _json_prefix_viable(
+                    self._buf, found.start(3)
+                ):
+                    # Abandoned/invalid JSON: not a live native call.
+                    search_from = found.start() + 1
+                    continue
                 match = found
+                json_end = candidate_end
                 break
 
             if match is None:
                 remaining = self._buf[self._emitted :]
-                last_nl = remaining.rfind("\n")
-                last_line = remaining[last_nl + 1 :]
-                last_line_start = self._emitted + last_nl + 1
-                if last_nl < 0:
-                    last_line_start = self._emitted
-                if (
-                    _PARTIAL_NATIVE.fullmatch(last_line)
-                    and _inside_skip(last_line_start, skip) is None
-                ):
-                    if last_nl >= 0:
-                        yield remaining[: last_nl + 1]
-                        self._emitted += last_nl + 1
-                    return
+                hold = _partial_native_hold_start(remaining)
+                if hold is not None:
+                    hold_abs = self._emitted + hold
+                    if _inside_skip(hold_abs, skip) is None:
+                        if hold > 0:
+                            yield remaining[:hold]
+                            self._emitted += hold
+                        return
                 yield remaining
                 self._emitted = len(self._buf)
                 return
@@ -230,7 +306,6 @@ class ToolCallDisplay:
                 yield self._buf[self._emitted : match.start()]
                 self._emitted = match.start()
 
-            json_end = find_json_end(self._buf, match.start(3))
             if json_end is None:
                 return
 

--- a/gptme/util/tool_display.py
+++ b/gptme/util/tool_display.py
@@ -1,0 +1,138 @@
+"""Terminal presentation of native IPython calls, without changing tool content."""
+
+import json
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from rich.console import Group
+from rich.syntax import Syntax
+from rich.text import Text
+
+_PREFIX = "@ipython("
+_HEADER = re.compile(r"@ipython\([\w\-:.]+\):\s*\{")
+_PARTIAL_HEADER = re.compile(r"@ipython\([\w\-:.]*(?:\)(?::\s*)?)?")
+_FENCE = re.compile(r" {0,3}(`{3,}|~{3,})(.*)")
+
+
+@dataclass
+class ToolCodeDisplay:
+    header: str
+    code: str
+    arguments: dict[str, Any]
+
+    def render(self, highlight: bool = True) -> Group:
+        parts: list[Text | Syntax] = [Text(self.header)]
+        if self.arguments:
+            parts.append(
+                Text("arguments: " + json.dumps(self.arguments, ensure_ascii=False))
+            )
+        parts.append(
+            Syntax(self.code, "python", background_color="default", word_wrap=True)
+            if highlight
+            else Text(self.code)
+        )
+        return Group(*parts)
+
+
+class ToolCallDisplay:
+    """Split terminal chunks into ordinary text and complete, strict native calls.
+
+    Only an IPython header and its JSON object are buffered. Other text keeps
+    streaming, and fenced examples are left alone. ``finish`` returns any
+    incomplete call verbatim, including when generation was interrupted.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[str] = []
+        self._header = ""
+        self._depth = 0
+        self._in_string = False
+        self._escaped = False
+        self._line: list[str] = []
+        self._fence = ""
+
+    def _record_text(self, char: str) -> None:
+        if char != "\n":
+            self._line.append(char)
+            return
+        if match := _FENCE.fullmatch("".join(self._line)):
+            fence, tail = match.groups()
+            if not self._fence:
+                self._fence = fence
+            elif (
+                fence[0] == self._fence[0]
+                and len(fence) >= len(self._fence)
+                and not tail.strip()
+            ):
+                self._fence = ""
+        self._line.clear()
+
+    def feed(self, text: str) -> Iterator[str | Text | ToolCodeDisplay]:
+        plain: list[str] = []
+        for char in text:
+            if not self._pending:
+                if char != "@" or self._line or self._fence:
+                    plain.append(char)
+                    self._record_text(char)
+                    continue
+            self._pending.append(char)
+            if not self._header:
+                candidate = "".join(self._pending)
+                if _HEADER.fullmatch(candidate):
+                    self._header = candidate[:-1].rstrip()
+                    self._depth = 1
+                    continue
+                if _PREFIX.startswith(candidate) or _PARTIAL_HEADER.fullmatch(
+                    candidate
+                ):
+                    continue
+                raw = self.finish()
+                plain.append(raw)
+                for c in raw:
+                    self._record_text(c)
+                continue
+
+            if self._escaped:
+                self._escaped = False
+            elif self._in_string and char == "\\":
+                self._escaped = True
+            elif char == '"':
+                self._in_string = not self._in_string
+            elif not self._in_string:
+                self._depth += (char == "{") - (char == "}")
+            if self._depth:
+                continue
+
+            header = self._header
+            raw = self.finish()
+            try:
+                arguments = json.loads(raw[raw.index("{") :])
+            except (ValueError, RecursionError):
+                arguments = None
+            if plain:
+                yield "".join(plain)
+                plain.clear()
+            if isinstance(arguments, dict) and isinstance(arguments.get("code"), str):
+                code = arguments.pop("code")
+                yield ToolCodeDisplay(header, code, arguments)
+                # A call is an opaque span: its JSON strings cannot open fences.
+                self._line[:] = ["@"]
+            else:
+                # Invalid/unsupported calls remain literal, including Rich markup
+                # and Markdown fences inside their argument strings.
+                yield Text(raw)
+                for c in raw:
+                    self._record_text(c)
+        if plain:
+            yield "".join(plain)
+
+    def finish(self) -> str:
+        raw = "".join(self._pending)
+        self._pending.clear()
+        self._header = ""
+        self._depth = 0
+        self._in_string = False
+        self._escaped = False
+        return raw

--- a/gptme/util/tool_display.py
+++ b/gptme/util/tool_display.py
@@ -1,19 +1,130 @@
-"""Terminal presentation of native IPython calls, without changing tool content."""
+"""Terminal presentation of native tool calls, without changing tool content.
+
+Native ``@tool(call-id): {...}`` spans are recognized with the same
+``toolcall_re`` / ``find_json_end`` path as ``ToolUse.iter_from_content``.
+The body is wrapped as a ``Codeblock`` so highlighting uses a codeblock
+language instead of a one-off IPython decoder. Tools without a body
+parameter fall back to pretty-printed JSON. Incomplete or invalid calls
+stay literal. Raw messages are unchanged.
+"""
+
+from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterator
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from rich.console import Group
 from rich.syntax import Syntax
 from rich.text import Text
 
-_PREFIX = "@ipython("
-_HEADER = re.compile(r"@ipython\([\w\-:.]+\):\s*\{")
-_PARTIAL_HEADER = re.compile(r"@ipython\([\w\-:.]*(?:\)(?::\s*)?)?")
+from ..codeblock import Codeblock
+from ..tools.base import ToolUse, find_json_end, toolcall_re
+
+_BODY_KEYS = ("code", "command", "content", "script")
+_HIGHLIGHT_LANG = {
+    "ipython": "python",
+    "py": "python",
+    "python": "python",
+    "shell": "bash",
+    "bash": "bash",
+    "sh": "bash",
+}
+_EXT_LANG = {
+    "py": "python",
+    "js": "javascript",
+    "ts": "typescript",
+    "sh": "bash",
+    "bash": "bash",
+    "md": "markdown",
+    "json": "json",
+    "toml": "toml",
+    "yml": "yaml",
+    "yaml": "yaml",
+    "rs": "rust",
+}
 _FENCE = re.compile(r" {0,3}(`{3,}|~{3,})(.*)")
+_PARTIAL_NATIVE = re.compile(r"@[\w.]*(?:\([\w\-:.]*\)?(?::\s*\{?)?)?")
+
+
+def _display_skip_ranges(content: str) -> list[tuple[int, int]]:
+    """Fenced regions that must keep native calls literal, including an unclosed fence."""
+    ranges: list[tuple[int, int]] = []
+    fence = ""
+    start: int | None = None
+    pos = 0
+    while pos <= len(content):
+        newline = content.find("\n", pos)
+        line_end = len(content) if newline == -1 else newline
+        match = _FENCE.fullmatch(content[pos:line_end])
+        if match:
+            mark, info = match.groups()
+            if start is None:
+                fence = mark
+                start = pos
+            elif mark[0] == fence[0] and len(mark) >= len(fence) and not info.strip():
+                ranges.append((start, line_end))
+                start = None
+                fence = ""
+        if newline == -1:
+            break
+        pos = newline + 1
+    if start is not None:
+        ranges.append((start, len(content)))
+    return ranges
+
+
+def _inside_skip(pos: int, ranges: list[tuple[int, int]]) -> int | None:
+    for start, end in ranges:
+        if start <= pos < end:
+            return end
+    return None
+
+
+def _highlight_lang(tool_name: str, arguments: dict[str, Any]) -> str:
+    lang = _HIGHLIGHT_LANG.get(tool_name, "text")
+    if lang != "text":
+        return lang
+    path = arguments.get("path")
+    if isinstance(path, str) and "." in path:
+        ext = path.rsplit(".", 1)[-1].lower()
+        return _EXT_LANG.get(ext, "text")
+    return lang
+
+
+def _display_from_tooluse(tool_use: ToolUse) -> ToolCodeDisplay:
+    params = dict(tool_use._to_params())
+    body: str | None = None
+    if isinstance(tool_use.content, str) and tool_use.content:
+        body = tool_use.content
+    else:
+        for key in _BODY_KEYS:
+            value = params.get(key)
+            if isinstance(value, str):
+                body = params.pop(key)
+                break
+    lang = _highlight_lang(tool_use.tool, params)
+    block = Codeblock(lang=lang, content=body or "")
+    call_id = tool_use.call_id
+    header = f"@{tool_use.tool}({call_id}):" if call_id else f"@{tool_use.tool}:"
+    if body is None:
+        return ToolCodeDisplay(
+            header=header,
+            code="",
+            arguments={},
+            fallback=params,
+            lang=block.lang,
+        )
+    return ToolCodeDisplay(
+        header=header,
+        code=block.content,
+        arguments=params,
+        lang=block.lang,
+    )
 
 
 @dataclass
@@ -21,118 +132,112 @@ class ToolCodeDisplay:
     header: str
     code: str
     arguments: dict[str, Any]
+    fallback: dict[str, Any] | None = None
+    lang: str = "text"
 
     def render(self, highlight: bool = True) -> Group:
         parts: list[Text | Syntax] = [Text(self.header)]
+        if self.fallback is not None:
+            dumped = json.dumps(self.fallback, indent=2, ensure_ascii=False)
+            parts.append(
+                Syntax(dumped, "json", background_color="default", word_wrap=True)
+                if highlight
+                else Text(dumped)
+            )
+            return Group(*parts)
         if self.arguments:
             parts.append(
                 Text("arguments: " + json.dumps(self.arguments, ensure_ascii=False))
             )
-        parts.append(
-            Syntax(self.code, "python", background_color="default", word_wrap=True)
-            if highlight
-            else Text(self.code)
-        )
+        if self.code:
+            parts.append(
+                Syntax(self.code, self.lang, background_color="default", word_wrap=True)
+                if highlight
+                else Text(self.code)
+            )
         return Group(*parts)
 
 
+@dataclass
 class ToolCallDisplay:
-    """Split terminal chunks into ordinary text and complete, strict native calls.
+    """Split terminal chunks into ordinary text and complete native tool calls.
 
-    Only an IPython header and its JSON object are buffered. Other text keeps
+    Complete ``@tool(call-id)`` JSON objects are projected. Other text keeps
     streaming, and fenced examples are left alone. ``finish`` returns any
     incomplete call verbatim, including when generation was interrupted.
     """
 
-    def __init__(self) -> None:
-        self._pending: list[str] = []
-        self._header = ""
-        self._depth = 0
-        self._in_string = False
-        self._escaped = False
-        self._line: list[str] = []
-        self._fence = ""
-
-    def _record_text(self, char: str) -> None:
-        if char != "\n":
-            self._line.append(char)
-            return
-        if match := _FENCE.fullmatch("".join(self._line)):
-            fence, tail = match.groups()
-            if not self._fence:
-                self._fence = fence
-            elif (
-                fence[0] == self._fence[0]
-                and len(fence) >= len(self._fence)
-                and not tail.strip()
-            ):
-                self._fence = ""
-        self._line.clear()
+    _buf: str = field(default="", init=False, repr=False)
+    _emitted: int = field(default=0, init=False, repr=False)
 
     def feed(self, text: str) -> Iterator[str | Text | ToolCodeDisplay]:
-        plain: list[str] = []
-        for char in text:
-            if not self._pending:
-                if char != "@" or self._line or self._fence:
-                    plain.append(char)
-                    self._record_text(char)
-                    continue
-            self._pending.append(char)
-            if not self._header:
-                candidate = "".join(self._pending)
-                if _HEADER.fullmatch(candidate):
-                    self._header = candidate[:-1].rstrip()
-                    self._depth = 1
-                    continue
-                if _PREFIX.startswith(candidate) or _PARTIAL_HEADER.fullmatch(
-                    candidate
-                ):
-                    continue
-                raw = self.finish()
-                plain.append(raw)
-                for c in raw:
-                    self._record_text(c)
-                continue
-
-            if self._escaped:
-                self._escaped = False
-            elif self._in_string and char == "\\":
-                self._escaped = True
-            elif char == '"':
-                self._in_string = not self._in_string
-            elif not self._in_string:
-                self._depth += (char == "{") - (char == "}")
-            if self._depth:
-                continue
-
-            header = self._header
-            raw = self.finish()
-            try:
-                arguments = json.loads(raw[raw.index("{") :])
-            except (ValueError, RecursionError):
-                arguments = None
-            if plain:
-                yield "".join(plain)
-                plain.clear()
-            if isinstance(arguments, dict) and isinstance(arguments.get("code"), str):
-                code = arguments.pop("code")
-                yield ToolCodeDisplay(header, code, arguments)
-                # A call is an opaque span: its JSON strings cannot open fences.
-                self._line[:] = ["@"]
-            else:
-                # Invalid/unsupported calls remain literal, including Rich markup
-                # and Markdown fences inside their argument strings.
-                yield Text(raw)
-                for c in raw:
-                    self._record_text(c)
-        if plain:
-            yield "".join(plain)
+        self._buf += text
+        yield from self._drain()
 
     def finish(self) -> str:
-        raw = "".join(self._pending)
-        self._pending.clear()
-        self._header = ""
-        self._depth = 0
-        self._in_string = False
-        self._escaped = False
-        return raw
+        leftover = self._buf[self._emitted :]
+        self._buf = ""
+        self._emitted = 0
+        return leftover
+
+    def _drain(self) -> Iterator[str | Text | ToolCodeDisplay]:
+        while self._emitted < len(self._buf):
+            skip = _display_skip_ranges(self._buf)
+            match = None
+            search_from = self._emitted
+            while found := toolcall_re.search(self._buf, search_from):
+                skipped_until = _inside_skip(found.start(), skip)
+                if skipped_until is not None:
+                    search_from = skipped_until
+                    continue
+                match = found
+                break
+
+            if match is None:
+                remaining = self._buf[self._emitted :]
+                last_nl = remaining.rfind("\n")
+                last_line = remaining[last_nl + 1 :]
+                last_line_start = self._emitted + last_nl + 1
+                if last_nl < 0:
+                    last_line_start = self._emitted
+                if (
+                    _PARTIAL_NATIVE.fullmatch(last_line)
+                    and _inside_skip(last_line_start, skip) is None
+                ):
+                    if last_nl >= 0:
+                        yield remaining[: last_nl + 1]
+                        self._emitted += last_nl + 1
+                    return
+                yield remaining
+                self._emitted = len(self._buf)
+                return
+
+            if match.start() > self._emitted:
+                yield self._buf[self._emitted : match.start()]
+                self._emitted = match.start()
+
+            json_end = find_json_end(self._buf, match.start(3))
+            if json_end is None:
+                return
+
+            raw = self._buf[match.start() : json_end]
+            json_str = self._buf[match.start(3) : json_end]
+            try:
+                kwargs = json.loads(json_str)
+            except (ValueError, RecursionError):
+                kwargs = None
+            if isinstance(kwargs, dict):
+                yield _display_from_tooluse(
+                    ToolUse(
+                        match.group(1),
+                        None,
+                        None,
+                        kwargs=kwargs,
+                        call_id=match.group(2),
+                        start=match.start(),
+                        _format="tool",
+                    )
+                )
+            else:
+                yield Text(raw)
+            self._emitted = json_end

--- a/gptme/util/tool_display.py
+++ b/gptme/util/tool_display.py
@@ -51,8 +51,8 @@ _FENCE = re.compile(r" {0,3}(`{3,}|~{3,})(.*)")
 _PARTIAL_NATIVE = re.compile(r"@[\w.]*(?:\([\w\-:.]*\)?(?::\s*\{?)?)?")
 
 
-def _display_skip_ranges(content: str) -> list[tuple[int, int]]:
-    """Fenced regions that must keep native calls literal, including an unclosed fence."""
+def _skip_state(content: str) -> tuple[list[tuple[int, int]], int | None]:
+    """Fenced skip ranges plus the start of an unclosed fence, if any."""
     ranges: list[tuple[int, int]] = []
     fence = ""
     start: int | None = None
@@ -75,7 +75,7 @@ def _display_skip_ranges(content: str) -> list[tuple[int, int]]:
         pos = newline + 1
     if start is not None:
         ranges.append((start, len(content)))
-    return ranges
+    return ranges, start
 
 
 def _inside_skip(pos: int, ranges: list[tuple[int, int]]) -> int | None:
@@ -173,6 +173,7 @@ class ToolCallDisplay:
     def feed(self, text: str) -> Iterator[str | Text | ToolCodeDisplay]:
         self._buf += text
         yield from self._drain()
+        self._compact()
 
     def finish(self) -> str:
         leftover = self._buf[self._emitted :]
@@ -180,9 +181,22 @@ class ToolCallDisplay:
         self._emitted = 0
         return leftover
 
+    def _compact(self) -> None:
+        """Drop emitted prefix; keep a partial native call or unclosed fence."""
+        if self._emitted <= 0:
+            return
+        keep_from = self._emitted
+        _, open_start = _skip_state(self._buf)
+        if open_start is not None and open_start < keep_from:
+            keep_from = open_start
+        if keep_from <= 0:
+            return
+        self._buf = self._buf[keep_from:]
+        self._emitted -= keep_from
+
     def _drain(self) -> Iterator[str | Text | ToolCodeDisplay]:
+        skip, _ = _skip_state(self._buf)
         while self._emitted < len(self._buf):
-            skip = _display_skip_ranges(self._buf)
             match = None
             search_from = self._emitted
             while found := toolcall_re.search(self._buf, search_from):

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -591,6 +591,76 @@ def test_tool_call_display_drops_closed_fence():
     assert display._emitted == 0
 
 
+def test_tool_call_display_abandoned_partial_call_streams_later_prose():
+    """An incomplete native call that turns into illegal JSON must not freeze."""
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    assert list(display.feed("@shell(call-2): {")) == []
+    parts = list(display.feed("\nThis is ordinary prose\nMore text\n"))
+    streamed = "".join(p for p in parts if isinstance(p, str))
+    assert "This is ordinary prose" in streamed
+    assert "More text" in streamed
+    assert not any(isinstance(p, ToolCodeDisplay) for p in parts)
+    assert display.finish() == ""
+
+
+def test_tool_call_display_pretty_printed_json_still_projects():
+    """A newline after '{' is still a live JSON prefix, not an abandoned call."""
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    assert list(display.feed("@shell(c1): {\n")) == []
+    parts = list(display.feed('  "command": "pwd"\n}'))
+    projected = [p for p in parts if isinstance(p, ToolCodeDisplay)]
+    assert len(projected) == 1
+    assert projected[0].code == "pwd"
+    assert display.finish() == ""
+
+
+def test_tool_call_display_holds_header_newline_for_next_json_chunk():
+    """Header plus newline must stay buffered so the JSON chunk is still a call."""
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    assert list(display.feed("@shell(c1):\n")) == []
+    assert display._buf.startswith("@shell")
+    parts = list(display.feed('{"command": "pwd"}'))
+    projected = [p for p in parts if isinstance(p, ToolCodeDisplay)]
+    assert len(projected) == 1
+    assert projected[0].code == "pwd"
+
+
+def test_reply_stream_abandoned_partial_call_still_streams_prose(monkeypatch):
+    """Abandoned '@shell(...): {' must not hide later streamed prose."""
+    import io
+
+    from rich.console import Console
+
+    from gptme.llm import _reply_stream, _StreamWithMetadata
+    from gptme.message import Message
+
+    captured = io.StringIO()
+    terminal = Console(file=captured, width=160, force_terminal=True, record=True)
+    monkeypatch.setattr("gptme.llm.rprint", terminal.print)
+    ordinary = "@shell(call-2): {\nThis is ordinary prose\n"
+
+    def chunks():
+        yield "@shell(call-2): {"
+        yield "\nThis is ordinary prose\n"
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _StreamWithMetadata(chunks(), "mock/echo"),
+    )
+    result = _reply_stream(
+        [Message("user", "hi")], "mock/echo", None, break_on_tooluse=False
+    )
+    assert result.content == ordinary
+    rendered = terminal.export_text()
+    assert "This is ordinary prose" in rendered
+
+
 @pytest.mark.parametrize("stream", [False, True])
 def test_reply_ipython_display_with_offline_provider(capsys, stream):
     """The actual provider/reply path shares terminal-only formatting."""

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+import pytest
+
 from gptme.llm.utils import apply_cache_control, parameters2dict, process_image_file
 from gptme.tools.base import Parameter
 
@@ -406,6 +408,145 @@ class TestProcessImageFile:
         content_parts2: list[dict] = []
         result2 = process_image_file(str(img_file), content_parts2, max_size_mb=3)
         assert result2 is not None
+
+
+@pytest.mark.parametrize("chunk_size", [1, 7, 10000])
+@pytest.mark.parametrize("break_on_tooluse", [False, True])
+def test_reply_stream_ipython_terminal_projection(
+    monkeypatch, chunk_size, break_on_tooluse
+):
+    """Terminal projection must not alter callbacks, saved content, or tool breaks."""
+    import io
+    import json
+
+    from rich.console import Console
+
+    from gptme.llm import _reply_stream, _StreamWithMetadata
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(["ipython"], include_mcp=False)
+    monkeypatch.setattr("gptme.tools.base.tool_format", "tool")
+    source = 'values = [1, 2]\nprint("} \\" [/tmp/source] ```")'
+    call = "@ipython(call-1): " + json.dumps(
+        {"code": source, "kernel": "python3"}, indent=2
+    )
+    suffix = "\nAfter the call"
+    raw = call + suffix
+
+    def chunks():
+        for i in range(0, len(raw), chunk_size):
+            yield raw[i : i + chunk_size]
+        return {"model": "mock/echo", "usage": {"output_tokens": 9}}
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _StreamWithMetadata(chunks(), "mock/echo"),
+    )
+    captured = io.StringIO()
+    terminal = Console(file=captured, width=160, force_terminal=True, record=True)
+    monkeypatch.setattr("gptme.llm.rprint", terminal.print)
+    tokens: list[str] = []
+    result = _reply_stream(
+        [Message("user", "hi")],
+        model="mock/echo",
+        tools=None,
+        on_token=tokens.append,
+        break_on_tooluse=break_on_tooluse,
+    )
+
+    expected = call if break_on_tooluse else raw
+    assert result.content == expected
+    assert "".join(tokens) == expected
+    assert result.metadata is not None
+    assert result.metadata["usage"]["output_tokens"] == 9
+    rendered = terminal.export_text()
+    assert "@ipython(call-1):" in rendered
+    assert source in rendered
+    assert 'arguments: {"kernel": "python3"}' in rendered
+    assert '"code":' not in rendered
+    assert ("After the call" in rendered) is (not break_on_tooluse)
+    assert "\x1b[" in captured.getvalue()
+
+
+def test_reply_stream_tool_display_preserves_prose_and_other_tools(monkeypatch):
+    """Ordinary text and non-code calls still reach the terminal each chunk."""
+    import io
+
+    from rich.console import Console
+
+    from gptme.llm import _reply_stream, _StreamWithMetadata
+    from gptme.message import Message
+
+    captured = io.StringIO()
+    terminal = Console(file=captured, width=160)
+    monkeypatch.setattr("gptme.llm.rprint", terminal.print)
+    ordinary = 'Hello\n@shell(call-2): {"command": "pwd"}\n'
+
+    def chunks():
+        yield "Hello"
+        assert "Hello" in captured.getvalue()
+        yield ordinary[len("Hello") :]
+        assert ordinary in captured.getvalue()
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _StreamWithMetadata(chunks(), "mock/echo"),
+    )
+    result = _reply_stream(
+        [Message("user", "hi")], "mock/echo", None, break_on_tooluse=False
+    )
+    assert result.content == ordinary
+
+
+@pytest.mark.parametrize("error", [None, KeyboardInterrupt, RuntimeError])
+def test_reply_stream_unfinished_ipython_display_is_flushed(monkeypatch, error):
+    """A cancelled or broken stream must display incomplete native calls once."""
+    import io
+
+    from rich.console import Console
+
+    from gptme.llm import _reply_stream, _StreamWithMetadata
+    from gptme.message import Message
+
+    raw = '@ipython(partial): {"code": "print(\\n[/tmp/source]'
+    captured = io.StringIO()
+    terminal = Console(file=captured, width=160)
+    monkeypatch.setattr("gptme.llm.rprint", terminal.print)
+
+    def chunks():
+        yield raw[:9]
+        yield raw[9:]
+        if error:
+            raise error()
+
+    monkeypatch.setattr(
+        "gptme.llm._stream",
+        lambda *args, **kwargs: _StreamWithMetadata(chunks(), "mock/echo"),
+    )
+    if error is RuntimeError:
+        with pytest.raises(RuntimeError):
+            _reply_stream([Message("user", "hi")], "mock/echo", None)
+    else:
+        result = _reply_stream([Message("user", "hi")], "mock/echo", None)
+        suffix = "... ^C Interrupted" if error is KeyboardInterrupt else ""
+        assert result.content == raw + suffix
+    assert captured.getvalue().count(raw) == 1
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_reply_ipython_display_with_offline_provider(capsys, stream):
+    """The actual provider/reply path shares terminal-only formatting."""
+    import json
+
+    from gptme.llm import reply
+    from gptme.message import Message
+
+    source = "values = [1, 2]\nprint(values)"
+    request = "\n@ipython(offline): " + json.dumps({"code": source})
+    result = reply([Message("user", request)], "mock/echo", stream=stream)
+    assert result.content == "Echo: " + request
+    assert source in capsys.readouterr().out
 
 
 def test_reply_stream_on_token_callback(monkeypatch):

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -469,8 +469,8 @@ def test_reply_stream_ipython_terminal_projection(
     assert "\x1b[" in captured.getvalue()
 
 
-def test_reply_stream_tool_display_preserves_prose_and_other_tools(monkeypatch):
-    """Ordinary text and non-code calls still reach the terminal each chunk."""
+def test_reply_stream_tool_display_projects_shell_and_streams_prose(monkeypatch):
+    """Prose streams immediately; complete native shell calls are projected."""
     import io
 
     from rich.console import Console
@@ -479,15 +479,14 @@ def test_reply_stream_tool_display_preserves_prose_and_other_tools(monkeypatch):
     from gptme.message import Message
 
     captured = io.StringIO()
-    terminal = Console(file=captured, width=160)
+    terminal = Console(file=captured, width=160, force_terminal=True, record=True)
     monkeypatch.setattr("gptme.llm.rprint", terminal.print)
-    ordinary = 'Hello\n@shell(call-2): {"command": "pwd"}\n'
+    ordinary = 'Hello\n@shell(call-2): {"command": "pwd"}\nAfter\n'
 
     def chunks():
         yield "Hello"
         assert "Hello" in captured.getvalue()
         yield ordinary[len("Hello") :]
-        assert ordinary in captured.getvalue()
 
     monkeypatch.setattr(
         "gptme.llm._stream",
@@ -497,6 +496,12 @@ def test_reply_stream_tool_display_preserves_prose_and_other_tools(monkeypatch):
         [Message("user", "hi")], "mock/echo", None, break_on_tooluse=False
     )
     assert result.content == ordinary
+    rendered = terminal.export_text()
+    assert "Hello" in rendered
+    assert "@shell(call-2):" in rendered
+    assert "pwd" in rendered
+    assert "After" in rendered
+    assert '"command":' not in rendered
 
 
 @pytest.mark.parametrize("error", [None, KeyboardInterrupt, RuntimeError])

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -539,6 +539,58 @@ def test_reply_stream_unfinished_ipython_display_is_flushed(monkeypatch, error):
     assert captured.getvalue().count(raw) == 1
 
 
+def test_tool_call_display_compacts_emitted_prefix():
+    """Emitted prose is dropped so later drain scans do not rescan the whole reply."""
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    prefix = "Hello world\n" * 40
+    streamed = "".join(part for part in display.feed(prefix) if isinstance(part, str))
+    assert streamed == prefix
+    assert "Hello world" not in display._buf
+    assert display._emitted == 0
+
+    parts = list(display.feed('@shell(c1): {"command": "pwd"}\nAfter\n'))
+    assert any(isinstance(p, ToolCodeDisplay) and p.code == "pwd" for p in parts)
+    assert any(isinstance(p, str) and "After" in p for p in parts)
+
+
+def test_tool_call_display_compacts_up_to_incomplete_call():
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    list(display.feed('Prose before\n@shell(c1): {"command": "pw'))
+    assert "Prose before" not in display._buf
+    assert display._buf.startswith("@shell")
+    parts = list(display.feed('d"}'))
+    assert any(isinstance(p, ToolCodeDisplay) and p.code == "pwd" for p in parts)
+    assert display.finish() == ""
+
+
+def test_tool_call_display_retains_open_fence_across_chunks():
+    """An unclosed fence must survive compaction so later native calls stay literal."""
+    from gptme.util.tool_display import ToolCallDisplay, ToolCodeDisplay
+
+    display = ToolCallDisplay()
+    list(display.feed("```example\n"))
+    assert "```example" in display._buf
+    parts = list(display.feed('@shell(c1): {"command": "pwd"}\n'))
+    assert not any(isinstance(p, ToolCodeDisplay) for p in parts)
+    parts = list(display.feed('```\nAfter\n@shell(c2): {"command": "ls"}\n'))
+    projected = [p for p in parts if isinstance(p, ToolCodeDisplay)]
+    assert len(projected) == 1
+    assert projected[0].code == "ls"
+
+
+def test_tool_call_display_drops_closed_fence():
+    from gptme.util.tool_display import ToolCallDisplay
+
+    display = ToolCallDisplay()
+    list(display.feed("```example\nfoo\n```\n"))
+    assert display._buf == ""
+    assert display._emitted == 0
+
+
 @pytest.mark.parametrize("stream", [False, True])
 def test_reply_ipython_display_with_offline_provider(capsys, stream):
     """The actual provider/reply path shares terminal-only formatting."""

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -316,8 +316,6 @@ def test_native_ipython_highlight_preserves_literal_source(monkeypatch):
 @pytest.mark.parametrize(
     "arguments",
     [
-        '{"kernel": "[bold]literal[/bold]"}',
-        '{"code": ["not source"]}',
         '{"code": "unterminated',
         '{"code": "print(1)", broken}',
     ],
@@ -328,6 +326,66 @@ def test_native_ipython_unrenderable_arguments_remain_raw(arguments):
     raw = "@ipython(call_3): " + arguments
     msg = Message("assistant", raw)
     assert format_msgs([msg])[0] == "Assistant: " + raw
+    assert msg.content == raw
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '{"kernel": "[bold]literal[/bold]"}',
+        '{"code": ["not source"]}',
+    ],
+)
+def test_native_tool_without_string_body_uses_json_fallback(arguments):
+    from gptme.message import format_msgs
+
+    raw = "@ipython(call_3): " + arguments
+    msg = Message("assistant", raw)
+    display = format_msgs([msg])[0]
+    assert "@ipython(call_3):" in display
+    assert "[bold]literal[/bold]" in display or "not source" in display
+    assert msg.content == raw
+
+
+def test_native_shell_display_highlights_command():
+    from gptme.message import format_msgs
+
+    command = 'pwd && echo "done"'
+    raw = "@shell(call_2): " + json.dumps({"command": command})
+    msg = Message("assistant", "Before\n" + raw + "\nAfter")
+    original = msg.to_dict()
+    (display,) = format_msgs([msg])
+    assert "@shell(call_2):" in display
+    assert command in display
+    assert '"command":' not in display
+    assert display.index("Before") < display.index("pwd") < display.index("After")
+    assert msg.to_dict() == original
+    assert raw in format_msgs([msg], terminal_projection=False)[0]
+
+
+def test_native_save_keeps_path_argument_and_projects_content():
+    from gptme.message import format_msgs
+
+    source = "def x():\n    return 1\n"
+    raw = "@save(s1): " + json.dumps({"path": "foo.py", "content": source})
+    msg = Message("assistant", raw)
+    (display,) = format_msgs([msg])
+    assert "@save(s1):" in display
+    assert "foo.py" in display
+    assert "def x():" in display
+    assert '"content":' not in display
+    assert msg.content == raw
+
+
+def test_native_read_without_body_uses_json_fallback():
+    from gptme.message import format_msgs
+
+    raw = "@read(r1): " + json.dumps({"path": "README.md", "start_line": 1})
+    msg = Message("assistant", raw)
+    (display,) = format_msgs([msg])
+    assert "@read(r1):" in display
+    assert "README.md" in display
+    assert "start_line" in display
     assert msg.content == raw
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,6 +1,10 @@
+import json
 from datetime import datetime, timezone
+from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import pytest
 
 from gptme.message import Message, msgs_to_toml, toml_to_msgs
 
@@ -261,6 +265,88 @@ def test_format_msgs_terminal_projection_false_uses_complete_content():
     )
     (content,) = format_msgs([msg], terminal_projection=False)
     assert "full stdout that was streamed live" in content
+
+
+def test_native_ipython_display_preserves_raw_message_and_arguments():
+    from gptme.message import format_msgs
+
+    code = "values = [1, 2]\nprint(values)"
+    raw_call = "@ipython(call_1): " + json.dumps(
+        {"code": code, "kernel": "python3", "options": {"timeout": 3, "quiet": False}}
+    )
+    msg = Message("assistant", "Before\n" + raw_call + "\nAfter")
+    original = msg.to_dict()
+
+    (display,) = format_msgs([msg])
+    assert "@ipython(call_1):" in display
+    assert code in display
+    assert '"kernel": "python3"' in display
+    assert '"options": {"timeout": 3, "quiet": false}' in display
+    assert display.index("Before") < display.index(code) < display.index("After")
+    assert '"code":' not in display
+    assert msg.to_dict() == original
+    assert raw_call in format_msgs([msg], terminal_projection=False)[0]
+
+
+def test_native_ipython_highlight_preserves_literal_source(monkeypatch):
+    from rich.console import Console
+    from rich.text import Text
+
+    from gptme.message import print_msg
+
+    code = 'values = [1, 2]\nprint("```python [bold]literal[/bold]")\nprint(values)'
+    msg = Message("assistant", "@ipython(call_2): " + json.dumps({"code": code}))
+    captured = StringIO()
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(
+        "gptme.message.console",
+        Console(file=captured, force_terminal=True, no_color=False, width=120),
+    )
+
+    assert print_msg(msg, highlight=True) == 1
+    rendered = Text.from_ansi(captured.getvalue())
+    assert code in rendered.plain
+    # Python identifiers get syntax styles; the role label alone is insufficient.
+    source_start = rendered.plain.index("values =")
+    assert any(span.start <= source_start < span.end for span in rendered.spans)
+    assert msg.content == "@ipython(call_2): " + json.dumps({"code": code})
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '{"kernel": "[bold]literal[/bold]"}',
+        '{"code": ["not source"]}',
+        '{"code": "unterminated',
+        '{"code": "print(1)", broken}',
+    ],
+)
+def test_native_ipython_unrenderable_arguments_remain_raw(arguments):
+    from gptme.message import format_msgs
+
+    raw = "@ipython(call_3): " + arguments
+    msg = Message("assistant", raw)
+    assert format_msgs([msg])[0] == "Assistant: " + raw
+    assert msg.content == raw
+
+
+@pytest.mark.parametrize("fence", ["```", "````", "~~~", "   ```"])
+def test_native_ipython_fenced_examples_keep_existing_rendering(fence):
+    from gptme.message import format_msgs
+
+    raw = '@ipython(example): {"code": "print(1)\\nprint(2)"}'
+    msg = Message("assistant", fence + "text\n" + raw + "\n" + fence)
+    assert format_msgs([msg]) == format_msgs([msg], terminal_projection=False)
+
+
+@pytest.mark.parametrize("role", ["user", "system"])
+def test_native_ipython_examples_in_other_roles_remain_raw(role):
+    from gptme.message import format_msgs
+
+    raw = '@ipython(example): {"code": "print(1)\\nprint(2)"}'
+    msg = Message(role, raw)
+    assert format_msgs([msg])[0].endswith(raw)
 
 
 def test_message_files_resolve_to_absolute(tmp_path, monkeypatch):


### PR DESCRIPTION
Native IPython calls currently print escaped JSON in the CLI. Render their `code` argument as highlighted Python in live replies, nonstream replies, and terminal history, with the call ID and other arguments still visible.

The display buffers each candidate IPython call until its JSON object is complete. Ordinary prose and other tools keep streaming; invalid or interrupted calls are shown literally. Raw messages, token callbacks, generation hooks, JSON output, and tool execution remain unchanged. Code is rendered directly, so literal Markdown fences and Rich markup in source survive.

Validation: 163 tests passed across message rendering, streaming, JSON output, timings, foreground-output deduplication, and summarization; scoped mypy and all pre-commit hooks passed. Includes actual offline-provider streaming/nonstream checks and an actual Rich Console regression for syntax colors and literal source.

Remaining presentation slice for ErikBjare/bob#1207; the telemetry and duplicate-output slices landed in gptme/gptme#3707 and gptme/gptme#3708.
