### PR TITLE
fix(webui): stop event-stream banner from flashing on conversation open

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -54,7 +54,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
   const queryClient = useQueryClient();
   const loadError = use$(() => conversation$?.loadError.get() ?? null);
   const messageCount = use$(() => conversation$?.data.log.get()?.length ?? 0);
-  const connectionStatus = use$(() => conversation$?.connectionStatus.get() ?? 'disconnected');
+  const connectionStatus = use$(() => conversation$?.connectionStatus.get() ?? 'idle');
   const reconnectAttempt = use$(() => conversation$?.reconnectAttempt.get() ?? null);
   const reconnectMaxAttempts = use$(() => conversation$?.reconnectMaxAttempts.get() ?? null);
   const reconnectRetryInMs = use$(() => conversation$?.reconnectRetryInMs.get() ?? null);
@@ -739,6 +739,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
     [forkConversation, navigate, queryClient, serverId]
   );
 
+  // Only surface the event-stream banner for a genuine problem: an established
+  // stream that dropped ('reconnecting') or a genuine failure with retries
+  // exhausted ('disconnected'). The initial 'idle' and in-progress 'connecting'
+  // states show nothing, so opening a conversation no longer flashes the banner
+  // during the normal idle → connecting → connected handshake.
   const showConnectionBanner =
     !isReadOnly && (connectionStatus === 'reconnecting' || connectionStatus === 'disconnected');
 

--- a/webui/src/components/__tests__/ConversationContent.test.tsx
+++ b/webui/src/components/__tests__/ConversationContent.test.tsx
@@ -103,7 +103,7 @@ function makeConversationState() {
     reconnectMaxAttempts: null,
     reconnectRetryInMs: null,
     reconnectRetryStartedAt: null,
-    connectionError: null,
+    connectionError: null as string | null,
     hasMoreBefore: false,
     isConnected: true,
     isGenerating: false,
@@ -447,6 +447,78 @@ describe('server disconnected banner — removed server', () => {
     mockIsDemoMode.mockReturnValue(true);
     render(<ConversationContent conversationId="demo/test" serverId="removed-server" />);
     expect(screen.queryByText(/server not connected/i)).toBeNull();
+  });
+});
+
+describe('event-stream connection banner', () => {
+  // The server-disconnected banner keys off isConnected$ (the API-level
+  // connection); keep that connected so these tests isolate the *event-stream*
+  // banner, which keys off the conversation's connectionStatus.
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDemoMode.mockReturnValue(false);
+    isConnected$.set(true);
+    lastConnectionResult$.set(null);
+    mockConversation$.set(makeConversationState().peek());
+  });
+
+  const setStatus = (status: string) =>
+    act(() => {
+      mockConversation$.connectionStatus.set(status);
+    });
+
+  // These three are the normal open handshake and must never flash the banner.
+  it.each(['idle', 'connecting', 'connected'])(
+    'does not show the banner while %s (never connected / connect in progress)',
+    (status) => {
+      setStatus(status);
+      renderComponent();
+      expect(screen.queryByText(/event stream disconnected/i)).toBeNull();
+      expect(screen.queryByText(/reconnecting event stream/i)).toBeNull();
+    }
+  );
+
+  it('shows the reconnecting banner when an established stream drops', () => {
+    setStatus('reconnecting');
+    renderComponent();
+    expect(screen.getByText(/reconnecting event stream/i)).toBeInTheDocument();
+  });
+
+  it('shows the disconnected banner when the connection genuinely fails', () => {
+    setStatus('disconnected');
+    renderComponent();
+    expect(screen.getByText(/event stream disconnected/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the specific connectionError when present', () => {
+    act(() => {
+      mockConversation$.connectionStatus.set('disconnected');
+      mockConversation$.connectionError.set('Stream failed after 5 retries');
+    });
+    renderComponent();
+    expect(screen.getByText(/stream failed after 5 retries/i)).toBeInTheDocument();
+  });
+
+  it('never flashes the banner across the idle → connecting → connected handshake', () => {
+    setStatus('idle');
+    renderComponent();
+    const bannerAbsent = () => {
+      expect(screen.queryByText(/event stream disconnected/i)).toBeNull();
+      expect(screen.queryByText(/reconnecting event stream/i)).toBeNull();
+    };
+    bannerAbsent();
+    setStatus('connecting');
+    bannerAbsent();
+    setStatus('connected');
+    bannerAbsent();
+  });
+
+  it('shows the banner when a connected stream transitions to disconnected', () => {
+    setStatus('connected');
+    renderComponent();
+    expect(screen.queryByText(/event stream disconnected/i)).toBeNull();
+    setStatus('disconnected');
+    expect(screen.getByText(/event stream disconnected/i)).toBeInTheDocument();
   });
 });
 

--- a/webui/src/stores/__tests__/conversations.test.ts
+++ b/webui/src/stores/__tests__/conversations.test.ts
@@ -6,6 +6,8 @@ import {
   replaceLog,
   prependLogPage,
   setCurrentBranch,
+  setConnected,
+  setConnectionStatus,
   toAbsoluteIndex,
   toLocalIndex,
 } from '../conversations';
@@ -215,5 +217,51 @@ describe('setCurrentBranch window metadata reset', () => {
     // Branch unchanged, window metadata unchanged
     expect(conv?.currentBranch.get()).toBe('main');
     expect(conv?.logOffset.get()).toBe(100); // still the windowed offset
+  });
+});
+
+describe('connection status transitions', () => {
+  const id = 'test-conv';
+
+  beforeEach(() => {
+    initConversation(id);
+  });
+
+  it('starts in idle, not disconnected (so the banner never flashes on open)', () => {
+    const conv = conversations$.get(id);
+    expect(conv?.connectionStatus.get()).toBe('idle');
+    expect(conv?.isConnected.get()).toBe(false);
+  });
+
+  it('setConnected(true) marks the stream connected', () => {
+    setConnected(id, true);
+    const conv = conversations$.get(id);
+    expect(conv?.connectionStatus.get()).toBe('connected');
+    expect(conv?.isConnected.get()).toBe(true);
+  });
+
+  it('setConnected(false) is an intentional teardown → idle, not disconnected', () => {
+    setConnected(id, true);
+    setConnected(id, false);
+    const conv = conversations$.get(id);
+    // A background eviction / page-unload teardown must not surface as a failure.
+    expect(conv?.connectionStatus.get()).toBe('idle');
+    expect(conv?.isConnected.get()).toBe(false);
+  });
+
+  it('setConnectionStatus reports a genuine disconnect with its error', () => {
+    setConnectionStatus(id, 'disconnected', { error: 'stream failed after 5 retries' });
+    const conv = conversations$.get(id);
+    expect(conv?.connectionStatus.get()).toBe('disconnected');
+    expect(conv?.isConnected.get()).toBe(false);
+    expect(conv?.connectionError.get()).toBe('stream failed after 5 retries');
+  });
+
+  it('setConnectionStatus tracks reconnecting attempts', () => {
+    setConnectionStatus(id, 'reconnecting', { attempt: 2, maxAttempts: 5, retryInMs: 1000 });
+    const conv = conversations$.get(id);
+    expect(conv?.connectionStatus.get()).toBe('reconnecting');
+    expect(conv?.reconnectAttempt.get()).toBe(2);
+    expect(conv?.reconnectMaxAttempts.get()).toBe(5);
   });
 });

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -16,9 +16,18 @@ export interface ExecutingTool {
 }
 
 export type ConversationConnectionStatus =
+  // Never connected yet, or intentionally disconnected (e.g. evicted to respect
+  // the connection cap, or torn down on page unload). This is the initial state
+  // and must NOT surface an alarming "disconnected" banner — no established
+  // stream has dropped and no connection attempt has failed.
+  | 'idle'
+  // A connection attempt is in progress (initial connect). No banner.
   | 'connecting'
   | 'connected'
+  // An established stream dropped and is auto-retrying. Shows a banner.
   | 'reconnecting'
+  // Genuine failure: the stream dropped or the initial connect failed and
+  // retries are exhausted. Shows a banner.
   | 'disconnected';
 
 export interface ConversationState {
@@ -100,7 +109,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       data: { id, name: '', log: [], logfile: id, branches: {}, workspace: '/default/workspace' },
       isGenerating: false,
       isConnected: false,
-      connectionStatus: 'disconnected',
+      connectionStatus: 'idle',
       reconnectAttempt: null,
       reconnectMaxAttempts: null,
       reconnectRetryInMs: null,
@@ -180,7 +189,12 @@ export function setGenerating(id: string, isGenerating: boolean) {
 export function setConnected(id: string, isConnected: boolean) {
   updateConversation(id, {
     isConnected,
-    connectionStatus: isConnected ? 'connected' : 'disconnected',
+    // A false here means an *intentional* teardown (evicting a background
+    // conversation to respect the connection cap, or closing the stream on page
+    // unload) — not a failure. Treat it as 'idle' so re-opening reconnects
+    // cleanly without flashing the "disconnected" banner. Genuine drops/failures
+    // come through setConnectionStatus(id, 'disconnected', ...) instead.
+    connectionStatus: isConnected ? 'connected' : 'idle',
     reconnectAttempt: null,
     reconnectMaxAttempts: null,
     reconnectRetryInMs: null,
@@ -274,7 +288,7 @@ export function initConversation(
     },
     isGenerating: false,
     isConnected: false,
-    connectionStatus: 'disconnected',
+    connectionStatus: 'idle',
     reconnectAttempt: null,
     reconnectMaxAttempts: null,
     reconnectRetryInMs: null,


### PR DESCRIPTION
## Problem

Whenever a conversation is opened (existing or new), an **\"Event stream disconnected\"** banner flashes briefly and then disappears once the SSE/event stream connects. The banner treated \"not yet connected\" the same as \"disconnected\".

Root cause: a conversation's `connectionStatus` defaulted to `'disconnected'`, and the banner gate showed the alarming banner for `'disconnected'`. So the normal open sequence — initial state → connecting → connected — passed through `'disconnected'` for a frame, flashing the banner.

## State machine — before → after

`ConversationConnectionStatus` before: `'connecting' | 'connected' | 'reconnecting' | 'disconnected'`, with `'disconnected'` doing double duty as both \"never connected yet\" and \"genuine failure\".

After, an explicit **`'idle'`** status is added:

| status | meaning | banner |
|---|---|---|
| `idle` | never connected yet, or intentionally torn down | **none** |
| `connecting` | initial connect in progress | none |
| `connected` | established | none |
| `reconnecting` | established stream dropped, auto-retrying | amber banner |
| `disconnected` | genuine failure, retries exhausted | red banner |

- Initial state (both `updateConversation` auto-init and `initConversation`) is now `'idle'` instead of `'disconnected'`.
- `setConnected(id, false)` — only ever called for **intentional** teardowns (evicting a background conversation to respect the connection cap, or closing the stream on page unload) — now sets `'idle'` instead of `'disconnected'`, so re-opening an evicted conversation reconnects cleanly without a flash. Genuine drops/failures still route through `setConnectionStatus(id, 'disconnected', { error })` from the event stream's `onConnectionState`.
- The banner gate (`reconnecting || disconnected`) is unchanged, but `'idle'`/`'connecting'` never match it, so the normal `idle → connecting → connected` handshake shows nothing.

## Files changed

- `webui/src/stores/conversations.ts` — add `'idle'` to the status union (with doc comments), use it for initial state and intentional `setConnected(false)` teardown.
- `webui/src/components/ConversationContent.tsx` — default fallback `'idle'`; comment explaining the banner gate.
- `webui/src/stores/__tests__/conversations.test.ts` — new `connection status transitions` block (initial idle, connected, intentional teardown → idle, genuine disconnect with error, reconnecting attempts).
- `webui/src/components/__tests__/ConversationContent.test.tsx` — new `event-stream connection banner` block: banner absent for idle/connecting/connected, present for reconnecting/disconnected, never flashes across idle → connecting → connected, appears on connected → disconnected.

## Tests

- \`npx jest\` — **824 passed** (74 suites), including the new tests.
- \`npx tsc -p tsconfig.app.json --noEmit\` — clean.
- \`npx eslint <changed files>\` — 0 errors (4 pre-existing `no-console` warnings in `conversations.ts`, untouched by this change).