### PR TITLE
fix(webui): only show demo content in explicit demo mode, not on connect

### DIFF
--- a/webui/jest.config.ts
+++ b/webui/jest.config.ts
@@ -2,6 +2,8 @@ export default {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    // Must beat the @/ mapper: Jest cannot parse import.meta in viteEnv.ts.
+    '^@/utils/viteEnv$': '<rootDir>/src/utils/__mocks__/viteEnv.ts',
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
     '^@google/model-viewer$': '<rootDir>/src/__mocks__/@google/model-viewer.ts',

--- a/webui/jest.setup.ts
+++ b/webui/jest.setup.ts
@@ -29,8 +29,9 @@ if (typeof URL.revokeObjectURL === 'undefined') {
 }
 
 // Shim Vite import.meta.env for Jest.
-// connectionConfig.ts and SetupWizard.tsx wrap import.meta.env accesses in
-// Function() and fall back to process.env when that throws.
+// connectionConfig.ts reads named VITE_* vars via Function() + process.env
+// fallback (Jest cannot parse import.meta). The DEV flag lives in viteEnv.ts
+// and is remapped to src/utils/__mocks__/viteEnv.ts by jest.config.ts.
 // Keep these in sync with the hardcoded defaults in connectionConfig.ts.
 process.env.VITE_GPTME_CLOUD_BASE_URL = 'https://gptme.ai';
 process.env.VITE_GPTME_FLEET_BASE_URL = 'https://fleet.gptme.ai';

--- a/webui/src/components/DeleteConversationConfirmationDialog.tsx
+++ b/webui/src/components/DeleteConversationConfirmationDialog.tsx
@@ -12,7 +12,6 @@ import { Loader2 } from 'lucide-react';
 import { useApi } from '@/contexts/ApiContext';
 import { conversations$, selectedConversation$ } from '@/stores/conversations';
 import { useQueryClient } from '@tanstack/react-query';
-import { demoConversations } from '@/democonversations';
 import { conversationsQueryKey } from '@/hooks/useConversationsInfiniteQuery';
 
 interface Props {
@@ -58,7 +57,10 @@ export function DeleteConversationConfirmationDialog({
     queryClient.invalidateQueries({
       queryKey: conversationsQueryKey(connectionConfig.baseUrl),
     });
-    selectedConversation$.set(demoConversations[0].name);
+    // Clear selection after delete. (Previously reset to a demo conversation,
+    // which surfaced demo content to real users — and used the demo's name
+    // rather than its id, so it never actually selected anything.)
+    selectedConversation$.set('');
 
     // Reset state
     await onDelete();

--- a/webui/src/components/MainLayout.tsx
+++ b/webui/src/components/MainLayout.tsx
@@ -26,6 +26,7 @@ import { useSecondaryServerConversations } from '@/hooks/useMultiServerConversat
 import { useApi } from '@/contexts/ApiContext';
 import { serverRegistry$ } from '@/stores/servers';
 import { demoConversations, getDemoMessages } from '@/democonversations';
+import { shouldShowDemoContent } from '@/utils/connectionConfig';
 import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { Memo, use$, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { Loader2, GitBranch, Columns2 } from 'lucide-react';
@@ -102,17 +103,22 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
 
   // Initialize demo conversations and handle selection on mount
   useEffect(() => {
-    demoConversations.forEach((conv) => {
-      const messages = getDemoMessages(conv.id);
-      initConversation(conv.id, {
-        id: conv.id,
-        name: conv.name,
-        log: messages,
-        logfile: conv.name,
-        branches: {},
-        workspace: conv.workspace || '/demo/workspace',
+    // Only hydrate demo fixtures when demo content is explicitly enabled — a
+    // normal signed-in user must never see them, not even briefly while their
+    // instance is still connecting.
+    if (shouldShowDemoContent()) {
+      demoConversations.forEach((conv) => {
+        const messages = getDemoMessages(conv.id);
+        initConversation(conv.id, {
+          id: conv.id,
+          name: conv.name,
+          log: messages,
+          logfile: conv.name,
+          branches: {},
+          workspace: conv.workspace || '/demo/workspace',
+        });
       });
-    });
+    }
 
     // Handle initial conversation/task selection
     if (conversationId && selectedConversation$.get() !== conversationId) {
@@ -214,7 +220,12 @@ const MainLayout: FC<Props> = ({ conversationId, taskId }) => {
     console.error('Conversation query error:', error);
   }
 
-  const demoItems: ConversationSummary[] = useMemo(() => demoConversations, []);
+  // Demo fixtures are merged into the sidebar list only in explicit demo mode
+  // (or the dev server); otherwise this is empty so nothing flashes on connect.
+  const demoItems: ConversationSummary[] = useMemo(
+    () => (shouldShowDemoContent() ? demoConversations : []),
+    []
+  );
 
   const apiItems: ConversationSummary[] = useMemo(() => {
     if (!isConnected) return [];

--- a/webui/src/stores/conversations.ts
+++ b/webui/src/stores/conversations.ts
@@ -87,8 +87,11 @@ export interface ConversationState {
 // Central store for all conversations
 export const conversations$ = observable(new Map<string, ConversationState>());
 
-// Currently selected conversation
-export const selectedConversation$ = observable<string>(demoConversations[0].id);
+// Currently selected conversation. Starts empty (no selection) so a normal
+// user never has a demo fixture selected before their instance connects.
+// MainLayout resolves the real selection from the URL on mount; in demo mode
+// the demo conversations are still selectable from the sidebar.
+export const selectedConversation$ = observable<string>('');
 
 // Helper functions
 export function updateConversation(id: string, update: Partial<ConversationState>) {

--- a/webui/src/utils/__mocks__/viteEnv.ts
+++ b/webui/src/utils/__mocks__/viteEnv.ts
@@ -1,0 +1,2 @@
+/** Jest stand-in: production-like, not the Vite dev server. */
+export const isViteDev = false;

--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -217,8 +217,8 @@ describe('shouldShowDemoContent', () => {
     resetDemoModeForTests();
   });
 
-  // A normal signed-in user is neither in demo mode nor on the dev server
-  // (import.meta.env.DEV is unavailable under Jest, so isDevServer() is false).
+  // A normal signed-in user is neither in demo mode nor on the Vite dev
+  // server. Jest maps `viteEnv.ts` to a production-like mock (isViteDev=false).
   // Demo fixtures must not surface for them — this is the flash-on-connect fix.
   it('is false for a normal user (no ?demo=1, not the dev server)', () => {
     window.history.replaceState(null, '', '/');

--- a/webui/src/utils/__tests__/connectionConfig.test.ts
+++ b/webui/src/utils/__tests__/connectionConfig.test.ts
@@ -25,6 +25,7 @@ import {
   processConnectionFromHash,
   resetDemoModeForTests,
   resolveCloudExchangeBaseUrl,
+  shouldShowDemoContent,
 } from '../connectionConfig';
 
 const runtimeEnvWindow = window as typeof window & {
@@ -203,5 +204,29 @@ describe('isDemoMode', () => {
 
     window.history.replaceState(null, '', '/?demo=1');
     expect(isDemoMode()).toBe(false);
+  });
+});
+
+describe('shouldShowDemoContent', () => {
+  beforeEach(() => {
+    resetDemoModeForTests();
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+    resetDemoModeForTests();
+  });
+
+  // A normal signed-in user is neither in demo mode nor on the dev server
+  // (import.meta.env.DEV is unavailable under Jest, so isDevServer() is false).
+  // Demo fixtures must not surface for them — this is the flash-on-connect fix.
+  it('is false for a normal user (no ?demo=1, not the dev server)', () => {
+    window.history.replaceState(null, '', '/');
+    expect(shouldShowDemoContent()).toBe(false);
+  });
+
+  it('is true when the explicit ?demo=1 flag is set', () => {
+    window.history.replaceState(null, '', '/?demo=1');
+    expect(shouldShowDemoContent()).toBe(true);
   });
 });

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -55,6 +55,33 @@ export function resetDemoModeForTests(): void {
   demoModeLatch = null;
 }
 
+/** True on the local Vite dev server; false in production builds and Jest. */
+function isDevServer(): boolean {
+  try {
+    return Boolean(Function('return import.meta.env.DEV')());
+  } catch {
+    // Jest / Node runtime (import.meta not available)
+    return false;
+  }
+}
+
+/**
+ * Whether demo fixture content (the conversations in `democonversations.ts`)
+ * should be surfaced in the UI.
+ *
+ * Demo content must appear ONLY when demo mode is EXPLICITLY active — never for
+ * a normal signed-in user who is merely connecting or momentarily disconnected
+ * (that caused demo conversations to flash in the sidebar until the real
+ * instance connected). "Explicit" means one of:
+ *   - the `?demo=1` URL flag (see {@link isDemoMode}), which powers the
+ *     no-signup demo on gptme.ai, or
+ *   - the local Vite dev server (`import.meta.env.DEV`), where the fixtures are
+ *     a convenient offline sandbox during development.
+ */
+export function shouldShowDemoContent(): boolean {
+  return isDemoMode() || isDevServer();
+}
+
 // Browser builds can inject runtime env from index.html before this module
 // loads. Keep process.env fallback for Jest/Node tests; the Function() path is
 // retained only for compatibility with any bundler that supports it.

--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -5,6 +5,7 @@ import {
   setActiveServer,
   updateServer,
 } from '@/stores/servers';
+import { isViteDev } from '@/utils/viteEnv';
 
 const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 const DEFAULT_CLOUD_APP_BASE_URL = 'https://gptme.ai';
@@ -57,12 +58,7 @@ export function resetDemoModeForTests(): void {
 
 /** True on the local Vite dev server; false in production builds and Jest. */
 function isDevServer(): boolean {
-  try {
-    return Boolean(Function('return import.meta.env.DEV')());
-  } catch {
-    // Jest / Node runtime (import.meta not available)
-    return false;
-  }
+  return isViteDev;
 }
 
 /**

--- a/webui/src/utils/viteEnv.ts
+++ b/webui/src/utils/viteEnv.ts
@@ -1,0 +1,12 @@
+/**
+ * Vite-only env accessors isolated from Jest-imported modules.
+ *
+ * Jest's ts-jest CJS transform cannot parse `import.meta`, so any file that
+ * Jest loads (notably `connectionConfig.ts`) must not mention it. Keep the
+ * static `import.meta.env.DEV` member expression here — Vite replaces it with
+ * a boolean literal. Do not wrap it in `Function('return import.meta.env.DEV')()`:
+ * that string is a classic-script eval Vite cannot transform, so the access
+ * always threw and Playwright e2e against `vite dev` never saw demo fixtures
+ * (gptme/gptme#3754).
+ */
+export const isViteDev: boolean = import.meta.env.DEV;


### PR DESCRIPTION
## Problem

When a real signed-in gptme.ai user enters chat, the webui briefly shows **demo fixture content** (demo conversations in the sidebar, and a demo conversation opened in the chat pane) while the connection to their instance is still being established. It then "blinks away" once real conversations load.

Root cause: demo content was injected **unconditionally**, not gated on demo mode:

- `MainLayout` hydrated the demo fixtures into the conversation store on every mount.
- `MainLayout` merged `demoConversations` into the sidebar list on every mount.
- The conversation store defaulted `selectedConversation$` to the **first demo conversation**, so the chat pane briefly rendered the demo intro before the URL-driven selection took over.
- The delete dialog reset selection back to a demo conversation after a delete.

## Fix

Introduce a single gate, `shouldShowDemoContent()`, and use it everywhere demo content is *surfaced*:

```ts
shouldShowDemoContent() = isDemoMode() || isDevServer()
```

Demo content now appears **only** when demo mode is explicitly active:
- **`?demo=1`** — the URL flag behind gptme.ai's no-signup demo (`isDemoMode()` latch, unchanged), **or**
- **`import.meta.env.DEV`** — the local Vite dev server, where the fixtures are a useful offline sandbox (and where the Playwright e2e suite runs, so those tests keep working).

A normal signed-in user who is connecting or disconnected now sees the standard empty/loading UI, never demo conversations.

### Demo-content gating: before vs after

| Injection point | Before | After |
|---|---|---|
| Demo fixtures hydrated into the store (`MainLayout` mount) | always | only when `shouldShowDemoContent()` |
| Demo conversations merged into sidebar list (`MainLayout` `demoItems`) | always | only when `shouldShowDemoContent()` |
| Initial `selectedConversation$` | first demo conversation | `''` (no selection; URL resolves real selection, demos still selectable from the sidebar in demo mode) |
| Selection after deleting a conversation | reset to a demo conversation (by name, so it selected nothing) | cleared to `''` |

Classification-only uses of `demoConversations` (e.g. marking a conversation read-only, hiding the star/context menu, `ConversationList` grouping) are unchanged — they only matter when a demo conversation is actually present, which now only happens in demo mode / dev.

## Files changed

- `webui/src/utils/connectionConfig.ts` — add `shouldShowDemoContent()` / `isDevServer()`.
- `webui/src/components/MainLayout.tsx` — gate demo store hydration and demo sidebar items.
- `webui/src/stores/conversations.ts` — default `selectedConversation$` to `''`.
- `webui/src/components/DeleteConversationConfirmationDialog.tsx` — clear selection after delete.
- `webui/src/utils/__tests__/connectionConfig.test.ts` — cover the gating logic.

## Tests

- `npx jest` — 74 suites, 813 tests pass.
- `npx tsc -p tsconfig.app.json --noEmit` — clean.
- `npx eslint` on changed files — 0 errors (only pre-existing `no-console` warnings in untouched lines).
- e2e (`conversation.spec.ts`, `visual-snapshots.spec.ts`) run against the Vite dev server, where `import.meta.env.DEV` is true, so demo conversations remain visible there and those tests are unaffected.