### PR TITLE
fix(shell): bound denylist matches to argument tokens

### DIFF
--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -85,9 +85,10 @@ deny_groups = [
     (
         [
             # Token boundary includes shell separators and `)` so
-            # `git add -A; ...` and `(git add -A)` still match. `-a` must
-            # be the first short-option letter so `-am` is denied but
-            # `-ma` / `-mabc` (message values) are not.
+            # `git add -A; ...` and `(git add -A)` still match. Quoted
+            # `)` is data, not a delimiter — `is_denylisted()` skips it.
+            # `-a` must be the first short-option letter so `-am` is
+            # denied but `-ma` / `-mabc` (message values) are not.
             r"git\s+add\s+\.(?:\s|$|[;&|)])",  # Match 'git add .' but not '.gitignore'
             r"git\s+add\s+-A(?:\s|$|[;&|)])",
             r"git\s+add\s+--all(?:\s|$|[;&|)])",
@@ -625,13 +626,20 @@ def is_denylisted(cmd: str) -> tuple[bool, str | None, str | None]:
     # We don't normalize because it would break heredoc detection
     for patterns, reason in deny_groups:
         for pattern in patterns:
-            match = re.search(pattern, cmd, re.IGNORECASE)
-            if match:
-                # Check if the match is within a safe region (quoted or heredoc)
-                match_start = match.start()
-                if not _is_in_quoted_region(match_start, safe_regions):
-                    # Return the matched text to show in error message
-                    return True, reason, match.group(0)
+            for match in re.finditer(pattern, cmd, re.IGNORECASE):
+                # Skip quoted/heredoc text. Keep scanning so a later
+                # unquoted occurrence (echo '...'; rm -rf /) still matches.
+                if _is_in_quoted_region(match.start(), safe_regions):
+                    continue
+                # `)` is a grouping delimiter only when unquoted. Quoted
+                # data such as echo '(rm -rf /)' is skipped via match.start()
+                # above; this also rejects mixed cases where the command is
+                # unquoted but the `)` that completed the match is data.
+                if match.group(0).endswith(")") and _is_in_quoted_region(
+                    match.end() - 1, safe_regions
+                ):
+                    continue
+                return True, reason, match.group(0)
 
     return False, None, None
 

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -84,11 +84,14 @@ allowlist_commands = [
 deny_groups = [
     (
         [
-            r"git\s+add\s+\.(?:\s|$)",  # Match 'git add .' but not '.gitignore'
-            r"git\s+add\s+-A(?:\s|$)",
-            r"git\s+add\s+--all(?:\s|$)",
-            r"git\s+commit\s+-[a-zA-Z]*a[a-zA-Z]*(?:\s|$)",  # -a / -am / -ma, not --amend
-            r"git\s+commit\s+--all(?:\s|$)",
+            # Token boundary includes shell separators so `git add -A; ...`
+            # still matches. `-a` must be the first short-option letter so
+            # `-am` is denied but `-ma` / `-mabc` (message values) are not.
+            r"git\s+add\s+\.(?:\s|$|[;&|])",  # Match 'git add .' but not '.gitignore'
+            r"git\s+add\s+-A(?:\s|$|[;&|])",
+            r"git\s+add\s+--all(?:\s|$|[;&|])",
+            r"git\s+commit\s+-a[a-zA-Z]*(?:\s|$|[;&|])",  # -a / -am, not -ma / --amend
+            r"git\s+commit\s+--all(?:\s|$|[;&|])",
         ],
         "Instead of bulk git operations, use selective commands: `git add <specific-files>` to stage only intended files, then `git commit`.",
     ),
@@ -104,10 +107,11 @@ deny_groups = [
     ),
     (
         [
-            # Root operand only: `/`, `/.`, `/..`, `//`, `/*`, optionally quoted.
-            # Do not prefix-match longer absolute paths such as `/tmp/foo`.
-            r"rm\s+-rf\s+['\"]?/(?:(?:\.){1,2}|/|\*)?['\"]?(?:\s|$|[;&|])",
-            r"sudo\s+rm\s+-rf\s+['\"]?/(?:(?:\.){1,2}|/|\*)?['\"]?(?:\s|$|[;&|])",
+            # Root-equivalent operand: `/`, `/./`, `/..`, `//`, `/*`, `'/'`,
+            # `/""`. Quotes and `.`/`*` after `/` may repeat; a real path
+            # component such as `/tmp/foo` does not match.
+            r"rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|])",
+            r"sudo\s+rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|])",
             r"rm\s+-rf\s+\*",
         ],
         "Destructive file operations are blocked. Specify exact paths and avoid operations that could delete system files or entire directories.",

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -85,10 +85,10 @@ deny_groups = [
     (
         [
             r"git\s+add\s+\.(?:\s|$)",  # Match 'git add .' but not '.gitignore'
-            r"git\s+add\s+-A",
-            r"git\s+add\s+--all",
-            r"git\s+commit\s+-a",
-            r"git\s+commit\s+--all",
+            r"git\s+add\s+-A(?:\s|$)",
+            r"git\s+add\s+--all(?:\s|$)",
+            r"git\s+commit\s+-[a-zA-Z]*a[a-zA-Z]*(?:\s|$)",  # -a / -am / -ma, not --amend
+            r"git\s+commit\s+--all(?:\s|$)",
         ],
         "Instead of bulk git operations, use selective commands: `git add <specific-files>` to stage only intended files, then `git commit`.",
     ),
@@ -104,8 +104,10 @@ deny_groups = [
     ),
     (
         [
-            r"rm\s+-rf\s+/",
-            r"sudo\s+rm\s+-rf\s+/",
+            # Root operand only: `/`, `/.`, `/..`, `//`, `/*`, optionally quoted.
+            # Do not prefix-match longer absolute paths such as `/tmp/foo`.
+            r"rm\s+-rf\s+['\"]?/(?:(?:\.){1,2}|/|\*)?['\"]?(?:\s|$|[;&|])",
+            r"sudo\s+rm\s+-rf\s+['\"]?/(?:(?:\.){1,2}|/|\*)?['\"]?(?:\s|$|[;&|])",
             r"rm\s+-rf\s+\*",
         ],
         "Destructive file operations are blocked. Specify exact paths and avoid operations that could delete system files or entire directories.",

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -84,14 +84,15 @@ allowlist_commands = [
 deny_groups = [
     (
         [
-            # Token boundary includes shell separators so `git add -A; ...`
-            # still matches. `-a` must be the first short-option letter so
-            # `-am` is denied but `-ma` / `-mabc` (message values) are not.
-            r"git\s+add\s+\.(?:\s|$|[;&|])",  # Match 'git add .' but not '.gitignore'
-            r"git\s+add\s+-A(?:\s|$|[;&|])",
-            r"git\s+add\s+--all(?:\s|$|[;&|])",
-            r"git\s+commit\s+-a[a-zA-Z]*(?:\s|$|[;&|])",  # -a / -am, not -ma / --amend
-            r"git\s+commit\s+--all(?:\s|$|[;&|])",
+            # Token boundary includes shell separators and `)` so
+            # `git add -A; ...` and `(git add -A)` still match. `-a` must
+            # be the first short-option letter so `-am` is denied but
+            # `-ma` / `-mabc` (message values) are not.
+            r"git\s+add\s+\.(?:\s|$|[;&|)])",  # Match 'git add .' but not '.gitignore'
+            r"git\s+add\s+-A(?:\s|$|[;&|)])",
+            r"git\s+add\s+--all(?:\s|$|[;&|)])",
+            r"git\s+commit\s+-a[a-zA-Z]*(?:\s|$|[;&|)])",  # -a / -am, not -ma / --amend
+            r"git\s+commit\s+--all(?:\s|$|[;&|)])",
         ],
         "Instead of bulk git operations, use selective commands: `git add <specific-files>` to stage only intended files, then `git commit`.",
     ),
@@ -110,8 +111,8 @@ deny_groups = [
             # Root-equivalent operand: `/`, `/./`, `/..`, `//`, `/*`, `'/'`,
             # `/""`. Quotes and `.`/`*` after `/` may repeat; a real path
             # component such as `/tmp/foo` does not match.
-            r"rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|])",
-            r"sudo\s+rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|])",
+            r"rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|)])",
+            r"sudo\s+rm\s+-rf\s+['\"]*(?:/(?:\.{1,2}|\*)?)+['\"]*(?:\s|$|[;&|)])",
             r"rm\s+-rf\s+\*",
         ],
         "Destructive file operations are blocked. Specify exact paths and avoid operations that could delete system files or entire directories.",

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -595,6 +595,28 @@ class TestIsDenylisted:
         denied, _, _ = is_denylisted('echo "rm -rf /"')
         assert not denied
 
+    def test_quoted_closing_paren_is_data_not_delimiter(self):
+        # `)` is a grouping delimiter only when unquoted. Inert text that
+        # merely looks protected must not hard-deny.
+        for cmd in (
+            "printf '%s\\n' 'git commit --all)'",
+            "echo '(rm -rf /)'",
+            "echo '(git add -A)'",
+            "echo '(git commit --all)'",
+        ):
+            denied, _, matched = is_denylisted(cmd)
+            assert not denied, (cmd, matched)
+
+    def test_quoted_then_real_dangerous_command_still_denied(self):
+        # Skipping a quoted match must not hide a later unquoted command.
+        for cmd in (
+            "echo '(rm -rf /)'; rm -rf /",
+            "echo 'git commit --all)'; git commit --all",
+            'echo "rm -rf /"; rm -rf /',
+        ):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
     def test_dangerous_in_heredoc(self):
         cmd = "cat << EOF\ngit add .\nrm -rf /\nEOF"
         denied, _, _ = is_denylisted(cmd)

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -395,6 +395,20 @@ class TestIsDenylisted:
         denied, _, _ = is_denylisted("git commit -am x")
         assert denied
 
+    def test_git_bulk_with_separators_still_denied(self):
+        for cmd in (
+            "git add -A; git commit",
+            "git commit --all&&git push",
+            "git commit -am|cat",
+        ):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
+    def test_git_commit_message_value_starting_with_a_ok(self):
+        for cmd in ("git commit -ma", "git commit -mabc"):
+            denied, _, matched = is_denylisted(cmd)
+            assert not denied, (cmd, matched)
+
     # --- Destructive git operations ---
 
     def test_git_reset_hard(self):
@@ -469,6 +483,11 @@ class TestIsDenylisted:
 
     def test_rm_rf_quoted_root_denied(self):
         for cmd in ("rm -rf '/'", 'rm -rf "/"'):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
+    def test_rm_rf_root_aliases_denied(self):
+        for cmd in ("rm -rf /./", "rm -rf /..", 'rm -rf /""', "rm -rf /''"):
             denied, _, matched = is_denylisted(cmd)
             assert denied, (cmd, matched)
 

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -383,6 +383,18 @@ class TestIsDenylisted:
         denied, _, _ = is_denylisted('git commit -m "fix: something"')
         assert not denied
 
+    def test_git_commit_allow_empty_ok(self):
+        denied, _, matched = is_denylisted("git commit --allow-empty -m x")
+        assert not denied, matched
+
+    def test_git_commit_amend_ok(self):
+        denied, _, matched = is_denylisted("git commit --amend -m x")
+        assert not denied, matched
+
+    def test_git_commit_all_with_message_still_denied(self):
+        denied, _, _ = is_denylisted("git commit -am x")
+        assert denied
+
     # --- Destructive git operations ---
 
     def test_git_reset_hard(self):
@@ -437,15 +449,32 @@ class TestIsDenylisted:
         denied, _, _ = is_denylisted("rm file.txt")
         assert not denied
 
-    def test_rm_rf_specific_dir_also_denied(self):
-        # rm -rf /path matches the "rm -rf /" pattern — any absolute path is blocked
-        denied, _, _ = is_denylisted("rm -rf /tmp/build")
-        assert denied
+    def test_rm_rf_specific_absolute_dir_ok(self):
+        denied, _, matched = is_denylisted("rm -rf /tmp/gptme-fp-example")
+        assert not denied, matched
+
+    def test_rm_rf_nested_absolute_dir_ok(self):
+        denied, _, matched = is_denylisted("rm -rf /Users/foo/bar")
+        assert not denied, matched
 
     def test_rm_rf_relative_dir_ok(self):
         # rm -rf of a relative dir should be allowed (not matching /path pattern)
         denied, _, _ = is_denylisted("rm -rf build/")
         assert not denied
+
+    def test_rm_rf_root_with_separators_denied(self):
+        for cmd in ("rm -rf /;", "rm -rf / && echo x", "rm -rf /|true"):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
+    def test_rm_rf_quoted_root_denied(self):
+        for cmd in ("rm -rf '/'", 'rm -rf "/"'):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
+    def test_sudo_rm_rf_tmp_ok(self):
+        denied, _, matched = is_denylisted("sudo rm -rf /tmp/gptme-fp-example")
+        assert not denied, matched
 
     # --- Permission operations ---
 

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -404,6 +404,16 @@ class TestIsDenylisted:
             denied, _, matched = is_denylisted(cmd)
             assert denied, (cmd, matched)
 
+    def test_git_bulk_grouped_commands_still_denied(self):
+        for cmd in (
+            "(git add -A)",
+            "$(git commit --all)",
+            "(git add .)",
+            "$(git commit -am x)",
+        ):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
     def test_git_commit_message_value_starting_with_a_ok(self):
         for cmd in ("git commit -ma", "git commit -mabc"):
             denied, _, matched = is_denylisted(cmd)
@@ -480,6 +490,15 @@ class TestIsDenylisted:
         for cmd in ("rm -rf /;", "rm -rf / && echo x", "rm -rf /|true"):
             denied, _, matched = is_denylisted(cmd)
             assert denied, (cmd, matched)
+
+    def test_rm_rf_grouped_root_denied(self):
+        for cmd in ("(rm -rf /)", "$(sudo rm -rf /)", "(sudo rm -rf /)"):
+            denied, _, matched = is_denylisted(cmd)
+            assert denied, (cmd, matched)
+
+    def test_rm_rf_grouped_tmp_ok(self):
+        denied, _, matched = is_denylisted("(rm -rf /tmp/gptme-fp-example)")
+        assert not denied, matched
 
     def test_rm_rf_quoted_root_denied(self):
         for cmd in ("rm -rf '/'", 'rm -rf "/"'):


### PR DESCRIPTION
## Summary

The shell denylist used unanchored prefix matches, so:

- `rm -rf /tmp/gptme-fp-example` was denied as `rm -rf /`
- `git commit --allow-empty` was denied as `git commit --all`

This keeps true root-deletion and bulk-commit flags blocked, but requires operand/option boundaries (including separators and quoted root operands).

`pkill`/`killall` policy is unchanged.

Fixes #3757

## Test plan

- [x] `uv run pytest tests/test_tools_shell_validation.py` (439 passed)
- [x] Added regressions for `/tmp` cleanup, quoted `/`, separators, `--allow-empty`, `--amend`, and `-am`