### PR TITLE
fix(cli): skip root scans and keep path inclusion interruptible

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -602,7 +602,14 @@ def _get_user_input(log: Log, workspace: Path | None) -> Message | None:
                 + truncation_suffix
             )
         msg = Message("user", inquiry, quiet=True)
-        msg = include_paths(msg, workspace)
+        # prompt_user() clears interruptible on return. Path inclusion can walk
+        # the filesystem, so Ctrl-C must cancel it instead of printing the
+        # Ctrl-D hint.
+        set_interruptible()
+        try:
+            msg = include_paths(msg, workspace)
+        finally:
+            clear_interruptible()
         return msg
     except (EOFError, KeyboardInterrupt):
         return None

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -715,6 +715,10 @@ def _find_potential_paths(content: str) -> list[str]:
         w = word.removeprefix("@") if word.startswith("@") else word
 
         def _is_path_like_bare(s: str) -> bool:
+            # A lone slash is prose/markdown ("open / not"), not a path.
+            # Implicitly attaching filesystem root is never useful (#3758).
+            if s.strip("/") == "":
+                return False
             return (
                 # Absolute/home/relative paths
                 any(s.startswith(p) for p in ["/", "~/", "./"])

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -6,6 +6,8 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
+import time
 import urllib
 import urllib.parse
 from collections import Counter
@@ -806,35 +808,127 @@ def _human_readable_size(size_bytes: int) -> str:
     return f"{size:.1f} TB"
 
 
-def _is_too_broad_directory(path: Path) -> bool:
-    """True for filesystem roots and other implicit broad directory attachments.
+def _resolved_or_none(path: Path) -> Path | None:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return None
 
-    Casual mentions like ``/`` must not trigger recursive listing. Project
-    subdirectories (three or more path parts, and not the user's home) remain
-    eligible so explicit directory context still works.
+
+def _broad_temp_directories() -> tuple[Path, ...]:
+    """Resolved temp roots that must never be attached as directory context.
+
+    Includes macOS ``/tmp`` → ``/private/tmp`` so a 3-part resolved temp path
+    is still treated as too broad. Nested temp workspaces remain eligible.
     """
-    try:
-        resolved = path.expanduser().resolve()
-    except OSError:
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for raw in (tempfile.gettempdir(), "/tmp", "/var/tmp", "/private/tmp"):
+        resolved = _resolved_or_none(Path(raw))
+        if resolved is None or resolved in seen:
+            continue
+        seen.add(resolved)
+        out.append(resolved)
+    return tuple(out)
+
+
+def _is_too_broad_directory(path: Path) -> bool:
+    """True for filesystem roots, home, and temp roots.
+
+    Casual mentions like ``/`` or ``/tmp`` must not trigger recursive listing.
+    Uses explicit resolved paths rather than a path-depth heuristic: on macOS
+    ``/tmp`` resolves to ``/private/tmp`` (three parts) and would otherwise
+    be treated as a project directory. Nested directories under temp/home
+    remain eligible.
+    """
+    resolved = _resolved_or_none(path)
+    if resolved is None:
         return True
-    if len(resolved.parts) < 3:
+    if resolved.parent == resolved:
         return True
-    try:
-        if resolved == Path.home().resolve():
+    home = _resolved_or_none(Path.home())
+    if home is not None and resolved == home:
+        return True
+    return resolved in _broad_temp_directories()
+
+
+def _fallback_dir_listing(
+    path: Path,
+    max_entries: int,
+    max_visited: int,
+    max_seconds: float,
+) -> tuple[list[str], bool]:
+    """Walk *path* for regular files, budgeting visits and wall time.
+
+    Counts every scandir entry (directories, files, excluded names, stat
+    failures), prunes ``.git`` before descending, and does not follow
+    symlinks. Returns ``(relative_paths, truncated)``.
+    """
+    entries: list[str] = []
+    visited = 0
+    truncated = False
+    deadline = time.monotonic() + max_seconds
+
+    def rec(current: Path) -> bool:
+        nonlocal visited, truncated
+        if time.monotonic() >= deadline:
+            truncated = True
             return True
-    except OSError:
-        pass
-    return False
+        try:
+            with os.scandir(current) as iterator:
+                children = list(iterator)
+        except OSError:
+            visited += 1
+            if visited >= max_visited:
+                truncated = True
+            return visited >= max_visited
+
+        for entry in children:
+            visited += 1
+            if visited > max_visited or time.monotonic() >= deadline:
+                truncated = True
+                return True
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+                is_file = entry.is_file(follow_symlinks=False)
+            except OSError:
+                continue
+            if is_dir:
+                if entry.name == ".git":
+                    continue
+                if rec(Path(entry.path)):
+                    return True
+            elif is_file:
+                try:
+                    rel = Path(entry.path).relative_to(path)
+                except ValueError:
+                    continue
+                entries.append(str(rel))
+                if len(entries) >= max_entries:
+                    truncated = True
+                    return True
+        return False
+
+    rec(path)
+    entries.sort()
+    return entries, truncated
 
 
-def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
+def _dir_to_listing(
+    path: Path,
+    prompt: str,
+    max_entries: int = 50,
+    max_visited: int | None = None,
+    max_seconds: float = 2.0,
+) -> str:
     """Generate a file listing for a directory, returned as a codeblock.
 
     Uses ``git ls-files`` when inside a git repo (respects .gitignore),
-    falls back to a bounded ``Path.rglob()`` otherwise. Traversal itself is
-    capped at *max_entries*; the output limit is not applied after walking
-    the entire tree.
+    falls back to a visit/time-bounded scandir walk otherwise. The fallback
+    budgets accepted files *and* visited entries so directory-heavy or
+    excluded-entry trees cannot walk unboundedly.
     """
+    visit_budget = max_visited if max_visited is not None else max(max_entries * 4, 200)
     entries: list[str] | None = None
     known_total: int | None = None
     try:
@@ -861,30 +955,13 @@ def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
         pass
 
     if entries is None:
-        # Fallback: list directory recursively, stopping once we have enough.
-        # Only exclude .git/ internals to avoid noise; dotfiles like
-        # .pre-commit-config.yaml, .github/, .env etc. are legitimate project files.
-        entries = []
-        saw_more = False
-        try:
-            for p in path.rglob("*"):
-                try:
-                    rel = p.relative_to(path)
-                    if ".git" in rel.parts:
-                        continue
-                    if not p.is_file():
-                        continue
-                except (OSError, ValueError):
-                    continue
-                entries.append(str(rel))
-                if len(entries) > max_entries:
-                    saw_more = True
-                    break
-        except PermissionError:
-            pass
-        entries.sort()
-        if saw_more:
-            entries = entries[:max_entries]
+        # Fallback: list directory recursively with visit/time budgets.
+        # Only skip .git/ internals; dotfiles like .pre-commit-config.yaml,
+        # .github/, .env etc. are legitimate project files.
+        entries, truncated = _fallback_dir_listing(
+            path, max_entries, visit_budget, max_seconds
+        )
+        if truncated:
             known_total = None  # remaining count unknown; walk was bounded
         else:
             known_total = len(entries)

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -806,14 +806,37 @@ def _human_readable_size(size_bytes: int) -> str:
     return f"{size:.1f} TB"
 
 
+def _is_too_broad_directory(path: Path) -> bool:
+    """True for filesystem roots and other implicit broad directory attachments.
+
+    Casual mentions like ``/`` must not trigger recursive listing. Project
+    subdirectories (three or more path parts, and not the user's home) remain
+    eligible so explicit directory context still works.
+    """
+    try:
+        resolved = path.expanduser().resolve()
+    except OSError:
+        return True
+    if len(resolved.parts) < 3:
+        return True
+    try:
+        if resolved == Path.home().resolve():
+            return True
+    except OSError:
+        pass
+    return False
+
+
 def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
     """Generate a file listing for a directory, returned as a codeblock.
 
     Uses ``git ls-files`` when inside a git repo (respects .gitignore),
-    falls back to ``Path.iterdir()`` otherwise.  Output is truncated to
-    *max_entries* to prevent context bloat.
+    falls back to a bounded ``Path.rglob()`` otherwise. Traversal itself is
+    capped at *max_entries*; the output limit is not applied after walking
+    the entire tree.
     """
     entries: list[str] | None = None
+    known_total: int | None = None
     try:
         # Try git ls-files first (respects .gitignore, lists tracked + untracked)
         result = subprocess.run(
@@ -831,31 +854,49 @@ def _dir_to_listing(path: Path, prompt: str, max_entries: int = 50) -> str:
             check=False,
         )
         if result.returncode == 0:
-            entries = sorted(result.stdout.strip().splitlines())
+            git_entries = sorted(line for line in result.stdout.splitlines() if line)
+            known_total = len(git_entries)
+            entries = git_entries[:max_entries]
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
     if entries is None:
-        # Fallback: list directory recursively.
+        # Fallback: list directory recursively, stopping once we have enough.
         # Only exclude .git/ internals to avoid noise; dotfiles like
         # .pre-commit-config.yaml, .github/, .env etc. are legitimate project files.
+        entries = []
+        saw_more = False
         try:
-            entries = sorted(
-                str(p.relative_to(path))
-                for p in path.rglob("*")
-                if p.is_file() and ".git" not in p.relative_to(path).parts
-            )
+            for p in path.rglob("*"):
+                try:
+                    rel = p.relative_to(path)
+                    if ".git" in rel.parts:
+                        continue
+                    if not p.is_file():
+                        continue
+                except (OSError, ValueError):
+                    continue
+                entries.append(str(rel))
+                if len(entries) > max_entries:
+                    saw_more = True
+                    break
         except PermissionError:
-            entries = []
+            pass
+        entries.sort()
+        if saw_more:
+            entries = entries[:max_entries]
+            known_total = None  # remaining count unknown; walk was bounded
+        else:
+            known_total = len(entries)
 
-    total = len(entries)
-    if total == 0:
+    if not entries:
         return md_codeblock(prompt, "(empty directory)")
 
-    truncated = entries[:max_entries]
-    listing = "\n".join(truncated)
-    if total > max_entries:
-        listing += f"\n... ({total - max_entries} more files)"
+    listing = "\n".join(entries)
+    if known_total is not None and known_total > max_entries:
+        listing += f"\n... ({known_total - max_entries} more files)"
+    elif known_total is None:
+        listing += f"\n... (listing truncated at {max_entries} files)"
 
     return md_codeblock(prompt, listing)
 
@@ -881,6 +922,9 @@ def _resource_to_codeblock(
             file_content = _check_content_size(file_content, str(f))
             return md_codeblock(prompt, file_content)
         if f.exists() and f.is_dir():
+            if _is_too_broad_directory(f):
+                logger.debug("skipping broad directory attachment: %s", f)
+                return None
             return _dir_to_listing(f, prompt)
     except OSError as oserr:
         # some prompts are too long to be a path, so we can't read them

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -204,6 +204,17 @@ def test_find_potential_paths_punctuation():
     assert "https://example.com" in paths
 
 
+def test_find_potential_paths_ignores_lone_slash():
+    """Prose/markdown ' / ' is not a filesystem path (#3758)."""
+    assert _find_potential_paths("**Still open / not done:**") == []
+    assert _find_potential_paths("also file the rm -rf / false-positive") == []
+    assert "/" not in _find_potential_paths("use `/` as the separator")
+    assert "//" not in _find_potential_paths("see // for details")
+    # Real absolute paths must still be detected
+    assert "/tmp/foo" in _find_potential_paths("clean /tmp/foo afterwards")
+    assert "/tmp" in _find_potential_paths("rm -rf /tmp,")
+
+
 def test_find_potential_paths_at_prefix(tmp_path, monkeypatch):
     """Test that @-prefixed paths are detected and the @ is stripped."""
     (tmp_path / "main.py").touch()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1193,3 +1193,54 @@ def test_step_marks_httpx_from_reply_as_provider_error():
     assert not is_provider_error(tool_err)
     mark_llm_reply_origin(tool_err)
     assert is_provider_error(tool_err)
+
+
+def test_get_user_input_interruptible_during_include_paths(monkeypatch):
+    """Path inclusion after prompt_user must run in an interruptible state."""
+    import sys
+
+    from gptme.chat import _get_user_input
+    from gptme.logmanager import Log
+    from gptme.message import Message
+    from gptme.util.interrupt import _interruptible_var, clear_interruptible
+
+    _chat_mod = sys.modules["gptme.chat"]
+    seen: dict[str, bool] = {}
+
+    def fake_include_paths(msg, workspace=None, **kwargs):
+        seen["interruptible"] = _interruptible_var.get()
+        return msg
+
+    monkeypatch.setattr(_chat_mod, "include_paths", fake_include_paths)
+    monkeypatch.setattr(_chat_mod, "prompt_user", lambda value=None: "hello /")
+    clear_interruptible()
+
+    result = _get_user_input(Log(messages=[Message("assistant", "ok")]), None)
+    assert result is not None
+    assert result.content == "hello /"
+    assert seen["interruptible"] is True
+    assert _interruptible_var.get() is False
+
+
+def test_get_user_input_cancels_on_include_paths_interrupt(monkeypatch):
+    """Ctrl-C during path inclusion must cancel preprocessing, not print Ctrl-D."""
+    import sys
+
+    from gptme.chat import _get_user_input
+    from gptme.logmanager import Log
+    from gptme.message import Message
+    from gptme.util.interrupt import _interruptible_var, clear_interruptible
+
+    _chat_mod = sys.modules["gptme.chat"]
+
+    def fake_include_paths(msg, workspace=None, **kwargs):
+        assert _interruptible_var.get() is True
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(_chat_mod, "include_paths", fake_include_paths)
+    monkeypatch.setattr(_chat_mod, "prompt_user", lambda value=None: "hello /")
+    clear_interruptible()
+
+    result = _get_user_input(Log(messages=[Message("assistant", "ok")]), None)
+    assert result is None
+    assert _interruptible_var.get() is False

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -420,47 +420,148 @@ def test_dir_to_listing_truncation(tmp_path):
 
 
 def test_dir_to_listing_bounds_rglob_walk(tmp_path):
-    """rglob fallback must stop walking once max_entries files are collected."""
+    """Fallback must stop once max_entries accepted files are collected."""
     from unittest.mock import MagicMock, patch
 
     from gptme.util.context import _dir_to_listing
 
-    walked = {"n": 0}
-
-    class FakePath:
-        def __init__(self, name: str):
-            self._name = name
-
-        def is_file(self) -> bool:
-            return True
-
-        def relative_to(self, _path):
-            from pathlib import Path
-
-            return Path(self._name)
-
-    def fake_rglob(_pattern):
-        while True:
-            walked["n"] += 1
-            if walked["n"] > 200:
-                raise AssertionError("unbounded rglob walk")
-            yield FakePath(f"file_{walked['n']:03d}.txt")
-
     bigdir = tmp_path / "big"
     bigdir.mkdir()
+    for i in range(80):
+        (bigdir / f"file_{i:03d}.txt").write_text("x")
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+
+    with patch("subprocess.run", return_value=mock_result):
+        result = _dir_to_listing(bigdir, str(bigdir), max_entries=50)
+
+    assert result is not None
+    assert "listing truncated at 50 files" in result
+    assert result.count(".txt") == 50
+
+
+def test_dir_to_listing_bounds_directory_heavy_walk(tmp_path):
+    """Visit budget stops a tree of directories with almost no files."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.util.context import _dir_to_listing
+
+    tree = tmp_path / "dirs"
+    tree.mkdir()
+    cursor = tree
+    for i in range(80):
+        cursor = cursor / f"d{i:02d}"
+        cursor.mkdir()
+    (cursor / "deep.txt").write_text("late")
+    (tree / "early.txt").write_text("early")
+
+    scandir_calls: list[str] = []
+    real_scandir = __import__("os").scandir
+
+    def spy_scandir(path):
+        scandir_calls.append(str(path))
+        if len(scandir_calls) > 40:
+            raise AssertionError("visit budget did not bound directory traversal")
+        return real_scandir(path)
+
     mock_result = MagicMock()
     mock_result.returncode = 1
     mock_result.stdout = ""
 
     with (
         patch("subprocess.run", return_value=mock_result),
-        patch.object(type(bigdir), "rglob", lambda self, pattern: fake_rglob(pattern)),
+        patch("os.scandir", side_effect=spy_scandir),
     ):
-        result = _dir_to_listing(bigdir, str(bigdir), max_entries=50)
+        result = _dir_to_listing(
+            tree, str(tree), max_entries=50, max_visited=12, max_seconds=2.0
+        )
 
     assert result is not None
-    assert "listing truncated at 50 files" in result
-    assert walked["n"] == 51
+    assert "deep.txt" not in result
+    assert len(scandir_calls) < 40
+
+
+def test_dir_to_listing_prunes_git_before_recursion(tmp_path):
+    """`.git` is counted as an excluded entry and never descended into."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.util.context import _dir_to_listing
+
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "readme.txt").write_text("ok")
+    git_objects = project / ".git" / "objects" / "aa"
+    git_objects.mkdir(parents=True)
+    for i in range(80):
+        (git_objects / f"{i:02d}").write_text("blob")
+
+    scandir_paths: list[str] = []
+    real_scandir = __import__("os").scandir
+
+    def spy_scandir(path):
+        scandir_paths.append(str(path))
+        return real_scandir(path)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("os.scandir", side_effect=spy_scandir),
+    ):
+        result = _dir_to_listing(project, str(project), max_entries=50, max_visited=20)
+
+    assert "readme.txt" in result
+    assert ".git/" not in result
+    assert not any(".git" in path.split("/") for path in scandir_paths)
+
+
+def test_dir_to_listing_bounds_excluded_entries(tmp_path):
+    """Directory entries consume the visit budget even when they yield no files."""
+    from gptme.util.context import _fallback_dir_listing
+
+    tree = tmp_path / "mixed"
+    tree.mkdir()
+    cursor = tree
+    for i in range(30):
+        cursor = cursor / f"dir_{i:02d}"
+        cursor.mkdir()
+    (cursor / "late.txt").write_text("late")
+    (tree / "only.txt").write_text("one")
+
+    entries, truncated = _fallback_dir_listing(
+        tree, max_entries=50, max_visited=10, max_seconds=2.0
+    )
+    assert truncated
+    assert "late.txt" not in entries
+    assert all(not name.endswith("late.txt") for name in entries)
+
+
+def test_dir_to_listing_time_budget(tmp_path):
+    """A zero-second deadline stops the walk without collecting the tree."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.util.context import _dir_to_listing
+
+    tree = tmp_path / "timed"
+    tree.mkdir()
+    nested = tree / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    (nested / "late.txt").write_text("late")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+
+    with patch("subprocess.run", return_value=mock_result):
+        result = _dir_to_listing(
+            tree, str(tree), max_entries=50, max_visited=1000, max_seconds=0.0
+        )
+
+    assert result is not None
+    assert "late.txt" not in result
 
 
 def test_dir_to_listing_nested(tmp_path):
@@ -638,12 +739,31 @@ def test_is_too_broad_directory_root_and_home():
     assert _is_too_broad_directory(Path.home())
 
 
+def test_is_too_broad_directory_temp_roots():
+    """Temp roots are blocked by resolved identity, not path depth.
+
+    On macOS /tmp resolves to /private/tmp (three parts), which the old
+    len(parts) < 3 heuristic treated as a project directory.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from gptme.util.context import _is_too_broad_directory
+
+    assert _is_too_broad_directory(Path("/tmp"))
+    assert _is_too_broad_directory(Path("/private/tmp"))
+    assert _is_too_broad_directory(Path("/var/tmp"))
+    assert _is_too_broad_directory(Path(tempfile.gettempdir()))
+
+
 def test_is_too_broad_directory_allows_project_subdir(tmp_path):
     from gptme.util.context import _is_too_broad_directory
 
     sub = tmp_path / "src"
     sub.mkdir()
     assert not _is_too_broad_directory(sub)
+    # Nested temp workspaces must remain attachable.
+    assert not _is_too_broad_directory(tmp_path)
 
 
 def test_include_paths_does_not_scan_root(monkeypatch):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -398,20 +398,69 @@ def test_dir_to_listing_all_gitignored(tmp_path, monkeypatch):
 
 
 def test_dir_to_listing_truncation(tmp_path):
-    """Test that large directories are truncated."""
+    """git ls-files listings are truncated after the known total is computed."""
+    from unittest.mock import MagicMock, patch
+
     from gptme.util.context import _dir_to_listing
 
     bigdir = tmp_path / "big"
     bigdir.mkdir()
-    for i in range(60):
-        (bigdir / f"file_{i:03d}.txt").write_text(f"content {i}")
+    files = [f"file_{i:03d}.txt" for i in range(60)]
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "\n".join(files) + "\n"
 
-    result = _dir_to_listing(bigdir, str(bigdir), max_entries=50)
+    with patch("subprocess.run", return_value=mock_result):
+        result = _dir_to_listing(bigdir, str(bigdir), max_entries=50)
     assert result is not None
     assert "10 more files" in result
-    # First 50 should be included
     assert "file_000.txt" in result
     assert "file_049.txt" in result
+    assert "file_059.txt" not in result
+
+
+def test_dir_to_listing_bounds_rglob_walk(tmp_path):
+    """rglob fallback must stop walking once max_entries files are collected."""
+    from unittest.mock import MagicMock, patch
+
+    from gptme.util.context import _dir_to_listing
+
+    walked = {"n": 0}
+
+    class FakePath:
+        def __init__(self, name: str):
+            self._name = name
+
+        def is_file(self) -> bool:
+            return True
+
+        def relative_to(self, _path):
+            from pathlib import Path
+
+            return Path(self._name)
+
+    def fake_rglob(_pattern):
+        while True:
+            walked["n"] += 1
+            if walked["n"] > 200:
+                raise AssertionError("unbounded rglob walk")
+            yield FakePath(f"file_{walked['n']:03d}.txt")
+
+    bigdir = tmp_path / "big"
+    bigdir.mkdir()
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch.object(type(bigdir), "rglob", lambda self, pattern: fake_rglob(pattern)),
+    ):
+        result = _dir_to_listing(bigdir, str(bigdir), max_entries=50)
+
+    assert result is not None
+    assert "listing truncated at 50 files" in result
+    assert walked["n"] == 51
 
 
 def test_dir_to_listing_nested(tmp_path):
@@ -578,3 +627,44 @@ def test_include_paths_pre_confirmed_urls_empty_skips_all(tmp_path, monkeypatch)
     mock_confirm.assert_not_called()
     # URL should not be fetched — result content is unchanged (just the original text)
     assert result.content == msg.content
+
+
+def test_is_too_broad_directory_root_and_home():
+    from pathlib import Path
+
+    from gptme.util.context import _is_too_broad_directory
+
+    assert _is_too_broad_directory(Path("/"))
+    assert _is_too_broad_directory(Path.home())
+
+
+def test_is_too_broad_directory_allows_project_subdir(tmp_path):
+    from gptme.util.context import _is_too_broad_directory
+
+    sub = tmp_path / "src"
+    sub.mkdir()
+    assert not _is_too_broad_directory(sub)
+
+
+def test_include_paths_does_not_scan_root(monkeypatch):
+    """A standalone slash must not trigger recursive root listing.
+
+    Do not enumerate the real root filesystem; mock the listing helper.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+    with patch(
+        "gptme.util.context._dir_to_listing",
+        return_value="[listing suppressed]",
+    ) as listing:
+        include_paths(
+            Message("user", "also file the rm -rf / false-positive"),
+            Path.cwd(),
+        )
+        called_paths = [Path(c.args[0]).resolve() for c in listing.call_args_list]
+        assert Path("/") not in called_paths

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -788,3 +788,45 @@ def test_include_paths_does_not_scan_root(monkeypatch):
         )
         called_paths = [Path(c.args[0]).resolve() for c in listing.call_args_list]
         assert Path("/") not in called_paths
+
+
+def test_include_paths_does_not_scan_root_from_markdown_heading(monkeypatch):
+    """Ordinary markdown ' / ' must not attach filesystem root (#3758)."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+    with patch(
+        "gptme.util.context._dir_to_listing",
+        return_value="[listing suppressed]",
+    ) as listing:
+        include_paths(
+            Message("user", "**Still open / not done:**"),
+            Path.cwd(),
+        )
+        assert listing.call_args_list == []
+
+
+def test_include_paths_does_not_scan_tmp_from_prose(monkeypatch):
+    """Prose mentioning /tmp must not attach the temp root (#3758)."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    monkeypatch.delenv("GPTME_DISABLE_PATH_INCLUDE", raising=False)
+    with patch(
+        "gptme.util.context._dir_to_listing",
+        return_value="[listing suppressed]",
+    ) as listing:
+        include_paths(
+            Message("user", "rm -rf /tmp,"),
+            Path.cwd(),
+        )
+        called_paths = [Path(c.args[0]).resolve() for c in listing.call_args_list]
+        tmp_roots = {Path("/tmp").resolve(), Path("/private/tmp").resolve()}
+        assert tmp_roots.isdisjoint(called_paths)


### PR DESCRIPTION
## Summary

A user message mentioning a standalone `/` triggered `include_paths` → `_dir_to_listing('/')`. The rglob fallback enumerated the whole tree before applying `max_entries`, and `prompt_user()` cleared interruptible state before that preprocessing, so Ctrl-C only printed the Ctrl-D hint.

This PR:

- Skips implicit attachment of filesystem roots / other too-broad directories
- Bounds the rglob walk itself (does not collect-then-truncate)
- Re-enables interruptible state around `include_paths` so Ctrl-C cancels preprocessing
- Preserves listings for explicit project subdirectories

Tests mock `_dir_to_listing` and never scan the real root.

Fixes #3758

## Test plan

- [x] `uv run pytest tests/test_context.py tests/test_chat.py tests/test_util_interrupt.py` (92 passed)
- [x] Reproduction from #3758 with `_dir_to_listing` mocked: `/` is not listed
- [x] Caller interrupt state around `include_paths` covered