### PR TITLE
fix(cli): reject ambiguous positional resume IDs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,8 +60,19 @@ Give a conversation an explicit name so you can return to it later:
     # Resume that same conversation in a future session
     gptme --name my-refactor
 
-    # Resume the most recently modified conversation (any name)
+    # Resume the most recently modified conversation in the current workspace
     gptme -r
+
+``--resume`` (or ``-r``) is a flag, not an option taking a conversation ID.
+Use ``gptme --resume --name my-refactor`` to select a specific existing
+conversation and fail if it does not exist. Positional arguments are new
+prompts: ``gptme --resume "continue"`` sends a follow-up to the latest
+conversation. An apparent positional conversation ID is rejected with
+guidance instead of silently sending it to a different conversation; use
+``gptme --resume -- my-refactor`` if you really intend the ID as prompt text.
+
+Separate invocations in the same terminal can create separate conversations.
+Check the startup ``Using logdir`` line when choosing which history to resume.
 
 Without ``--name``, gptme assigns a random name (e.g. ``hopping-blue-robot``).
 

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -613,7 +613,7 @@ Run 'gptme-util --help' for all utility commands."""
     "-r",
     "--resume",
     is_flag=True,
-    help="Load most recent conversation.",
+    help="Load the most recent conversation in this workspace. Use --name ID to select one.",
 )
 @click.option(
     "-y",
@@ -902,6 +902,32 @@ def main(
     # (observed to occur in some Click versions when --name "" is passed)
     if not name or not name.strip():
         name = "random"
+
+    # --resume is a flag, not an option taking an ID. A positional session
+    # name would otherwise be sent as a new prompt to the *latest* conversation.
+    # Keep ordinary continuation prompts and explicit "--" literals working.
+    if (
+        resume
+        and name == "random"
+        and prompts
+        and not dispatch_suppressed
+        and not show_version
+    ):
+        import re
+
+        from ..logmanager import conversation_name_error
+
+        candidate = prompts[0]
+        if not conversation_name_error(candidate) and (
+            re.fullmatch(r"\d{4}-\d{2}-\d{2}-[\w-]+", candidate)
+            or (get_logs_dir() / candidate / "conversation.jsonl").is_file()
+        ):
+            raise click.UsageError(
+                "--resume does not take a conversation ID as a positional argument. "
+                f"Use --resume --name {shlex.quote(candidate)} to select that conversation. "
+                "To send the ID as a literal prompt to the latest conversation, "
+                f"use --resume -- {shlex.quote(candidate)}."
+            )
 
     if no_workspace and context_include:
         raise click.UsageError(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2061,3 +2061,106 @@ class TestPluginDiscovery:
 def _record_subprocess_call(args, calls: list[list[str]]) -> int:
     calls.append(list(args))
     return 0
+
+
+@pytest.mark.parametrize("extra_prompts", [[], ["continue"]])
+def test_resume_rejects_positional_conversation_id_before_setup(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, extra_prompts: list[str]
+) -> None:
+    """A session ID must not silently become a prompt in the latest session."""
+    target = _write_conversation("resume-positional-target", workspace=Path.cwd())
+    _write_conversation("resume-positional-newer", workspace=Path.cwd())
+    before = (target / "conversation.jsonl").read_bytes()
+    monkeypatch.setattr(
+        "gptme.telemetry.init_telemetry",
+        lambda **kwargs: pytest.fail("ambiguous resume reached setup"),
+    )
+    result = runner.invoke(
+        cli.main, ["--resume", target.name, *extra_prompts, "--non-interactive"]
+    )
+    assert result.exit_code == 2, result.output
+    assert "--resume does not take a conversation ID" in result.output
+    assert f"--resume --name {target.name}" in result.output
+    assert (target / "conversation.jsonl").read_bytes() == before
+
+
+def test_resume_rejects_missing_generated_positional_id(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "gptme.telemetry.init_telemetry",
+        lambda **kwargs: pytest.fail("ambiguous resume reached setup"),
+    )
+    result = runner.invoke(
+        cli.main, ["--resume", "2026-01-02-running-blue-cat", "--non-interactive"]
+    )
+    assert result.exit_code == 2, result.output
+    assert "--resume --name 2026-01-02-running-blue-cat" in result.output
+
+
+@pytest.mark.parametrize(
+    "mode", ["named", "named-latest", "named-prompt", "prompt", "literal"]
+)
+def test_resume_selection_loads_complete_history(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mode: str
+) -> None:
+    """Selection + real loader preserve late messages, not just the first turn."""
+    from gptme.logmanager import Log, LogManager
+
+    workspace = tmp_path / "workspace"
+    older = _write_conversation("resume-full-older", workspace=workspace)
+    latest = _write_conversation("resume-full-latest", workspace=workspace)
+    histories = {}
+    for logdir, count in [(older, 4), (latest, 270)]:
+        messages = [
+            Message("user" if i % 2 == 0 else "assistant", f"{logdir.name}: {i}")
+            for i in range(count)
+        ]
+        Log(messages).write_jsonl(logdir / "conversation.jsonl")
+        histories[logdir] = [m.content for m in messages]
+    os.utime(older / "conversation.jsonl", (1, 1))
+    os.utime(latest / "conversation.jsonl", (2, 2))
+    snapshots = {p: (p / "conversation.jsonl").read_bytes() for p in [older, latest]}
+    seen = []
+    monkeypatch.setattr("gptme.telemetry.init_telemetry", lambda **kwargs: None)
+
+    def fake_chat(
+        prompt_msgs: list[Message],
+        initial_msgs: list[Message],
+        logdir: Path,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        # Exercise actual disk loading, while stopping before any LLM request.
+        manager = LogManager.load(logdir, initial_msgs=initial_msgs, lock=False)
+        seen.append(
+            (logdir, [m.content for m in manager.log], [m.content for m in prompt_msgs])
+        )
+
+    monkeypatch.setattr(importlib.import_module("gptme.chat"), "chat", fake_chat)
+    expected_prompts: list[str]
+    if mode == "named":
+        # Explicit --name always wins, even with a newer session in the same cwd.
+        args = ["--name", older.name]
+        expected_dir, expected_prompts = older, []
+    elif mode == "named-latest":
+        args = ["--name", latest.name]
+        expected_dir, expected_prompts = latest, []
+    elif mode == "named-prompt":
+        args = ["--name", older.name, latest.name]
+        expected_dir, expected_prompts = older, [latest.name]
+    elif mode == "literal":
+        args = ["--", older.name]
+        expected_dir, expected_prompts = latest, [older.name]
+    else:
+        args = ["continue"]
+        expected_dir, expected_prompts = latest, ["continue"]
+    result = runner.invoke(
+        cli.main,
+        ["--resume", "--workspace", str(workspace), "--non-interactive", *args],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert seen == [(expected_dir, histories[expected_dir], expected_prompts)]
+    for path, before in snapshots.items():
+        assert (path / "conversation.jsonl").read_bytes() == before

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2485,10 +2485,8 @@ class TestContextWindowValidation:
     def test_context_window_zero_is_valid(self, monkeypatch, tmp_path):
         """context_window=0 must not raise — it is the minimal-context mode.
 
-        This validates the synchronous guard in subagent() (line 159) accepts
-        context_window=0. Forwarding to _create_subagent_thread happens in a
-        daemon thread and requires thread synchronization to test — that is
-        covered at the integration level.
+        Keep the executor mocked until the daemon thread exits: a real executor
+        can lazy-import provider modules after teardown and race the next test.
         """
         import importlib
 
@@ -2501,15 +2499,23 @@ class TestContextWindowValidation:
         monkeypatch.setattr(
             exec_mod, "get_slot_sem", lambda: __import__("threading").Semaphore(10)
         )
+        create_thread = MagicMock()
+        monkeypatch.setattr(exec_mod, "_create_subagent_thread", create_thread)
 
         from gptme.tools.subagent.api import subagent
         from gptme.tools.subagent.types import _subagents, _subagents_lock
 
         subagent("isolation-test", "do something", context_window=0)
 
-        # Clean up registered subagent
+        # Join inside the mock window, and leave the agent registered so the
+        # autouse cleanup can still find it if this assertion fails.
         with _subagents_lock:
-            _subagents[:] = [s for s in _subagents if s.agent_id != "isolation-test"]
+            sa = next(s for s in _subagents if s.agent_id == "isolation-test")
+        assert sa.thread is not None
+        sa.thread.join(timeout=5)
+        assert not sa.thread.is_alive(), "subagent must finish before mocks revert"
+        create_thread.assert_called_once()
+        assert create_thread.call_args.kwargs["context_window"] == 0
 
 
 class TestWorkdir:


### PR DESCRIPTION
## Summary
- Reject an apparent session ID passed positionally after the boolean --resume flag, before it can become a new prompt in the latest session.
- Explain --resume --name ID and the literal --resume -- ID escape; clarify current-workspace selection in help/docs.
- Preserve ordinary follow-up prompts and explicit named resumes.
- Regression tests exercise CLI selection plus real disk loading of a 270-message history, explicit older/newer sessions, literal prompts, missing generated IDs, and unchanged log files.

The investigated apparent truncation was selection of an older conversation from the same terminal pane; the longer history remained intact. This PR fixes the demonstrated argument ambiguity rather than claiming a log-recovery defect.

Fixes #3760. Independent of the directory-preprocessing freeze in #3758.

## Validation
- Before fix: 3 new ambiguity tests failed; full-history selection tests already passed.
- Targeted resume/loading/persistence tests: 25 passed.
- CLI + log-manager tests excluding slow/API tests: 160 passed.
- prek on changed files: passed (including mypy and documentation checks).
- No real conversation data or destructive commands in tests.
