### PR TITLE
feat(memory): Codex/AGENTS.md integration for cross-harness memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,54 @@ CI benchmarks enforce startup thresholds.
 
 See [docs/glossary.md](docs/glossary.md) for full terminology.
 
+## Memory
+
+gptme uses a cross-harness memory store that is shared between gptme, Claude
+Code, and Codex sessions. Memories are Claude Code–compatible Markdown files
+written to the CC per-project directory and optionally to a `memory/` folder
+at the workspace root.
+
+### Recall at session start
+
+Run recall once to surface the entries most relevant to the current task:
+
+```bash
+gptme-util memory recall "<one-line task description>" -k 5
+```
+
+If `gptme-rag` (with the `lexical` extra) is installed the TF-IDF backend is
+used automatically; a deterministic token-overlap fallback is used otherwise.
+The output line always names the backend that ran.
+
+### Save a memory
+
+When you learn something worth keeping across sessions — a user preference, a
+project decision, a recurring pattern — persist it:
+
+```bash
+gptme-util memory save <slug> "<one-line description>" --type <type> <<'EOF'
+<body — as many lines as useful>
+EOF
+```
+
+Valid `--type` values: `user`, `feedback`, `project`, `reference`.
+
+The entry is written to the nearest writable root (project `memory/` when
+present, else the CC per-project directory) and indexed automatically by both
+gptme and Claude Code in their next session.
+
+### Inspect and manage
+
+```bash
+gptme-util memory roots          # Which roots are active for this workspace
+gptme-util memory list           # All living entries across all roots
+gptme-util memory show <slug>    # Full text of one entry
+gptme-util memory index --write  # Regenerate MEMORY.md (auto-loaded by CC)
+```
+
+See [docs/memory.rst](docs/memory.rst) or <https://gptme.org/docs/memory.html>
+for the full reference.
+
 ## Subsystem Guides
 
 - [webui/AGENTS.md](webui/AGENTS.md) - Web UI architecture and gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,8 @@ See [docs/glossary.md](docs/glossary.md) for full terminology.
 
 gptme uses a cross-harness memory store that is shared between gptme, Claude
 Code, and Codex sessions. Memories are Claude Code–compatible Markdown files
-written to the CC per-project directory and optionally to a `memory/` folder
-at the workspace root.
+in layered roots: project `memory/` when that directory exists, then the
+Claude Code per-project directory, then agent/user roots.
 
 ### Recall at session start
 
@@ -97,7 +97,8 @@ gptme-util memory recall "<one-line task description>" -k 5
 
 If `gptme-rag` (with the `lexical` extra) is installed the TF-IDF backend is
 used automatically; a deterministic token-overlap fallback is used otherwise.
-The output line always names the backend that ran.
+The output line always names the backend that ran (`backend=tfidf` or
+`backend=overlap`). Recall searches every layered root.
 
 ### Save a memory
 
@@ -112,9 +113,13 @@ EOF
 
 Valid `--type` values: `user`, `feedback`, `project`, `reference`.
 
-The entry is written to the nearest writable root (project `memory/` when
-present, else the CC per-project directory) and indexed automatically by both
-gptme and Claude Code in their next session.
+Default write root is project `memory/` if that directory exists, else
+`~/.claude/projects/<workspace-hash>/memory/`. Existence is the only check —
+an unwritable project directory is an error, not a fallback. `recall` (and
+the Claude Code hook) search every layered root, so other harnesses see the
+entry on their next recall. gptme's session-start workspace prompt and
+Claude Code's native `MEMORY.md` auto-load only the CC root; pass
+`--scope cc` when that auto-load path is required.
 
 ### Inspect and manage
 
@@ -122,7 +127,7 @@ gptme and Claude Code in their next session.
 gptme-util memory roots          # Which roots are active for this workspace
 gptme-util memory list           # All living entries across all roots
 gptme-util memory show <slug>    # Full text of one entry
-gptme-util memory index --write  # Regenerate MEMORY.md (auto-loaded by CC)
+gptme-util memory index --write  # Regenerate MEMORY.md in the write root
 ```
 
 See [docs/memory.rst](docs/memory.rst) or <https://gptme.org/docs/memory.html>

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -92,7 +92,14 @@ The two key patterns for Codex agents:
 Valid ``--type`` values match Claude Code's memory taxonomy: ``user``,
 ``feedback``, ``project``, ``reference``.
 
-The entry is written to the nearest writable root (project ``memory/`` if it
-exists, otherwise ``~/.claude/projects/<workspace-hash>/memory/``) and will
-be picked up automatically by Claude Code and gptme in their next session —
-completing the write path for cross-harness memory sharing.
+The entry is written to project ``memory/`` when that directory exists,
+otherwise to ``~/.claude/projects/<workspace-hash>/memory/``. The selector
+checks existence, not writability: an unwritable project directory makes
+``save`` fail rather than falling back.
+
+``gptme-util memory recall`` (and the Claude Code hook) search every
+layered root, so other harnesses see the entry on their next recall.
+gptme's session-start workspace prompt and Claude Code's native
+``MEMORY.md`` auto-load only the Claude Code root. Pass ``--scope cc``
+when the memory must appear on that auto-load path without running
+recall.

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -64,3 +64,35 @@ returns a valid ``additionalContext`` response:
 The hook is read-only and returns empty ``additionalContext`` when there is no
 relevant memory. Keep the executable on Claude Code's hook ``PATH``; if the
 workspace uses an isolated environment, call its absolute ``gptme-util`` path.
+
+Codex / AGENTS.md integration
+------------------------------
+
+Codex has no hook mechanism, so memory access is driven by instructions in
+``AGENTS.md``. The gptme repository's own ``AGENTS.md`` already contains a
+``## Memory`` section; copy or adapt it for any workspace that runs Codex
+sessions.
+
+The two key patterns for Codex agents:
+
+**Recall at session start** — surface memories relevant to the current task:
+
+.. code-block:: bash
+
+   gptme-util memory recall "<one-line task description>" -k 5
+
+**Save a memory** — persist something worth keeping across sessions:
+
+.. code-block:: bash
+
+   gptme-util memory save <slug> "<one-line description>" --type <type> <<'EOF'
+   <body>
+   EOF
+
+Valid ``--type`` values match Claude Code's memory taxonomy: ``user``,
+``feedback``, ``project``, ``reference``.
+
+The entry is written to the nearest writable root (project ``memory/`` if it
+exists, otherwise ``~/.claude/projects/<workspace-hash>/memory/``) and will
+be picked up automatically by Claude Code and gptme in their next session —
+completing the write path for cross-harness memory sharing.

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -21,6 +21,26 @@ Inspect and write memory
 ``index`` prints by default. Pass ``--write`` only when you want to replace the
 selected root's ``MEMORY.md`` with a generated index.
 
+Supersession and audit
+----------------------
+
+Replace an obsolete entry with an already-existing living entry, then check the
+root's strict YAML and bidirectional supersession links:
+
+.. code-block:: console
+
+   $ gptme-util memory supersede old-belief new-belief
+   $ gptme-util memory audit
+   $ gptme-util memory audit --quiet
+
+``supersede`` updates both entries (``superseded_by`` on the old entry and
+``supersedes`` on the replacement) and regenerates the selected root's index.
+Both entries must be in the same root; use ``--scope`` when needed. The command
+refuses malformed YAML and invalid field types rather than rewriting them
+through the lenient read fallback. ``audit`` exits non-zero for malformed
+entries, duplicate names, dangling targets, or asymmetric links, making
+``audit --quiet`` suitable for lifecycle hooks.
+
 Recall
 ------
 

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -276,7 +276,7 @@ def memory_supersede(old_name: str, new_name: str, scope: str | None):
         old, new = _store().supersede(old_name, new_name, scope=scope)
     except (KeyError, OSError, ValueError) as e:
         raise click.ClickException(str(e)) from e
-    click.echo(f"Superseded {old.name} -> {new.name}")
+    click.echo(f"Superseded {_clean(old.name)} -> {_clean(new.name)}")
 
 
 @memory.command("audit")

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -266,6 +266,36 @@ def memory_recall(
         click.echo(rendered)
 
 
+@memory.command("supersede")
+@click.argument("old_name")
+@click.argument("new_name")
+@click.option("--scope", help="Root containing both entries (default: write root).")
+def memory_supersede(old_name: str, new_name: str, scope: str | None):
+    """Mark OLD_NAME superseded by NEW_NAME and link both entries."""
+    try:
+        old, new = _store().supersede(old_name, new_name, scope=scope)
+    except (KeyError, OSError, ValueError) as e:
+        raise click.ClickException(str(e)) from e
+    click.echo(f"Superseded {old.name} -> {new.name}")
+
+
+@memory.command("audit")
+@click.option("--scope", help="Root to audit (default: write root).")
+@click.option("--quiet", is_flag=True, help="Print nothing when the audit passes.")
+def memory_audit(scope: str | None, quiet: bool):
+    """Check strict YAML parsing and supersession links."""
+    try:
+        issues = _store().audit(scope=scope)
+    except KeyError as e:
+        raise click.ClickException(str(e)) from e
+    for issue in issues:
+        click.echo(f"{issue.code}: {issue.entry}: {issue.detail}")
+    if issues:
+        raise click.exceptions.Exit(1)
+    if not quiet:
+        click.echo("Memory audit passed")
+
+
 @memory.command("index")
 @click.option("--scope", help="Root whose index to generate (default: the write root).")
 @click.option("--write", is_flag=True, help="Write MEMORY.md instead of printing it.")

--- a/gptme/memory/__init__.py
+++ b/gptme/memory/__init__.py
@@ -13,11 +13,19 @@ from .recall import (
     render_recall,
 )
 from .roots import MemoryRoot, resolve_roots
-from .schema import MemoryEntry, MemoryParseError, parse_entry, slugify
-from .store import MemoryStore, update_index_line
+from .schema import (
+    MemoryEntry,
+    MemoryFrontmatterError,
+    MemoryParseError,
+    parse_entry,
+    slugify,
+)
+from .store import AuditIssue, MemoryStore, update_index_line
 
 __all__ = [
+    "AuditIssue",
     "MemoryEntry",
+    "MemoryFrontmatterError",
     "MemoryParseError",
     "MemoryRoot",
     "MemoryStore",

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -243,13 +243,17 @@ def entry_from_text(
         raw_name = data["name"]
         if strict and (not isinstance(raw_name, str) or not raw_name.strip()):
             raise MemoryFrontmatterError("invalid name: expected non-empty string")
+        # Strict mode already rejected non-string names above.
+        # Lenient mode preserves the old behaviour: coerce truthy non-strings
+        # with str() so existing entries with e.g. ``name: 42`` keep their
+        # identity instead of silently switching to the filename stem.
         name = (
             raw_name
             if isinstance(raw_name, str) and raw_name
-            else (path.stem if path is not None else None)
+            else (
+                str(raw_name) if raw_name else (path.stem if path is not None else None)
+            )
         )
-        if name is not None and not isinstance(name, str):
-            name = str(name)
     else:
         name = path.stem if path is not None else None
     if not name:

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -33,6 +33,10 @@ class MemoryParseError(ValueError):
     """Raised when a file is not a memory entry (no or unusable frontmatter)."""
 
 
+class MemoryFrontmatterError(MemoryParseError):
+    """Raised when strict parsing is required but the YAML is invalid."""
+
+
 def slugify(name: str) -> str:
     """Convert a name to a safe filename slug (``My Fact!`` → ``my-fact``)."""
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")
@@ -174,71 +178,156 @@ def _lenient_load(raw: str) -> dict[str, Any]:
     return data
 
 
-def parse_frontmatter(raw: str) -> dict[str, Any]:
+def parse_frontmatter(raw: str, *, strict: bool = False) -> dict[str, Any]:
     try:
         loaded = yaml.safe_load(raw)
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        if strict:
+            raise MemoryFrontmatterError(f"invalid YAML: {exc}") from exc
         return _lenient_load(raw)
     if not isinstance(loaded, dict):
+        if strict:
+            raise MemoryFrontmatterError("invalid YAML: frontmatter is not a mapping")
         return _lenient_load(raw)
     return loaded
 
 
-def _as_list(value: Any) -> list[str]:
+def _as_list(
+    value: Any, *, field_name: str = "value", strict: bool = False
+) -> list[str]:
     if value is None:
         return []
     if isinstance(value, str):
         return [value]
+    if strict and (
+        not isinstance(value, list) or not all(isinstance(v, str) for v in value)
+    ):
+        raise MemoryFrontmatterError(f"invalid {field_name}: expected string list")
+    if not isinstance(value, list):
+        return [str(value)]
     return [str(v) for v in value]
 
 
+def _optional_str(value: Any, *, field_name: str, strict: bool = False) -> str | None:
+    if value is None or value == "":
+        return None
+    if strict and not isinstance(value, str):
+        raise MemoryFrontmatterError(f"invalid {field_name}: expected string")
+    return str(value)
+
+
 def entry_from_text(
-    text: str, path: Path | None = None, scope: str | None = None
+    text: str,
+    path: Path | None = None,
+    scope: str | None = None,
+    *,
+    strict: bool = False,
 ) -> MemoryEntry:
     parts = split_frontmatter(text)
     if parts is None:
         raise MemoryParseError(f"no frontmatter: {path or '<text>'}")
     raw, body = parts
-    data = parse_frontmatter(raw)
+    data = parse_frontmatter(raw, strict=strict)
     if not data:
         raise MemoryParseError(f"empty frontmatter: {path or '<text>'}")
 
-    metadata = data.get("metadata")
-    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    raw_metadata = data.get("metadata")
+    if strict and raw_metadata is not None and not isinstance(raw_metadata, dict):
+        raise MemoryFrontmatterError("invalid metadata: expected mapping")
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
     type_ = metadata.pop("type", None) or data.get("type") or DEFAULT_TYPE
+    if strict and not isinstance(type_, str):
+        raise MemoryFrontmatterError("invalid type: expected string")
 
-    name = data.get("name") or (path.stem if path is not None else None)
+    if "name" in data:
+        raw_name = data["name"]
+        if strict and (not isinstance(raw_name, str) or not raw_name.strip()):
+            raise MemoryFrontmatterError("invalid name: expected non-empty string")
+        name = (
+            raw_name
+            if isinstance(raw_name, str) and raw_name
+            else (path.stem if path is not None else None)
+        )
+        if name is not None and not isinstance(name, str):
+            name = str(name)
+    else:
+        name = path.stem if path is not None else None
     if not name:
         raise MemoryParseError(f"entry has no name: {path or '<text>'}")
 
     confidence = data.get("confidence")
-    try:
-        confidence = float(confidence) if confidence is not None else None
-    except (TypeError, ValueError):
-        confidence = None
+    if confidence is None:
+        parsed_confidence = None
+    elif isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        if strict:
+            raise MemoryFrontmatterError("invalid confidence: expected number")
+        try:
+            parsed_confidence = float(confidence)
+        except (TypeError, ValueError):
+            parsed_confidence = None
+    else:
+        parsed_confidence = float(confidence)
+    if strict and parsed_confidence is not None and not 0 <= parsed_confidence <= 1:
+        raise MemoryFrontmatterError("invalid confidence: expected 0..1")
 
     provenance = data.get("provenance")
-    status = str(data.get("status") or DEFAULT_STATUS)
+    if strict and provenance is not None and not isinstance(provenance, dict):
+        raise MemoryFrontmatterError("invalid provenance: expected mapping")
+    if "status" in data:
+        raw_status = data["status"]
+    else:
+        raw_status = DEFAULT_STATUS
+    if strict:
+        if not isinstance(raw_status, str) or raw_status not in STATUSES:
+            raise MemoryFrontmatterError(
+                f"invalid status: expected one of {', '.join(STATUSES)}"
+            )
+        status = raw_status
+    else:
+        status = str(raw_status) if raw_status else DEFAULT_STATUS
+        if status not in STATUSES:
+            status = DEFAULT_STATUS
+
+    raw_description = data.get("description")
+    if raw_description is None:
+        description = ""
+    elif strict and not isinstance(raw_description, str):
+        raise MemoryFrontmatterError("invalid description: expected string")
+    else:
+        description = str(raw_description).strip()
+
+    raw_title = data.get("title")
+    if strict and raw_title is not None and not isinstance(raw_title, str):
+        raise MemoryFrontmatterError("invalid title: expected string")
+    title = str(raw_title) if raw_title else None
 
     return MemoryEntry(
         name=str(name),
-        description=str(data.get("description") or "").strip(),
+        description=description,
         type=str(type_),
         body=body.strip("\n"),
-        title=str(data["title"]) if data.get("title") else None,
-        status=status if status in STATUSES else DEFAULT_STATUS,
-        supersedes=_as_list(data.get("supersedes")),
-        superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
+        title=title,
+        status=status,
+        supersedes=_as_list(
+            data.get("supersedes"), field_name="supersedes", strict=strict
+        ),
+        superseded_by=_optional_str(
+            data.get("superseded_by"), field_name="superseded_by", strict=strict
+        ),
         provenance=dict(provenance) if isinstance(provenance, dict) else {},
-        confidence=confidence,
-        keywords=_as_list(data.get("keywords")),
-        recheck=str(data["recheck"]) if data.get("recheck") else None,
+        confidence=parsed_confidence,
+        keywords=_as_list(data.get("keywords"), field_name="keywords", strict=strict),
+        recheck=_optional_str(data.get("recheck"), field_name="recheck", strict=strict),
         metadata=metadata,
         path=path,
         scope=scope,
     )
 
 
-def parse_entry(path: Path, scope: str | None = None) -> MemoryEntry:
+def parse_entry(
+    path: Path, scope: str | None = None, *, strict: bool = False
+) -> MemoryEntry:
     """Parse one memory file. Raises :class:`MemoryParseError` for non-entries."""
-    return entry_from_text(path.read_text(encoding="utf-8"), path=path, scope=scope)
+    return entry_from_text(
+        path.read_text(encoding="utf-8"), path=path, scope=scope, strict=strict
+    )

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -61,10 +61,8 @@ def _atomic_write(path: Path, text: str) -> None:
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-        try:
-            os.write(fd, text.encode("utf-8"))
-        finally:
-            os.close(fd)
+        with os.fdopen(fd, "wb") as f:
+            f.write(text.encode("utf-8"))
         _preserve_mode(tmp, path)
         os.replace(tmp, path)
     except OSError:
@@ -88,10 +86,8 @@ def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
             dest.parent.mkdir(parents=True, exist_ok=True)
             tmp = dest.with_name(f".{dest.name}.{os.getpid()}.tmp")
             fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-            try:
-                os.write(fd, text.encode("utf-8"))
-            finally:
-                os.close(fd)
+            with os.fdopen(fd, "wb") as f:
+                f.write(text.encode("utf-8"))
             _preserve_mode(tmp, dest)
             staged.append((dest, tmp, original))
         for dest, tmp, original in staged:

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+import stat
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -15,7 +18,9 @@ from .schema import (
     DEFAULT_TYPE,
     TYPE_ORDER,
     MemoryEntry,
+    MemoryFrontmatterError,
     MemoryParseError,
+    entry_from_text,
     is_index_file,
     parse_entry,
     slugify,
@@ -25,6 +30,84 @@ logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "MEMORY.md"
 INDEX_HEADER = "# Persistent Memory"
+
+
+def _preserve_mode(tmp: Path, dest: Path) -> None:
+    """Copy dest's permission bits onto tmp so ``os.replace`` does not widen access."""
+    try:
+        mode = stat.S_IMODE(dest.stat().st_mode)
+    except FileNotFoundError:
+        return
+    os.chmod(tmp, mode)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via a same-directory temp file and ``os.replace``.
+
+    Staging the content first means ENOSPC cannot truncate the destination.
+    ``os.replace`` is atomic on POSIX when source and dest share a filesystem.
+    Existing destination permission bits are copied onto the staged file so a
+    private ``0600`` memory file is not rewritten as world-readable.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        _preserve_mode(tmp, path)
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
+    """Replace each destination with staged content; restore on failure.
+
+    All payloads land in sibling temp files before any destination is renamed
+    into place, so a disk-full error during staging leaves originals untouched.
+    Destinations already renamed are restored from the in-memory snapshot.
+    Existing destination modes are copied onto each staged file before replace.
+    """
+    staged: list[tuple[Path, Path, str | None]] = []
+    replaced: list[tuple[Path, str | None]] = []
+    try:
+        for dest, text in pairs:
+            original = dest.read_text(encoding="utf-8") if dest.is_file() else None
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dest.with_name(f".{dest.name}.{os.getpid()}.tmp")
+            tmp.write_text(text, encoding="utf-8")
+            _preserve_mode(tmp, dest)
+            staged.append((dest, tmp, original))
+        for dest, tmp, original in staged:
+            os.replace(tmp, dest)
+            replaced.append((dest, original))
+    except OSError:
+        for _dest, tmp, _original in staged:
+            tmp.unlink(missing_ok=True)
+        restore_errors: list[OSError] = []
+        for dest, original in replaced:
+            try:
+                if original is None:
+                    dest.unlink(missing_ok=True)
+                else:
+                    dest.write_text(original, encoding="utf-8")
+            except OSError as restore_exc:
+                restore_errors.append(restore_exc)
+        if restore_errors:
+            raise OSError(
+                f"write failed and rollback incomplete ({restore_errors[0]})"
+            ) from restore_errors[0]
+        raise
+
+
+@dataclass(frozen=True)
+class AuditIssue:
+    """One actionable consistency problem in a memory root."""
+
+    code: str
+    entry: str
+    detail: str
+
 
 try:
     import fcntl as _fcntl
@@ -192,6 +275,136 @@ class MemoryStore:
         logger.debug("saved memory %s to %s", entry.name, entry.path)
         return entry.path
 
+    def supersede(
+        self, old_name: str, new_name: str, *, scope: str | None = None
+    ) -> tuple[MemoryEntry, MemoryEntry]:
+        """Mark ``old_name`` superseded by ``new_name`` and link both entries.
+
+        Supersession is scoped to one root so a project memory can never mutate
+        a same-named user memory. Strict parsing prevents the write from
+        normalizing malformed frontmatter through the lenient read fallback.
+        """
+        root = self.root(scope)
+        old = self.get(old_name, scope=root.scope)
+        new = self.get(new_name, scope=root.scope)
+        if old is None:
+            raise KeyError(f"no memory entry named {old_name!r} in {root.scope}")
+        if new is None:
+            raise KeyError(f"no memory entry named {new_name!r} in {root.scope}")
+        if old.path == new.path:
+            raise ValueError("an entry cannot supersede itself")
+        assert old.path is not None and new.path is not None
+        old_path, new_path = old.path, new.path
+        old = parse_entry(old_path, scope=root.scope, strict=True)
+        new = parse_entry(new_path, scope=root.scope, strict=True)
+        if not new.is_living:
+            raise ValueError(f"replacement entry {new.name!r} is not living")
+        if not old.is_living and old.superseded_by != new.name:
+            raise ValueError(f"entry {old.name!r} is not living")
+
+        old = replace(old, status="superseded", superseded_by=new.name)
+        new_supersedes = list(new.supersedes)
+        if old.name not in new_supersedes:
+            new_supersedes.append(old.name)
+        new = replace(new, supersedes=new_supersedes)
+        old_text = old.to_markdown()
+        new_text = new.to_markdown()
+
+        # Validate both complete serializations before the first write.
+        entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
+        entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
+
+        updated_entries = []
+        for entry in self.index_entries(root.scope):
+            if entry.path == old_path:
+                updated_entries.append(old)
+            elif entry.path == new_path:
+                updated_entries.append(new)
+            else:
+                updated_entries.append(entry)
+        seen_paths = {entry.path for entry in updated_entries}
+        if old_path not in seen_paths:
+            updated_entries.append(old)
+        if new_path not in seen_paths:
+            updated_entries.append(new)
+        index_text = self.render_index(updated_entries)
+        _commit_replacements(
+            [
+                (old_path, old_text),
+                (new_path, new_text),
+                (self.index_path(root.scope), index_text),
+            ]
+        )
+        return old, new
+
+    def audit(self, *, scope: str | None = None) -> list[AuditIssue]:
+        """Return parse and supersession consistency issues for one root."""
+        root = self.root(scope)
+        entries: dict[str, MemoryEntry] = {}
+        issues: list[AuditIssue] = []
+        if not root.path.is_dir():
+            return issues
+        for path in sorted(root.path.glob("*.md")):
+            if is_index_file(path):
+                continue
+            try:
+                entry = parse_entry(path, scope=root.scope, strict=True)
+            except MemoryFrontmatterError as exc:
+                issues.append(AuditIssue("invalid-yaml", path.name, str(exc)))
+                continue
+            except (MemoryParseError, OSError, UnicodeDecodeError) as exc:
+                issues.append(AuditIssue("invalid-entry", path.name, str(exc)))
+                continue
+            if entry.name in entries:
+                issues.append(
+                    AuditIssue(
+                        "duplicate-name",
+                        path.name,
+                        f"name {entry.name!r} is also used by {entries[entry.name].path}",
+                    )
+                )
+                continue
+            entries[entry.name] = entry
+
+        for entry in entries.values():
+            if entry.superseded_by:
+                replacement = entries.get(entry.superseded_by)
+                if replacement is None:
+                    issues.append(
+                        AuditIssue(
+                            "dangling-superseded-by",
+                            entry.name,
+                            f"replacement {entry.superseded_by!r} does not exist",
+                        )
+                    )
+                elif entry.name not in replacement.supersedes:
+                    issues.append(
+                        AuditIssue(
+                            "asymmetric-supersession",
+                            entry.name,
+                            f"{entry.superseded_by!r} does not point back to this entry",
+                        )
+                    )
+            for old_name in entry.supersedes:
+                old = entries.get(old_name)
+                if old is None:
+                    issues.append(
+                        AuditIssue(
+                            "dangling-supersedes",
+                            entry.name,
+                            f"superseded entry {old_name!r} does not exist",
+                        )
+                    )
+                elif old.superseded_by != entry.name:
+                    issues.append(
+                        AuditIssue(
+                            "asymmetric-supersession",
+                            entry.name,
+                            f"{old_name!r} does not point back to this entry",
+                        )
+                    )
+        return issues
+
     # -- index -------------------------------------------------------------
 
     @staticmethod
@@ -267,9 +480,8 @@ class MemoryStore:
     ) -> Path:
         root = self.root(scope)
         text = self.render_index(self.index_entries(scope), budget=budget)
-        root.path.mkdir(parents=True, exist_ok=True)
         path = root.path / INDEX_FILENAME
-        path.write_text(text, encoding="utf-8")
+        _atomic_write(path, text)
         return path
 
     def check_index(

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -51,11 +51,20 @@ def _atomic_write(path: Path, text: str) -> None:
     ``os.replace`` is atomic on POSIX when source and dest share a filesystem.
     Existing destination permission bits are copied onto the staged file so a
     private ``0600`` memory file is not rewritten as world-readable.
+
+    The temp file is opened with a restrictive mode (0o600) so that a private
+    destination is never readable by other users even during the staging window.
+    ``_preserve_mode`` then adjusts the mode to match the destination before the
+    atomic rename, restoring broader read bits when the destination is public.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
-        tmp.write_text(text, encoding="utf-8")
+        fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, text.encode("utf-8"))
+        finally:
+            os.close(fd)
         _preserve_mode(tmp, path)
         os.replace(tmp, path)
     except OSError:
@@ -78,7 +87,11 @@ def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
             original = dest.read_text(encoding="utf-8") if dest.is_file() else None
             dest.parent.mkdir(parents=True, exist_ok=True)
             tmp = dest.with_name(f".{dest.name}.{os.getpid()}.tmp")
-            tmp.write_text(text, encoding="utf-8")
+            fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+            try:
+                os.write(fd, text.encode("utf-8"))
+            finally:
+                os.close(fd)
             _preserve_mode(tmp, dest)
             staged.append((dest, tmp, original))
         for dest, tmp, original in staged:
@@ -295,7 +308,13 @@ class MemoryStore:
         title: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Path:
-        """Write ``<slug>.md`` into the scope's root and upsert its index line."""
+        """Write ``<slug>.md`` into the scope's root and upsert its index line.
+
+        The root lock serialises this write against concurrent ``supersede`` calls.
+        ``supersede`` replaces ``MEMORY.md`` via ``os.replace``, which would drop
+        a POSIX flock held on the old inode by a concurrent ``update_index_line``.
+        Acquiring ``_locked_root`` here prevents that interleaving.
+        """
         slug = slugify(name)
         if slug.upper().startswith("MEMORY"):
             raise ValueError(
@@ -314,8 +333,9 @@ class MemoryStore:
             scope=root.scope,
         )
         entry.path = root.path / entry.filename
-        entry.path.write_text(entry.to_markdown(), encoding="utf-8")
-        update_index_line(root.path, entry)
+        with _locked_root(root.path):
+            entry.path.write_text(entry.to_markdown(), encoding="utf-8")
+            update_index_line(root.path, entry)
         logger.debug("saved memory %s to %s", entry.name, entry.path)
         return entry.path
 

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -354,9 +354,18 @@ class MemoryStore:
                 raise KeyError(f"no memory entry named {old_name!r} in {root.scope}")
             if new is None:
                 raise KeyError(f"no memory entry named {new_name!r} in {root.scope}")
+            # Reject cross-root supersession: both entries must live in the locked root.
+            assert old.path is not None and new.path is not None
+            if old.path.parent != root.path:
+                raise KeyError(
+                    f"entry {old_name!r} lives in {old.path.parent}, not the locked root {root.path}"
+                )
+            if new.path.parent != root.path:
+                raise KeyError(
+                    f"entry {new_name!r} lives in {new.path.parent}, not the locked root {root.path}"
+                )
             if old.path == new.path:
                 raise ValueError("an entry cannot supersede itself")
-            assert old.path is not None and new.path is not None
             old_path, new_path = old.path, new.path
             old = parse_entry(old_path, scope=root.scope, strict=True)
             new = parse_entry(new_path, scope=root.scope, strict=True)
@@ -544,7 +553,8 @@ class MemoryStore:
         root = self.root(scope)
         text = self.render_index(self.index_entries(scope), budget=budget)
         path = root.path / INDEX_FILENAME
-        _atomic_write(path, text)
+        with _locked_root(root.path):
+            _atomic_write(path, text)
         return path
 
     def check_index(

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 import re
@@ -112,21 +113,30 @@ class AuditIssue:
 
 
 try:
-    import fcntl as _fcntl
+    _fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None
 
-    def _lock_exclusive(f) -> None:
+try:
+    _msvcrt: Any = importlib.import_module("msvcrt")
+except ImportError:  # pragma: no cover - POSIX
+    _msvcrt = None
+
+
+def _lock_exclusive(f) -> None:
+    """Lock ``MEMORY.md`` for in-place upserts. Unix flock only.
+
+    Windows first-save opens an empty index; byte-range locking that file is
+    unreliable, so concurrent ``save`` stays best-effort there. ``supersede``
+    serializes through ``_locked_root`` instead.
+    """
+    if _fcntl is not None:
         _fcntl.flock(f, _fcntl.LOCK_EX)
 
-    def _unlock(f) -> None:
+
+def _unlock(f) -> None:
+    if _fcntl is not None:
         _fcntl.flock(f, _fcntl.LOCK_UN)
-
-except ImportError:  # Windows: no flock, best effort
-
-    def _lock_exclusive(f) -> None:
-        pass
-
-    def _unlock(f) -> None:
-        pass
 
 
 @contextmanager
@@ -137,14 +147,28 @@ def _locked_root(root_path: Path):
     ``supersede`` mutates two entries plus the index and cannot use that file as
     the lock target: ``os.replace`` of ``MEMORY.md`` would drop the flock onto
     a replaced inode. A dedicated lock file stays put for the whole window.
+
+    Unix uses ``fcntl.flock``; Windows uses ``msvcrt.locking`` on a 1-byte
+    sidecar (same pattern as ``gptme.logmanager.eventlog``).
     """
     root_path.mkdir(parents=True, exist_ok=True)
-    with open(root_path / LOCK_FILENAME, "a+", encoding="utf-8") as f:
-        _lock_exclusive(f)
+    with open(root_path / LOCK_FILENAME, "a+b") as lock:
+        if _fcntl is not None:
+            _fcntl.flock(lock, _fcntl.LOCK_EX)
+        elif _msvcrt is not None:  # pragma: no cover - Windows
+            if lock.seek(0, os.SEEK_END) == 0:
+                lock.write(b"\0")
+                lock.flush()
+            lock.seek(0)
+            _msvcrt.locking(lock.fileno(), _msvcrt.LK_LOCK, 1)
         try:
             yield
         finally:
-            _unlock(f)
+            if _fcntl is not None:
+                _fcntl.flock(lock, _fcntl.LOCK_UN)
+            elif _msvcrt is not None:  # pragma: no cover - Windows
+                lock.seek(0)
+                _msvcrt.locking(lock.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 def update_index_line(memory_dir: Path, entry: MemoryEntry) -> None:

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import stat
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "MEMORY.md"
 INDEX_HEADER = "# Persistent Memory"
+LOCK_FILENAME = ".memory.lock"
 
 
 def _preserve_mode(tmp: Path, dest: Path) -> None:
@@ -125,6 +127,24 @@ except ImportError:  # Windows: no flock, best effort
 
     def _unlock(f) -> None:
         pass
+
+
+@contextmanager
+def _locked_root(root_path: Path):
+    """Exclusive lock covering one memory root's read-validate-commit window.
+
+    ``update_index_line`` already flocks ``MEMORY.md`` for single-line upserts.
+    ``supersede`` mutates two entries plus the index and cannot use that file as
+    the lock target: ``os.replace`` of ``MEMORY.md`` would drop the flock onto
+    a replaced inode. A dedicated lock file stays put for the whole window.
+    """
+    root_path.mkdir(parents=True, exist_ok=True)
+    with open(root_path / LOCK_FILENAME, "a+", encoding="utf-8") as f:
+        _lock_exclusive(f)
+        try:
+            yield
+        finally:
+            _unlock(f)
 
 
 def update_index_line(memory_dir: Path, entry: MemoryEntry) -> None:
@@ -283,59 +303,62 @@ class MemoryStore:
         Supersession is scoped to one root so a project memory can never mutate
         a same-named user memory. Strict parsing prevents the write from
         normalizing malformed frontmatter through the lenient read fallback.
+        A root-scoped lock serializes concurrent supersedes so two replacements
+        cannot both observe the same living entry and corrupt the links.
         """
         root = self.root(scope)
-        old = self.get(old_name, scope=root.scope)
-        new = self.get(new_name, scope=root.scope)
-        if old is None:
-            raise KeyError(f"no memory entry named {old_name!r} in {root.scope}")
-        if new is None:
-            raise KeyError(f"no memory entry named {new_name!r} in {root.scope}")
-        if old.path == new.path:
-            raise ValueError("an entry cannot supersede itself")
-        assert old.path is not None and new.path is not None
-        old_path, new_path = old.path, new.path
-        old = parse_entry(old_path, scope=root.scope, strict=True)
-        new = parse_entry(new_path, scope=root.scope, strict=True)
-        if not new.is_living:
-            raise ValueError(f"replacement entry {new.name!r} is not living")
-        if not old.is_living and old.superseded_by != new.name:
-            raise ValueError(f"entry {old.name!r} is not living")
+        with _locked_root(root.path):
+            old = self.get(old_name, scope=root.scope)
+            new = self.get(new_name, scope=root.scope)
+            if old is None:
+                raise KeyError(f"no memory entry named {old_name!r} in {root.scope}")
+            if new is None:
+                raise KeyError(f"no memory entry named {new_name!r} in {root.scope}")
+            if old.path == new.path:
+                raise ValueError("an entry cannot supersede itself")
+            assert old.path is not None and new.path is not None
+            old_path, new_path = old.path, new.path
+            old = parse_entry(old_path, scope=root.scope, strict=True)
+            new = parse_entry(new_path, scope=root.scope, strict=True)
+            if not new.is_living:
+                raise ValueError(f"replacement entry {new.name!r} is not living")
+            if not old.is_living and old.superseded_by != new.name:
+                raise ValueError(f"entry {old.name!r} is not living")
 
-        old = replace(old, status="superseded", superseded_by=new.name)
-        new_supersedes = list(new.supersedes)
-        if old.name not in new_supersedes:
-            new_supersedes.append(old.name)
-        new = replace(new, supersedes=new_supersedes)
-        old_text = old.to_markdown()
-        new_text = new.to_markdown()
+            old = replace(old, status="superseded", superseded_by=new.name)
+            new_supersedes = list(new.supersedes)
+            if old.name not in new_supersedes:
+                new_supersedes.append(old.name)
+            new = replace(new, supersedes=new_supersedes)
+            old_text = old.to_markdown()
+            new_text = new.to_markdown()
 
-        # Validate both complete serializations before the first write.
-        entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
-        entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
+            # Validate both complete serializations before the first write.
+            entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
+            entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
 
-        updated_entries = []
-        for entry in self.index_entries(root.scope):
-            if entry.path == old_path:
+            updated_entries = []
+            for entry in self.index_entries(root.scope):
+                if entry.path == old_path:
+                    updated_entries.append(old)
+                elif entry.path == new_path:
+                    updated_entries.append(new)
+                else:
+                    updated_entries.append(entry)
+            seen_paths = {entry.path for entry in updated_entries}
+            if old_path not in seen_paths:
                 updated_entries.append(old)
-            elif entry.path == new_path:
+            if new_path not in seen_paths:
                 updated_entries.append(new)
-            else:
-                updated_entries.append(entry)
-        seen_paths = {entry.path for entry in updated_entries}
-        if old_path not in seen_paths:
-            updated_entries.append(old)
-        if new_path not in seen_paths:
-            updated_entries.append(new)
-        index_text = self.render_index(updated_entries)
-        _commit_replacements(
-            [
-                (old_path, old_text),
-                (new_path, new_text),
-                (self.index_path(root.scope), index_text),
-            ]
-        )
-        return old, new
+            index_text = self.render_index(updated_entries)
+            _commit_replacements(
+                [
+                    (old_path, old_text),
+                    (new_path, new_text),
+                    (self.index_path(root.scope), index_text),
+                ]
+            )
+            return old, new
 
     def audit(self, *, scope: str | None = None) -> list[AuditIssue]:
         """Return parse and supersession consistency issues for one root."""

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -536,6 +536,126 @@ class TestCli:
         assert r.exit_code == 0 and "explicit" in r.output and "(missing)" in r.output
 
 
+class TestCodexAgentsMdPattern:
+    """Exercises the Codex / AGENTS.md integration pattern.
+
+    Codex has no hook mechanism; it drives memory via shell commands listed in
+    AGENTS.md. These tests verify that the exact CLI patterns documented there
+    and in docs/memory.rst produce the expected round-trip behaviour.
+    """
+
+    @pytest.fixture
+    def mem_env(self, tmp_path, monkeypatch):
+        """Isolated memory root so tests don't interact with real user memory."""
+        root = tmp_path / "mem"
+        monkeypatch.setenv("GPTME_MEMORY_DIRS", str(root))
+        return root
+
+    def test_save_from_agents_md_pattern(self, mem_env):
+        """gptme-util memory save <slug> "<desc>" --type feedback <<'EOF' ... EOF"""
+        runner = CliRunner()
+        r = runner.invoke(
+            util_main,
+            [
+                "memory",
+                "save",
+                "codex-pref",
+                "Prefer succinct responses.",
+                "--type",
+                "feedback",
+            ],
+            input="Keep answers short and code-first.\n",
+        )
+        assert r.exit_code == 0, r.output
+        # File written to the explicit root
+        assert (mem_env / "codex-pref.md").exists()
+        content = (mem_env / "codex-pref.md").read_text()
+        assert "name: codex-pref" in content
+        assert "Prefer succinct responses." in content
+        assert "Keep answers short and code-first." in content
+
+    def test_recall_plain_text_from_agents_md_pattern(self, mem_env):
+        """gptme-util memory recall "<query>" -k 5  (AGENTS.md session-start pattern)."""
+        _write(
+            mem_env,
+            "provider-policy",
+            "---\n"
+            "name: provider-policy\n"
+            'description: "Route sensitive code through private providers"\n'
+            "metadata:\n"
+            "  type: feedback\n"
+            "---\n"
+            "Never send private code to public training providers.\n",
+        )
+        runner = CliRunner()
+        r = runner.invoke(
+            util_main,
+            [
+                "memory",
+                "recall",
+                "which provider for sensitive code review",
+                "-k",
+                "5",
+                "--backend",
+                "overlap",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        # Plain text output must contain the matched entry name and body text
+        assert "provider-policy" in r.output
+        assert "private code" in r.output
+
+    def test_cross_harness_roundtrip(self, mem_env):
+        """Memory saved by Codex (via CLI) appears in index readable by CC/gptme."""
+        runner = CliRunner()
+        # Codex saves a memory
+        r = runner.invoke(
+            util_main,
+            [
+                "memory",
+                "save",
+                "xharness",
+                "Cross-harness test entry.",
+                "--type",
+                "project",
+            ],
+            input="Written by a Codex session to test cross-harness sharing.\n",
+        )
+        assert r.exit_code == 0, r.output
+
+        # Verify the entry is visible to list (what gptme prompt_workspace would read)
+        r = runner.invoke(util_main, ["memory", "list"])
+        assert r.exit_code == 0 and "xharness" in r.output
+
+        # Index the memories (what CC's Stop hook calls via `memory index --write`)
+        r = runner.invoke(util_main, ["memory", "index", "--write"])
+        assert r.exit_code == 0
+
+        # The generated MEMORY.md contains the Codex-written entry
+        index_file = mem_env / "MEMORY.md"
+        assert index_file.exists()
+        assert "xharness" in index_file.read_text()
+
+    def test_save_all_valid_types(self, mem_env):
+        """All four types documented in AGENTS.md are accepted without error."""
+        runner = CliRunner()
+        for type_ in ("user", "feedback", "project", "reference"):
+            r = runner.invoke(
+                util_main,
+                [
+                    "memory",
+                    "save",
+                    f"test-{type_}",
+                    f"Test {type_} entry.",
+                    "--type",
+                    type_,
+                ],
+                input=f"Body for {type_}.\n",
+            )
+            assert r.exit_code == 0, f"--type {type_} failed: {r.output}"
+            assert (mem_env / f"test-{type_}.md").exists()
+
+
 @pytest.mark.skipif(
     not Path("/home/bob/bob/memory").is_dir(), reason="Bob's memory dir not present"
 )

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1046,3 +1046,99 @@ def test_bob_memory_dir_round_trip(tmp_path):
     assert all(e.description for e in entries[:50])
     store.write_index()
     assert store.check_index()
+
+
+# ── regression tests for AI-review findings (2026-09-09) ───────────────────
+
+
+def test_supersede_rejects_cross_root_old_entry(tmp_path):
+    """P1: supersede must reject when old entry lives in a different root.
+
+    A multi-root store with two roots sharing the same scope name lets
+    self.get() find entries in either root.  The locked root is always the
+    *first* root with that scope.  If old is only in the second root,
+    supersede must raise rather than write across the lock boundary.
+    """
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    # Two roots sharing scope "explicit"; save() and root() both resolve to root_a.
+    store = MemoryStore(
+        [MemoryRoot("explicit", root_a), MemoryRoot("explicit", root_b)]
+    )
+    # new-entry goes to root_a (the locked root).
+    store.save("new-entry", "new description", body="new")
+
+    # Write old-entry directly to root_b to simulate an entry from a foreign root.
+    root_b.mkdir(parents=True, exist_ok=True)
+    old_md = MemoryEntry(
+        name="old-entry",
+        description="from root_b",
+        type="reference",
+        body="old",
+        scope="explicit",
+    )
+    old_path = root_b / old_md.filename
+    old_path.write_text(old_md.to_markdown(), encoding="utf-8")
+
+    # supersede locks root_a; get() finds old-entry in root_b → must reject.
+    with pytest.raises(KeyError, match="old-entry"):
+        store.supersede("old-entry", "new-entry")
+
+
+def test_supersede_rejects_cross_root_new_entry(tmp_path):
+    """P1: supersede must reject when *new* entry lives in a different root."""
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    # Two roots sharing scope; old goes to root_a (locked); new only in root_b.
+    store = MemoryStore(
+        [MemoryRoot("explicit", root_a), MemoryRoot("explicit", root_b)]
+    )
+    store.save("old-entry", "old", body="old")
+
+    root_b.mkdir(parents=True, exist_ok=True)
+    new_md = MemoryEntry(
+        name="new-entry",
+        description="from root_b",
+        type="user",
+        body="new",
+        scope="explicit",
+    )
+    new_path = root_b / new_md.filename
+    new_path.write_text(new_md.to_markdown(), encoding="utf-8")
+
+    # new-entry is outside the locked root_a → must reject.
+    with pytest.raises(KeyError, match="new-entry"):
+        store.supersede("old-entry", "new-entry")
+
+
+def test_entry_from_text_lenient_coerces_non_string_name(tmp_path):
+    """P2 (schema.py): lenient mode must coerce numeric names with str(), not fall back to stem.
+
+    Old behaviour (pre-PR): ``name: 42`` in file ``my-note.md`` produced entry
+    name ``"42"`` because the code called ``str(name)`` on the raw value.
+    The PR changed the logic to use ``isinstance(..., str)`` which silently
+    switched the name to ``"my-note"``, breaking recall lookups for existing
+    entries.  The fix restores the old coercion in lenient mode.
+    """
+    note = tmp_path / "my-note.md"
+    note.write_text(
+        "---\nname: 42\ndescription: numeric name test\n---\nBody.\n",
+        encoding="utf-8",
+    )
+    entry = entry_from_text(note.read_text(), path=note, strict=False)
+    assert entry.name == "42", (
+        f"lenient mode should coerce 42 → '42', got {entry.name!r}"
+    )
+
+
+def test_entry_from_text_strict_rejects_non_string_name(tmp_path):
+    """Strict mode rejects numeric names (no coercion there)."""
+    from gptme.memory.schema import MemoryFrontmatterError
+
+    note = tmp_path / "my-note.md"
+    note.write_text(
+        "---\nname: 42\ndescription: numeric name test\n---\nBody.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(MemoryFrontmatterError, match="name"):
+        entry_from_text(note.read_text(), path=note, strict=True)

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -2,6 +2,7 @@
 
 import importlib
 import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -151,6 +152,230 @@ class TestStore:
                 MemoryRoot("user", tmp_path / "user"),
             ]
         )
+
+    def test_supersede_links_both_entries_and_regenerates_index(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old-belief", "Old belief", "Old body", scope="project")
+        store.save("new-belief", "New belief", "New body", scope="project")
+
+        old, new = store.supersede("old-belief", "new-belief", scope="project")
+
+        assert old.status == "superseded"
+        assert old.superseded_by == "new-belief"
+        assert new.supersedes == ["old-belief"]
+        assert not old.is_living
+        reparsed_old = parse_entry(tmp_path / "project" / "old-belief.md")
+        reparsed_new = parse_entry(tmp_path / "project" / "new-belief.md")
+        assert reparsed_old.superseded_by == "new-belief"
+        assert reparsed_new.supersedes == ["old-belief"]
+        index = (tmp_path / "project" / "MEMORY.md").read_text()
+        assert "new-belief.md" in index
+        assert "old-belief.md" not in index
+
+    def test_supersede_requires_strict_frontmatter_before_rewriting(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: unquoted: colon\n---\nold body\n",
+        )
+        _write(root, "new", "---\nname: new\ndescription: fine\n---\nnew body\n")
+        store = self._store(tmp_path)
+
+        with pytest.raises(ValueError, match="invalid YAML"):
+            store.supersede("old", "new", scope="project")
+
+        assert "status: superseded" not in (root / "old.md").read_text()
+
+    def test_supersede_rolls_back_entries_when_index_write_fails(
+        self, tmp_path, monkeypatch
+    ):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        before = {path.name: path.read_text() for path in root.glob("*.md")}
+
+        def fail_commit(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("gptme.memory.store._commit_replacements", fail_commit)
+        with pytest.raises(OSError, match="disk full"):
+            store.supersede("old", "new", scope="project")
+
+        assert {path.name: path.read_text() for path in root.glob("*.md")} == before
+
+    def test_supersede_restores_after_partial_replace(self, tmp_path, monkeypatch):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        before = {path.name: path.read_text() for path in root.glob("*.md")}
+        real_replace = __import__("os").replace
+        calls = {"n": 0}
+
+        def fail_second(src, dst, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise OSError("rename failed")
+            return real_replace(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr("gptme.memory.store.os.replace", fail_second)
+        with pytest.raises(OSError, match="rename failed"):
+            store.supersede("old", "new", scope="project")
+
+        assert {path.name: path.read_text() for path in root.glob("*.md")} == before
+
+    def test_supersede_preserves_existing_file_mode(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        for name in ("old.md", "new.md", "MEMORY.md"):
+            (root / name).chmod(0o600)
+
+        previous = os.umask(0o022)
+        try:
+            store.supersede("old", "new", scope="project")
+        finally:
+            os.umask(previous)
+
+        for name in ("old.md", "new.md", "MEMORY.md"):
+            assert stat.S_IMODE((root / name).stat().st_mode) == 0o600
+
+    def test_write_index_preserves_existing_file_mode(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("fact", "fact", scope="project")
+        index = tmp_path / "project" / "MEMORY.md"
+        index.chmod(0o600)
+
+        previous = os.umask(0o022)
+        try:
+            store.write_index(scope="project")
+        finally:
+            os.umask(previous)
+
+        assert stat.S_IMODE(index.stat().st_mode) == 0o600
+
+    def test_supersede_rejects_cross_root_entries(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="user")
+
+        with pytest.raises(KeyError, match="new"):
+            store.supersede("old", "new", scope="project")
+
+    def test_supersede_rejects_self_and_non_living_replacement(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("one", "one", scope="project")
+        store.save("two", "two", scope="project")
+
+        with pytest.raises(ValueError, match="itself"):
+            store.supersede("one", "one", scope="project")
+        store.supersede("one", "two", scope="project")
+        # Repeating the exact supersession is idempotent.
+        store.supersede("one", "two", scope="project")
+        store.save("three", "three", scope="project")
+        with pytest.raises(ValueError, match="not living"):
+            store.supersede("three", "one", scope="project")
+        with pytest.raises(ValueError, match="not living"):
+            store.supersede("one", "three", scope="project")
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "status: bogus",
+            "status: false",
+            "confidence: nope",
+            "confidence: 2",
+            "confidence: true",
+            "metadata: nope",
+            "provenance: nope",
+            "supersedes: 42",
+            "keywords: [fine, 42]",
+            "superseded_by: 42",
+            "recheck: 42",
+            "title: 42",
+            "description: 42",
+            "name: false",
+            "name: ''",
+        ],
+    )
+    def test_audit_reports_invalid_field_types(self, tmp_path, field):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "invalid",
+            f"---\nname: invalid\ndescription: invalid\n{field}\n---\nbody\n",
+        )
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert len(issues) == 1
+        assert issues[0].code == "invalid-yaml"
+
+    def test_audit_reports_duplicate_names(self, tmp_path):
+        root = tmp_path / "project"
+        _write(root, "a", "---\nname: same\ndescription: first\n---\n")
+        _write(root, "z", "---\nname: same\ndescription: second\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert [(issue.code, issue.entry) for issue in issues] == [
+            ("duplicate-name", "z.md")
+        ]
+
+    def test_audit_reports_invalid_yaml_and_broken_supersession(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "invalid",
+            "---\nname: invalid\ndescription: unquoted: colon\n---\nbody\n",
+        )
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: old\nstatus: superseded\nsuperseded_by: missing\n---\n",
+        )
+        store = self._store(tmp_path)
+
+        issues = store.audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} >= {
+            ("invalid-yaml", "invalid.md"),
+            ("dangling-superseded-by", "old"),
+        }
+
+    def test_audit_reports_asymmetric_reverse_link(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: old\nstatus: superseded\nsuperseded_by: new\n---\n",
+        )
+        _write(root, "new", "---\nname: new\ndescription: new\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} == {
+            ("asymmetric-supersession", "old")
+        }
+
+    def test_audit_reports_dangling_and_asymmetric_forward_links(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "new",
+            "---\nname: new\ndescription: new\nsupersedes: [missing, old]\n---\n",
+        )
+        _write(root, "old", "---\nname: old\ndescription: old\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} == {
+            ("dangling-supersedes", "new"),
+            ("asymmetric-supersession", "new"),
+        }
 
     def test_union_and_nearest_wins(self, tmp_path):
         _write(
@@ -481,6 +706,35 @@ class TestCli:
     def test_index_budget_cli_rejects_non_positive(self, env):
         r = CliRunner().invoke(util_main, ["memory", "index", "--budget", "0"])
         assert r.exit_code != 0
+
+    def test_supersede_and_audit_cli(self, env):
+        runner = CliRunner()
+        for name in ("old", "new"):
+            result = runner.invoke(
+                util_main,
+                ["memory", "save", name, f"{name} description"],
+            )
+            assert result.exit_code == 0, result.output
+
+        result = runner.invoke(util_main, ["memory", "supersede", "old", "new"])
+        assert result.exit_code == 0, result.output
+        assert "old -> new" in result.output
+        result = runner.invoke(util_main, ["memory", "audit", "--quiet"])
+        assert result.exit_code == 0, result.output
+        assert result.output == ""
+
+    def test_audit_cli_fails_on_invalid_yaml(self, env):
+        _write(
+            env,
+            "invalid",
+            "---\nname: invalid\ndescription: unquoted: colon\n---\nbody\n",
+        )
+
+        result = CliRunner().invoke(util_main, ["memory", "audit"])
+
+        assert result.exit_code == 1
+        assert "invalid-yaml" in result.output
+        assert "invalid.md" in result.output
 
     def test_recall_hook_json_reads_claude_payload(self, env):
         _write(

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -311,7 +311,6 @@ class TestStore:
         with pytest.raises(ValueError, match="not living"):
             store.supersede("one", "three", scope="project")
 
-    @pytest.mark.skipif(os.name == "nt", reason="flock is a no-op on Windows")
     def test_supersede_waits_for_held_root_lock(self, tmp_path):
         from gptme.memory.store import _locked_root
 
@@ -335,7 +334,6 @@ class TestStore:
         assert not proc.is_alive()
         assert result.get(timeout=2)[0] == "ok"
 
-    @pytest.mark.skipif(os.name == "nt", reason="flock is a no-op on Windows")
     def test_concurrent_supersede_keeps_links_consistent(self, tmp_path):
         store = self._store(tmp_path)
         store.save("old", "old", scope="project")
@@ -370,8 +368,10 @@ class TestStore:
         assert store.audit(scope="project") == []
         old = store.get("old", scope="project")
         assert old is not None
-        assert old.superseded_by == oks[0][1]
-        winner = store.get(old.superseded_by, scope="project")
+        winner_name = old.superseded_by
+        assert winner_name is not None
+        assert winner_name == oks[0][1]
+        winner = store.get(winner_name, scope="project")
         assert winner is not None
         assert "old" in winner.supersedes
         loser_name = "b" if old.superseded_by == "a" else "a"

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -596,11 +596,11 @@ class TestCodexAgentsMdPattern:
                 "which provider for sensitive code review",
                 "-k",
                 "5",
-                "--backend",
-                "overlap",
             ],
         )
         assert r.exit_code == 0, r.output
+        # Documented no-flag command names the backend that actually ran
+        assert "backend=tfidf" in r.output or "backend=overlap" in r.output
         # Plain text output must contain the matched entry name and body text
         assert "provider-policy" in r.output
         assert "private code" in r.output
@@ -623,7 +623,7 @@ class TestCodexAgentsMdPattern:
         )
         assert r.exit_code == 0, r.output
 
-        # Verify the entry is visible to list (what gptme prompt_workspace would read)
+        # Verify the entry is visible to list (recall searches every layered root)
         r = runner.invoke(util_main, ["memory", "list"])
         assert r.exit_code == 0 and "xharness" in r.output
 

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,6 +1,7 @@
 """Tests for gptme.memory: schema round-trip, layered roots, store, index, CLI."""
 
 import importlib
+import multiprocessing
 import os
 import stat
 from pathlib import Path
@@ -42,6 +43,35 @@ def _write(dir_: Path, name: str, text: str) -> Path:
     p = dir_ / f"{name}.md"
     p.write_text(text, encoding="utf-8")
     return p
+
+
+def _mp_supersede(root: str, old: str, new: str, started, go, result) -> None:
+    """Spawn-safe worker: wait for ``go``, then supersede ``old`` with ``new``."""
+    from gptme.memory.roots import MemoryRoot
+    from gptme.memory.store import MemoryStore
+
+    started.set()
+    go.wait(timeout=15)
+    store = MemoryStore([MemoryRoot("project", Path(root))])
+    try:
+        store.supersede(old, new, scope="project")
+        result.put(("ok", new))
+    except Exception as exc:
+        result.put(("err", new, type(exc).__name__, str(exc)))
+
+
+def _mp_supersede_now(root: str, old: str, new: str, started, result) -> None:
+    """Spawn-safe worker: signal ready, then supersede immediately."""
+    from gptme.memory.roots import MemoryRoot
+    from gptme.memory.store import MemoryStore
+
+    started.set()
+    store = MemoryStore([MemoryRoot("project", Path(root))])
+    try:
+        store.supersede(old, new, scope="project")
+        result.put(("ok", new))
+    except Exception as exc:
+        result.put(("err", new, type(exc).__name__, str(exc)))
 
 
 class TestSchema:
@@ -280,6 +310,74 @@ class TestStore:
             store.supersede("three", "one", scope="project")
         with pytest.raises(ValueError, match="not living"):
             store.supersede("one", "three", scope="project")
+
+    @pytest.mark.skipif(os.name == "nt", reason="flock is a no-op on Windows")
+    def test_supersede_waits_for_held_root_lock(self, tmp_path):
+        from gptme.memory.store import _locked_root
+
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        ctx = multiprocessing.get_context("spawn")
+        started = ctx.Event()
+        result = ctx.Queue()
+        proc = ctx.Process(
+            target=_mp_supersede_now,
+            args=(str(tmp_path / "project"), "old", "new", started, result),
+        )
+        with _locked_root(tmp_path / "project"):
+            proc.start()
+            assert started.wait(timeout=10)
+            proc.join(timeout=1.0)
+            assert proc.is_alive(), "supersede returned while the root lock was held"
+            assert result.empty()
+        proc.join(timeout=10)
+        assert not proc.is_alive()
+        assert result.get(timeout=2)[0] == "ok"
+
+    @pytest.mark.skipif(os.name == "nt", reason="flock is a no-op on Windows")
+    def test_concurrent_supersede_keeps_links_consistent(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("a", "a", scope="project")
+        store.save("b", "b", scope="project")
+        ctx = multiprocessing.get_context("spawn")
+        go = ctx.Event()
+        result = ctx.Queue()
+        procs = []
+        for name in ("a", "b"):
+            started = ctx.Event()
+            proc = ctx.Process(
+                target=_mp_supersede,
+                args=(str(tmp_path / "project"), "old", name, started, go, result),
+            )
+            proc.start()
+            assert started.wait(timeout=10)
+            procs.append(proc)
+        go.set()
+        for proc in procs:
+            proc.join(timeout=10)
+            assert not proc.is_alive()
+
+        outcomes = [result.get(timeout=2) for _ in range(2)]
+        oks = [item for item in outcomes if item[0] == "ok"]
+        errs = [item for item in outcomes if item[0] == "err"]
+        assert len(oks) == 1, outcomes
+        assert len(errs) == 1, outcomes
+        assert "not living" in errs[0][-1]
+
+        store = self._store(tmp_path)
+        assert store.audit(scope="project") == []
+        old = store.get("old", scope="project")
+        assert old is not None
+        assert old.superseded_by == oks[0][1]
+        winner = store.get(old.superseded_by, scope="project")
+        assert winner is not None
+        assert "old" in winner.supersedes
+        loser_name = "b" if old.superseded_by == "a" else "a"
+        loser = store.get(loser_name, scope="project")
+        assert loser is not None
+        assert "old" not in loser.supersedes
 
     @pytest.mark.parametrize(
         "field",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,6 +1,7 @@
 """Tests for gptme.memory: schema round-trip, layered roots, store, index, CLI."""
 
 import importlib
+import os
 from pathlib import Path
 
 import pytest
@@ -599,16 +600,34 @@ class TestCodexAgentsMdPattern:
             ],
         )
         assert r.exit_code == 0, r.output
-        # Documented no-flag command names the backend that actually ran
-        assert "backend=tfidf" in r.output or "backend=overlap" in r.output
+        # Documented no-flag command names the backend that actually ran.
+        # Mirror recall()'s auto path: try the optional TF-IDF import, else overlap.
+        try:
+            import gptme_rag.lexical  # noqa: F401
+        except ImportError:
+            expected_backend = "overlap"
+        else:
+            expected_backend = "tfidf"
+        assert f"backend={expected_backend}" in r.output
         # Plain text output must contain the matched entry name and body text
         assert "provider-policy" in r.output
         assert "private code" in r.output
 
-    def test_cross_harness_roundtrip(self, mem_env):
-        """Memory saved by Codex (via CLI) appears in index readable by CC/gptme."""
+    def test_cross_harness_roundtrip(self, tmp_path, monkeypatch):
+        """Codex-written memory is reachable from a reader whose write root differs.
+
+        Save lands on the Codex write root. A second harness then lists/recalls
+        with its own root first and the Codex root still in the layer list —
+        the lookup that would miss if list/recall only searched the write root.
+        """
+        write_root = tmp_path / "codex"
+        reader_root = tmp_path / "cc"
+        write_root.mkdir()
+        reader_root.mkdir()
+        monkeypatch.setenv(
+            "GPTME_MEMORY_DIRS", os.pathsep.join((str(write_root), str(reader_root)))
+        )
         runner = CliRunner()
-        # Codex saves a memory
         r = runner.invoke(
             util_main,
             [
@@ -622,19 +641,23 @@ class TestCodexAgentsMdPattern:
             input="Written by a Codex session to test cross-harness sharing.\n",
         )
         assert r.exit_code == 0, r.output
+        assert (write_root / "xharness.md").exists()
+        assert not (reader_root / "xharness.md").exists()
 
-        # Verify the entry is visible to list (recall searches every layered root)
+        # Reader harness: own root first, Codex write root still layered in
+        monkeypatch.setenv(
+            "GPTME_MEMORY_DIRS", os.pathsep.join((str(reader_root), str(write_root)))
+        )
         r = runner.invoke(util_main, ["memory", "list"])
         assert r.exit_code == 0 and "xharness" in r.output
 
-        # Index the memories (what CC's Stop hook calls via `memory index --write`)
-        r = runner.invoke(util_main, ["memory", "index", "--write"])
-        assert r.exit_code == 0
-
-        # The generated MEMORY.md contains the Codex-written entry
-        index_file = mem_env / "MEMORY.md"
-        assert index_file.exists()
-        assert "xharness" in index_file.read_text()
+        r = runner.invoke(
+            util_main,
+            ["memory", "recall", "Cross-harness test entry", "-k", "5"],
+        )
+        assert r.exit_code == 0, r.output
+        assert "xharness" in r.output
+        assert "Written by a Codex session to test cross-harness sharing." in r.output
 
     def test_save_all_valid_types(self, mem_env):
         """All four types documented in AGENTS.md are accepted without error."""


### PR DESCRIPTION
## Summary

Implements plan item 7 of #3734: the Codex harness has no hook surface, so memory access is driven by instructions in `AGENTS.md`.

### Changes

- **`AGENTS.md`**: Add `## Memory` section with the two core Codex patterns — recall at session start and save to persist across sessions. Documents all four types (`user`/`feedback`/`project`/`reference`), plus `index` and `roots` commands. Save-root vs auto-load is explicit: default write is project `memory/` if that directory exists, else the CC root; native `MEMORY.md` auto-load only reads the CC root (`--scope cc` for that path). `recall` searches every layered root.

- **`docs/memory.rst`**: Add _Codex / AGENTS.md integration_ section alongside the existing Claude Code hook section. Explains the shell-command approach and the same save-root vs auto-load distinction.

- **`tests/test_memory_store.py`**: Add `TestCodexAgentsMdPattern` with 4 tests exercising the exact CLI patterns from AGENTS.md: save, recall (documented no-flag command, including backend marker), cross-harness round-trip, and all four documented types.

## Acceptance criteria from #3625

| Criterion | Status |
|---|---|
| gptme reads CC memories | ✅ #3626 |
| gptme writes to CC-compatible path | ✅ #3735 |
| `gptme-util memory recall` (cross-harness) | ✅ #3740 |
| Codex reads/writes shared memory store | ✅ **this PR** |

Together these four PRs complete the full cross-harness round-trip: CC, gptme, and Codex can all read and write to the same layered memory store. Codex's write path is `gptme-util memory save`; its read path is `gptme-util memory recall` (all roots). Native session-start auto-load of `MEMORY.md` remains CC-root-only.

## Test plan

- [x] 4 new `TestCodexAgentsMdPattern` tests pass (save, recall, round-trip, type coverage)
- [x] All 64 existing memory tests still pass (`test_memory_store.py` + `test_memory_tool.py`)
- [x] ruff check + format clean
- [x] Pre-commit hooks pass

Part of #3734; closes #3625

<!-- gptme-id:v1:gai_Ec4bhB4abeMKOMeVZFm9rr0ZUfhS5jVolxJ1gkFrv1V -->
