### PR TITLE
feat(memory): add supersession and audit commands

### DIFF
--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -21,6 +21,25 @@ Inspect and write memory
 ``index`` prints by default. Pass ``--write`` only when you want to replace the
 selected root's ``MEMORY.md`` with a generated index.
 
+Supersession and audit
+----------------------
+
+Replace an obsolete entry with an already-existing living entry, then check the
+root's strict YAML and bidirectional supersession links:
+
+.. code-block:: console
+
+   $ gptme-util memory supersede old-belief new-belief
+   $ gptme-util memory audit
+   $ gptme-util memory audit --quiet
+
+``supersede`` updates both entries (``superseded_by`` on the old entry and
+``supersedes`` on the replacement) and regenerates the selected root's index.
+Both entries must be in the same root; use ``--scope`` when needed. The command
+refuses malformed YAML rather than rewriting it through the lenient read
+fallback. ``audit`` exits non-zero for malformed entries, dangling targets, or
+asymmetric links, making ``audit --quiet`` suitable for lifecycle hooks.
+
 Recall
 ------
 

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -36,9 +36,10 @@ root's strict YAML and bidirectional supersession links:
 ``supersede`` updates both entries (``superseded_by`` on the old entry and
 ``supersedes`` on the replacement) and regenerates the selected root's index.
 Both entries must be in the same root; use ``--scope`` when needed. The command
-refuses malformed YAML rather than rewriting it through the lenient read
-fallback. ``audit`` exits non-zero for malformed entries, dangling targets, or
-asymmetric links, making ``audit --quiet`` suitable for lifecycle hooks.
+refuses malformed YAML and invalid field types rather than rewriting them
+through the lenient read fallback. ``audit`` exits non-zero for malformed
+entries, duplicate names, dangling targets, or asymmetric links, making
+``audit --quiet`` suitable for lifecycle hooks.
 
 Recall
 ------

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -266,6 +266,36 @@ def memory_recall(
         click.echo(rendered)
 
 
+@memory.command("supersede")
+@click.argument("old_name")
+@click.argument("new_name")
+@click.option("--scope", help="Root containing both entries (default: write root).")
+def memory_supersede(old_name: str, new_name: str, scope: str | None):
+    """Mark OLD_NAME superseded by NEW_NAME and link both entries."""
+    try:
+        old, new = _store().supersede(old_name, new_name, scope=scope)
+    except (KeyError, OSError, ValueError) as e:
+        raise click.ClickException(str(e)) from e
+    click.echo(f"Superseded {old.name} -> {new.name}")
+
+
+@memory.command("audit")
+@click.option("--scope", help="Root to audit (default: write root).")
+@click.option("--quiet", is_flag=True, help="Print nothing when the audit passes.")
+def memory_audit(scope: str | None, quiet: bool):
+    """Check strict YAML parsing and supersession links."""
+    try:
+        issues = _store().audit(scope=scope)
+    except KeyError as e:
+        raise click.ClickException(str(e)) from e
+    for issue in issues:
+        click.echo(f"{issue.code}: {issue.entry}: {issue.detail}")
+    if issues:
+        raise click.exceptions.Exit(1)
+    if not quiet:
+        click.echo("Memory audit passed")
+
+
 @memory.command("index")
 @click.option("--scope", help="Root whose index to generate (default: the write root).")
 @click.option("--write", is_flag=True, help="Write MEMORY.md instead of printing it.")

--- a/gptme/memory/__init__.py
+++ b/gptme/memory/__init__.py
@@ -13,11 +13,19 @@ from .recall import (
     render_recall,
 )
 from .roots import MemoryRoot, resolve_roots
-from .schema import MemoryEntry, MemoryParseError, parse_entry, slugify
-from .store import MemoryStore, update_index_line
+from .schema import (
+    MemoryEntry,
+    MemoryFrontmatterError,
+    MemoryParseError,
+    parse_entry,
+    slugify,
+)
+from .store import AuditIssue, MemoryStore, update_index_line
 
 __all__ = [
+    "AuditIssue",
     "MemoryEntry",
+    "MemoryFrontmatterError",
     "MemoryParseError",
     "MemoryRoot",
     "MemoryStore",

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -33,6 +33,10 @@ class MemoryParseError(ValueError):
     """Raised when a file is not a memory entry (no or unusable frontmatter)."""
 
 
+class MemoryFrontmatterError(MemoryParseError):
+    """Raised when strict parsing is required but the YAML is invalid."""
+
+
 def slugify(name: str) -> str:
     """Convert a name to a safe filename slug (``My Fact!`` → ``my-fact``)."""
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")
@@ -174,12 +178,16 @@ def _lenient_load(raw: str) -> dict[str, Any]:
     return data
 
 
-def parse_frontmatter(raw: str) -> dict[str, Any]:
+def parse_frontmatter(raw: str, *, strict: bool = False) -> dict[str, Any]:
     try:
         loaded = yaml.safe_load(raw)
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        if strict:
+            raise MemoryFrontmatterError(f"invalid YAML: {exc}") from exc
         return _lenient_load(raw)
     if not isinstance(loaded, dict):
+        if strict:
+            raise MemoryFrontmatterError("invalid YAML: frontmatter is not a mapping")
         return _lenient_load(raw)
     return loaded
 
@@ -193,13 +201,17 @@ def _as_list(value: Any) -> list[str]:
 
 
 def entry_from_text(
-    text: str, path: Path | None = None, scope: str | None = None
+    text: str,
+    path: Path | None = None,
+    scope: str | None = None,
+    *,
+    strict: bool = False,
 ) -> MemoryEntry:
     parts = split_frontmatter(text)
     if parts is None:
         raise MemoryParseError(f"no frontmatter: {path or '<text>'}")
     raw, body = parts
-    data = parse_frontmatter(raw)
+    data = parse_frontmatter(raw, strict=strict)
     if not data:
         raise MemoryParseError(f"empty frontmatter: {path or '<text>'}")
 
@@ -239,6 +251,10 @@ def entry_from_text(
     )
 
 
-def parse_entry(path: Path, scope: str | None = None) -> MemoryEntry:
+def parse_entry(
+    path: Path, scope: str | None = None, *, strict: bool = False
+) -> MemoryEntry:
     """Parse one memory file. Raises :class:`MemoryParseError` for non-entries."""
-    return entry_from_text(path.read_text(encoding="utf-8"), path=path, scope=scope)
+    return entry_from_text(
+        path.read_text(encoding="utf-8"), path=path, scope=scope, strict=strict
+    )

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -192,11 +192,19 @@ def parse_frontmatter(raw: str, *, strict: bool = False) -> dict[str, Any]:
     return loaded
 
 
-def _as_list(value: Any) -> list[str]:
+def _as_list(
+    value: Any, *, field_name: str = "value", strict: bool = False
+) -> list[str]:
     if value is None:
         return []
     if isinstance(value, str):
         return [value]
+    if strict and (
+        not isinstance(value, list) or not all(isinstance(v, str) for v in value)
+    ):
+        raise MemoryFrontmatterError(f"invalid {field_name}: expected string list")
+    if not isinstance(value, list):
+        return [str(value)]
     return [str(v) for v in value]
 
 
@@ -215,22 +223,39 @@ def entry_from_text(
     if not data:
         raise MemoryParseError(f"empty frontmatter: {path or '<text>'}")
 
-    metadata = data.get("metadata")
-    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    raw_metadata = data.get("metadata")
+    if strict and raw_metadata is not None and not isinstance(raw_metadata, dict):
+        raise MemoryFrontmatterError("invalid metadata: expected mapping")
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
     type_ = metadata.pop("type", None) or data.get("type") or DEFAULT_TYPE
+    if strict and not isinstance(type_, str):
+        raise MemoryFrontmatterError("invalid type: expected string")
 
     name = data.get("name") or (path.stem if path is not None else None)
     if not name:
         raise MemoryParseError(f"entry has no name: {path or '<text>'}")
+    if strict and not isinstance(name, str):
+        raise MemoryFrontmatterError("invalid name: expected string")
 
     confidence = data.get("confidence")
     try:
         confidence = float(confidence) if confidence is not None else None
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        if strict:
+            raise MemoryFrontmatterError("invalid confidence: expected number") from exc
         confidence = None
+    if strict and confidence is not None and not 0 <= confidence <= 1:
+        raise MemoryFrontmatterError("invalid confidence: expected 0..1")
 
     provenance = data.get("provenance")
-    status = str(data.get("status") or DEFAULT_STATUS)
+    if strict and provenance is not None and not isinstance(provenance, dict):
+        raise MemoryFrontmatterError("invalid provenance: expected mapping")
+    raw_status = data.get("status") or DEFAULT_STATUS
+    if strict and (not isinstance(raw_status, str) or raw_status not in STATUSES):
+        raise MemoryFrontmatterError(
+            f"invalid status: expected one of {', '.join(STATUSES)}"
+        )
+    status = str(raw_status)
 
     return MemoryEntry(
         name=str(name),
@@ -239,11 +264,13 @@ def entry_from_text(
         body=body.strip("\n"),
         title=str(data["title"]) if data.get("title") else None,
         status=status if status in STATUSES else DEFAULT_STATUS,
-        supersedes=_as_list(data.get("supersedes")),
+        supersedes=_as_list(
+            data.get("supersedes"), field_name="supersedes", strict=strict
+        ),
         superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
         provenance=dict(provenance) if isinstance(provenance, dict) else {},
         confidence=confidence,
-        keywords=_as_list(data.get("keywords")),
+        keywords=_as_list(data.get("keywords"), field_name="keywords", strict=strict),
         recheck=str(data["recheck"]) if data.get("recheck") else None,
         metadata=metadata,
         path=path,

--- a/gptme/memory/schema.py
+++ b/gptme/memory/schema.py
@@ -208,6 +208,14 @@ def _as_list(
     return [str(v) for v in value]
 
 
+def _optional_str(value: Any, *, field_name: str, strict: bool = False) -> str | None:
+    if value is None or value == "":
+        return None
+    if strict and not isinstance(value, str):
+        raise MemoryFrontmatterError(f"invalid {field_name}: expected string")
+    return str(value)
+
+
 def entry_from_text(
     text: str,
     path: Path | None = None,
@@ -231,47 +239,85 @@ def entry_from_text(
     if strict and not isinstance(type_, str):
         raise MemoryFrontmatterError("invalid type: expected string")
 
-    name = data.get("name") or (path.stem if path is not None else None)
+    if "name" in data:
+        raw_name = data["name"]
+        if strict and (not isinstance(raw_name, str) or not raw_name.strip()):
+            raise MemoryFrontmatterError("invalid name: expected non-empty string")
+        name = (
+            raw_name
+            if isinstance(raw_name, str) and raw_name
+            else (path.stem if path is not None else None)
+        )
+        if name is not None and not isinstance(name, str):
+            name = str(name)
+    else:
+        name = path.stem if path is not None else None
     if not name:
         raise MemoryParseError(f"entry has no name: {path or '<text>'}")
-    if strict and not isinstance(name, str):
-        raise MemoryFrontmatterError("invalid name: expected string")
 
     confidence = data.get("confidence")
-    try:
-        confidence = float(confidence) if confidence is not None else None
-    except (TypeError, ValueError) as exc:
+    if confidence is None:
+        parsed_confidence = None
+    elif isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
         if strict:
-            raise MemoryFrontmatterError("invalid confidence: expected number") from exc
-        confidence = None
-    if strict and confidence is not None and not 0 <= confidence <= 1:
+            raise MemoryFrontmatterError("invalid confidence: expected number")
+        try:
+            parsed_confidence = float(confidence)
+        except (TypeError, ValueError):
+            parsed_confidence = None
+    else:
+        parsed_confidence = float(confidence)
+    if strict and parsed_confidence is not None and not 0 <= parsed_confidence <= 1:
         raise MemoryFrontmatterError("invalid confidence: expected 0..1")
 
     provenance = data.get("provenance")
     if strict and provenance is not None and not isinstance(provenance, dict):
         raise MemoryFrontmatterError("invalid provenance: expected mapping")
-    raw_status = data.get("status") or DEFAULT_STATUS
-    if strict and (not isinstance(raw_status, str) or raw_status not in STATUSES):
-        raise MemoryFrontmatterError(
-            f"invalid status: expected one of {', '.join(STATUSES)}"
-        )
-    status = str(raw_status)
+    if "status" in data:
+        raw_status = data["status"]
+    else:
+        raw_status = DEFAULT_STATUS
+    if strict:
+        if not isinstance(raw_status, str) or raw_status not in STATUSES:
+            raise MemoryFrontmatterError(
+                f"invalid status: expected one of {', '.join(STATUSES)}"
+            )
+        status = raw_status
+    else:
+        status = str(raw_status) if raw_status else DEFAULT_STATUS
+        if status not in STATUSES:
+            status = DEFAULT_STATUS
+
+    raw_description = data.get("description")
+    if raw_description is None:
+        description = ""
+    elif strict and not isinstance(raw_description, str):
+        raise MemoryFrontmatterError("invalid description: expected string")
+    else:
+        description = str(raw_description).strip()
+
+    raw_title = data.get("title")
+    if strict and raw_title is not None and not isinstance(raw_title, str):
+        raise MemoryFrontmatterError("invalid title: expected string")
+    title = str(raw_title) if raw_title else None
 
     return MemoryEntry(
         name=str(name),
-        description=str(data.get("description") or "").strip(),
+        description=description,
         type=str(type_),
         body=body.strip("\n"),
-        title=str(data["title"]) if data.get("title") else None,
-        status=status if status in STATUSES else DEFAULT_STATUS,
+        title=title,
+        status=status,
         supersedes=_as_list(
             data.get("supersedes"), field_name="supersedes", strict=strict
         ),
-        superseded_by=str(data["superseded_by"]) if data.get("superseded_by") else None,
+        superseded_by=_optional_str(
+            data.get("superseded_by"), field_name="superseded_by", strict=strict
+        ),
         provenance=dict(provenance) if isinstance(provenance, dict) else {},
-        confidence=confidence,
+        confidence=parsed_confidence,
         keywords=_as_list(data.get("keywords"), field_name="keywords", strict=strict),
-        recheck=str(data["recheck"]) if data.get("recheck") else None,
+        recheck=_optional_str(data.get("recheck"), field_name="recheck", strict=strict),
         metadata=metadata,
         path=path,
         scope=scope,

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -223,6 +223,8 @@ class MemoryStore:
         new = parse_entry(new_path, scope=root.scope, strict=True)
         if not new.is_living:
             raise ValueError(f"replacement entry {new.name!r} is not living")
+        if not old.is_living and old.superseded_by != new.name:
+            raise ValueError(f"entry {old.name!r} is not living")
 
         old_original = old.to_markdown()
         new_original = new.to_markdown()
@@ -268,14 +270,24 @@ class MemoryStore:
             entries[entry.name] = entry
 
         for entry in entries.values():
-            if entry.superseded_by and entry.superseded_by not in entries:
-                issues.append(
-                    AuditIssue(
-                        "dangling-superseded-by",
-                        entry.name,
-                        f"replacement {entry.superseded_by!r} does not exist",
+            if entry.superseded_by:
+                replacement = entries.get(entry.superseded_by)
+                if replacement is None:
+                    issues.append(
+                        AuditIssue(
+                            "dangling-superseded-by",
+                            entry.name,
+                            f"replacement {entry.superseded_by!r} does not exist",
+                        )
                     )
-                )
+                elif entry.name not in replacement.supersedes:
+                    issues.append(
+                        AuditIssue(
+                            "asymmetric-supersession",
+                            entry.name,
+                            f"{entry.superseded_by!r} does not point back to this entry",
+                        )
+                    )
             for old_name in entry.supersedes:
                 old = entries.get(old_name)
                 if old is None:

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import stat
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -31,16 +32,28 @@ INDEX_FILENAME = "MEMORY.md"
 INDEX_HEADER = "# Persistent Memory"
 
 
+def _preserve_mode(tmp: Path, dest: Path) -> None:
+    """Copy dest's permission bits onto tmp so ``os.replace`` does not widen access."""
+    try:
+        mode = stat.S_IMODE(dest.stat().st_mode)
+    except FileNotFoundError:
+        return
+    os.chmod(tmp, mode)
+
+
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` via a same-directory temp file and ``os.replace``.
 
     Staging the content first means ENOSPC cannot truncate the destination.
     ``os.replace`` is atomic on POSIX when source and dest share a filesystem.
+    Existing destination permission bits are copied onto the staged file so a
+    private ``0600`` memory file is not rewritten as world-readable.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         tmp.write_text(text, encoding="utf-8")
+        _preserve_mode(tmp, path)
         os.replace(tmp, path)
     except OSError:
         tmp.unlink(missing_ok=True)
@@ -53,6 +66,7 @@ def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
     All payloads land in sibling temp files before any destination is renamed
     into place, so a disk-full error during staging leaves originals untouched.
     Destinations already renamed are restored from the in-memory snapshot.
+    Existing destination modes are copied onto each staged file before replace.
     """
     staged: list[tuple[Path, Path, str | None]] = []
     replaced: list[tuple[Path, str | None]] = []
@@ -62,6 +76,7 @@ def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
             dest.parent.mkdir(parents=True, exist_ok=True)
             tmp = dest.with_name(f".{dest.name}.{os.getpid()}.tmp")
             tmp.write_text(text, encoding="utf-8")
+            _preserve_mode(tmp, dest)
             staged.append((dest, tmp, original))
         for dest, tmp, original in staged:
             os.replace(tmp, dest)

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -226,8 +226,12 @@ class MemoryStore:
         if not old.is_living and old.superseded_by != new.name:
             raise ValueError(f"entry {old.name!r} is not living")
 
-        old_original = old.to_markdown()
-        new_original = new.to_markdown()
+        old_original = old_path.read_text(encoding="utf-8")
+        new_original = new_path.read_text(encoding="utf-8")
+        index_path = self.index_path(root.scope)
+        index_original = (
+            index_path.read_text(encoding="utf-8") if index_path.is_file() else None
+        )
         old = replace(old, status="superseded", superseded_by=new.name)
         new_supersedes = list(new.supersedes)
         if old.name not in new_supersedes:
@@ -239,14 +243,18 @@ class MemoryStore:
         # Validate both complete serializations before the first write.
         entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
         entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
-        old_path.write_text(old_text, encoding="utf-8")
         try:
+            old_path.write_text(old_text, encoding="utf-8")
             new_path.write_text(new_text, encoding="utf-8")
+            self.write_index(root.scope)
         except OSError:
             old_path.write_text(old_original, encoding="utf-8")
             new_path.write_text(new_original, encoding="utf-8")
+            if index_original is None:
+                index_path.unlink(missing_ok=True)
+            else:
+                index_path.write_text(index_original, encoding="utf-8")
             raise
-        self.write_index(root.scope)
         return old, new
 
     def audit(self, *, scope: str | None = None) -> list[AuditIssue]:
@@ -266,6 +274,15 @@ class MemoryStore:
                 continue
             except (MemoryParseError, OSError, UnicodeDecodeError) as exc:
                 issues.append(AuditIssue("invalid-entry", path.name, str(exc)))
+                continue
+            if entry.name in entries:
+                issues.append(
+                    AuditIssue(
+                        "duplicate-name",
+                        path.name,
+                        f"name {entry.name!r} is also used by {entries[entry.name].path}",
+                    )
+                )
                 continue
             entries[entry.name] = entry
 

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -15,7 +16,9 @@ from .schema import (
     DEFAULT_TYPE,
     TYPE_ORDER,
     MemoryEntry,
+    MemoryFrontmatterError,
     MemoryParseError,
+    entry_from_text,
     is_index_file,
     parse_entry,
     slugify,
@@ -25,6 +28,16 @@ logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "MEMORY.md"
 INDEX_HEADER = "# Persistent Memory"
+
+
+@dataclass(frozen=True)
+class AuditIssue:
+    """One actionable consistency problem in a memory root."""
+
+    code: str
+    entry: str
+    detail: str
+
 
 try:
     import fcntl as _fcntl
@@ -185,6 +198,103 @@ class MemoryStore:
         update_index_line(root.path, entry)
         logger.debug("saved memory %s to %s", entry.name, entry.path)
         return entry.path
+
+    def supersede(
+        self, old_name: str, new_name: str, *, scope: str | None = None
+    ) -> tuple[MemoryEntry, MemoryEntry]:
+        """Mark ``old_name`` superseded by ``new_name`` and link both entries.
+
+        Supersession is scoped to one root so a project memory can never mutate
+        a same-named user memory. Strict parsing prevents the write from
+        normalizing malformed frontmatter through the lenient read fallback.
+        """
+        root = self.root(scope)
+        old = self.get(old_name, scope=root.scope)
+        new = self.get(new_name, scope=root.scope)
+        if old is None:
+            raise KeyError(f"no memory entry named {old_name!r} in {root.scope}")
+        if new is None:
+            raise KeyError(f"no memory entry named {new_name!r} in {root.scope}")
+        if old.path == new.path:
+            raise ValueError("an entry cannot supersede itself")
+        assert old.path is not None and new.path is not None
+        old_path, new_path = old.path, new.path
+        old = parse_entry(old_path, scope=root.scope, strict=True)
+        new = parse_entry(new_path, scope=root.scope, strict=True)
+        if not new.is_living:
+            raise ValueError(f"replacement entry {new.name!r} is not living")
+
+        old_original = old.to_markdown()
+        new_original = new.to_markdown()
+        old = replace(old, status="superseded", superseded_by=new.name)
+        new_supersedes = list(new.supersedes)
+        if old.name not in new_supersedes:
+            new_supersedes.append(old.name)
+        new = replace(new, supersedes=new_supersedes)
+        old_text = old.to_markdown()
+        new_text = new.to_markdown()
+
+        # Validate both complete serializations before the first write.
+        entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
+        entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
+        old_path.write_text(old_text, encoding="utf-8")
+        try:
+            new_path.write_text(new_text, encoding="utf-8")
+        except OSError:
+            old_path.write_text(old_original, encoding="utf-8")
+            new_path.write_text(new_original, encoding="utf-8")
+            raise
+        self.write_index(root.scope)
+        return old, new
+
+    def audit(self, *, scope: str | None = None) -> list[AuditIssue]:
+        """Return parse and supersession consistency issues for one root."""
+        root = self.root(scope)
+        entries: dict[str, MemoryEntry] = {}
+        issues: list[AuditIssue] = []
+        if not root.path.is_dir():
+            return issues
+        for path in sorted(root.path.glob("*.md")):
+            if is_index_file(path):
+                continue
+            try:
+                entry = parse_entry(path, scope=root.scope, strict=True)
+            except MemoryFrontmatterError as exc:
+                issues.append(AuditIssue("invalid-yaml", path.name, str(exc)))
+                continue
+            except (MemoryParseError, OSError, UnicodeDecodeError) as exc:
+                issues.append(AuditIssue("invalid-entry", path.name, str(exc)))
+                continue
+            entries[entry.name] = entry
+
+        for entry in entries.values():
+            if entry.superseded_by and entry.superseded_by not in entries:
+                issues.append(
+                    AuditIssue(
+                        "dangling-superseded-by",
+                        entry.name,
+                        f"replacement {entry.superseded_by!r} does not exist",
+                    )
+                )
+            for old_name in entry.supersedes:
+                old = entries.get(old_name)
+                if old is None:
+                    issues.append(
+                        AuditIssue(
+                            "dangling-supersedes",
+                            entry.name,
+                            f"superseded entry {old_name!r} does not exist",
+                        )
+                    )
+                elif old.superseded_by != entry.name:
+                    issues.append(
+                        AuditIssue(
+                            "asymmetric-supersession",
+                            entry.name,
+                            f"{old_name!r} does not point back to this entry",
+                        )
+                    )
+        return issues
 
     # -- index -------------------------------------------------------------
 

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,60 @@ logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "MEMORY.md"
 INDEX_HEADER = "# Persistent Memory"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via a same-directory temp file and ``os.replace``.
+
+    Staging the content first means ENOSPC cannot truncate the destination.
+    ``os.replace`` is atomic on POSIX when source and dest share a filesystem.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _commit_replacements(pairs: list[tuple[Path, str]]) -> None:
+    """Replace each destination with staged content; restore on failure.
+
+    All payloads land in sibling temp files before any destination is renamed
+    into place, so a disk-full error during staging leaves originals untouched.
+    Destinations already renamed are restored from the in-memory snapshot.
+    """
+    staged: list[tuple[Path, Path, str | None]] = []
+    replaced: list[tuple[Path, str | None]] = []
+    try:
+        for dest, text in pairs:
+            original = dest.read_text(encoding="utf-8") if dest.is_file() else None
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dest.with_name(f".{dest.name}.{os.getpid()}.tmp")
+            tmp.write_text(text, encoding="utf-8")
+            staged.append((dest, tmp, original))
+        for dest, tmp, original in staged:
+            os.replace(tmp, dest)
+            replaced.append((dest, original))
+    except OSError:
+        for _dest, tmp, _original in staged:
+            tmp.unlink(missing_ok=True)
+        restore_errors: list[OSError] = []
+        for dest, original in replaced:
+            try:
+                if original is None:
+                    dest.unlink(missing_ok=True)
+                else:
+                    dest.write_text(original, encoding="utf-8")
+            except OSError as restore_exc:
+                restore_errors.append(restore_exc)
+        if restore_errors:
+            raise OSError(
+                f"write failed and rollback incomplete ({restore_errors[0]})"
+            ) from restore_errors[0]
+        raise
 
 
 @dataclass(frozen=True)
@@ -226,12 +281,6 @@ class MemoryStore:
         if not old.is_living and old.superseded_by != new.name:
             raise ValueError(f"entry {old.name!r} is not living")
 
-        old_original = old_path.read_text(encoding="utf-8")
-        new_original = new_path.read_text(encoding="utf-8")
-        index_path = self.index_path(root.scope)
-        index_original = (
-            index_path.read_text(encoding="utf-8") if index_path.is_file() else None
-        )
         old = replace(old, status="superseded", superseded_by=new.name)
         new_supersedes = list(new.supersedes)
         if old.name not in new_supersedes:
@@ -243,18 +292,28 @@ class MemoryStore:
         # Validate both complete serializations before the first write.
         entry_from_text(old_text, path=old_path, scope=root.scope, strict=True)
         entry_from_text(new_text, path=new_path, scope=root.scope, strict=True)
-        try:
-            old_path.write_text(old_text, encoding="utf-8")
-            new_path.write_text(new_text, encoding="utf-8")
-            self.write_index(root.scope)
-        except OSError:
-            old_path.write_text(old_original, encoding="utf-8")
-            new_path.write_text(new_original, encoding="utf-8")
-            if index_original is None:
-                index_path.unlink(missing_ok=True)
+
+        updated_entries = []
+        for entry in self.index_entries(root.scope):
+            if entry.path == old_path:
+                updated_entries.append(old)
+            elif entry.path == new_path:
+                updated_entries.append(new)
             else:
-                index_path.write_text(index_original, encoding="utf-8")
-            raise
+                updated_entries.append(entry)
+        seen_paths = {entry.path for entry in updated_entries}
+        if old_path not in seen_paths:
+            updated_entries.append(old)
+        if new_path not in seen_paths:
+            updated_entries.append(new)
+        index_text = self.render_index(updated_entries)
+        _commit_replacements(
+            [
+                (old_path, old_text),
+                (new_path, new_text),
+                (self.index_path(root.scope), index_text),
+            ]
+        )
         return old, new
 
     def audit(self, *, scope: str | None = None) -> list[AuditIssue]:
@@ -400,9 +459,8 @@ class MemoryStore:
     ) -> Path:
         root = self.root(scope)
         text = self.render_index(self.index_entries(scope), budget=budget)
-        root.path.mkdir(parents=True, exist_ok=True)
         path = root.path / INDEX_FILENAME
-        path.write_text(text, encoding="utf-8")
+        _atomic_write(path, text)
         return path
 
     def check_index(

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -152,6 +152,97 @@ class TestStore:
             ]
         )
 
+    def test_supersede_links_both_entries_and_regenerates_index(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old-belief", "Old belief", "Old body", scope="project")
+        store.save("new-belief", "New belief", "New body", scope="project")
+
+        old, new = store.supersede("old-belief", "new-belief", scope="project")
+
+        assert old.status == "superseded"
+        assert old.superseded_by == "new-belief"
+        assert new.supersedes == ["old-belief"]
+        assert not old.is_living
+        reparsed_old = parse_entry(tmp_path / "project" / "old-belief.md")
+        reparsed_new = parse_entry(tmp_path / "project" / "new-belief.md")
+        assert reparsed_old.superseded_by == "new-belief"
+        assert reparsed_new.supersedes == ["old-belief"]
+        index = (tmp_path / "project" / "MEMORY.md").read_text()
+        assert "new-belief.md" in index
+        assert "old-belief.md" not in index
+
+    def test_supersede_requires_strict_frontmatter_before_rewriting(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: unquoted: colon\n---\nold body\n",
+        )
+        _write(root, "new", "---\nname: new\ndescription: fine\n---\nnew body\n")
+        store = self._store(tmp_path)
+
+        with pytest.raises(ValueError, match="invalid YAML"):
+            store.supersede("old", "new", scope="project")
+
+        assert "status: superseded" not in (root / "old.md").read_text()
+
+    def test_supersede_rejects_cross_root_entries(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="user")
+
+        with pytest.raises(KeyError, match="new"):
+            store.supersede("old", "new", scope="project")
+
+    def test_supersede_rejects_self_and_non_living_replacement(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("one", "one", scope="project")
+        store.save("two", "two", scope="project")
+
+        with pytest.raises(ValueError, match="itself"):
+            store.supersede("one", "one", scope="project")
+        store.supersede("one", "two", scope="project")
+        store.save("three", "three", scope="project")
+        with pytest.raises(ValueError, match="not living"):
+            store.supersede("three", "one", scope="project")
+
+    def test_audit_reports_invalid_yaml_and_broken_supersession(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "invalid",
+            "---\nname: invalid\ndescription: unquoted: colon\n---\nbody\n",
+        )
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: old\nstatus: superseded\nsuperseded_by: missing\n---\n",
+        )
+        store = self._store(tmp_path)
+
+        issues = store.audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} >= {
+            ("invalid-yaml", "invalid.md"),
+            ("dangling-superseded-by", "old"),
+        }
+
+    def test_audit_reports_dangling_and_asymmetric_forward_links(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "new",
+            "---\nname: new\ndescription: new\nsupersedes: [missing, old]\n---\n",
+        )
+        _write(root, "old", "---\nname: old\ndescription: old\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} == {
+            ("dangling-supersedes", "new"),
+            ("asymmetric-supersession", "new"),
+        }
+
     def test_union_and_nearest_wins(self, tmp_path):
         _write(
             tmp_path / "project",
@@ -464,6 +555,35 @@ class TestCli:
     def test_index_budget_cli_rejects_non_positive(self, env):
         r = CliRunner().invoke(util_main, ["memory", "index", "--budget", "0"])
         assert r.exit_code != 0
+
+    def test_supersede_and_audit_cli(self, env):
+        runner = CliRunner()
+        for name in ("old", "new"):
+            result = runner.invoke(
+                util_main,
+                ["memory", "save", name, f"{name} description"],
+            )
+            assert result.exit_code == 0, result.output
+
+        result = runner.invoke(util_main, ["memory", "supersede", "old", "new"])
+        assert result.exit_code == 0, result.output
+        assert "old -> new" in result.output
+        result = runner.invoke(util_main, ["memory", "audit", "--quiet"])
+        assert result.exit_code == 0, result.output
+        assert result.output == ""
+
+    def test_audit_cli_fails_on_invalid_yaml(self, env):
+        _write(
+            env,
+            "invalid",
+            "---\nname: invalid\ndescription: unquoted: colon\n---\nbody\n",
+        )
+
+        result = CliRunner().invoke(util_main, ["memory", "audit"])
+
+        assert result.exit_code == 1
+        assert "invalid-yaml" in result.output
+        assert "invalid.md" in result.output
 
     def test_recall_hook_json_reads_claude_payload(self, env):
         _write(

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -202,9 +202,13 @@ class TestStore:
         with pytest.raises(ValueError, match="itself"):
             store.supersede("one", "one", scope="project")
         store.supersede("one", "two", scope="project")
+        # Repeating the exact supersession is idempotent.
+        store.supersede("one", "two", scope="project")
         store.save("three", "three", scope="project")
         with pytest.raises(ValueError, match="not living"):
             store.supersede("three", "one", scope="project")
+        with pytest.raises(ValueError, match="not living"):
+            store.supersede("one", "three", scope="project")
 
     def test_audit_reports_invalid_yaml_and_broken_supersession(self, tmp_path):
         root = tmp_path / "project"
@@ -225,6 +229,21 @@ class TestStore:
         assert {(issue.code, issue.entry) for issue in issues} >= {
             ("invalid-yaml", "invalid.md"),
             ("dangling-superseded-by", "old"),
+        }
+
+    def test_audit_reports_asymmetric_reverse_link(self, tmp_path):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "old",
+            "---\nname: old\ndescription: old\nstatus: superseded\nsuperseded_by: new\n---\n",
+        )
+        _write(root, "new", "---\nname: new\ndescription: new\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert {(issue.code, issue.entry) for issue in issues} == {
+            ("asymmetric-supersession", "old")
         }
 
     def test_audit_reports_dangling_and_asymmetric_forward_links(self, tmp_path):

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -195,11 +195,32 @@ class TestStore:
         root = tmp_path / "project"
         before = {path.name: path.read_text() for path in root.glob("*.md")}
 
-        def fail_index(*_args, **_kwargs):
+        def fail_commit(*_args, **_kwargs):
             raise OSError("disk full")
 
-        monkeypatch.setattr(store, "write_index", fail_index)
+        monkeypatch.setattr("gptme.memory.store._commit_replacements", fail_commit)
         with pytest.raises(OSError, match="disk full"):
+            store.supersede("old", "new", scope="project")
+
+        assert {path.name: path.read_text() for path in root.glob("*.md")} == before
+
+    def test_supersede_restores_after_partial_replace(self, tmp_path, monkeypatch):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        before = {path.name: path.read_text() for path in root.glob("*.md")}
+        real_replace = __import__("os").replace
+        calls = {"n": 0}
+
+        def fail_second(src, dst, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise OSError("rename failed")
+            return real_replace(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr("gptme.memory.store.os.replace", fail_second)
+        with pytest.raises(OSError, match="rename failed"):
             store.supersede("old", "new", scope="project")
 
         assert {path.name: path.read_text() for path in root.glob("*.md")} == before
@@ -232,12 +253,20 @@ class TestStore:
         "field",
         [
             "status: bogus",
+            "status: false",
             "confidence: nope",
             "confidence: 2",
+            "confidence: true",
             "metadata: nope",
             "provenance: nope",
             "supersedes: 42",
             "keywords: [fine, 42]",
+            "superseded_by: 42",
+            "recheck: 42",
+            "title: 42",
+            "description: 42",
+            "name: false",
+            "name: ''",
         ],
     )
     def test_audit_reports_invalid_field_types(self, tmp_path, field):

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -186,6 +186,24 @@ class TestStore:
 
         assert "status: superseded" not in (root / "old.md").read_text()
 
+    def test_supersede_rolls_back_entries_when_index_write_fails(
+        self, tmp_path, monkeypatch
+    ):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        before = {path.name: path.read_text() for path in root.glob("*.md")}
+
+        def fail_index(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(store, "write_index", fail_index)
+        with pytest.raises(OSError, match="disk full"):
+            store.supersede("old", "new", scope="project")
+
+        assert {path.name: path.read_text() for path in root.glob("*.md")} == before
+
     def test_supersede_rejects_cross_root_entries(self, tmp_path):
         store = self._store(tmp_path)
         store.save("old", "old", scope="project")
@@ -209,6 +227,42 @@ class TestStore:
             store.supersede("three", "one", scope="project")
         with pytest.raises(ValueError, match="not living"):
             store.supersede("one", "three", scope="project")
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "status: bogus",
+            "confidence: nope",
+            "confidence: 2",
+            "metadata: nope",
+            "provenance: nope",
+            "supersedes: 42",
+            "keywords: [fine, 42]",
+        ],
+    )
+    def test_audit_reports_invalid_field_types(self, tmp_path, field):
+        root = tmp_path / "project"
+        _write(
+            root,
+            "invalid",
+            f"---\nname: invalid\ndescription: invalid\n{field}\n---\nbody\n",
+        )
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert len(issues) == 1
+        assert issues[0].code == "invalid-yaml"
+
+    def test_audit_reports_duplicate_names(self, tmp_path):
+        root = tmp_path / "project"
+        _write(root, "a", "---\nname: same\ndescription: first\n---\n")
+        _write(root, "z", "---\nname: same\ndescription: second\n---\n")
+
+        issues = self._store(tmp_path).audit(scope="project")
+
+        assert [(issue.code, issue.entry) for issue in issues] == [
+            ("duplicate-name", "z.md")
+        ]
 
     def test_audit_reports_invalid_yaml_and_broken_supersession(self, tmp_path):
         root = tmp_path / "project"

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -2,6 +2,7 @@
 
 import importlib
 import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -224,6 +225,37 @@ class TestStore:
             store.supersede("old", "new", scope="project")
 
         assert {path.name: path.read_text() for path in root.glob("*.md")} == before
+
+    def test_supersede_preserves_existing_file_mode(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("old", "old", scope="project")
+        store.save("new", "new", scope="project")
+        root = tmp_path / "project"
+        for name in ("old.md", "new.md", "MEMORY.md"):
+            (root / name).chmod(0o600)
+
+        previous = os.umask(0o022)
+        try:
+            store.supersede("old", "new", scope="project")
+        finally:
+            os.umask(previous)
+
+        for name in ("old.md", "new.md", "MEMORY.md"):
+            assert stat.S_IMODE((root / name).stat().st_mode) == 0o600
+
+    def test_write_index_preserves_existing_file_mode(self, tmp_path):
+        store = self._store(tmp_path)
+        store.save("fact", "fact", scope="project")
+        index = tmp_path / "project" / "MEMORY.md"
+        index.chmod(0o600)
+
+        previous = os.umask(0o022)
+        try:
+            store.write_index(scope="project")
+        finally:
+            os.umask(previous)
+
+        assert stat.S_IMODE(index.stat().st_mode) == 0o600
 
     def test_supersede_rejects_cross_root_entries(self, tmp_path):
         store = self._store(tmp_path)


### PR DESCRIPTION
## Summary

Adds the Phase 2.2 lifecycle primitives from gptme/gptme#3734:

- `gptme-util memory supersede OLD NEW [--scope SCOPE]` marks the old entry `superseded`, links both directions, and regenerates that root's index
- `gptme-util memory audit [--scope SCOPE] [--quiet]` fails on invalid YAML, malformed entries, dangling supersession targets, and asymmetric links
- strict parsing is opt-in for mutation/audit, preserving the existing lenient read path for real Claude Code memory files
- supersession is constrained to one root and refuses self-links, non-living replacements, and retargeting an already-superseded entry

## Safety

`supersede` parses both source files strictly and validates both rendered entries before writing. It is idempotent for the same `OLD -> NEW` pair. It never crosses layered roots.

This PR stacks on gptme/gptme#3764 because both add tests and docs to the same Phase 1 files. The functional diff is the two commits after `57d8963b2`.

## Verification

- `pytest tests/test_memory_store.py -q`: **45 passed, 1 skipped**
- `ruff check` on all changed Python files: clean
- `mypy gptme/memory gptme/cli/cmd_memory.py --ignore-missing-imports --follow-imports=skip`: clean
- pre-commit hooks: clean on both commits

Part of gptme/gptme#3734.
