### PR TITLE
feat(server): add /preview/{port}/ proxy for cloud port exposure (gptme-cloud#910)

### DIFF
--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -112,6 +112,7 @@ def create_app(
     from .auth import auth_api  # fmt: skip
     from .computer_api import computer_api  # fmt: skip
     from .panels_api import panels_api  # fmt: skip
+    from .preview_proxy_api import preview_proxy_api  # fmt: skip
     from .skills_api import skills_api  # fmt: skip
     from .tasks_api import tasks_api  # fmt: skip
     from .tools_api import tools_api  # fmt: skip
@@ -129,6 +130,7 @@ def create_app(
     app.register_blueprint(tools_api)
     app.register_blueprint(tts_api)
     app.register_blueprint(computer_api)
+    app.register_blueprint(preview_proxy_api)
 
     # Register OpenAPI documentation
     from .openapi_docs import docs_api  # fmt: skip

--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -38,6 +38,10 @@ _DEFAULT_ALLOWED_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # Cookie configuration
 AUTH_COOKIE_NAME = "gptme_auth"
 AUTH_COOKIE_MAX_AGE = 86400  # 24 hours
+# Dual path: /api/ for SSE and capability routes; /preview/ for iframe
+# document/WebSocket requests. Preview HTML is never served under /api/
+# (that would grant untrusted content the API cookie scope).
+AUTH_COOKIE_PATHS: tuple[str, ...] = ("/api/", "/preview/")
 
 # Blueprint for auth endpoints
 auth_api = flask.Blueprint("auth_api", __name__)
@@ -363,15 +367,16 @@ def set_auth_cookie():
         return jsonify({"error": "Authentication system error"}), 500
 
     response = jsonify({"ok": True, "message": "Auth cookie set"})
-    response.set_cookie(
-        AUTH_COOKIE_NAME,
-        server_token,
-        max_age=AUTH_COOKIE_MAX_AGE,
-        httponly=True,
-        samesite="Lax",
-        secure=request.is_secure,
-        path="/api/",
-    )
+    for cookie_path in AUTH_COOKIE_PATHS:
+        response.set_cookie(
+            AUTH_COOKIE_NAME,
+            server_token,
+            max_age=AUTH_COOKIE_MAX_AGE,
+            httponly=True,
+            samesite="Lax",
+            secure=request.is_secure,
+            path=cookie_path,
+        )
     logger.info("Auth cookie set for client")
     return response
 
@@ -384,11 +389,12 @@ def clear_auth_cookie():
         200 with success message and expired Set-Cookie header.
     """
     response = jsonify({"ok": True, "message": "Auth cookie cleared"})
-    response.delete_cookie(
-        AUTH_COOKIE_NAME,
-        path="/api/",
-        secure=request.is_secure,
-        samesite="Lax",
-    )
+    for cookie_path in AUTH_COOKIE_PATHS:
+        response.delete_cookie(
+            AUTH_COOKIE_NAME,
+            path=cookie_path,
+            secure=request.is_secure,
+            samesite="Lax",
+        )
     logger.info("Auth cookie cleared for client")
     return response

--- a/gptme/server/preview_proxy_api.py
+++ b/gptme/server/preview_proxy_api.py
@@ -1,0 +1,360 @@
+"""
+Preview port proxy for gptme-server.
+
+Exposes in-pod TCP ports under the authenticated ``/preview/{port}/`` path so
+that the browser (and noVNC) can reach agent-started services without any
+infrastructure changes.
+
+Route (HTTP)::
+
+    ANY /preview/<port>/[<path>]  →  http://127.0.0.1:<port>/[<path>]
+
+Route (WebSocket)::
+
+    WS  /preview/<port>/[<path>]  →  ws://127.0.0.1:<port>/[<path>]
+    (detected by ``Upgrade: websocket`` request header)
+
+The path is reachable via the existing Traefik-authenticated ``/api/v1/instances/{id}``
+strip-prefix path in the cloud deployment, so no infra changes are required —
+authentication, ownership, and WebSocket forwarding are all inherited.
+
+Security
+--------
+- Only loopback targets (``127.0.0.1``) — user-supplied hostnames are rejected
+  (SSRF guard).
+- Ports below 1024 are rejected (privileged).
+- A small set of well-known ports are explicitly blocked (e.g. gptme-server
+  itself on 5700, raw x11vnc on 5900).
+- ``require_auth`` applied to every route.
+
+noVNC / VNC
+-----------
+Interactive noVNC (websockify on :6080) is proxied via::
+
+    /preview/6080/vnc.html
+    /preview/6080/websockify   (WebSocket)
+
+The ``ComputerPreview`` webui component should build this URL from the
+server-relative base path instead of hard-coding ``http://localhost:6080``.
+
+Design reference: gptme/gptme-cloud#910 (Option A — gptme-server sub-path proxy).
+"""
+
+from __future__ import annotations
+
+import logging
+import select
+import socket
+import threading
+from typing import TYPE_CHECKING, Any
+
+import flask
+import requests as req_lib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from .auth import require_auth
+
+logger = logging.getLogger(__name__)
+
+preview_proxy_api = flask.Blueprint("preview_proxy_api", __name__)
+
+# Ports below this threshold are rejected (privileged / system ports).
+_MIN_ALLOWED_PORT: int = 1024
+# Ports above 65535 are invalid.
+_MAX_ALLOWED_PORT: int = 65535
+
+# Ports explicitly blocked even above 1024 (well-known dangerous local services).
+_BLOCKED_PORTS: frozenset[int] = frozenset(
+    {
+        5700,  # gptme-server itself — avoid self-proxy loops
+        5900,  # x11vnc raw VNC — allow only via websockify/noVNC on 6080
+    }
+)
+
+# Hop-by-hop headers that must not be forwarded end-to-end (RFC 7230 §6.1).
+_HOP_BY_HOP: frozenset[str] = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_port(port: int) -> str | None:
+    """Return an error string if the port is disallowed, else ``None``."""
+    if port < _MIN_ALLOWED_PORT:
+        return f"port {port} is below the minimum allowed port ({_MIN_ALLOWED_PORT})"
+    if port > _MAX_ALLOWED_PORT:
+        return f"port {port} exceeds maximum ({_MAX_ALLOWED_PORT})"
+    if port in _BLOCKED_PORTS:
+        return f"port {port} is explicitly blocked"
+    return None
+
+
+def _is_websocket_upgrade(request: flask.Request) -> bool:
+    """Return True when the HTTP request carries a WebSocket upgrade."""
+    return (
+        request.headers.get("Upgrade", "").lower() == "websocket"
+        and "upgrade" in request.headers.get("Connection", "").lower()
+    )
+
+
+def _get_raw_client_socket(environ: dict[str, Any]) -> socket.socket | None:
+    """Extract the raw client TCP socket from a WSGI environ dict.
+
+    Works with Werkzeug (development server), gunicorn-gevent, and
+    gunicorn-sync transports that back ``wsgi.input`` with a real socket.
+    Returns ``None`` when the transport does not expose a raw socket
+    (e.g. eventlet with a wrapped file object that has no ``_sock``).
+    """
+    # Werkzeug dev server exposes the socket directly.
+    if "werkzeug.socket" in environ:
+        return environ["werkzeug.socket"]
+    # gunicorn exposes it under gunicorn.socket.
+    if "gunicorn.socket" in environ:
+        return environ["gunicorn.socket"]
+    # Fall back: inspect wsgi.input for a backing socket object.
+    wsgi_input = environ.get("wsgi.input")
+    if wsgi_input is None:
+        return None
+    # gevent / gunicorn-gevent: wsgi.input.raw._sock
+    raw = getattr(wsgi_input, "raw", None)
+    if raw is not None:
+        sock = getattr(raw, "_sock", None)
+        if isinstance(sock, socket.socket):
+            return sock
+    # Simple case: wsgi.input._sock
+    sock = getattr(wsgi_input, "_sock", None)
+    if isinstance(sock, socket.socket):
+        return sock
+    return None
+
+
+def _build_upstream_request_line(
+    port: int, subpath: str, environ: dict[str, Any]
+) -> bytes:
+    """Build the raw HTTP/1.1 request bytes to forward to the upstream server.
+
+    This includes the request line, all forwarded headers, and the
+    double CRLF terminator.  The resulting bytes are sent verbatim over
+    the upstream TCP socket so the upstream can complete the WebSocket
+    handshake and then exchange frames with the browser.
+    """
+    method = environ.get("REQUEST_METHOD", "GET")
+    path = "/" + subpath.lstrip("/")
+    qs = environ.get("QUERY_STRING", "")
+    if qs:
+        path = f"{path}?{qs}"
+    http_version = environ.get("SERVER_PROTOCOL", "HTTP/1.1")
+
+    lines: list[str] = [f"{method} {path} {http_version}"]
+    for key, value in flask.request.headers:
+        if key.lower() not in _HOP_BY_HOP and key.lower() != "host":
+            lines.append(f"{key}: {value}")
+    lines.append(f"Host: 127.0.0.1:{port}")
+    lines.append("Connection: Upgrade")
+    lines.append("Upgrade: websocket")
+    # Two trailing CRLFs: one ends the last header, one ends the header block.
+    raw = "\r\n".join(lines) + "\r\n\r\n"
+    return raw.encode("latin-1")
+
+
+def _pump_bidirectional(client_sock: socket.socket, target_sock: socket.socket) -> None:
+    """Forward bytes between *client_sock* and *target_sock* until both close.
+
+    Spawns two daemon threads (one per direction) and blocks until both
+    finish.  Each thread shuts down the write half of the opposite socket
+    when the source side closes, which propagates EOF correctly.
+    """
+
+    def _pump(src: socket.socket, dst: socket.socket, label: str) -> None:
+        try:
+            while True:
+                # Use select with a short timeout so we can notice if the
+                # other thread already closed dst.
+                ready, _, _ = select.select([src], [], [src], 1.0)
+                if not ready:
+                    continue
+                data = src.recv(65536)
+                if not data:
+                    break
+                dst.sendall(data)
+        except OSError:
+            pass
+        finally:
+            try:
+                dst.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+    t_fwd = threading.Thread(
+        target=_pump, args=(client_sock, target_sock, "client→target"), daemon=True
+    )
+    t_rev = threading.Thread(
+        target=_pump, args=(target_sock, client_sock, "target→client"), daemon=True
+    )
+    t_fwd.start()
+    t_rev.start()
+    t_fwd.join()
+    t_rev.join()
+
+
+def _websocket_tunnel(
+    port: int,
+    subpath: str,
+    environ: dict[str, Any],
+) -> flask.Response:
+    """Handle a WebSocket upgrade by opening a raw TCP tunnel to the target port.
+
+    The function connects to ``127.0.0.1:{port}``, forwards the upgrade
+    request, then pumps bytes bidirectionally until both sides close.
+
+    Returns a 501 response when the WSGI transport does not expose a raw socket.
+    Returns a 502 response when the target port is unreachable.
+    """
+    client_sock = _get_raw_client_socket(environ)
+    if client_sock is None:
+        logger.warning(
+            "preview_proxy: WS tunnel requested for port %d but WSGI transport "
+            "does not expose a raw socket — falling back to 501",
+            port,
+        )
+        return flask.jsonify(
+            {
+                "error": (
+                    "WebSocket tunnelling is not supported by this server transport. "
+                    "Run gptme-server under gunicorn-gevent or Werkzeug."
+                )
+            }
+        ), 501
+
+    raw_request = _build_upstream_request_line(port, subpath, environ)
+
+    try:
+        target_sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+    except OSError as exc:
+        logger.warning("preview_proxy: cannot connect to 127.0.0.1:%d — %s", port, exc)
+        return flask.jsonify({"error": f"target unreachable: {exc}"}), 502
+
+    target_sock.sendall(raw_request)
+    _pump_bidirectional(client_sock, target_sock)
+    target_sock.close()
+
+    # The socket is already closed; the WSGI layer must not write any body.
+    # Returning a minimal 101 response satisfies Flask's response contract even
+    # though no bytes will actually be sent (the connection is gone).
+    return flask.Response(status=101)
+
+
+def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
+    """Forward an HTTP request to ``127.0.0.1:{port}`` and stream the response."""
+    qs = flask.request.query_string.decode("latin-1")
+    target_path = "/" + subpath.lstrip("/")
+    if qs:
+        target_path = f"{target_path}?{qs}"
+    target_url = f"http://127.0.0.1:{port}{target_path}"
+
+    fwd_headers = {
+        k: v
+        for k, v in flask.request.headers
+        if k.lower() not in _HOP_BY_HOP and k.lower() != "host"
+    }
+
+    try:
+        upstream = req_lib.request(
+            method=flask.request.method,
+            url=target_url,
+            headers=fwd_headers,
+            data=flask.request.get_data(),
+            stream=True,
+            timeout=30,
+            allow_redirects=False,
+        )
+    except req_lib.exceptions.ConnectionError as exc:
+        logger.debug("preview_proxy: upstream %s unreachable: %s", target_url, exc)
+        return flask.jsonify({"error": f"target unreachable: {exc}"}), 502
+    except req_lib.exceptions.Timeout:
+        return flask.jsonify({"error": "upstream timed out"}), 504
+
+    # Strip hop-by-hop headers from upstream response before forwarding.
+    response_headers = [
+        (k, v) for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP
+    ]
+
+    def _generate() -> Iterator[bytes]:
+        for chunk in upstream.iter_content(chunk_size=65536):
+            if chunk:
+                yield chunk
+
+    return flask.Response(
+        _generate(),
+        status=upstream.status_code,
+        headers=response_headers,
+        direct_passthrough=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+_PROXY_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+
+
+@preview_proxy_api.route(
+    "/preview/<int:port>/",
+    defaults={"subpath": ""},
+    methods=_PROXY_METHODS,
+)
+@preview_proxy_api.route(
+    "/preview/<int:port>/<path:subpath>",
+    methods=_PROXY_METHODS,
+)
+@require_auth
+def preview_proxy(port: int, subpath: str) -> flask.Response:
+    """Proxy HTTP and WebSocket requests to an in-pod loopback port.
+
+    This exposes an arbitrary pod-local TCP port under the authenticated
+    ``/preview/{port}/`` path so browser clients can reach agent-started
+    services (Vite dev server, noVNC/websockify, etc.) without any
+    infrastructure changes.
+
+    **Security**: only ``127.0.0.1`` targets are allowed (SSRF guard).
+    Ports below 1024 and a small set of explicitly blocked ports are
+    rejected with 400.  Authentication is required via ``require_auth``.
+
+    **WebSocket**: detected via ``Upgrade: websocket`` header.  The proxy
+    opens a raw TCP tunnel to the target and forwards the full upgrade
+    handshake plus subsequent frames bidirectionally.  Requires the WSGI
+    transport to expose the raw client socket (Werkzeug dev server and
+    gunicorn-gevent are supported).
+
+    **noVNC**: interactive desktop access through::
+
+        /preview/6080/vnc.html           (noVNC HTML page)
+        /preview/6080/websockify         (WebSocket ↔ VNC bridge)
+
+    The webui ``ComputerPreview`` component should build these URLs from
+    the server-relative ``baseUrl + /preview/6080/`` path.
+    """
+    err = _check_port(port)
+    if err:
+        return flask.jsonify({"error": err}), 400
+
+    if _is_websocket_upgrade(flask.request):
+        return _websocket_tunnel(port, subpath, flask.request.environ)
+
+    return _http_stream_proxy(port, subpath)

--- a/gptme/server/preview_proxy_api.py
+++ b/gptme/server/preview_proxy_api.py
@@ -1,17 +1,23 @@
 """
 Preview port proxy for gptme-server.
 
-Exposes in-pod TCP ports under the authenticated ``/preview/{port}/`` path so
-that the browser (and noVNC) can reach agent-started services without any
-infrastructure changes.
+Exposes in-pod TCP ports under the authenticated ``/preview/{port}/`` and
+``/api/v2/preview/{port}/`` paths so that the browser (and noVNC) can reach
+agent-started services without any infrastructure changes.
+
+The ``/api/v2/preview/`` alias sits under the auth-cookie path (``/api/``)
+so iframe and WebSocket clients can authenticate without an Authorization
+header — browsers cannot attach bearer tokens to iframe navigations.
 
 Route (HTTP)::
 
-    ANY /preview/<port>/[<path>]  →  http://127.0.0.1:<port>/[<path>]
+    ANY /preview/<port>/[<path>]           →  http://127.0.0.1:<port>/[<path>]
+    ANY /api/v2/preview/<port>/[<path>]    →  http://127.0.0.1:<port>/[<path>]
 
 Route (WebSocket)::
 
-    WS  /preview/<port>/[<path>]  →  ws://127.0.0.1:<port>/[<path>]
+    WS  /preview/<port>/[<path>]           →  ws://127.0.0.1:<port>/[<path>]
+    WS  /api/v2/preview/<port>/[<path>]    →  ws://127.0.0.1:<port>/[<path>]
     (detected by ``Upgrade: websocket`` request header)
 
 The path is reachable via the existing Traefik-authenticated ``/api/v1/instances/{id}``
@@ -47,6 +53,7 @@ import select
 import socket
 import threading
 from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qsl, urlencode
 
 import flask
 import requests as req_lib
@@ -86,6 +93,91 @@ _HOP_BY_HOP: frozenset[str] = frozenset(
         "upgrade",
     }
 )
+
+# Auth / identity headers must never be forwarded to loopback listeners.
+# Local processes are untrusted; the server token authorizes every protected
+# route.  Also drop Traefik ForwardAuth identity headers.
+_IDENTITY_HEADERS: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+    }
+)
+
+# Response headers that become invalid once requests.iter_content() has
+# decoded a compressed body.  Flask recomputes Content-Length as needed.
+_DECODED_RESPONSE_STRIP: frozenset[str] = frozenset(
+    {
+        "content-encoding",
+        "content-length",
+        "content-md5",
+    }
+)
+
+
+def _is_identity_header(name: str) -> bool:
+    """Return True for credentials or trusted-identity headers."""
+    lower = name.lower()
+    if lower in _IDENTITY_HEADERS:
+        return True
+    return lower.startswith(("x-forwarded-", "x-auth-request-"))
+
+
+def _json_error(message: str, status: int) -> flask.Response:
+    """Build a JSON error Response with an explicit status code.
+
+    Returning ``(jsonify(...), status)`` is a tuple, which mypy rejects
+    when the function is annotated as ``-> flask.Response``.
+    """
+    response = flask.jsonify({"error": message})
+    response.status_code = status
+    return response
+
+
+def _sanitize_query_string(qs: str) -> str:
+    """Drop the deprecated ``token`` auth query param before forwarding."""
+    if not qs:
+        return ""
+    pairs = [
+        (key, value)
+        for key, value in parse_qsl(qs, keep_blank_values=True)
+        if key.lower() != "token"
+    ]
+    return urlencode(pairs)
+
+
+def _forward_request_headers(
+    headers: Any,
+    *,
+    drop_accept_encoding: bool = False,
+) -> dict[str, str]:
+    """Copy request headers, stripping hop-by-hop, Host, and identity."""
+    forwarded: dict[str, str] = {}
+    for key, value in headers:
+        lower = key.lower()
+        if lower in _HOP_BY_HOP or lower == "host":
+            continue
+        if drop_accept_encoding and lower == "accept-encoding":
+            continue
+        if _is_identity_header(key):
+            continue
+        forwarded[key] = value
+    if drop_accept_encoding:
+        # Prevent requests from injecting Accept-Encoding: gzip, which would
+        # make iter_content() decode a body whose Content-Encoding we must
+        # then strip.  identity asks the upstream not to compress.
+        forwarded["Accept-Encoding"] = "identity"
+    return forwarded
+
+
+def _forward_response_headers(headers: Any) -> list[tuple[str, str]]:
+    """Copy upstream response headers, dropping hop-by-hop and decoded-body fields."""
+    return [
+        (key, value)
+        for key, value in headers.items()
+        if key.lower() not in _HOP_BY_HOP and key.lower() not in _DECODED_RESPONSE_STRIP
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -155,15 +247,14 @@ def _build_upstream_request_line(
     """
     method = environ.get("REQUEST_METHOD", "GET")
     path = "/" + subpath.lstrip("/")
-    qs = environ.get("QUERY_STRING", "")
+    qs = _sanitize_query_string(environ.get("QUERY_STRING", ""))
     if qs:
         path = f"{path}?{qs}"
     http_version = environ.get("SERVER_PROTOCOL", "HTTP/1.1")
 
     lines: list[str] = [f"{method} {path} {http_version}"]
-    for key, value in flask.request.headers:
-        if key.lower() not in _HOP_BY_HOP and key.lower() != "host":
-            lines.append(f"{key}: {value}")
+    for key, value in _forward_request_headers(flask.request.headers).items():
+        lines.append(f"{key}: {value}")
     lines.append(f"Host: 127.0.0.1:{port}")
     lines.append("Connection: Upgrade")
     lines.append("Upgrade: websocket")
@@ -232,14 +323,11 @@ def _websocket_tunnel(
             "does not expose a raw socket — falling back to 501",
             port,
         )
-        return flask.jsonify(
-            {
-                "error": (
-                    "WebSocket tunnelling is not supported by this server transport. "
-                    "Run gptme-server under gunicorn-gevent or Werkzeug."
-                )
-            }
-        ), 501
+        return _json_error(
+            "WebSocket tunnelling is not supported by this server transport. "
+            "Run gptme-server under gunicorn-gevent or Werkzeug.",
+            501,
+        )
 
     raw_request = _build_upstream_request_line(port, subpath, environ)
 
@@ -247,7 +335,7 @@ def _websocket_tunnel(
         target_sock = socket.create_connection(("127.0.0.1", port), timeout=5)
     except OSError as exc:
         logger.warning("preview_proxy: cannot connect to 127.0.0.1:%d — %s", port, exc)
-        return flask.jsonify({"error": f"target unreachable: {exc}"}), 502
+        return _json_error(f"target unreachable: {exc}", 502)
 
     target_sock.sendall(raw_request)
     _pump_bidirectional(client_sock, target_sock)
@@ -261,17 +349,19 @@ def _websocket_tunnel(
 
 def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
     """Forward an HTTP request to ``127.0.0.1:{port}`` and stream the response."""
-    qs = flask.request.query_string.decode("latin-1")
+    qs = _sanitize_query_string(flask.request.query_string.decode("latin-1"))
     target_path = "/" + subpath.lstrip("/")
     if qs:
         target_path = f"{target_path}?{qs}"
     target_url = f"http://127.0.0.1:{port}{target_path}"
 
-    fwd_headers = {
-        k: v
-        for k, v in flask.request.headers
-        if k.lower() not in _HOP_BY_HOP and k.lower() != "host"
-    }
+    # Drop Accept-Encoding so we prefer an uncompressed upstream body.
+    # iter_content() still decodes if the upstream gzips anyway; response
+    # Content-Encoding / Content-Length are stripped below so the browser
+    # never sees a decoded body labeled as compressed.
+    fwd_headers = _forward_request_headers(
+        flask.request.headers, drop_accept_encoding=True
+    )
 
     try:
         upstream = req_lib.request(
@@ -285,19 +375,19 @@ def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
         )
     except req_lib.exceptions.ConnectionError as exc:
         logger.debug("preview_proxy: upstream %s unreachable: %s", target_url, exc)
-        return flask.jsonify({"error": f"target unreachable: {exc}"}), 502
+        return _json_error(f"target unreachable: {exc}", 502)
     except req_lib.exceptions.Timeout:
-        return flask.jsonify({"error": "upstream timed out"}), 504
+        return _json_error("upstream timed out", 504)
 
-    # Strip hop-by-hop headers from upstream response before forwarding.
-    response_headers = [
-        (k, v) for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP
-    ]
+    response_headers = _forward_response_headers(upstream.headers)
 
     def _generate() -> Iterator[bytes]:
-        for chunk in upstream.iter_content(chunk_size=65536):
-            if chunk:
-                yield chunk
+        try:
+            for chunk in upstream.iter_content(chunk_size=65536):
+                if chunk:
+                    yield chunk
+        finally:
+            upstream.close()
 
     return flask.Response(
         _generate(),
@@ -314,6 +404,23 @@ def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
 _PROXY_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 
 
+def _preview_proxy_impl(port: int, subpath: str) -> flask.Response:
+    """Shared implementation for both ``/preview/`` and ``/api/v2/preview/``.
+
+    Two Flask endpoints are required: registering both URL prefixes on the
+    same view function makes Werkzeug treat one as an alias and 308-redirect
+    the other (``/preview/6080/`` → ``/api/v2/preview/6080/``).
+    """
+    err = _check_port(port)
+    if err:
+        return _json_error(err, 400)
+
+    if _is_websocket_upgrade(flask.request):
+        return _websocket_tunnel(port, subpath, flask.request.environ)
+
+    return _http_stream_proxy(port, subpath)
+
+
 @preview_proxy_api.route(
     "/preview/<int:port>/",
     defaults={"subpath": ""},
@@ -325,36 +432,20 @@ _PROXY_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 )
 @require_auth
 def preview_proxy(port: int, subpath: str) -> flask.Response:
-    """Proxy HTTP and WebSocket requests to an in-pod loopback port.
+    """Proxy HTTP/WebSocket to a loopback port (Traefik Option A path)."""
+    return _preview_proxy_impl(port, subpath)
 
-    This exposes an arbitrary pod-local TCP port under the authenticated
-    ``/preview/{port}/`` path so browser clients can reach agent-started
-    services (Vite dev server, noVNC/websockify, etc.) without any
-    infrastructure changes.
 
-    **Security**: only ``127.0.0.1`` targets are allowed (SSRF guard).
-    Ports below 1024 and a small set of explicitly blocked ports are
-    rejected with 400.  Authentication is required via ``require_auth``.
-
-    **WebSocket**: detected via ``Upgrade: websocket`` header.  The proxy
-    opens a raw TCP tunnel to the target and forwards the full upgrade
-    handshake plus subsequent frames bidirectionally.  Requires the WSGI
-    transport to expose the raw client socket (Werkzeug dev server and
-    gunicorn-gevent are supported).
-
-    **noVNC**: interactive desktop access through::
-
-        /preview/6080/vnc.html           (noVNC HTML page)
-        /preview/6080/websockify         (WebSocket ↔ VNC bridge)
-
-    The webui ``ComputerPreview`` component should build these URLs from
-    the server-relative ``baseUrl + /preview/6080/`` path.
-    """
-    err = _check_port(port)
-    if err:
-        return flask.jsonify({"error": err}), 400
-
-    if _is_websocket_upgrade(flask.request):
-        return _websocket_tunnel(port, subpath, flask.request.environ)
-
-    return _http_stream_proxy(port, subpath)
+@preview_proxy_api.route(
+    "/api/v2/preview/<int:port>/",
+    defaults={"subpath": ""},
+    methods=_PROXY_METHODS,
+)
+@preview_proxy_api.route(
+    "/api/v2/preview/<int:port>/<path:subpath>",
+    methods=_PROXY_METHODS,
+)
+@require_auth
+def preview_proxy_v2(port: int, subpath: str) -> flask.Response:
+    """Cookie-auth alias under ``/api/`` so iframes send the auth cookie."""
+    return _preview_proxy_impl(port, subpath)

--- a/gptme/server/preview_proxy_api.py
+++ b/gptme/server/preview_proxy_api.py
@@ -37,6 +37,9 @@ Security
   ``allow-same-origin``, so preview documents run in an opaque origin and
   cannot inherit API privileges. Upstream CSP is stripped so a malicious
   listener cannot opt back into ``allow-same-origin``.
+- Upstream ``Set-Cookie`` / ``Clear-Site-Data`` are stripped so a preview
+  service cannot overwrite the ``Path=/preview/`` auth cookie or wipe
+  origin credentials.
 
 noVNC / VNC
 -----------
@@ -130,6 +133,18 @@ _ISOLATION_STRIP: frozenset[str] = frozenset(
     }
 )
 
+# Cookie-setting / credential-clearing headers from untrusted upstreams
+# must not reach the browser.  A preview service can otherwise overwrite
+# gptme_auth (Path=/preview/) and 401 later preview requests, or wipe
+# origin credentials via Clear-Site-Data.
+_CREDENTIAL_RESPONSE_STRIP: frozenset[str] = frozenset(
+    {
+        "set-cookie",
+        "set-cookie2",
+        "clear-site-data",
+    }
+)
+
 # Documents that can execute script.  Unique-origin sandbox them so they
 # cannot call cookie-authenticated /api/ routes as the user.
 _HTML_LIKE_MIME: frozenset[str] = frozenset(
@@ -206,8 +221,13 @@ def _forward_request_headers(
 
 
 def _forward_response_headers(headers: Any) -> list[tuple[str, str]]:
-    """Copy upstream response headers, dropping hop-by-hop, decoded-body, isolation."""
-    skip = _HOP_BY_HOP | _DECODED_RESPONSE_STRIP | _ISOLATION_STRIP
+    """Copy upstream response headers, dropping hop-by-hop, decoded-body, isolation, cookies."""
+    skip = (
+        _HOP_BY_HOP
+        | _DECODED_RESPONSE_STRIP
+        | _ISOLATION_STRIP
+        | _CREDENTIAL_RESPONSE_STRIP
+    )
     return [(key, value) for key, value in headers.items() if key.lower() not in skip]
 
 

--- a/gptme/server/preview_proxy_api.py
+++ b/gptme/server/preview_proxy_api.py
@@ -1,23 +1,24 @@
 """
 Preview port proxy for gptme-server.
 
-Exposes in-pod TCP ports under the authenticated ``/preview/{port}/`` and
-``/api/v2/preview/{port}/`` paths so that the browser (and noVNC) can reach
-agent-started services without any infrastructure changes.
+Exposes in-pod TCP ports under the authenticated ``/preview/{port}/`` path
+so that the browser (and noVNC) can reach agent-started services without
+any infrastructure changes.
 
-The ``/api/v2/preview/`` alias sits under the auth-cookie path (``/api/``)
-so iframe and WebSocket clients can authenticate without an Authorization
-header — browsers cannot attach bearer tokens to iframe navigations.
+Preview content is intentionally **not** mounted under ``/api/``. Serving
+agent-controlled HTML on the cookie-authenticated API path would give that
+document the gptme-server origin *and* the ``gptme_auth`` cookie scope, so
+preview JavaScript could invoke protected API routes as the user. Iframe
+and WebSocket clients authenticate with the ``Path=/preview/`` auth cookie
+(set alongside ``Path=/api/``) or via Traefik ForwardAuth in the cloud.
 
 Route (HTTP)::
 
     ANY /preview/<port>/[<path>]           →  http://127.0.0.1:<port>/[<path>]
-    ANY /api/v2/preview/<port>/[<path>]    →  http://127.0.0.1:<port>/[<path>]
 
 Route (WebSocket)::
 
     WS  /preview/<port>/[<path>]           →  ws://127.0.0.1:<port>/[<path>]
-    WS  /api/v2/preview/<port>/[<path>]    →  ws://127.0.0.1:<port>/[<path>]
     (detected by ``Upgrade: websocket`` request header)
 
 The path is reachable via the existing Traefik-authenticated ``/api/v1/instances/{id}``
@@ -32,6 +33,10 @@ Security
 - A small set of well-known ports are explicitly blocked (e.g. gptme-server
   itself on 5700, raw x11vnc on 5900).
 - ``require_auth`` applied to every route.
+- HTML-like responses get ``Content-Security-Policy: sandbox`` *without*
+  ``allow-same-origin``, so preview documents run in an opaque origin and
+  cannot inherit API privileges. Upstream CSP is stripped so a malicious
+  listener cannot opt back into ``allow-same-origin``.
 
 noVNC / VNC
 -----------
@@ -115,6 +120,35 @@ _DECODED_RESPONSE_STRIP: frozenset[str] = frozenset(
     }
 )
 
+# Upstream isolation headers are replaced — a malicious listener must not
+# weaken or remove our sandbox CSP.
+_ISOLATION_STRIP: frozenset[str] = frozenset(
+    {
+        "content-security-policy",
+        "content-security-policy-report-only",
+        "x-content-type-options",
+    }
+)
+
+# Documents that can execute script.  Unique-origin sandbox them so they
+# cannot call cookie-authenticated /api/ routes as the user.
+_HTML_LIKE_MIME: frozenset[str] = frozenset(
+    {
+        "text/html",
+        "application/xhtml+xml",
+        "image/svg+xml",
+        "text/xml",
+        "application/xml",
+    }
+)
+
+# No allow-same-origin: that flag plus allow-scripts restores the parent
+# origin and reopens the API-privilege hole this header exists to close.
+PREVIEW_CSP_SANDBOX = (
+    "sandbox allow-scripts allow-forms allow-modals "
+    "allow-pointer-lock allow-popups allow-popups-to-escape-sandbox"
+)
+
 
 def _is_identity_header(name: str) -> bool:
     """Return True for credentials or trusted-identity headers."""
@@ -172,12 +206,22 @@ def _forward_request_headers(
 
 
 def _forward_response_headers(headers: Any) -> list[tuple[str, str]]:
-    """Copy upstream response headers, dropping hop-by-hop and decoded-body fields."""
-    return [
-        (key, value)
-        for key, value in headers.items()
-        if key.lower() not in _HOP_BY_HOP and key.lower() not in _DECODED_RESPONSE_STRIP
-    ]
+    """Copy upstream response headers, dropping hop-by-hop, decoded-body, isolation."""
+    skip = _HOP_BY_HOP | _DECODED_RESPONSE_STRIP | _ISOLATION_STRIP
+    return [(key, value) for key, value in headers.items() if key.lower() not in skip]
+
+
+def _isolation_headers(content_type: str | None) -> list[tuple[str, str]]:
+    """Return origin-isolation headers for a proxied response.
+
+    HTML-like documents are unique-origin sandboxed so preview JavaScript
+    cannot exercise the user's ``gptme_auth`` cookie against ``/api/``.
+    """
+    headers: list[tuple[str, str]] = [("X-Content-Type-Options", "nosniff")]
+    mime = (content_type or "").split(";", 1)[0].strip().lower()
+    if mime in _HTML_LIKE_MIME:
+        headers.append(("Content-Security-Policy", PREVIEW_CSP_SANDBOX))
+    return headers
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +424,11 @@ def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
         return _json_error("upstream timed out", 504)
 
     response_headers = _forward_response_headers(upstream.headers)
+    content_type = next(
+        (value for key, value in response_headers if key.lower() == "content-type"),
+        upstream.headers.get("Content-Type"),
+    )
+    response_headers.extend(_isolation_headers(content_type))
 
     def _generate() -> Iterator[bytes]:
         try:
@@ -404,23 +453,6 @@ def _http_stream_proxy(port: int, subpath: str) -> flask.Response:
 _PROXY_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 
 
-def _preview_proxy_impl(port: int, subpath: str) -> flask.Response:
-    """Shared implementation for both ``/preview/`` and ``/api/v2/preview/``.
-
-    Two Flask endpoints are required: registering both URL prefixes on the
-    same view function makes Werkzeug treat one as an alias and 308-redirect
-    the other (``/preview/6080/`` → ``/api/v2/preview/6080/``).
-    """
-    err = _check_port(port)
-    if err:
-        return _json_error(err, 400)
-
-    if _is_websocket_upgrade(flask.request):
-        return _websocket_tunnel(port, subpath, flask.request.environ)
-
-    return _http_stream_proxy(port, subpath)
-
-
 @preview_proxy_api.route(
     "/preview/<int:port>/",
     defaults={"subpath": ""},
@@ -433,19 +465,11 @@ def _preview_proxy_impl(port: int, subpath: str) -> flask.Response:
 @require_auth
 def preview_proxy(port: int, subpath: str) -> flask.Response:
     """Proxy HTTP/WebSocket to a loopback port (Traefik Option A path)."""
-    return _preview_proxy_impl(port, subpath)
+    err = _check_port(port)
+    if err:
+        return _json_error(err, 400)
 
+    if _is_websocket_upgrade(flask.request):
+        return _websocket_tunnel(port, subpath, flask.request.environ)
 
-@preview_proxy_api.route(
-    "/api/v2/preview/<int:port>/",
-    defaults={"subpath": ""},
-    methods=_PROXY_METHODS,
-)
-@preview_proxy_api.route(
-    "/api/v2/preview/<int:port>/<path:subpath>",
-    methods=_PROXY_METHODS,
-)
-@require_auth
-def preview_proxy_v2(port: int, subpath: str) -> flask.Response:
-    """Cookie-auth alias under ``/api/`` so iframes send the auth cookie."""
-    return _preview_proxy_impl(port, subpath)
+    return _http_stream_proxy(port, subpath)

--- a/tests/test_preview_proxy.py
+++ b/tests/test_preview_proxy.py
@@ -22,6 +22,7 @@ from flask.testing import FlaskClient  # fmt: skip
 from gptme.server.preview_proxy_api import (  # fmt: skip
     _BLOCKED_PORTS,
     _MIN_ALLOWED_PORT,
+    PREVIEW_CSP_SANDBOX,
     _check_port,
     _forward_request_headers,
     _is_websocket_upgrade,
@@ -214,12 +215,10 @@ class TestPreviewProxyHTTP:
         assert received == ["/some/path?foo=bar"]
         srv.server_close()
 
-    def test_api_v2_alias_proxies(self, client: FlaskClient):
-        """The /api/v2/preview/ alias (auth-cookie path) forwards the same way."""
-        with _loopback_http_server(b"via-api") as port:
-            resp = client.get(f"/api/v2/preview/{port}/")
-            assert resp.status_code == 200
-            assert resp.data == b"via-api"
+    def test_api_v2_preview_is_not_mounted(self, client: FlaskClient):
+        """Untrusted preview content must not live under the /api/ cookie path."""
+        resp = client.get("/api/v2/preview/6080/")
+        assert resp.status_code == 404
 
     def test_does_not_forward_authorization_or_cookie(self, client: FlaskClient):
         """Bearer tokens and auth cookies must not leak to loopback listeners."""
@@ -318,6 +317,50 @@ class TestPreviewProxyHTTP:
         assert resp.data == raw
         assert "Content-Encoding" not in resp.headers
         assert resp.headers.get("Content-Encoding") is None
+
+    def test_html_response_is_unique_origin_sandboxed(self, client: FlaskClient):
+        """HTML previews must not inherit gptme-server origin privileges."""
+        html = (
+            b"<html><body><script>fetch('/api/v2/conversations')</script></body></html>"
+        )
+
+        class _HtmlHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(html)))
+                self.send_header(
+                    "Content-Security-Policy",
+                    "sandbox allow-scripts allow-same-origin",
+                )
+                self.end_headers()
+                self.wfile.write(html)
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _HtmlHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        resp = client.get(f"/preview/{port}/index.html")
+        t.join(timeout=3)
+        srv.server_close()
+
+        assert resp.status_code == 200
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert csp == PREVIEW_CSP_SANDBOX
+        assert "allow-same-origin" not in csp
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_plain_text_does_not_get_csp_sandbox(self, client: FlaskClient):
+        """Non-document responses only get nosniff, not a document sandbox."""
+        with _loopback_http_server(b"hello") as port:
+            resp = client.get(f"/preview/{port}/")
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+        assert "Content-Security-Policy" not in resp.headers
 
 
 class TestHeaderHelpers:

--- a/tests/test_preview_proxy.py
+++ b/tests/test_preview_proxy.py
@@ -25,6 +25,7 @@ from gptme.server.preview_proxy_api import (  # fmt: skip
     PREVIEW_CSP_SANDBOX,
     _check_port,
     _forward_request_headers,
+    _forward_response_headers,
     _is_websocket_upgrade,
     _sanitize_query_string,
 )
@@ -362,6 +363,40 @@ class TestPreviewProxyHTTP:
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
         assert "Content-Security-Policy" not in resp.headers
 
+    def test_strips_upstream_set_cookie(self, client: FlaskClient):
+        """Untrusted upstreams must not overwrite the preview auth cookie."""
+
+        class _CookieHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header(
+                    "Set-Cookie",
+                    "gptme_auth=poisoned; Path=/preview/",
+                )
+                self.send_header("Clear-Site-Data", '"cookies"')
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _CookieHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        resp = client.get(f"/preview/{port}/")
+        t.join(timeout=3)
+        srv.server_close()
+
+        assert resp.status_code == 200
+        assert resp.data == b"ok"
+        assert resp.headers.get("Set-Cookie") is None
+        assert resp.headers.getlist("Set-Cookie") == []
+        assert resp.headers.get("Clear-Site-Data") is None
+        assert client.get_cookie("gptme_auth") is None
+
 
 class TestHeaderHelpers:
     def test_sanitize_drops_token(self):
@@ -390,3 +425,25 @@ class TestHeaderHelpers:
         assert "connection" not in lower
         assert forwarded.get("Accept-Encoding") == "identity"
         assert forwarded["Accept"] == "text/html"
+
+    def test_forward_response_headers_strips_cookies(self):
+        headers = {
+            "Content-Type": "text/html",
+            "Set-Cookie": "gptme_auth=poisoned; Path=/preview/",
+            "Set-Cookie2": "obsolete=1",
+            "Clear-Site-Data": '"cookies"',
+            "Content-Encoding": "gzip",
+            "Content-Security-Policy": "sandbox allow-same-origin",
+            "Connection": "close",
+            "X-Custom": "keep",
+        }
+        forwarded = _forward_response_headers(headers)
+        lower = {key.lower() for key, _ in forwarded}
+        assert "set-cookie" not in lower
+        assert "set-cookie2" not in lower
+        assert "clear-site-data" not in lower
+        assert "content-encoding" not in lower
+        assert "content-security-policy" not in lower
+        assert "connection" not in lower
+        assert ("X-Custom", "keep") in forwarded
+        assert ("Content-Type", "text/html") in forwarded

--- a/tests/test_preview_proxy.py
+++ b/tests/test_preview_proxy.py
@@ -1,0 +1,213 @@
+"""Tests for the preview port proxy (gptme-cloud#910, Option A).
+
+Covers:
+- SSRF guard: privileged ports (<1024) and blocked ports (5700, 5900) are rejected.
+- HTTP streaming proxy: successful and unreachable-target paths.
+- WebSocket detection helper.
+- ``_check_port`` boundary conditions.
+"""
+
+import socket
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Skip entire module when Flask is not installed.
+pytest.importorskip("flask", reason="flask not installed; install -E server")
+
+from flask.testing import FlaskClient  # fmt: skip
+
+from gptme.server.preview_proxy_api import (  # fmt: skip
+    _BLOCKED_PORTS,
+    _MIN_ALLOWED_PORT,
+    _check_port,
+    _is_websocket_upgrade,
+)
+
+pytestmark = [pytest.mark.timeout(10)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _loopback_http_server(response_body: bytes = b"hello", status: int = 200):
+    """Spin up a minimal HTTP server on a random loopback port.
+
+    Yields the port number.  The server shuts down when the context exits.
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
+        def log_message(self, *args):  # silence test output
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _check_port
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPort:
+    def test_accepts_valid_high_port(self):
+        assert _check_port(8080) is None
+
+    def test_accepts_minimum_allowed_port(self):
+        assert _check_port(_MIN_ALLOWED_PORT) is None
+
+    def test_rejects_port_zero(self):
+        assert _check_port(0) is not None
+
+    def test_rejects_privileged_port_80(self):
+        assert _check_port(80) is not None
+
+    def test_rejects_privileged_port_1023(self):
+        assert _check_port(1023) is not None
+
+    def test_rejects_port_above_65535(self):
+        assert _check_port(65536) is not None
+
+    @pytest.mark.parametrize("port", sorted(_BLOCKED_PORTS))
+    def test_rejects_explicitly_blocked_port(self, port: int):
+        err = _check_port(port)
+        assert err is not None, f"port {port} should be blocked"
+
+    def test_accepts_novnc_websockify_port(self):
+        """Port 6080 (noVNC / websockify) must be allowed."""
+        assert _check_port(6080) is None
+
+    def test_accepts_vite_default_port(self):
+        """Port 5173 (Vite dev server default) must be allowed."""
+        assert _check_port(5173) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_websocket_upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestIsWebsocketUpgrade:
+    def test_detects_upgrade_request(self, client: FlaskClient):
+        """_is_websocket_upgrade returns True for an Upgrade: websocket header."""
+        with client.application.test_request_context(
+            "/preview/6080/",
+            headers={
+                "Upgrade": "websocket",
+                "Connection": "Upgrade",
+            },
+        ):
+            import flask
+
+            assert _is_websocket_upgrade(flask.request) is True
+
+    def test_ignores_plain_request(self, client: FlaskClient):
+        with client.application.test_request_context("/preview/6080/"):
+            import flask
+
+            assert _is_websocket_upgrade(flask.request) is False
+
+    def test_case_insensitive(self, client: FlaskClient):
+        with client.application.test_request_context(
+            "/preview/6080/",
+            headers={
+                "Upgrade": "WebSocket",
+                "Connection": "upgrade",
+            },
+        ):
+            import flask
+
+            assert _is_websocket_upgrade(flask.request) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via Flask test client
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewProxySSRF:
+    """Proxy returns 400 for disallowed ports (SSRF guard)."""
+
+    def test_blocks_port_80(self, client: FlaskClient):
+        resp = client.get("/preview/80/index.html")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_blocks_port_1023(self, client: FlaskClient):
+        resp = client.get("/preview/1023/")
+        assert resp.status_code == 400
+
+    def test_blocks_gptme_server_port(self, client: FlaskClient):
+        """Port 5700 (gptme-server) is explicitly blocked to prevent loops."""
+        resp = client.get("/preview/5700/")
+        assert resp.status_code == 400
+
+    def test_blocks_raw_vnc_port(self, client: FlaskClient):
+        """Port 5900 (x11vnc) is blocked; only websockify/noVNC on 6080 is allowed."""
+        resp = client.get("/preview/5900/")
+        assert resp.status_code == 400
+
+
+class TestPreviewProxyHTTP:
+    """HTTP forwarding through the proxy."""
+
+    def test_proxy_successful_get(self, client: FlaskClient):
+        """The proxy forwards a GET to a real local server and streams back the body."""
+        with _loopback_http_server(b"world") as port:
+            resp = client.get(f"/preview/{port}/")
+            assert resp.status_code == 200
+            assert resp.data == b"world"
+
+    def test_proxy_unreachable_target_returns_502(self, client: FlaskClient):
+        """A connection refused to a closed port produces a 502."""
+        # Pick a port that is very likely to be closed (OS will refuse immediately).
+        # Bind + immediately close to get a port we know is free/closed.
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            closed_port = s.getsockname()[1]
+        # s is now closed; the port is not listening.
+        resp = client.get(f"/preview/{closed_port}/")
+        assert resp.status_code == 502
+
+    def test_proxy_forwards_path_and_query(self, client: FlaskClient):
+        """The subpath and query-string are forwarded to the upstream server."""
+        received: list[str] = []
+
+        class _CaptureHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                received.append(self.path)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _CaptureHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        client.get(f"/preview/{port}/some/path?foo=bar")
+        t.join(timeout=3)
+
+        assert received == ["/some/path?foo=bar"]
+        srv.server_close()

--- a/tests/test_preview_proxy.py
+++ b/tests/test_preview_proxy.py
@@ -23,7 +23,9 @@ from gptme.server.preview_proxy_api import (  # fmt: skip
     _BLOCKED_PORTS,
     _MIN_ALLOWED_PORT,
     _check_port,
+    _forward_request_headers,
     _is_websocket_upgrade,
+    _sanitize_query_string,
 )
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -211,3 +213,137 @@ class TestPreviewProxyHTTP:
 
         assert received == ["/some/path?foo=bar"]
         srv.server_close()
+
+    def test_api_v2_alias_proxies(self, client: FlaskClient):
+        """The /api/v2/preview/ alias (auth-cookie path) forwards the same way."""
+        with _loopback_http_server(b"via-api") as port:
+            resp = client.get(f"/api/v2/preview/{port}/")
+            assert resp.status_code == 200
+            assert resp.data == b"via-api"
+
+    def test_does_not_forward_authorization_or_cookie(self, client: FlaskClient):
+        """Bearer tokens and auth cookies must not leak to loopback listeners."""
+        captured: list[dict[str, str]] = []
+
+        class _CaptureHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                captured.append({k.lower(): v for k, v in self.headers.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _CaptureHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        client.get(
+            f"/preview/{port}/",
+            headers={
+                "Authorization": "Bearer super-secret-token",
+                "Cookie": "gptme_token=super-secret-token",
+                "X-Forwarded-User": "erik",
+                "X-Auth-Request-Access-Token": "traefik-token",
+            },
+        )
+        t.join(timeout=3)
+        srv.server_close()
+
+        assert captured, "upstream should have received the proxied request"
+        headers = captured[0]
+        assert "authorization" not in headers
+        assert "cookie" not in headers
+        assert "x-forwarded-user" not in headers
+        assert "x-auth-request-access-token" not in headers
+
+    def test_strips_token_query_param(self, client: FlaskClient):
+        """Deprecated ?token= auth must not be forwarded upstream."""
+        received: list[str] = []
+
+        class _CaptureHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                received.append(self.path)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _CaptureHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        client.get(f"/preview/{port}/page?token=secret&foo=bar")
+        t.join(timeout=3)
+        srv.server_close()
+
+        assert received == ["/page?foo=bar"]
+
+    def test_decoded_gzip_does_not_keep_content_encoding(self, client: FlaskClient):
+        """Decoded gzip bodies must not keep Content-Encoding: gzip."""
+        import gzip
+
+        raw = b"hello gzip body"
+        compressed = gzip.compress(raw)
+
+        class _GzipHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Encoding", "gzip")
+                self.send_header("Content-Length", str(len(compressed)))
+                self.end_headers()
+                self.wfile.write(compressed)
+
+            def log_message(self, *args):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _GzipHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.handle_request, daemon=True)
+        t.start()
+
+        resp = client.get(
+            f"/preview/{port}/",
+            headers={"Accept-Encoding": "gzip"},
+        )
+        t.join(timeout=3)
+        srv.server_close()
+
+        assert resp.status_code == 200
+        assert resp.data == raw
+        assert "Content-Encoding" not in resp.headers
+        assert resp.headers.get("Content-Encoding") is None
+
+
+class TestHeaderHelpers:
+    def test_sanitize_drops_token(self):
+        assert _sanitize_query_string("token=secret&foo=bar") == "foo=bar"
+        assert _sanitize_query_string("token=secret") == ""
+        assert _sanitize_query_string("") == ""
+
+    def test_forward_request_headers_strips_identity(self):
+        headers = [
+            ("Authorization", "Bearer abc"),
+            ("Cookie", "gptme_token=abc"),
+            ("X-Forwarded-User", "bob"),
+            ("X-Auth-Request-Email", "a@b.c"),
+            ("Accept", "text/html"),
+            ("Host", "example.com"),
+            ("Connection", "keep-alive"),
+            ("Accept-Encoding", "gzip"),
+        ]
+        forwarded = _forward_request_headers(headers, drop_accept_encoding=True)
+        lower = {k.lower() for k in forwarded}
+        assert "authorization" not in lower
+        assert "cookie" not in lower
+        assert "x-forwarded-user" not in lower
+        assert "x-auth-request-email" not in lower
+        assert "host" not in lower
+        assert "connection" not in lower
+        assert forwarded.get("Accept-Encoding") == "identity"
+        assert forwarded["Accept"] == "text/html"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1240,11 +1240,13 @@ def test_auth_cookie_set(auth_client):
     data = response.get_json()
     assert data["ok"] is True
 
-    # Verify Set-Cookie header properties
-    set_cookie = response.headers.get("Set-Cookie", "")
-    assert cookie_name in set_cookie
-    assert "HttpOnly" in set_cookie
-    assert "Path=/api/" in set_cookie
+    # Dual-path cookies: /api/ for capability routes, /preview/ for iframes.
+    cookies = response.headers.getlist("Set-Cookie")
+    joined = "\n".join(cookies)
+    assert cookie_name in joined
+    assert "HttpOnly" in joined
+    assert any("Path=/api/" in cookie for cookie in cookies)
+    assert any("Path=/preview/" in cookie for cookie in cookies)
 
 
 def test_auth_cookie_rejected_without_token(auth_client):

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -11,9 +11,10 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 /**
  * Build the noVNC URL for a given server base URL.
  *
- * Mounted under ``/api/v2/preview/`` so the HttpOnly auth cookie (path=/api/)
- * is sent with both the iframe document request and the noVNC WebSocket.
- * Iframes cannot attach the API client's Authorization header.
+ * Mounted under ``/preview/`` — never under ``/api/``. Agent-controlled HTML
+ * on the API cookie path would inherit gptme-server origin privileges.
+ * Same-origin iframe auth uses the ``Path=/preview/`` auth cookie; cloud
+ * deployments authenticate at Traefik. Iframes cannot attach a bearer header.
  *
  * noVNC 1.5.0 defaults its WebSocket path to root-relative ``/websockify``.
  * The ``path`` query param points it at the proxied websockify endpoint,
@@ -21,7 +22,7 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
  */
 export function buildVncUrl(baseUrl: string): string {
   const base = baseUrl.replace(/\/+$/, '');
-  const previewPrefix = `/api/v2/preview/${VNC_PORT}`;
+  const previewPrefix = `/preview/${VNC_PORT}`;
   const pageUrl = `${base}${previewPrefix}/vnc.html`;
   const wsPath = new URL(`${base}${previewPrefix}/websockify`).pathname.replace(/^\//, '');
   const params = new URLSearchParams({
@@ -219,6 +220,7 @@ export const ComputerPreview: FC = () => {
           src={buildVncUrl(baseUrl)}
           className="h-full w-full rounded-md border-0"
           allow="clipboard-read; clipboard-write"
+          sandbox="allow-scripts allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox"
           title="VNC Viewer"
         />
       </div>

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -4,8 +4,28 @@ import { Button } from '@/components/ui/button';
 import { useApi } from '@/contexts/ApiContext';
 import type { FC } from 'react';
 
-const VNC_URL = 'http://localhost:6080/vnc.html';
+// noVNC port used by the computer-use Docker stack (websockify on :6080).
+const VNC_PORT = 6080;
 const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+/**
+ * Build the noVNC URL for a given server base URL.
+ *
+ * In the cloud deployment the gptme-server is reachable at a path-based URL
+ * such as ``https://fleet.gptme.ai/api/v1/instances/{id}``.  The preview proxy
+ * (gptme-cloud#910) exposes in-pod ports under ``{baseUrl}/preview/{port}/``,
+ * so noVNC is served from a server-relative path that Traefik's ForwardAuth
+ * already covers — no extra infra changes required.
+ *
+ * Locally (baseUrl = "http://localhost:5700") the URL becomes
+ * ``http://localhost:5700/preview/6080/vnc.html`` which the preview proxy also
+ * serves.  This replaces the old hard-coded ``http://localhost:6080/vnc.html``
+ * which only ever worked on a local Docker-based install.
+ */
+function buildVncUrl(baseUrl: string): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  return `${base}/preview/${VNC_PORT}/vnc.html`;
+}
 
 interface BackendStatus {
   screenshot_available: boolean;
@@ -191,7 +211,7 @@ export const ComputerPreview: FC = () => {
           <span className="text-xs text-muted-foreground">VNC mode (requires Docker)</span>
         </div>
         <iframe
-          src={VNC_URL}
+          src={buildVncUrl(baseUrl)}
           className="h-full w-full rounded-md border-0"
           allow="clipboard-read; clipboard-write"
           title="VNC Viewer"

--- a/webui/src/components/ComputerPreview.tsx
+++ b/webui/src/components/ComputerPreview.tsx
@@ -11,20 +11,25 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 /**
  * Build the noVNC URL for a given server base URL.
  *
- * In the cloud deployment the gptme-server is reachable at a path-based URL
- * such as ``https://fleet.gptme.ai/api/v1/instances/{id}``.  The preview proxy
- * (gptme-cloud#910) exposes in-pod ports under ``{baseUrl}/preview/{port}/``,
- * so noVNC is served from a server-relative path that Traefik's ForwardAuth
- * already covers — no extra infra changes required.
+ * Mounted under ``/api/v2/preview/`` so the HttpOnly auth cookie (path=/api/)
+ * is sent with both the iframe document request and the noVNC WebSocket.
+ * Iframes cannot attach the API client's Authorization header.
  *
- * Locally (baseUrl = "http://localhost:5700") the URL becomes
- * ``http://localhost:5700/preview/6080/vnc.html`` which the preview proxy also
- * serves.  This replaces the old hard-coded ``http://localhost:6080/vnc.html``
- * which only ever worked on a local Docker-based install.
+ * noVNC 1.5.0 defaults its WebSocket path to root-relative ``/websockify``.
+ * The ``path`` query param points it at the proxied websockify endpoint,
+ * including any cloud instance prefix on ``baseUrl``.
  */
-function buildVncUrl(baseUrl: string): string {
+export function buildVncUrl(baseUrl: string): string {
   const base = baseUrl.replace(/\/+$/, '');
-  return `${base}/preview/${VNC_PORT}/vnc.html`;
+  const previewPrefix = `/api/v2/preview/${VNC_PORT}`;
+  const pageUrl = `${base}${previewPrefix}/vnc.html`;
+  const wsPath = new URL(`${base}${previewPrefix}/websockify`).pathname.replace(/^\//, '');
+  const params = new URLSearchParams({
+    path: wsPath,
+    autoconnect: '1',
+    resize: 'scale',
+  });
+  return `${pageUrl}?${params.toString()}`;
 }
 
 interface BackendStatus {

--- a/webui/src/components/__tests__/ComputerPreview.test.tsx
+++ b/webui/src/components/__tests__/ComputerPreview.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ComputerPreview } from '../ComputerPreview';
+import { buildVncUrl, ComputerPreview } from '../ComputerPreview';
 
 // Mock useApi so we don't need the full ApiContext tree
 jest.mock('@/contexts/ApiContext', () => ({
@@ -92,8 +92,29 @@ describe('ComputerPreview', () => {
     const vncButton = screen.getByTitle(/vnc viewer/i);
     await user.click(vncButton);
 
-    expect(screen.getByTitle('VNC Viewer')).toBeInTheDocument();
-    expect(screen.getByTitle('VNC Viewer').tagName).toBe('IFRAME');
+    const iframe = screen.getByTitle('VNC Viewer');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.tagName).toBe('IFRAME');
+    const src = iframe.getAttribute('src') ?? '';
+    expect(src).toContain('/api/v2/preview/6080/vnc.html');
+    expect(src).toContain('path=');
+    expect(src).toContain('autoconnect=1');
+    // Cookie path is /api/; a root-level /preview/ URL would 401.
+    expect(src).not.toMatch(/:5700\/preview\//);
+  });
+
+  it('buildVncUrl points noVNC WebSocket at the proxied prefix', () => {
+    const local = buildVncUrl('http://127.0.0.1:5700');
+    expect(local).toContain('http://127.0.0.1:5700/api/v2/preview/6080/vnc.html');
+    expect(local).toContain(encodeURIComponent('api/v2/preview/6080/websockify'));
+
+    const cloud = buildVncUrl('https://fleet.gptme.ai/api/v1/instances/abc');
+    expect(cloud).toContain(
+      'https://fleet.gptme.ai/api/v1/instances/abc/api/v2/preview/6080/vnc.html'
+    );
+    expect(cloud).toContain(
+      encodeURIComponent('api/v1/instances/abc/api/v2/preview/6080/websockify')
+    );
   });
 
   it('returns to screenshot view when back button is clicked in VNC mode', async () => {

--- a/webui/src/components/__tests__/ComputerPreview.test.tsx
+++ b/webui/src/components/__tests__/ComputerPreview.test.tsx
@@ -96,25 +96,25 @@ describe('ComputerPreview', () => {
     expect(iframe).toBeInTheDocument();
     expect(iframe.tagName).toBe('IFRAME');
     const src = iframe.getAttribute('src') ?? '';
-    expect(src).toContain('/api/v2/preview/6080/vnc.html');
+    expect(src).toContain('/preview/6080/vnc.html');
+    expect(src).not.toContain('/api/v2/preview/');
     expect(src).toContain('path=');
     expect(src).toContain('autoconnect=1');
-    // Cookie path is /api/; a root-level /preview/ URL would 401.
-    expect(src).not.toMatch(/:5700\/preview\//);
+    // Unique-origin sandbox: allow-scripts without allow-same-origin so
+    // preview JS cannot invoke cookie-authenticated /api/ routes.
+    expect(iframe.getAttribute('sandbox')).toContain('allow-scripts');
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin');
   });
 
   it('buildVncUrl points noVNC WebSocket at the proxied prefix', () => {
     const local = buildVncUrl('http://127.0.0.1:5700');
-    expect(local).toContain('http://127.0.0.1:5700/api/v2/preview/6080/vnc.html');
-    expect(local).toContain(encodeURIComponent('api/v2/preview/6080/websockify'));
+    expect(local).toContain('http://127.0.0.1:5700/preview/6080/vnc.html');
+    expect(local).toContain(encodeURIComponent('preview/6080/websockify'));
+    expect(local).not.toContain('/api/v2/preview/');
 
     const cloud = buildVncUrl('https://fleet.gptme.ai/api/v1/instances/abc');
-    expect(cloud).toContain(
-      'https://fleet.gptme.ai/api/v1/instances/abc/api/v2/preview/6080/vnc.html'
-    );
-    expect(cloud).toContain(
-      encodeURIComponent('api/v1/instances/abc/api/v2/preview/6080/websockify')
-    );
+    expect(cloud).toContain('https://fleet.gptme.ai/api/v1/instances/abc/preview/6080/vnc.html');
+    expect(cloud).toContain(encodeURIComponent('api/v1/instances/abc/preview/6080/websockify'));
   });
 
   it('returns to screenshot view when back button is clicked in VNC mode', async () => {


### PR DESCRIPTION
## Summary

Adds a `/preview/{port}/` route to gptme-server that proxies HTTP and
WebSocket requests to an arbitrary pod-local loopback port.

This is **Option A** from the design analysis in
[gptme/gptme-cloud#910](https://github.com/gptme/gptme-cloud/issues/910):
an in-pod reverse proxy under the existing authenticated 5700 path.

## What changed

- **`gptme/server/preview_proxy_api.py`** (new) — Flask blueprint exposing
  `ANY /preview/<int:port>/<path:subpath>`
  - HTTP proxy via `requests` streaming to `http://127.0.0.1:{port}/{path}`
  - WebSocket proxy via raw bidirectional TCP tunnel (Werkzeug + gunicorn-gevent)
  - SSRF guard: only loopback targets; ports <1024 and 5700/5900 blocked
  - `require_auth` on all routes (inherits ForwardAuth + ownership from Traefik)
- **`gptme/server/app.py`** — registers the new blueprint
- **`webui/src/components/ComputerPreview.tsx`** — builds the noVNC URL from
  the server `baseUrl` (e.g. `{baseUrl}/preview/6080/vnc.html`) instead of
  the hard-coded `http://localhost:6080/vnc.html`
- **`tests/test_preview_proxy.py`** (new) — 20 tests covering SSRF guard,
  HTTP proxy success/failure, WebSocket detection, path+query forwarding

## Why no infra changes

The proxy lives on port 5700 — the existing authenticated Traefik path:

```
Browser → Traefik ForwardAuth → strip-prefix → gptme-server:5700/preview/{port}/path
                                                              ↓
                                                    127.0.0.1:{port}/path
```

Auth, ownership, and WebSocket forwarding (Traefik already passes `Upgrade`)
are all inherited from the existing cloud setup.

## noVNC / VNC

Interactive desktop works via:
- `/preview/6080/vnc.html` — noVNC HTML page
- `/preview/6080/websockify` — WebSocket ↔ VNC bridge

## Security

- Loopback-only targets (SSRF guard — no user-supplied hosts)
- Ports <1024 blocked (privileged services)
- Port 5700 blocked (self-proxy loop prevention)
- Port 5900 blocked (raw x11vnc — use websockify/noVNC on 6080 instead)
- `require_auth` on all routes

## Known gaps / Phase 2

- Base-path problem: Vite apps must be launched with `--base=/api/v1/instances/{id}/preview/{port}/` or HMR will break
- WebSocket tunnel requires WSGI transport to expose raw socket (Werkzeug + gunicorn-gevent; falls back to 501 for eventlet)
- Shareable/public previews need Phase 2 (wildcard subdomain per instance) tracked in gptme/gptme-cloud#910

## Tests

```
uv run pytest tests/test_preview_proxy.py -v  # 20 passed
```
