### PR TITLE
fix(webui): use Bookmark icon for set-default (not Star — fixes confusion with favorites)

### DIFF
--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -406,23 +406,29 @@ const SetDefaultModelFooter: FC<{ model: string }> = ({ model }) => {
   // Use Bookmark/BookmarkCheck (distinct from the Star used for favorites)
   // so users can tell the two controls apart at a glance.
   const DefaultIcon = isDefault ? BookmarkCheck : Bookmark;
+  const title = isDefault ? 'This is already your default model' : 'Set as default for new chats';
 
   return (
     <div className="border-t p-1">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 w-full justify-start text-xs font-normal"
-        disabled={isDefault || saving}
-        title={isDefault ? 'This is already your default model' : 'Set as default for new chats'}
-        onClick={() => void handleSetDefault()}
-      >
-        <DefaultIcon
-          className={`mr-2 h-3.5 w-3.5 ${isDefault ? 'fill-current text-primary' : ''}`}
-        />
-        {isDefault ? 'Default for new chats' : 'Set as default for new chats'}
-      </Button>
+      {/* Title lives on a non-disabled wrapper. Button uses
+          `disabled:pointer-events-none`, so a title on the button itself
+          cannot appear when this model is already the default. */}
+      <span className="block w-full" title={title}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full justify-start text-xs font-normal"
+          disabled={isDefault || saving}
+          data-testid="set-default-model"
+          onClick={() => void handleSetDefault()}
+        >
+          <DefaultIcon
+            className={`mr-2 h-3.5 w-3.5 ${isDefault ? 'fill-current text-primary' : ''}`}
+          />
+          {isDefault ? 'Default for new chats' : 'Set as default for new chats'}
+        </Button>
+      </span>
     </div>
   );
 };

--- a/webui/src/components/ChatInput.tsx
+++ b/webui/src/components/ChatInput.tsx
@@ -10,7 +10,8 @@ import {
   File,
   ChevronDown,
   SlidersHorizontal,
-  Star,
+  Bookmark,
+  BookmarkCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -375,7 +376,11 @@ const ModelBadge: FC<{
   );
 };
 
-/** Footer in the model dropdown to make the current model the default for new chats. */
+/** Footer in the model dropdown to make the current model the default for new chats.
+ *
+ * Uses a Bookmark icon (not the Star used for favorites) so the two controls
+ * are visually distinct: ⭐ = add to favorites, 🔖 = set as default model.
+ */
 const SetDefaultModelFooter: FC<{ model: string }> = ({ model }) => {
   const { defaultModel, saveDefaultModel } = useModels();
   const { toast } = useToast();
@@ -398,6 +403,10 @@ const SetDefaultModelFooter: FC<{ model: string }> = ({ model }) => {
     }
   };
 
+  // Use Bookmark/BookmarkCheck (distinct from the Star used for favorites)
+  // so users can tell the two controls apart at a glance.
+  const DefaultIcon = isDefault ? BookmarkCheck : Bookmark;
+
   return (
     <div className="border-t p-1">
       <Button
@@ -406,10 +415,11 @@ const SetDefaultModelFooter: FC<{ model: string }> = ({ model }) => {
         size="sm"
         className="h-7 w-full justify-start text-xs font-normal"
         disabled={isDefault || saving}
+        title={isDefault ? 'This is already your default model' : 'Set as default for new chats'}
         onClick={() => void handleSetDefault()}
       >
-        <Star
-          className={`mr-2 h-3.5 w-3.5 ${isDefault ? 'fill-yellow-400 text-yellow-400' : ''}`}
+        <DefaultIcon
+          className={`mr-2 h-3.5 w-3.5 ${isDefault ? 'fill-current text-primary' : ''}`}
         />
         {isDefault ? 'Default for new chats' : 'Set as default for new chats'}
       </Button>

--- a/webui/src/components/__tests__/ChatInput.test.tsx
+++ b/webui/src/components/__tests__/ChatInput.test.tsx
@@ -70,14 +70,18 @@ jest.mock('@/stores/conversations', () => {
   };
 });
 
+const mockSaveDefaultModel = jest.fn();
+let mockDefaultModel = '';
+
 jest.mock('@/hooks/useModels', () => ({
   useModels: () => ({
     models: [],
-    defaultModel: '',
+    defaultModel: mockDefaultModel,
     availableModels: [],
     recommendedModels: [],
     isLoading: false,
     error: null,
+    saveDefaultModel: mockSaveDefaultModel,
   }),
 }));
 
@@ -134,6 +138,9 @@ describe('ChatInput', () => {
         },
       ],
     });
+    mockSaveDefaultModel.mockReset();
+    mockSaveDefaultModel.mockResolvedValue({ ok: true, restartRequired: false });
+    mockDefaultModel = '';
     window.localStorage.clear();
     mockConversation$.set({
       isGenerating: false,
@@ -459,5 +466,48 @@ describe('Model selector (gptme#3440)', () => {
     // Badge must remain enabled — user should be able to change model mid-stream
     // for the next turn (isDisabled is tied to isReadOnly/!isConnected, not isGenerating)
     expect(screen.getByTestId('model-selector')).not.toBeDisabled();
+  });
+});
+
+// Regression suite for gptme/gptme#3768 — set-default footer must not reuse the
+// Star icon (that's the per-model favorites toggle in ModelPicker).
+describe('Set-default footer (gptme#3768)', () => {
+  beforeEach(() => {
+    mockSaveDefaultModel.mockReset();
+    mockSaveDefaultModel.mockResolvedValue({ ok: true, restartRequired: false });
+    mockDefaultModel = '';
+    mockConversation$.set({
+      isGenerating: false,
+      executingTool: null,
+      chatConfig: { chat: { model: 'openai/gpt-4o' } },
+    });
+  });
+
+  async function openModelPicker() {
+    const autoFocus$ = observable(false);
+    render(<ChatInput conversationId="conv-a" onSend={jest.fn()} autoFocus$={autoFocus$} />);
+    fireEvent.click(screen.getByTestId('model-selector'));
+    return waitFor(() => screen.getByTestId('set-default-model'));
+  }
+
+  it('uses a Bookmark icon, not Star, for set-default', async () => {
+    const footer = await openModelPicker();
+    expect(footer.querySelector('svg.lucide-bookmark')).toBeInTheDocument();
+    expect(footer.querySelector('svg.lucide-star')).not.toBeInTheDocument();
+    expect(footer).toHaveTextContent('Set as default for new chats');
+    expect(footer).not.toBeDisabled();
+  });
+
+  it('keeps the already-default tooltip on a hoverable wrapper', async () => {
+    mockDefaultModel = 'openai/gpt-4o';
+    const footer = await openModelPicker();
+    expect(footer).toBeDisabled();
+    expect(footer.querySelector('svg.lucide-bookmark-check')).toBeInTheDocument();
+    expect(footer.querySelector('svg.lucide-star')).not.toBeInTheDocument();
+    expect(footer).toHaveTextContent('Default for new chats');
+    // Button is disabled (pointer-events-none). Title must live on a wrapper
+    // that can still receive hover — otherwise the new tooltip is unreachable.
+    expect(footer).not.toHaveAttribute('title');
+    expect(footer.parentElement).toHaveAttribute('title', 'This is already your default model');
   });
 });


### PR DESCRIPTION
## Problem

The `SetDefaultModelFooter` button in the model dropdown used the same `Star` icon as the per-model favorites toggle in `ModelPicker`, making the two actions look visually identical. This matched the 'stars seem mixed up' UX confusion reported in gptme/gptme-cloud#904.

## What this changes

- `SetDefaultModelFooter` now uses `Bookmark` / `BookmarkCheck` icons instead of `Star`.
- The per-model favorites button in `ModelPicker` still uses `Star`, as before.
- Added a `title` attribute on a **non-disabled wrapper** so hovering still shows a tooltip when the model is already the default (the button itself uses `disabled:pointer-events-none`).

**Before:** both controls show a ⭐ — clicks on the per-model star looked like 'set default' but only added to favorites.

**After (rendered):**
- ⭐ Star = add/remove from favorites (ModelPicker per-model button, unchanged)
- 🔖 Bookmark = set as default model for new chats (dropdown footer)

![Set-default footer uses Bookmark, not Star](https://s3.bob.gptme.org/screenshots/gptme-3768-set-default-bookmark-picker.png)

![Model dropdown in context](https://s3.bob.gptme.org/screenshots/gptme-3768-set-default-bookmark-full.png)

## Related

- gptme/gptme-cloud#904 — root issue (default model UX, cloud instances stuck on claude-sonnet-4-6)
