### PR TITLE
fix(shell): use poll() in _run_with_tty reader (#3715)

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -570,8 +570,10 @@ class ShellSession:
 
             # Use threads to drain stdout and stderr concurrently — the same
             # mechanism as communicate(), but with real-time printing as data
-            # arrives. select() alone is unreliable when /dev/tty is the child's
-            # stdin and the process produces no output before exiting.
+            # arrives. A blocking read on a quiet stream is unreliable when
+            # /dev/tty is the child's stdin and the process produces no output
+            # before exiting. Poll via `_wait_readable` (not `select.select`)
+            # so descriptors >= FD_SETSIZE still work; see gptme/gptme#3715.
             data_q: Queue[tuple[str, bytes] | None] = Queue()
 
             stop_readers = threading.Event()
@@ -580,7 +582,7 @@ class ShellSession:
                 fd = src.fileno()
                 try:
                     while True:
-                        readable, _, _ = select.select([fd], [], [], 0.1)
+                        readable = _wait_readable([fd], 0.1)
                         if not readable:
                             if stop_readers.is_set():
                                 break

--- a/tests/test_shell_high_fd.py
+++ b/tests/test_shell_high_fd.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from gptme.tools.shell import _wait_readable
+from gptme.tools.shell import ShellSession, _wait_readable
 
 fcntl = pytest.importorskip("fcntl", reason="POSIX-only test")
 resource = pytest.importorskip("resource", reason="POSIX-only test")
@@ -114,3 +114,27 @@ def test_wait_readable_preserves_zero_timeout():
     with patch("gptme.tools.shell.select.poll", return_value=poller):
         assert _wait_readable([7], 0) == []
     poller.poll.assert_called_once_with(0)
+
+
+def test_run_with_tty_reader_does_not_use_select_select():
+    """_run_with_tty must not call select.select (FD_SETSIZE leftover, #3715).
+
+    Pre-fix the reader threads raised ``ValueError: filedescriptor out of range
+    in select()`` and the main thread still returned success with empty output
+    (each reader sent its sentinel from ``finally``). After the fix, output is
+    collected via ``_wait_readable`` / ``poll()``.
+    """
+
+    def boom(*args, **kwargs):
+        raise ValueError("filedescriptor out of range in select()")
+
+    session = ShellSession()
+    try:
+        with patch("gptme.tools.shell.select.select", boom):
+            ret, out, _err = session._run_with_tty(
+                "echo tty-high-fd-safe", output=False
+            )
+        assert ret == 0
+        assert "tty-high-fd-safe" in out
+    finally:
+        session.close()


### PR DESCRIPTION
## Why

gptme/gptme#3716 already moved `_run_pipe` onto `_wait_readable` / `poll()`. The leftover TTY reader in `_run_with_tty` still called `select.select()`.

Under `pytest -n 16`, pipe fds can sit at or above `FD_SETSIZE` (1024). `select()` then raises `ValueError: filedescriptor out of range in select()` in the reader **threads**, so the main thread still returns success with empty output. `test_needs_tty_sudo_detection` was in the original flake list and goes through this path.

## Change

- `_run_with_tty`'s stdout/stderr reader now waits with `_wait_readable` (same helper as the pipe path).
- Regression: patch `select.select` to raise the FD_SETSIZE error and assert `_run_with_tty("echo …")` still returns the output.

Does not close gptme/gptme#3715 by itself: `gptme/tools/shell_background.py` still uses `select.select` on background-process fds. That is a separate path from this leftover.

## Tests

```text
PYTHONPATH=. pytest tests/test_shell_high_fd.py tests/test_shell_stream_oneshot.py -q
24 passed
```

Pre-fix reproduction: patching `select.select` made `_run_with_tty("echo hello")` return `(0, '', '')` while the reader threads printed the ValueError. Post-fix: `(0, 'hello', '')`.