### PR TITLE
fix(shell): use poll() in background job reader (#3715)

### DIFF
--- a/gptme/tools/shell_background.py
+++ b/gptme/tools/shell_background.py
@@ -36,6 +36,33 @@ logger = logging.getLogger(__name__)
 _MAX_BUFFER_SIZE = 1024 * 1024
 
 
+def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
+    """Return the subset of `fds` that are readable, waiting up to `timeout` seconds.
+
+    Uses `poll()` rather than `select()`. `select()` is backed by `fd_set`, which
+    cannot represent a descriptor >= FD_SETSIZE (1024) and raises
+    `ValueError: filedescriptor out of range in select()` instead of degrading.
+    Background jobs in long-lived processes and parallel test runs
+    (`pytest -n 16`) routinely push descriptors past that line. `poll()` has no
+    such ceiling. See gptme/gptme#3715.
+    """
+    if not fds:
+        return []
+    assert select is not None
+    poller = select.poll()
+    for fd in fds:
+        # POLLHUP/POLLERR are reported regardless of the requested mask, so EOF
+        # still wakes the poll — matching select(), which reports EOF as readable.
+        poller.register(fd, select.POLLIN)
+    # select() takes seconds (None == block forever); poll() takes integer
+    # milliseconds (negative == block forever). Round positive sub-millisecond
+    # waits up so they do not become busy-spinning non-blocking polls.
+    timeout_ms = (
+        -1 if timeout is None else max(0 if timeout == 0 else 1, int(timeout * 1000))
+    )
+    return [fd for fd, _event in poller.poll(timeout_ms)]
+
+
 @dataclass
 class BackgroundJob:
     """Tracks a background process with its output."""
@@ -95,7 +122,7 @@ class BackgroundJob:
             assert select is not None
             while not self._stop_event.is_set() and self.process.poll() is None:
                 try:
-                    readable, _, _ = select.select(fds, [], [], 0.1)
+                    readable = _wait_readable(fds, 0.1)
                     for fd in readable:
                         data = os.read(fd, 4096).decode("utf-8", errors="replace")
                         if data:

--- a/gptme/tools/shell_background.py
+++ b/gptme/tools/shell_background.py
@@ -39,6 +39,11 @@ _MAX_BUFFER_SIZE = 1024 * 1024
 def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
     """Return the subset of `fds` that are readable, waiting up to `timeout` seconds.
 
+    POSIX-only. `_read_output` never calls this on Windows: the `_is_windows`
+    branch uses non-blocking `os.read` instead. `select.poll` is not available
+    on Windows, and this helper refuses to silently fall back to `select()` —
+    that is the FD_SETSIZE bug this exists to close.
+
     Uses `poll()` rather than `select()`. `select()` is backed by `fd_set`, which
     cannot represent a descriptor >= FD_SETSIZE (1024) and raises
     `ValueError: filedescriptor out of range in select()` instead of degrading.
@@ -49,6 +54,11 @@ def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
     if not fds:
         return []
     assert select is not None
+    if not hasattr(select, "poll"):
+        raise OSError(
+            "select.poll is unavailable; Windows uses the non-blocking "
+            "os.read path in BackgroundJob._read_output"
+        )
     poller = select.poll()
     for fd in fds:
         # POLLHUP/POLLERR are reported regardless of the requested mask, so EOF

--- a/tests/test_shell_background.py
+++ b/tests/test_shell_background.py
@@ -264,6 +264,8 @@ class TestWaitReadable:
             os.close(write_fd)
 
     def test_rounds_positive_submillisecond_timeout_up(self):
+        if not hasattr(__import__("select"), "poll"):
+            pytest.skip("select.poll is POSIX-only")
         poller = Mock()
         poller.poll.return_value = []
         with patch("gptme.tools.shell_background.select.poll", return_value=poller):
@@ -271,11 +273,23 @@ class TestWaitReadable:
         poller.poll.assert_called_once_with(1)
 
     def test_preserves_zero_timeout(self):
+        if not hasattr(__import__("select"), "poll"):
+            pytest.skip("select.poll is POSIX-only")
         poller = Mock()
         poller.poll.return_value = []
         with patch("gptme.tools.shell_background.select.poll", return_value=poller):
             assert _wait_readable([7], 0) == []
         poller.poll.assert_called_once_with(0)
+
+    def test_raises_when_poll_unavailable(self):
+        class _NoPoll:
+            pass
+
+        with (
+            patch("gptme.tools.shell_background.select", _NoPoll()),
+            pytest.raises(OSError, match="select.poll is unavailable"),
+        ):
+            _wait_readable([7], 0)
 
     def test_handles_fd_above_fd_setsize(self):
         """A readable descriptor >= FD_SETSIZE must be reported, not raise."""

--- a/tests/test_shell_background.py
+++ b/tests/test_shell_background.py
@@ -6,16 +6,19 @@ Covers:
 - Command handlers (bg, jobs, output, kill)
 """
 
+import os
 import re
 import subprocess
 import sys
 import time
+from unittest.mock import Mock, patch
 
 import pytest
 
 from gptme.tools.shell_background import (
     _MAX_BUFFER_SIZE,
     BackgroundJob,
+    _wait_readable,
     cleanup_finished_jobs,
     execute_bg_command,
     execute_jobs_command,
@@ -187,6 +190,120 @@ class TestOutputCapture:
         time.sleep(0.5)
         stdout, _ = job.get_output()
         assert len(stdout) >= 100_000
+
+    def test_reader_does_not_use_select_select_while_running(self):
+        """Streaming capture must not go through select.select (#3715 leftover).
+
+        Pre-fix the POSIX reader called ``select.select`` and treated
+        ``ValueError: filedescriptor out of range in select()`` as a stop
+        condition, so output was only flushed in the final ``.read()`` after
+        the process exited. A live job would therefore look silent.
+        """
+        pytest.importorskip("fcntl", reason="POSIX-only path")
+
+        def boom(*args, **kwargs):
+            raise ValueError("filedescriptor out of range in select()")
+
+        with patch("gptme.tools.shell_background.select.select", boom):
+            job = start_background_job("echo bg-high-fd-safe; sleep 5")
+            stdout = ""
+            deadline = time.time() + 2.0
+            try:
+                while time.time() < deadline:
+                    stdout, _ = job.get_output()
+                    if "bg-high-fd-safe" in stdout:
+                        break
+                    time.sleep(0.05)
+                assert "bg-high-fd-safe" in stdout
+            finally:
+                job.kill()
+
+
+# ---------------------------------------------------------------------------
+# _wait_readable — poll() instead of select() (gptme/gptme#3715)
+# ---------------------------------------------------------------------------
+
+# Anything at or above FD_SETSIZE is unrepresentable in an fd_set.
+_FD_SETSIZE = 1024
+_FD_SCAN_WINDOW = 256
+
+
+def _find_free_fd(start: int) -> int:
+    """Return an unused descriptor >= `start` without clobbering a live fd."""
+    fcntl = pytest.importorskip("fcntl", reason="POSIX-only test")
+    for candidate in range(start, start + _FD_SCAN_WINDOW):
+        try:
+            fcntl.fcntl(candidate, fcntl.F_GETFD)
+        except OSError:
+            return candidate
+    pytest.skip(f"no free descriptor in [{start}, {start + _FD_SCAN_WINDOW})")
+
+
+class TestWaitReadable:
+    def test_empty_fds(self):
+        assert _wait_readable([], 0.01) == []
+
+    def test_reports_only_ready_fds(self):
+        pytest.importorskip("fcntl", reason="POSIX-only test")
+        idle_r, idle_w = os.pipe()
+        ready_r, ready_w = os.pipe()
+        try:
+            os.write(ready_w, b"x")
+            assert _wait_readable([idle_r, ready_r], 0.1) == [ready_r]
+        finally:
+            for fd in (idle_r, idle_w, ready_r, ready_w):
+                os.close(fd)
+
+    def test_times_out_with_no_data(self):
+        pytest.importorskip("fcntl", reason="POSIX-only test")
+        read_fd, write_fd = os.pipe()
+        try:
+            assert _wait_readable([read_fd], 0.05) == []
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
+
+    def test_rounds_positive_submillisecond_timeout_up(self):
+        poller = Mock()
+        poller.poll.return_value = []
+        with patch("gptme.tools.shell_background.select.poll", return_value=poller):
+            assert _wait_readable([7], 0.0001) == []
+        poller.poll.assert_called_once_with(1)
+
+    def test_preserves_zero_timeout(self):
+        poller = Mock()
+        poller.poll.return_value = []
+        with patch("gptme.tools.shell_background.select.poll", return_value=poller):
+            assert _wait_readable([7], 0) == []
+        poller.poll.assert_called_once_with(0)
+
+    def test_handles_fd_above_fd_setsize(self):
+        """A readable descriptor >= FD_SETSIZE must be reported, not raise."""
+        resource = pytest.importorskip("resource", reason="POSIX-only test")
+        pytest.importorskip("fcntl", reason="POSIX-only test")
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        needed = _FD_SETSIZE + _FD_SCAN_WINDOW + 16
+        if soft < needed:
+            if hard != resource.RLIM_INFINITY and hard < needed:
+                pytest.skip(f"RLIMIT_NOFILE hard limit {hard} < {needed}")
+            resource.setrlimit(resource.RLIMIT_NOFILE, (needed, hard))
+        read_fd, write_fd = os.pipe()
+        high_read_fd = None
+        try:
+            high_read_fd = _find_free_fd(_FD_SETSIZE)
+            os.dup2(read_fd, high_read_fd)
+            assert high_read_fd >= _FD_SETSIZE
+            os.write(write_fd, b"payload")
+            assert _wait_readable([high_read_fd], 1.0) == [high_read_fd]
+            assert os.read(high_read_fd, 16) == b"payload"
+        finally:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+            for fd in (high_read_fd, read_fd, write_fd):
+                if fd is not None:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

gptme/gptme#3769 moves the TTY/pipe readers onto `_wait_readable` / `poll()`. The leftover POSIX reader in `shell_background.py` still called `select.select()` on the job's stdout/stderr fds.

Under `pytest -n 16`, those fds can sit at or above `FD_SETSIZE` (1024). `select()` then raises `ValueError: filedescriptor out of range in select()`, and the reader treated that as a stop condition — so a live background job looked silent until it exited (the final `.read()` only runs after `process.poll()` is not `None`).

This cannot reuse `shell.py`'s helper: `shell.py` already imports `shell_background.py`.

## Change

- Local `_wait_readable` in `shell_background.py` waits with `poll()`.
- The POSIX reader loop uses that helper instead of `select.select()`.

Does not close gptme/gptme#3715 by itself: gptme/gptme#3769 is still the TTY leftover, and `gptme/cli/main.py` still uses `select.select` on stdin (a different path).

## Tests

```text
PYTHONPATH=. pytest tests/test_shell_background.py -q
56 passed
```

- Live-job regression: patch `select.select` to raise the FD_SETSIZE error and assert a still-running `echo …; sleep 5` job streams output.
- High-fd unit test: a readable descriptor `>= 1024` is reported, not raised.