### PR TITLE
fix(acp): attach host-supplied MCP servers to sessions

### DIFF
--- a/gptme/acp/__main__.py
+++ b/gptme/acp/__main__.py
@@ -178,12 +178,16 @@ async def _run_acp(real_stdin: IO[bytes], real_stdout: IO[bytes]) -> None:
     # run_agent params use client perspective:
     #   input_stream = writer (agent writes to client's input)
     #   output_stream = reader (agent reads from client's output)
-    await run_agent(
-        GptmeAgent(),
-        input_stream=writer,
-        output_stream=reader,
-        **connection_kwargs,
-    )
+    agent = GptmeAgent()
+    try:
+        await run_agent(
+            agent,
+            input_stream=writer,
+            output_stream=reader,
+            **connection_kwargs,
+        )
+    finally:
+        await agent.shutdown()
 
 
 def main() -> int:

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -687,15 +687,23 @@ class GptmeAgent:
         if server_configs:
             loop = asyncio.get_running_loop()
             config = get_config()
-            injected_tools = await loop.run_in_executor(
-                None,
-                lambda: create_mcp_tools(
-                    config,
-                    servers=server_configs,
-                    clients=session_clients,
-                    strict=True,
-                ),
-            )
+            try:
+                injected_tools = await loop.run_in_executor(
+                    None,
+                    lambda: create_mcp_tools(
+                        config,
+                        servers=server_configs,
+                        clients=session_clients,
+                        strict=True,
+                    ),
+                )
+            except Exception:
+                # Defense in depth: create_mcp_tools(strict=True) already closes
+                # clients it owned, but if anything is still in the registry
+                # (or a future caller stores before raising), do not leak them.
+                await self._close_mcp_clients(list(session_clients.values()))
+                session_clients.clear()
+                raise
         else:
             injected_tools = []
         requested_session_tools = [*base_tools, *injected_tools]
@@ -1597,8 +1605,12 @@ class GptmeAgent:
             session_id: Session to cancel
         """
         logger.info("Cancelling session %s", session_id)
-        clients = self._cleanup_session(session_id)
+        # Close owned clients before dropping session state. close() waits for
+        # any in-flight call_tool(); if this await is interrupted, shutdown can
+        # still find the clients in the session registry.
+        clients = list(self._session_mcp_clients.get(session_id, {}).values())
         await self._close_mcp_clients(clients)
+        self._cleanup_session(session_id)
 
     async def list_sessions(
         self,

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -44,6 +44,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Bound for closing one host-supplied MCP client during cancel/shutdown.
+# MCPClient.close() also interrupts in-flight calls; this is the ACP-side cap
+# so a stuck close cannot block session cancellation indefinitely.
+_MCP_CLIENT_CLOSE_TIMEOUT_S = 5.0
+
 # Lazy imports to avoid dependency issues when acp is not installed
 Agent: type | None = None
 AuthMethodAgent: type | None = None
@@ -1580,7 +1585,12 @@ class GptmeAgent:
         loop = asyncio.get_running_loop()
         for client in clients:
             try:
-                await loop.run_in_executor(None, client.close)
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, client.close),
+                    timeout=_MCP_CLIENT_CLOSE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning("Timed out closing session MCP client")
             except Exception:
                 logger.warning("Failed to close session MCP client", exc_info=True)
 
@@ -1605,12 +1615,14 @@ class GptmeAgent:
             session_id: Session to cancel
         """
         logger.info("Cancelling session %s", session_id)
-        # Close owned clients before dropping session state. close() waits for
-        # any in-flight call_tool(); if this await is interrupted, shutdown can
-        # still find the clients in the session registry.
+        # Close owned clients before dropping session state. close() interrupts
+        # in-flight call_tool() and is itself time-bounded; if this await is
+        # interrupted, shutdown can still find the clients in the session registry.
         clients = list(self._session_mcp_clients.get(session_id, {}).values())
-        await self._close_mcp_clients(clients)
-        self._cleanup_session(session_id)
+        try:
+            await self._close_mcp_clients(clients)
+        finally:
+            self._cleanup_session(session_id)
 
     async def list_sessions(
         self,

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..config import ChatConfig, get_project_config
+from ..config import ChatConfig, MCPServerConfig, get_config, get_project_config
 from ..dirs import get_logs_dir
 from ..init import init
 from ..llm.models import get_default_model, set_default_model
@@ -25,6 +25,7 @@ from ..model_attestation import record_runtime_selection
 from ..prompts import get_prompt
 from ..session import SessionRegistry
 from ..tools import ToolUse, get_tools, set_tools
+from ..tools.mcp_adapter import create_mcp_tools
 from ..util.auto_naming import generate_conversation_id
 from ..util.context import md_codeblock
 from .adapter import acp_content_to_gptme_message, gptme_message_to_acp_content
@@ -149,6 +150,92 @@ def _auth_methods() -> list:
     ]
 
 
+def _descriptor_value(descriptor: Any, name: str) -> Any:
+    """Read one ACP descriptor field from a Pydantic model or mapping."""
+    if isinstance(descriptor, dict):
+        return descriptor.get(name)
+    return getattr(descriptor, name, None)
+
+
+def _name_value_pairs(values: Any, field: str) -> dict[str, str]:
+    """Convert ACP environment/header entries into gptme's mapping shape."""
+    if values is None:
+        return {}
+    if not isinstance(values, list):
+        raise ValueError(f"ACP MCP server {field} must be a list")
+    result: dict[str, str] = {}
+    for item in values:
+        name = _descriptor_value(item, "name")
+        value = _descriptor_value(item, "value")
+        if not isinstance(name, str) or not name or not isinstance(value, str):
+            raise ValueError(
+                f"ACP MCP server {field} entries require string name/value"
+            )
+        if name in result:
+            raise ValueError(f"Duplicate ACP MCP server {field} name: {name!r}")
+        result[name] = value
+    return result
+
+
+def _mcp_server_configs(descriptors: list[Any]) -> list[MCPServerConfig]:
+    """Convert supported ACP MCP descriptors into gptme server configs."""
+    configs: list[MCPServerConfig] = []
+    names: set[str] = set()
+    for descriptor in descriptors:
+        name = _descriptor_value(descriptor, "name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("Malformed ACP MCP server descriptor: missing name")
+        if name in names:
+            raise ValueError(f"Duplicate ACP MCP server name: {name!r}")
+        names.add(name)
+
+        transport = _descriptor_value(descriptor, "type")
+        command = _descriptor_value(descriptor, "command")
+        url = _descriptor_value(descriptor, "url")
+        if transport == "sse":
+            raise ValueError(f"ACP MCP server {name!r} uses unsupported SSE transport")
+        if transport == "acp":
+            raise ValueError(f"ACP MCP server {name!r} uses unsupported ACP transport")
+        if transport == "http":
+            if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"Malformed ACP MCP server descriptor for {name!r}: invalid URL"
+                )
+            configs.append(
+                MCPServerConfig(
+                    name=name,
+                    url=url,
+                    headers=_name_value_pairs(
+                        _descriptor_value(descriptor, "headers"), "headers"
+                    ),
+                )
+            )
+            continue
+        if transport is not None:
+            raise ValueError(
+                f"ACP MCP server {name!r} uses unsupported {transport!r} transport"
+            )
+        if not isinstance(command, str) or not Path(command).is_absolute():
+            raise ValueError(
+                f"Malformed ACP MCP server descriptor for {name!r}: "
+                "stdio command must be absolute"
+            )
+        args = _descriptor_value(descriptor, "args")
+        if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+            raise ValueError(
+                f"Malformed ACP MCP server descriptor for {name!r}: args must be strings"
+            )
+        configs.append(
+            MCPServerConfig(
+                name=name,
+                command=command,
+                args=list(args),
+                env=_name_value_pairs(_descriptor_value(descriptor, "env"), "env"),
+            )
+        )
+    return configs
+
+
 def _cwd_session_id(cwd: str) -> str:
     """Derive a deterministic session ID from a workspace path.
 
@@ -176,6 +263,10 @@ class GptmeAgent:
         self._tools: list[Any] | None = None
         # Per-session model overrides (populated from per-project gptme.toml)
         self._session_models: dict[str, str | None] = {}
+        # ACP host-supplied tools and their owned MCP clients. Host definitions
+        # never enter persistent config or the process-global MCP registries.
+        self._session_tools: dict[str, list[Any]] = {}
+        self._session_mcp_clients: dict[str, dict[str, Any]] = {}
         # Per-session mode (default: "default", can be "auto" for no-confirm)
         self._session_modes: dict[str, str] = {}
         # Phase 2: Track active tool calls per session
@@ -590,6 +681,25 @@ class GptmeAgent:
         if self._tools is not None:
             set_tools(self._tools)
 
+        base_tools = list(self._tools or get_tools())
+        server_configs = _mcp_server_configs(mcp_servers)
+        session_clients: dict[str, Any] = {}
+        if server_configs:
+            loop = asyncio.get_running_loop()
+            config = get_config()
+            injected_tools = await loop.run_in_executor(
+                None,
+                lambda: create_mcp_tools(
+                    config,
+                    servers=server_configs,
+                    clients=session_clients,
+                    strict=True,
+                ),
+            )
+        else:
+            injected_tools = []
+        requested_session_tools = [*base_tools, *injected_tools]
+
         # Resolve per-project model from gptme.toml in the session's cwd.
         # Each Zed window may have its own project with a different MODEL in gptme.toml,
         # so we check the project config and override the global model for this session.
@@ -646,7 +756,19 @@ class GptmeAgent:
 
         logdir = logs_dir / session_id
 
-        # Store per-session model for use in prompt() and other handlers
+        existing_tools = self._session_tools.get(session_id)
+        if resumed and existing_tools is not None and not server_configs:
+            session_tools = existing_tools
+        else:
+            session_tools = requested_session_tools
+            old_clients = self._session_mcp_clients.pop(session_id, {})
+            if old_clients:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(
+                    None, lambda: [client.close() for client in old_clients.values()]
+                )
+            self._session_tools[session_id] = session_tools
+            self._session_mcp_clients[session_id] = session_clients
         self._session_models[session_id] = session_model
 
         # Apply session model to context for this task
@@ -655,9 +777,8 @@ class GptmeAgent:
 
         if not resumed:
             # Get tools and initial prompt for a fresh session
-            tools = get_tools()
             initial_msgs = get_prompt(
-                tools=tools,
+                tools=session_tools,
                 tool_format="markdown",
                 prompt="full",
                 interactive=False,
@@ -1044,7 +1165,9 @@ class GptmeAgent:
         if effective_model:
             set_default_model(effective_model)
             record_runtime_selection(effective_model, "acp_runtime")
-        if self._tools is not None:
+        if session_id in self._session_tools:
+            set_tools(self._session_tools[session_id])
+        elif self._tools is not None:
             set_tools(self._tools)
 
         # Resend AvailableCommandsUpdate if not yet sent for this session.
@@ -1427,19 +1550,41 @@ class GptmeAgent:
 
         return _NewSessionResponse(**response_kwargs)
 
-    def _cleanup_session(self, session_id: str) -> None:
-        """Remove all per-session state for a given session.
+    def _cleanup_session(self, session_id: str) -> list[Any]:
+        """Remove per-session state and return MCP clients that need closing.
 
         Cleans up _session_models, _session_modes, _tool_calls, and
         _permission_policies to prevent unbounded memory growth from
         accumulated sessions.
         """
         self._session_models.pop(session_id, None)
+        self._session_tools.pop(session_id, None)
+        clients = list(self._session_mcp_clients.pop(session_id, {}).values())
         self._session_modes.pop(session_id, None)
         self._tool_calls.pop(session_id, None)
         self._permission_policies.pop(session_id, None)
         self._session_commands_advertised.discard(session_id)
         self._registry.remove(session_id)
+        return clients
+
+    async def _close_mcp_clients(self, clients: list[Any]) -> None:
+        """Close owned MCP clients without blocking the ACP event loop."""
+        loop = asyncio.get_running_loop()
+        for client in clients:
+            try:
+                await loop.run_in_executor(None, client.close)
+            except Exception:
+                logger.warning("Failed to close session MCP client", exc_info=True)
+
+    async def shutdown(self) -> None:
+        """Close host-supplied MCP clients for every active ACP session."""
+        clients = [
+            client
+            for session_clients in self._session_mcp_clients.values()
+            for client in session_clients.values()
+        ]
+        self._session_mcp_clients.clear()
+        await self._close_mcp_clients(clients)
 
     async def cancel(
         self,
@@ -1452,7 +1597,8 @@ class GptmeAgent:
             session_id: Session to cancel
         """
         logger.info("Cancelling session %s", session_id)
-        self._cleanup_session(session_id)
+        clients = self._cleanup_session(session_id)
+        await self._close_mcp_clients(clients)
 
     async def list_sessions(
         self,

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import threading
 from collections.abc import Callable, Coroutine
 from contextlib import AsyncExitStack
 from typing import Any
@@ -58,6 +59,10 @@ class MCPClient:
         """Initialize the client with optional config"""
         self.config = config or get_config()
         self.loop = asyncio.new_event_loop()
+        # Serializes _run_async() with close() so a cancel/shutdown thread cannot
+        # run_until_complete (or close) the private loop while a tool call is
+        # already using it.
+        self._op_lock = threading.Lock()
         # Don't call asyncio.set_event_loop() — each client owns its own loop
         # and uses it exclusively via self.loop.run_until_complete() in _run_async().
         # Setting it as the thread-global loop would cause multiple MCPClient
@@ -76,36 +81,42 @@ class MCPClient:
         """Run a coroutine in the event loop.
 
         Handles KeyboardInterrupt gracefully to avoid killing the MCP server
-        when the user interrupts a conversation.
+        when the user interrupts a conversation. Serialized with close() so
+        ACP cancel cannot race this loop from another thread.
         """
-        try:
-            logger.debug(f"_run_async start - Loop ID: {id(self.loop)}")
-            result = self.loop.run_until_complete(coro)
-            logger.debug(f"_run_async end - Loop ID: {id(self.loop)}")
-            return result
-        except KeyboardInterrupt:
-            # Cancel the pending task gracefully instead of letting the interrupt
-            # propagate and potentially kill the MCP server process
-            logger.info("MCP operation interrupted by user")
-            # Cancel any pending tasks in the event loop
-            for task in asyncio.all_tasks(self.loop):
-                if not task.done():
-                    task.cancel()
-            # Give tasks a chance to clean up
+        with self._op_lock:
+            if self.loop.is_closed():
+                if hasattr(coro, "close"):
+                    coro.close()
+                raise RuntimeError("MCP client is closed")
             try:
-                self.loop.run_until_complete(asyncio.sleep(0.1))
-            except (asyncio.CancelledError, KeyboardInterrupt):
-                pass
-            # Raise a regular exception instead of re-raising KeyboardInterrupt
-            # This prevents the interrupt from propagating to the stdio_client
-            # context manager and killing the server process
-            raise MCPInterruptedError("MCP operation interrupted by user") from None
-        except Exception as e:
-            if _is_connection_error(e):
-                logger.info(f"MCP connection error (will retry): {e}")
-            else:
-                logger.error(f"Unexpected MCP error: {e}")
-            raise
+                logger.debug(f"_run_async start - Loop ID: {id(self.loop)}")
+                result = self.loop.run_until_complete(coro)
+                logger.debug(f"_run_async end - Loop ID: {id(self.loop)}")
+                return result
+            except KeyboardInterrupt:
+                # Cancel the pending task gracefully instead of letting the interrupt
+                # propagate and potentially kill the MCP server process
+                logger.info("MCP operation interrupted by user")
+                # Cancel any pending tasks in the event loop
+                for task in asyncio.all_tasks(self.loop):
+                    if not task.done():
+                        task.cancel()
+                # Give tasks a chance to clean up
+                try:
+                    self.loop.run_until_complete(asyncio.sleep(0.1))
+                except (asyncio.CancelledError, KeyboardInterrupt):
+                    pass
+                # Raise a regular exception instead of re-raising KeyboardInterrupt
+                # This prevents the interrupt from propagating to the stdio_client
+                # context manager and killing the server process
+                raise MCPInterruptedError("MCP operation interrupted by user") from None
+            except Exception as e:
+                if _is_connection_error(e):
+                    logger.info(f"MCP connection error (will retry): {e}")
+                else:
+                    logger.error(f"Unexpected MCP error: {e}")
+                raise
 
     async def _read_stderr(self, stderr):
         """Read stderr without blocking the main flow"""
@@ -278,16 +289,21 @@ class MCPClient:
         return tools, session
 
     def close(self) -> None:
-        """Close the MCP session, transport, and private event loop."""
-        try:
-            if self.stack is not None:
-                self.loop.run_until_complete(self.stack.__aexit__(None, None, None))
-        finally:
-            self.stack = None
-            self.session = None
-            self.tools = None
-            if not self.loop.is_closed():
-                self.loop.close()
+        """Close the MCP session, transport, and private event loop.
+
+        Waits for any in-flight ``_run_async()`` call (tool execution, connect)
+        so cancel/shutdown cannot close a loop that is already running.
+        """
+        with self._op_lock:
+            try:
+                if self.stack is not None and not self.loop.is_closed():
+                    self.loop.run_until_complete(self.stack.__aexit__(None, None, None))
+            finally:
+                self.stack = None
+                self.session = None
+                self.tools = None
+                if not self.loop.is_closed():
+                    self.loop.close()
 
     def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Synchronous tool call method.

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -23,6 +23,11 @@ ElicitationCallback = Callable[
 
 logger = logging.getLogger(__name__)
 
+# Upper bound for close() waiting on an in-flight _run_async() after it has
+# requested cancellation. ACP session cancel must not hang if a tool call
+# never returns.
+MCP_CLOSE_TIMEOUT_S = 5.0
+
 
 class MCPInterruptedError(Exception):
     """Raised when an MCP operation is interrupted by the user.
@@ -63,6 +68,10 @@ class MCPClient:
         # run_until_complete (or close) the private loop while a tool call is
         # already using it.
         self._op_lock = threading.Lock()
+        self._closing = threading.Event()
+        # Set only while close() is interrupting an in-flight call. Cleared
+        # before stack aexit so a queued cancel callback cannot cancel cleanup.
+        self._interrupt_ops = threading.Event()
         # Don't call asyncio.set_event_loop() — each client owns its own loop
         # and uses it exclusively via self.loop.run_until_complete() in _run_async().
         # Setting it as the thread-global loop would cause multiple MCPClient
@@ -77,6 +86,14 @@ class MCPClient:
         # The breaker protects call_tool() calls from hammering a broken server.
         self._circuit_breaker: CircuitBreaker | None = None
 
+    def _cancel_running_tasks(self) -> None:
+        """Cancel tasks on the private loop. Must run on that loop's thread."""
+        if not self._interrupt_ops.is_set():
+            return
+        for task in asyncio.all_tasks(self.loop):
+            if not task.done():
+                task.cancel()
+
     def _run_async(self, coro):
         """Run a coroutine in the event loop.
 
@@ -85,7 +102,7 @@ class MCPClient:
         ACP cancel cannot race this loop from another thread.
         """
         with self._op_lock:
-            if self.loop.is_closed():
+            if self._closing.is_set() or self.loop.is_closed():
                 if hasattr(coro, "close"):
                     coro.close()
                 raise RuntimeError("MCP client is closed")
@@ -94,6 +111,8 @@ class MCPClient:
                 result = self.loop.run_until_complete(coro)
                 logger.debug(f"_run_async end - Loop ID: {id(self.loop)}")
                 return result
+            except asyncio.CancelledError:
+                raise RuntimeError("MCP client is closed") from None
             except KeyboardInterrupt:
                 # Cancel the pending task gracefully instead of letting the interrupt
                 # propagate and potentially kill the MCP server process
@@ -291,19 +310,42 @@ class MCPClient:
     def close(self) -> None:
         """Close the MCP session, transport, and private event loop.
 
-        Waits for any in-flight ``_run_async()`` call (tool execution, connect)
-        so cancel/shutdown cannot close a loop that is already running.
+        Interrupts any in-flight ``_run_async()`` call so ACP session
+        cancellation cannot block indefinitely on a stalled MCP tool call.
+        After the in-flight call unwinds (or a timeout), close the stack and
+        loop. Serialized with ``_run_async()`` so we never ``run_until_complete``
+        on a loop that is already running.
         """
-        with self._op_lock:
+        self._closing.set()
+        self._interrupt_ops.set()
+        if not self.loop.is_closed() and self.loop.is_running():
+            try:
+                self.loop.call_soon_threadsafe(self._cancel_running_tasks)
+            except RuntimeError:
+                pass
+
+        acquired = self._op_lock.acquire(timeout=MCP_CLOSE_TIMEOUT_S)
+        try:
+            if not acquired:
+                logger.warning(
+                    "MCP client close timed out waiting for in-flight operation"
+                )
+                return
+            self._interrupt_ops.clear()
             try:
                 if self.stack is not None and not self.loop.is_closed():
                     self.loop.run_until_complete(self.stack.__aexit__(None, None, None))
+            except (asyncio.CancelledError, Exception):
+                logger.debug("MCP stack close raised", exc_info=True)
             finally:
                 self.stack = None
                 self.session = None
                 self.tools = None
                 if not self.loop.is_closed():
                     self.loop.close()
+        finally:
+            if acquired:
+                self._op_lock.release()
 
     def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Synchronous tool call method.

--- a/gptme/mcp/client.py
+++ b/gptme/mcp/client.py
@@ -277,6 +277,18 @@ class MCPClient:
         logger.info(f"Tools: {tools}")
         return tools, session
 
+    def close(self) -> None:
+        """Close the MCP session, transport, and private event loop."""
+        try:
+            if self.stack is not None:
+                self.loop.run_until_complete(self.stack.__aexit__(None, None, None))
+        finally:
+            self.stack = None
+            self.session = None
+            self.tools = None
+            if not self.loop.is_closed():
+                self.loop.close()
+
     def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Synchronous tool call method.
 

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -230,6 +230,10 @@ def create_mcp_tools(
         client_config.user = replace(config.user)
         client_config.user.mcp = MCPConfig(enabled=True, servers=server_configs)
 
+    # Names stored in client_registry during this call. On strict failure we
+    # close these so a later server's exception cannot leak earlier connections.
+    owned_this_call: list[str] = []
+
     # Initialize connections to all servers
     for server_config in server_configs:
         client: MCPClient | None = None
@@ -241,6 +245,7 @@ def create_mcp_tools(
 
             # Store the client in the caller-selected registry for execution/restart.
             client_registry[server_config.name] = client
+            owned_this_call.append(server_config.name)
 
             # Create tool specs for each tool
             for mcp_tool in tools.tools:
@@ -318,6 +323,16 @@ def create_mcp_tools(
                 except Exception:
                     logger.debug("Failed to close rejected MCP client", exc_info=True)
             if strict:
+                for name in owned_this_call:
+                    leftover = client_registry.pop(name, None)
+                    if leftover is not None and leftover is not client:
+                        try:
+                            leftover.close()
+                        except Exception:
+                            logger.debug(
+                                "Failed to close leftover MCP client after strict setup failure",
+                                exc_info=True,
+                            )
                 raise RuntimeError(
                     f"Failed to connect to MCP server {server_config.name!r}: {e}"
                 ) from e

--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -151,6 +151,7 @@ def _call_mcp_tool_with_retry(
     arguments: dict,
     config: Config,
     max_retries: int = 1,
+    clients: dict[str, MCPClient] | None = None,
 ) -> str:
     """Call an MCP tool with automatic retry on connection failures"""
     from ..mcp.client import _is_connection_error
@@ -160,7 +161,11 @@ def _call_mcp_tool_with_retry(
     for attempt in range(max_retries + 1):
         try:
             # Get the client for this server
-            client = _mcp_clients.get(server_name)
+            client = (
+                clients.get(server_name)
+                if clients is not None
+                else _get_mcp_client(server_name)
+            )
             if client is None:
                 raise RuntimeError(f"No MCP client found for server: {server_name}")
 
@@ -172,7 +177,17 @@ def _call_mcp_tool_with_retry(
 
             if _is_connection_error(e) and attempt < max_retries:
                 logger.info(f"MCP connection failed for {server_name}, restarting...")
-                _restart_mcp_client(server_name, config)
+                if clients is None:
+                    _restart_mcp_client(server_name, config)
+                else:
+                    client = clients.pop(server_name, None)
+                    if client is not None:
+                        client.close()
+                    from ..mcp.client import MCPClient as MCPClientRuntime
+
+                    replacement = MCPClientRuntime(config=config)
+                    replacement.connect(server_name)
+                    clients[server_name] = replacement
                 continue
             break
 
@@ -182,28 +197,50 @@ def _call_mcp_tool_with_retry(
 
 
 # Function to create MCP tools
-def create_mcp_tools(config: Config) -> list[ToolSpec]:
-    """Create tool specs for all MCP tools from the config"""
-    tool_specs: list[ToolSpec] = []
+def create_mcp_tools(
+    config: Config,
+    *,
+    servers: list[MCPServerConfig] | None = None,
+    clients: dict[str, MCPClient] | None = None,
+    strict: bool = False,
+) -> list[ToolSpec]:
+    """Create tool specs for configured or explicitly supplied MCP servers.
 
-    # Skip if MCP is not enabled or no servers are configured.
-    # Checked before the MCPClient import: pulling in the mcp SDK costs
-    # ~0.5s+ at startup, so don't pay it when there is nothing to connect to.
-    if not config.mcp.enabled or not config.mcp.servers:
+    Explicit ``servers`` and ``clients`` let protocol adapters keep injected MCP
+    connections session-scoped instead of adding them to gptme's global registry.
+    """
+    tool_specs: list[ToolSpec] = []
+    server_configs = config.mcp.servers if servers is None else servers
+
+    # Skip if MCP is disabled, unless a protocol host explicitly supplied servers.
+    # Checked before the MCPClient import: pulling in the mcp SDK costs ~0.5s+.
+    if (servers is None and not config.mcp.enabled) or not server_configs:
         return tool_specs
 
     from ..mcp.client import MCPClient
 
+    client_registry = _mcp_clients if clients is None else clients
+    client_config = config
+    if servers is not None:
+        from dataclasses import replace
+
+        from gptme.config import MCPConfig
+
+        client_config = replace(config)
+        client_config.user = replace(config.user)
+        client_config.user.mcp = MCPConfig(enabled=True, servers=server_configs)
+
     # Initialize connections to all servers
-    for server_config in config.mcp.servers:
+    for server_config in server_configs:
+        client: MCPClient | None = None
         try:
-            client = MCPClient(config=config)
+            client = MCPClient(config=client_config)
 
             # Connect to server
             tools, session = client.connect(server_config.name)
 
-            # Store the client globally for restart capability
-            _mcp_clients[server_config.name] = client
+            # Store the client in the caller-selected registry for execution/restart.
+            client_registry[server_config.name] = client
 
             # Create tool specs for each tool
             for mcp_tool in tools.tools:
@@ -260,7 +297,10 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                     desc=f"[{server_config.name}] {mcp_tool.description}",
                     parameters=parameters,
                     execute=create_mcp_execute_function(
-                        mcp_tool.name, server_config.name, config
+                        mcp_tool.name,
+                        server_config.name,
+                        client_config,
+                        clients=client_registry,
                     ),
                     available=True,
                     examples=make_examples(name, example_str),
@@ -272,19 +312,27 @@ def create_mcp_tools(config: Config) -> list[ToolSpec]:
                 tool_specs.append(tool_spec)
 
         except (Exception, asyncio.CancelledError) as e:
-            import traceback
-
-            error_details = traceback.format_exc()
-            logger.error(
-                f"Failed to connect to MCP server {server_config.name}: {e}\n{error_details}"
-            )
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Failed to close rejected MCP client", exc_info=True)
+            if strict:
+                raise RuntimeError(
+                    f"Failed to connect to MCP server {server_config.name!r}: {e}"
+                ) from e
+            logger.exception("Failed to connect to MCP server %s", server_config.name)
 
     return tool_specs
 
 
 # Function to create execute function for a specific MCP tool
 def create_mcp_execute_function(
-    tool_name: str, server_name: str, config: Config
+    tool_name: str,
+    server_name: str,
+    config: Config,
+    *,
+    clients: dict[str, MCPClient] | None = None,
 ) -> ExecuteFunc:
     """Create an execute function for an MCP tool"""
 
@@ -308,7 +356,11 @@ def create_mcp_execute_function(
         try:
             # Get the client for getting tool definition
             tool_def = None
-            client = _mcp_clients.get(server_name)
+            client = (
+                clients.get(server_name)
+                if clients is not None
+                else _get_mcp_client(server_name)
+            )
             if client is None:
                 raise RuntimeError(f"No MCP client found for server: {server_name}")
             if client.tools is not None:
@@ -338,7 +390,9 @@ def create_mcp_execute_function(
                 ) from err
 
             # Execute the tool with retry on connection failures
-            result = _call_mcp_tool_with_retry(server_name, tool_name, kwargs, config)
+            result = _call_mcp_tool_with_retry(
+                server_name, tool_name, kwargs, config, clients=clients
+            )
             yield Message("system", result)
         except MCPInterruptedError:
             # User interrupted the operation - don't log as error, just inform

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -1649,8 +1649,10 @@ class TestHostSuppliedMcpServers:
     """Tests for MCP servers supplied by the ACP host at session creation."""
 
     def test_descriptor_conversion_and_validation(self):
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
         from acp.schema import (
-            AcpMcpServer,
             EnvVariable,
             HttpHeader,
             HttpMcpServer,
@@ -1702,9 +1704,9 @@ class TestHostSuppliedMcpServers:
                 ]
             )
         with pytest.raises(ValueError, match="ACP transport"):
-            _mcp_server_configs(
-                [AcpMcpServer(name="proxied", server_id="server-1", type="acp")]
-            )
+            # Dict form avoids AcpMcpServer field-name churn (id vs server_id
+            # across SDK versions) while still exercising the type=="acp" reject.
+            _mcp_server_configs([{"name": "proxied", "type": "acp"}])
         with pytest.raises(ValueError, match="Malformed ACP MCP server descriptor"):
             _mcp_server_configs([{"name": "broken"}])
 

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -10,7 +10,7 @@ new test dependency.
 import asyncio
 import builtins
 import threading
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1606,6 +1606,236 @@ class TestPromptErrorHandling:
         error_call = agent._conn.session_update.await_args_list[-1]
         update = error_call.kwargs.get("update")
         assert "boom chat import" in str(update)
+
+
+class TestHostSuppliedMcpServers:
+    """Tests for MCP servers supplied by the ACP host at session creation."""
+
+    def test_descriptor_conversion_and_validation(self):
+        from acp.schema import (
+            AcpMcpServer,
+            EnvVariable,
+            HttpHeader,
+            HttpMcpServer,
+            McpServerStdio,
+            SseMcpServer,
+        )
+
+        from gptme.acp.agent import _mcp_server_configs
+
+        configs = _mcp_server_configs(
+            [
+                McpServerStdio(
+                    name="notebook",
+                    command="/usr/bin/python3",
+                    args=["server.py"],
+                    env=[EnvVariable(name="TOKEN", value="secret")],
+                ),
+                HttpMcpServer(
+                    name="artifacts",
+                    url="https://example.test/mcp",
+                    headers=[HttpHeader(name="Authorization", value="Bearer test")],
+                    type="http",
+                ),
+            ]
+        )
+
+        assert configs[0].name == "notebook"
+        assert configs[0].command == "/usr/bin/python3"
+        assert configs[0].args == ["server.py"]
+        assert configs[0].env == {"TOKEN": "secret"}
+        assert configs[1].name == "artifacts"
+        assert configs[1].url == "https://example.test/mcp"
+        assert configs[1].headers == {"Authorization": "Bearer test"}
+
+        duplicate = McpServerStdio(
+            name="notebook", command="/usr/bin/python3", args=[], env=[]
+        )
+        with pytest.raises(ValueError, match="Duplicate ACP MCP server name"):
+            _mcp_server_configs([duplicate, duplicate])
+        with pytest.raises(ValueError, match="SSE transport"):
+            _mcp_server_configs(
+                [
+                    SseMcpServer(
+                        name="events",
+                        url="https://example.test/sse",
+                        headers=[],
+                        type="sse",
+                    )
+                ]
+            )
+        with pytest.raises(ValueError, match="ACP transport"):
+            _mcp_server_configs(
+                [AcpMcpServer(name="proxied", server_id="server-1", type="acp")]
+            )
+        with pytest.raises(ValueError, match="Malformed ACP MCP server descriptor"):
+            _mcp_server_configs([{"name": "broken"}])
+
+    def test_new_session_adds_host_tools_and_cleanup_is_scoped(self, tmp_path):
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        from acp.schema import McpServerStdio
+
+        from gptme.message import Message
+        from gptme.tools.base import ToolSpec
+
+        def execute_stub(*_):
+            yield Message("system", "ok")
+
+        base_tool = ToolSpec(name="read", desc="Read", execute=execute_stub)
+        host_tool = ToolSpec(
+            name="notebook.echo", desc="Echo", execute=execute_stub, is_mcp=True
+        )
+        host_client = MagicMock()
+        descriptor = McpServerStdio(
+            name="notebook", command="/bin/echo", args=[], env=[]
+        )
+        agent = GptmeAgent()
+        agent._tools = [base_tool]
+
+        def fake_create_mcp_tools(config, *, servers, clients, strict):
+            assert strict is True
+            assert [server.name for server in servers] == ["notebook"]
+            clients["notebook"] = host_client
+            return [host_tool]
+
+        with (
+            patch("gptme.acp.agent.get_logs_dir", return_value=tmp_path / "logs"),
+            patch("gptme.acp.agent.get_prompt", return_value=[]) as get_prompt,
+            patch("gptme.acp.agent.ChatConfig"),
+            patch(
+                "gptme.acp.agent.create_mcp_tools",
+                side_effect=fake_create_mcp_tools,
+            ),
+        ):
+            result = _run(
+                agent.new_session(cwd=str(tmp_path), mcp_servers=[descriptor])
+            )
+
+        session_id = result.session_id
+        assert agent._session_tools[session_id] == [base_tool, host_tool]
+        assert agent._session_mcp_clients[session_id] == {"notebook": host_client}
+        assert get_prompt.call_args.kwargs["tools"] == [base_tool, host_tool]
+
+        clients = agent._cleanup_session(session_id)
+        for client in clients:
+            client.close()
+
+        host_client.close.assert_called_once_with()
+        assert session_id not in agent._session_tools
+        assert session_id not in agent._session_mcp_clients
+
+    def test_host_tool_execute_uses_the_session_client(self):
+        from gptme.config import Config
+        from gptme.message import Message
+        from gptme.tools.mcp_adapter import create_mcp_execute_function
+
+        client = MagicMock()
+        client.call_tool.return_value = "session result"
+        execute = create_mcp_execute_function(
+            "echo", "notebook", Config(), clients={"notebook": client}
+        )
+
+        with patch(
+            "gptme.tools.mcp_adapter.execute_with_confirmation",
+            side_effect=lambda content, args, kwargs, execute_fn, **unused: execute_fn(
+                content
+            ),
+        ):
+            result = execute('{"value": "hello"}', None, None)
+            assert not isinstance(result, Message)
+            messages = list(result)
+
+        assert [message.content for message in messages] == ["session result"]
+        client.call_tool.assert_called_once_with("echo", {"value": "hello"})
+
+    def test_shutdown_closes_all_host_clients(self):
+        agent = GptmeAgent()
+        first = MagicMock()
+        second = MagicMock()
+        agent._session_mcp_clients = {
+            "first": {"one": first},
+            "second": {"two": second},
+        }
+
+        _run(agent.shutdown())
+
+        first.close.assert_called_once_with()
+        second.close.assert_called_once_with()
+        assert agent._session_mcp_clients == {}
+
+    def test_two_sessions_keep_host_tools_isolated(self, tmp_path):
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        from acp.schema import McpServerStdio
+
+        from gptme.message import Message
+        from gptme.tools.base import ToolSpec
+
+        def execute_stub(*_):
+            yield Message("system", "ok")
+
+        agent = GptmeAgent()
+        agent._tools = []
+
+        def fake_create_mcp_tools(config, *, servers, clients, strict):
+            server = servers[0]
+            clients[server.name] = MagicMock()
+            return [
+                ToolSpec(
+                    name=f"{server.name}.echo",
+                    desc="Echo",
+                    execute=execute_stub,
+                    is_mcp=True,
+                )
+            ]
+
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        with (
+            patch("gptme.acp.agent.get_logs_dir", return_value=tmp_path / "logs"),
+            patch("gptme.acp.agent.get_prompt", return_value=[]),
+            patch("gptme.acp.agent.ChatConfig"),
+            patch(
+                "gptme.acp.agent.create_mcp_tools",
+                side_effect=fake_create_mcp_tools,
+            ),
+        ):
+            first_result = _run(
+                agent.new_session(
+                    cwd=str(first),
+                    mcp_servers=[
+                        McpServerStdio(
+                            name="first", command="/bin/echo", args=[], env=[]
+                        )
+                    ],
+                )
+            )
+            second_result = _run(
+                agent.new_session(
+                    cwd=str(second),
+                    mcp_servers=[
+                        McpServerStdio(
+                            name="second", command="/bin/echo", args=[], env=[]
+                        )
+                    ],
+                )
+            )
+
+        assert [
+            tool.name for tool in agent._session_tools[first_result.session_id]
+        ] == ["first.echo"]
+        assert [
+            tool.name for tool in agent._session_tools[second_result.session_id]
+        ] == ["second.echo"]
+        assert (
+            agent._session_mcp_clients[first_result.session_id]
+            is not agent._session_mcp_clients[second_result.session_id]
+        )
 
 
 class TestNewSessionResume:

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -10,6 +10,7 @@ new test dependency.
 import asyncio
 import builtins
 import threading
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -603,6 +604,28 @@ class TestCleanupSession:
         _run(agent.cancel(session_id=sid))
 
         client.close.assert_called_once_with()
+        assert sid not in agent._session_mcp_clients
+        assert sid not in agent._session_models
+
+    def test_cancel_does_not_hang_on_stalled_mcp_close(self, monkeypatch):
+        """cancel() must drop session state even if MCP close never returns."""
+        monkeypatch.setattr("gptme.acp.agent._MCP_CLIENT_CLOSE_TIMEOUT_S", 0.2)
+        agent = GptmeAgent()
+        sid = "session_cancel_stall"
+        client = MagicMock()
+        # Longer than the cancel timeout so a missing wait_for would fail.
+        # Short enough that asyncio.run can drain the executor thread.
+        client.close.side_effect = lambda: time.sleep(1.0)
+        agent._session_mcp_clients[sid] = {"notebook": client}
+        agent._session_models[sid] = "some-model"
+
+        async def run_cancel() -> float:
+            started = time.monotonic()
+            await agent.cancel(session_id=sid)
+            return time.monotonic() - started
+
+        elapsed = _run(run_cancel())
+        assert elapsed < 0.8, f"cancel() hung for {elapsed:.2f}s"
         assert sid not in agent._session_mcp_clients
         assert sid not in agent._session_models
 

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -592,6 +592,20 @@ class TestCleanupSession:
         assert sid not in agent._tool_calls
         assert sid not in agent._permission_policies
 
+    def test_cancel_closes_mcp_clients_before_dropping_session(self):
+        """cancel() must close owned MCP clients, then drop session state."""
+        agent = GptmeAgent()
+        sid = "session_cancel_mcp"
+        client = MagicMock()
+        agent._session_mcp_clients[sid] = {"notebook": client}
+        agent._session_models[sid] = "some-model"
+
+        _run(agent.cancel(session_id=sid))
+
+        client.close.assert_called_once_with()
+        assert sid not in agent._session_mcp_clients
+        assert sid not in agent._session_models
+
 
 class TestPerSessionModel:
     """Tests for per-session model override behavior.
@@ -1725,6 +1739,42 @@ class TestHostSuppliedMcpServers:
         host_client.close.assert_called_once_with()
         assert session_id not in agent._session_tools
         assert session_id not in agent._session_mcp_clients
+
+    def test_new_session_strict_failure_closes_partial_clients(self, tmp_path):
+        """new_session must close leftover host clients if strict setup raises."""
+        if not _import_acp():
+            pytest.skip("acp not installed")
+
+        from acp.schema import McpServerStdio
+
+        leftover = MagicMock()
+
+        def fake_create_mcp_tools(config, *, servers, clients, strict):
+            clients["ok"] = leftover
+            raise RuntimeError("Failed to connect to MCP server 'bad': boom")
+
+        agent = GptmeAgent()
+        with (
+            patch("gptme.acp.agent.get_logs_dir", return_value=tmp_path / "logs"),
+            patch("gptme.acp.agent.get_prompt", return_value=[]),
+            patch("gptme.acp.agent.ChatConfig"),
+            patch(
+                "gptme.acp.agent.create_mcp_tools",
+                side_effect=fake_create_mcp_tools,
+            ),
+            pytest.raises(RuntimeError, match="Failed to connect"),
+        ):
+            _run(
+                agent.new_session(
+                    cwd=str(tmp_path),
+                    mcp_servers=[
+                        McpServerStdio(name="ok", command="/bin/echo", args=[], env=[])
+                    ],
+                )
+            )
+
+        leftover.close.assert_called_once_with()
+        assert agent._session_mcp_clients == {}
 
     def test_host_tool_execute_uses_the_session_client(self):
         from gptme.config import Config

--- a/tests/test_acp_e2e_smoke.py
+++ b/tests/test_acp_e2e_smoke.py
@@ -13,6 +13,7 @@ canonical client implementation.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -22,6 +23,51 @@ pytest.importorskip(
     "acp",
     reason="agent-client-protocol not installed (pip install agent-client-protocol)",
 )
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_acp_agent_discovers_host_supplied_mcp_tool(tmp_path):
+    """The official ACP client can inject and discover a session-only MCP tool."""
+    from acp.schema import McpServerStdio
+
+    from gptme.acp.client import acp_client
+
+    server = tmp_path / "fixture_mcp.py"
+    server.write_text(
+        """from mcp.server.fastmcp import FastMCP
+
+server = FastMCP(\"fixture\", log_level=\"ERROR\")
+
+@server.tool()
+def echo(value: str) -> str:
+    \"\"\"Echo a value for ACP/MCP discovery tests.\"\"\"
+    return value
+
+server.run(transport=\"stdio\")
+"""
+    )
+    descriptor = McpServerStdio(
+        name="fixture",
+        command=sys.executable,
+        args=[str(server)],
+        env=[],
+    )
+    env = {**os.environ, "GPTME_LOG_LEVEL": "WARNING"}
+    updates: list[str] = []
+
+    async with acp_client(
+        workspace=tmp_path,
+        command="gptme-acp",
+        env=env,
+        auto_confirm=True,
+        on_update=lambda _sid, update: updates.append(str(update)),
+    ) as client:
+        session_id = await client.new_session(cwd=tmp_path, mcp_servers=[descriptor])
+        response = await client.prompt(session_id, "/tools")
+
+    assert response.stop_reason == "end_turn"
+    assert any("fixture.echo" in update for update in updates)
 
 
 @pytest.mark.slow

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -364,3 +364,70 @@ def test_mcp_client_event_loop_isolation():
     client_a.loop.close()
     client_b.loop.close()
     client_c.loop.close()
+
+
+def test_mcp_client_close_waits_for_in_flight_call():
+    """close() must not run_until_complete while call_tool owns the private loop."""
+    import threading
+    from unittest.mock import MagicMock
+
+    from gptme.mcp.client import MCPClient
+
+    client = MCPClient()
+    client.session = MagicMock()
+    order: list[str] = []
+    in_run = threading.Event()
+    finish_run = threading.Event()
+
+    def fake_run_until_complete(coro):
+        order.append("run-start")
+        in_run.set()
+        assert finish_run.wait(timeout=2)
+        order.append("run-end")
+        if hasattr(coro, "close"):
+            coro.close()
+        return "ok"
+
+    client.loop.run_until_complete = fake_run_until_complete  # type: ignore[method-assign]
+
+    call_error: list[BaseException] = []
+
+    def do_call() -> None:
+        try:
+            client.call_tool("echo", {})
+        except BaseException as exc:
+            call_error.append(exc)
+
+    caller = threading.Thread(target=do_call)
+    caller.start()
+    assert in_run.wait(timeout=2)
+
+    closed = threading.Event()
+
+    def do_close() -> None:
+        client.close()
+        order.append("close")
+        closed.set()
+
+    closer = threading.Thread(target=do_close)
+    closer.start()
+    closer.join(timeout=0.2)
+    assert closer.is_alive(), "close() must wait for the in-flight call_tool"
+    assert not closed.is_set()
+
+    finish_run.set()
+    caller.join(timeout=2)
+    closer.join(timeout=2)
+    assert not caller.is_alive()
+    assert not closer.is_alive()
+    assert call_error == []
+    assert order == ["run-start", "run-end", "close"]
+    assert client.loop.is_closed()
+
+    with pytest.raises(RuntimeError, match="Not connected to MCP server"):
+        client.call_tool("echo", {})
+
+    # Reconstruct a session handle so the closed-loop guard is the one that fires.
+    client.session = MagicMock()
+    with pytest.raises(RuntimeError, match="MCP client is closed"):
+        client.call_tool("echo", {})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -431,3 +431,47 @@ def test_mcp_client_close_waits_for_in_flight_call():
     client.session = MagicMock()
     with pytest.raises(RuntimeError, match="MCP client is closed"):
         client.call_tool("echo", {})
+
+
+def test_mcp_client_close_interrupts_stalled_call():
+    """close() must not hang if call_tool never returns."""
+    import asyncio
+    import threading
+    import time
+    from unittest.mock import MagicMock
+
+    from gptme.mcp.client import MCPClient
+
+    client = MCPClient()
+    started = threading.Event()
+
+    async def stall(*args, **kwargs):
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("stalled call resumed")
+
+    client.session = MagicMock()
+    client.session.call_tool = stall
+
+    call_error: list[BaseException] = []
+
+    def do_call() -> None:
+        try:
+            client.call_tool("echo", {})
+        except BaseException as exc:
+            call_error.append(exc)
+
+    caller = threading.Thread(target=do_call)
+    caller.start()
+    assert started.wait(timeout=2)
+
+    t0 = time.monotonic()
+    client.close()
+    elapsed = time.monotonic() - t0
+    caller.join(timeout=2)
+
+    assert elapsed < 2.0, f"close() hung for {elapsed:.2f}s"
+    assert not caller.is_alive()
+    assert client.loop.is_closed()
+    assert call_error
+    assert any("closed" in str(exc).lower() for exc in call_error)

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -299,6 +299,29 @@ def test_unload_mcp_server_success():
     assert "test-server" not in _dynamic_servers
 
 
+def test_session_client_retry_stays_in_session_registry(mock_config):
+    """Connection recovery must replace only the supplied session client."""
+    from gptme.mcp.client import MCPClient
+    from gptme.tools.mcp_adapter import _call_mcp_tool_with_retry
+
+    old_client = MagicMock(spec=MCPClient)
+    old_client.call_tool.side_effect = RuntimeError("connection closed")
+    replacement = MagicMock(spec=MCPClient)
+    replacement.call_tool.return_value = "recovered"
+    clients: dict[str, MCPClient] = {"test-server": old_client}
+
+    with patch("gptme.mcp.client.MCPClient", return_value=replacement):
+        result = _call_mcp_tool_with_retry(
+            "test-server", "test_tool", {}, mock_config, clients=clients
+        )
+
+    assert result == "recovered"
+    old_client.close.assert_called_once_with()
+    replacement.connect.assert_called_once_with("test-server")
+    assert clients == {"test-server": replacement}
+    assert "test-server" not in _mcp_clients
+
+
 def test_restart_mcp_client_survives_cleanup_failure_and_reconnects(mock_config):
     """Test restart tolerates cleanup failures from the old client."""
 

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -143,6 +143,35 @@ def test_create_mcp_tools_connection_error(mock_config):
         assert isinstance(tools, list)
 
 
+def test_create_mcp_tools_strict_closes_earlier_clients():
+    """A later strict-setup failure must close servers that already connected."""
+    config = Config()
+    servers = [
+        MCPServerConfig(name="ok", enabled=True, command="ok-cmd"),
+        MCPServerConfig(name="bad", enabled=True, command="bad-cmd"),
+    ]
+    config.user.mcp = MCPConfig(enabled=True, servers=servers)
+
+    ok_client = MagicMock()
+    ok_tools = MagicMock()
+    ok_tools.tools = []
+    ok_client.connect.return_value = (ok_tools, MagicMock())
+
+    bad_client = MagicMock()
+    bad_client.connect.side_effect = Exception("boom")
+
+    registry: dict = {}
+    with (
+        patch("gptme.mcp.client.MCPClient", side_effect=[ok_client, bad_client]),
+        pytest.raises(RuntimeError, match="Failed to connect to MCP server 'bad'"),
+    ):
+        create_mcp_tools(config, servers=servers, clients=registry, strict=True)
+
+    ok_client.close.assert_called_once_with()
+    bad_client.close.assert_called_once_with()
+    assert registry == {}
+
+
 def test_create_mcp_execute_function(mock_config):
     """Test create_mcp_execute_function creates valid execute function."""
     mock_client = MagicMock()


### PR DESCRIPTION
## Problem

ACP `session/new` accepts `mcpServers`, but gptme silently ignored the field. Hosts could therefore report attached capabilities that were unavailable to the session.

## Changes

- validate and convert ACP stdio and HTTP MCP descriptors into gptme server configs
- reject unsupported SSE/ACP transports, malformed descriptors, and duplicate names explicitly
- connect host MCP servers off the ACP event loop and expose namespaced tools only in that session
- keep session client registries isolated, reconnect within the same registry, and close clients on cancel/process shutdown
- add an official ACP-client integration test that discovers a fixture tool through `/tools` without a model call

## Verification

- `uv run pytest tests/test_mcp_adapter.py tests/test_acp_agent.py -q` (129 passed, 4 skipped)
- `uv run pytest tests/test_acp_e2e_smoke.py::test_acp_agent_discovers_host_supplied_mcp_tool -q` (1 passed)
- pre-commit hooks (ruff, format, mypy) passed
- `scripts/pr-quality-gate.py --repo gptme/gptme` scored 100/100

The production-config local AI reviewer was attempted three times but timed out after 120 seconds each; this is recorded as tooling friction, not treated as a quality verdict.
