### PR TITLE
fix(memory): reject reserved index names

### DIFF
--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -158,7 +158,7 @@ def memory_save(
     store = _store()
     try:
         path = store.save(name, description, body, type=type_, scope=scope, title=title)
-    except (KeyError, OSError) as e:
+    except (KeyError, OSError, ValueError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
     if as_json:

--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -169,10 +169,16 @@ class MemoryStore:
         metadata: dict[str, Any] | None = None,
     ) -> Path:
         """Write ``<slug>.md`` into the scope's root and upsert its index line."""
+        slug = slugify(name)
+        if slug.upper().startswith("MEMORY"):
+            raise ValueError(
+                f"memory name {name!r} is reserved for memory indexes; "
+                "choose a name that does not start with 'memory'"
+            )
         root = self.root(scope)
         root.path.mkdir(parents=True, exist_ok=True)
         entry = MemoryEntry(
-            name=slugify(name),
+            name=slug,
             description=description.strip(),
             type=type,
             body=body,

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -199,6 +199,15 @@ class TestStore:
         with pytest.raises(KeyError):
             store.save("u", "d", scope="agent")
 
+    @pytest.mark.parametrize("name", ["memory", "MEMORY", "memory archive"])
+    def test_save_rejects_reserved_index_names(self, tmp_path, name):
+        store = self._store(tmp_path)
+
+        with pytest.raises(ValueError, match="reserved for memory indexes"):
+            store.save(name, "description")
+
+        assert not (tmp_path / "project" / "MEMORY.md").exists()
+
     def test_index_groups_by_type_and_is_byte_stable(self, tmp_path):
         store = self._store(tmp_path)
         store.save("b-proj", "B", type="project")
@@ -440,6 +449,14 @@ class TestCli:
         assert r.exit_code == 0
         r = runner.invoke(util_main, ["memory", "index", "--check"])
         assert r.exit_code == 0, r.output
+
+    @pytest.mark.parametrize("name", ["memory", "MEMORY", "memory archive"])
+    def test_save_rejects_reserved_index_names(self, env, name):
+        r = CliRunner().invoke(util_main, ["memory", "save", name, "description"])
+
+        assert r.exit_code == 1
+        assert "reserved for memory indexes" in r.output
+        assert not env.exists()
 
     def test_human_output_strips_controls_but_preserves_lines(self, env):
         _write(


### PR DESCRIPTION
## Summary

- reject memory names whose normalized filename starts with `memory`, which the reader reserves for `MEMORY.md` and archive index files
- return a clean CLI error before creating the memory root or a dangling index link
- cover both the store API and `gptme-util memory save`

## Reproduction

On current `origin/master`:

```console
$ gptme-util memory save MEMORY "Reserved basename" --json
{
  "path": "/tmp/.../memory.md"
}
$ gptme-util memory list --json
[]
$ gptme-util memory show memory --json
Error: no memory entry named 'memory'
```

The save reported success and added an index link, but all read paths intentionally skip `memory*.md` as index files. The entry was therefore unreachable.

## Verification

- `uv run pytest tests/test_memory_store.py -q` — 38 passed, 1 skipped
- `uv run ruff check gptme/memory/store.py gptme/cli/cmd_memory.py tests/test_memory_store.py`
- `uv run ruff format --check gptme/memory/store.py gptme/cli/cmd_memory.py tests/test_memory_store.py`

This overlaps gptme/gptme#3766 in files, but not behavior: #3766 adds lifecycle audit/supersession on a stacked branch; this is an independent save/read round-trip invariant against `master`.
