### PR TITLE
fix(codeblock): track triple-quote state in ipython blocks (#3704)

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -227,38 +227,50 @@ def _find_heredoc_terminator(
     return None, in_single, in_double, in_ansi_c
 
 
+def _line_ends_with_continuation(line: str) -> bool:
+    """True if ``line`` ends with an unescaped backslash (Python line continuation)."""
+    n = 0
+    i = len(line) - 1
+    while i >= 0 and line[i] == "\\":
+        n += 1
+        i -= 1
+    return n % 2 == 1
+
+
 def _scan_ipython_triple_quote(
     line: str,
     in_triple_double: bool,
     in_triple_single: bool,
-) -> tuple[bool, bool]:
-    """Scan one line of IPython content and return updated triple-quote state.
+    in_single: bool = False,
+    in_double: bool = False,
+) -> tuple[bool, bool, bool, bool]:
+    """Scan one line of IPython content and return updated quote state.
 
     IPython embeds Python, which supports triple-single-quote and
     triple-double-quote strings spanning multiple lines.  A fence
     (bare `` ``` `` or language-tagged) inside such a string is literal
     Python source, not a markdown block delimiter.
 
-    Ordinary ``'...'`` / ``"..."`` strings are tracked within the line so
+    Ordinary ``'...'`` / ``"..."`` strings are tracked so
     ``value = '\"\"\"'`` does not open triple-double state and
     ``prefix = "#"; text = \"\"\"`` does not treat the ``#`` as a comment
     that hides the real opener.  Backslash escapes skip the next character
     inside any string.  ``#`` starts a comment only at top-level.
 
-    It does not attempt to resolve f-string expressions ``{...}``, raw /
-    bytes prefixes as a distinct mode, or ``\\`` line continuation that
-    would carry an ordinary quote across lines — cases that almost never
-    appear in the triple-quoted-string-wrapping-a-fence failure scenario
-    this targets.
+    Ordinary strings persist across a physical line break only when the
+    line ends in an unescaped backslash (Python line continuation).  An
+    unterminated quote without continuation is a syntax error and must
+    not poison the next line — otherwise ``s = 'abc \\`` followed by
+    ``\"\"\"`` falsely opens triple-double state.
 
-    Returns ``(in_triple_double, in_triple_single)`` after processing the line.
+    It does not attempt to resolve f-string expressions ``{...}`` or raw /
+    bytes prefixes as a distinct mode.
+
+    Returns ``(in_triple_double, in_triple_single, in_single, in_double)``
+    after processing the line.
     """
     i = 0
     n = len(line)
-    # Ordinary quotes are tracked within the line only: Python non-triple
-    # strings do not span lines (without ``\\`` continuation, which we ignore).
-    in_single = False
-    in_double = False
     while i < n:
         c = line[i]
 
@@ -322,7 +334,12 @@ def _scan_ipython_triple_quote(
 
         i += 1
 
-    return in_triple_double, in_triple_single
+    # Ordinary strings do not span lines unless this line is backslash-continued.
+    if (in_single or in_double) and not _line_ends_with_continuation(line):
+        in_single = False
+        in_double = False
+
+    return in_triple_double, in_triple_single, in_single, in_double
 
 
 def _extract_codeblocks(
@@ -477,8 +494,12 @@ def _extract_codeblocks(
             # For IPython blocks: track whether we are inside a Python triple-quoted
             # string (``"""`` or ``'''``).  A bare fence inside such a string is
             # literal Python source, not a markdown block delimiter.
+            # Ordinary quote flags persist only across backslash-continued lines
+            # so ``s = 'abc \\`` + ``\"\"\"`` does not open triple-double state.
             _ipython_in_triple_double: bool = False
             _ipython_in_triple_single: bool = False
+            _ipython_in_single: bool = False
+            _ipython_in_double: bool = False
 
             # Collect content until we find the matching closing ```
             while i < len(lines):
@@ -567,12 +588,17 @@ def _extract_codeblocks(
                     # Update triple-quoted-string state line-by-line so that
                     # bare fences inside ``"""..."""`` or ``'''...'''`` are
                     # treated as literal Python content rather than block closers.
-                    _ipython_in_triple_double, _ipython_in_triple_single = (
-                        _scan_ipython_triple_quote(
-                            line,
-                            _ipython_in_triple_double,
-                            _ipython_in_triple_single,
-                        )
+                    (
+                        _ipython_in_triple_double,
+                        _ipython_in_triple_single,
+                        _ipython_in_single,
+                        _ipython_in_double,
+                    ) = _scan_ipython_triple_quote(
+                        line,
+                        _ipython_in_triple_double,
+                        _ipython_in_triple_single,
+                        _ipython_in_single,
+                        _ipython_in_double,
                     )
 
                 # Check if this line starts with backticks (potential opening or closing)

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -227,6 +227,57 @@ def _find_heredoc_terminator(
     return None, in_single, in_double, in_ansi_c
 
 
+def _scan_ipython_triple_quote(
+    line: str,
+    in_triple_double: bool,
+    in_triple_single: bool,
+) -> tuple[bool, bool]:
+    """Scan one line of IPython content and return updated triple-quote state.
+
+    IPython embeds Python, which supports triple-single-quote and
+    triple-double-quote strings spanning multiple lines.  A bare fence
+    (`` ``` ``) inside such a string is literal Python source, not a markdown
+    block delimiter.
+
+    The scanner handles the common cases: triple-quote openers/closers,
+    backslash escaping within strings, and ``#`` line comments (outside
+    strings).  It does not attempt to resolve f-string expressions ``{...}``,
+    all string prefix variants (``rb``, ``u``, …), or deeply nested escape
+    sequences — cases that almost never appear in the triple-quoted-string-
+    wrapping-a-fence failure scenario this targets.
+
+    Returns ``(in_triple_double, in_triple_single)`` after processing the line.
+    """
+    i = 0
+    n = len(line)
+    while i < n:
+        # Skip rest of line when inside a comment (only outside strings).
+        if not in_triple_double and not in_triple_single and line[i] == "#":
+            break
+
+        # Backslash escape: skip the next character (only inside a string).
+        if (in_triple_double or in_triple_single) and line[i] == "\\":
+            i += 2
+            continue
+
+        # Triple-double-quote — checked before single to avoid mis-parsing
+        # ``"`` followed by ``""`` as two separate events.
+        if i + 2 < n and line[i : i + 3] == '"""' and not in_triple_single:
+            in_triple_double = not in_triple_double
+            i += 3
+            continue
+
+        # Triple-single-quote.
+        if i + 2 < n and line[i : i + 3] == "'''" and not in_triple_double:
+            in_triple_single = not in_triple_single
+            i += 3
+            continue
+
+        i += 1
+
+    return in_triple_double, in_triple_single
+
+
 def _extract_codeblocks(
     markdown: str, streaming: bool = False
 ) -> Generator[Codeblock, None, None]:
@@ -376,6 +427,11 @@ def _extract_codeblocks(
             _qs_in_single: bool = False
             _qs_in_double: bool = False
             _qs_in_ansi_c: bool = False
+            # For IPython blocks: track whether we are inside a Python triple-quoted
+            # string (``"""`` or ``'''``).  A bare fence inside such a string is
+            # literal Python source, not a markdown block delimiter.
+            _ipython_in_triple_double: bool = False
+            _ipython_in_triple_single: bool = False
 
             # Collect content until we find the matching closing ```
             while i < len(lines):
@@ -460,6 +516,17 @@ def _extract_codeblocks(
                         _qs_in_single = False
                         _qs_in_double = False
                         _qs_in_ansi_c = False
+                elif lang == "ipython":
+                    # Update triple-quoted-string state line-by-line so that
+                    # bare fences inside ``"""..."""`` or ``'''...'''`` are
+                    # treated as literal Python content rather than block closers.
+                    _ipython_in_triple_double, _ipython_in_triple_single = (
+                        _scan_ipython_triple_quote(
+                            line,
+                            _ipython_in_triple_double,
+                            _ipython_in_triple_single,
+                        )
+                    )
 
                 # Check if this line starts with backticks (potential opening or closing)
                 line_fence_match = re.match(r"^(`{3,})", line)
@@ -472,9 +539,16 @@ def _extract_codeblocks(
                     is_outer_close = is_bare_fence and line_fence_len == fence_len
                     if is_outer_close or (is_bare_fence and nesting_depth > 1):
                         # Bare fence - determine if opening or closing based on context
-                        # A fence inside an open quoted string is literal content,
-                        # not a markdown delimiter (same rationale as heredoc bodies).
-                        if _qs_in_single or _qs_in_double or _qs_in_ansi_c:
+                        # A fence inside an open quoted string or a Python
+                        # triple-quoted string is literal content, not a markdown
+                        # delimiter (same rationale as heredoc bodies).
+                        if (
+                            _qs_in_single
+                            or _qs_in_double
+                            or _qs_in_ansi_c
+                            or _ipython_in_triple_double
+                            or _ipython_in_triple_single
+                        ):
                             content_lines.append(line)
                             i += 1
                             continue
@@ -605,6 +679,8 @@ def _extract_codeblocks(
                                 and not _qs_in_single
                                 and not _qs_in_double
                                 and not _qs_in_ansi_c
+                                and not _ipython_in_triple_double
+                                and not _ipython_in_triple_single
                             ):
                                 yield Codeblock(
                                     lang,

--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -235,42 +235,89 @@ def _scan_ipython_triple_quote(
     """Scan one line of IPython content and return updated triple-quote state.
 
     IPython embeds Python, which supports triple-single-quote and
-    triple-double-quote strings spanning multiple lines.  A bare fence
-    (`` ``` ``) inside such a string is literal Python source, not a markdown
-    block delimiter.
+    triple-double-quote strings spanning multiple lines.  A fence
+    (bare `` ``` `` or language-tagged) inside such a string is literal
+    Python source, not a markdown block delimiter.
 
-    The scanner handles the common cases: triple-quote openers/closers,
-    backslash escaping within strings, and ``#`` line comments (outside
-    strings).  It does not attempt to resolve f-string expressions ``{...}``,
-    all string prefix variants (``rb``, ``u``, …), or deeply nested escape
-    sequences — cases that almost never appear in the triple-quoted-string-
-    wrapping-a-fence failure scenario this targets.
+    Ordinary ``'...'`` / ``"..."`` strings are tracked within the line so
+    ``value = '\"\"\"'`` does not open triple-double state and
+    ``prefix = "#"; text = \"\"\"`` does not treat the ``#`` as a comment
+    that hides the real opener.  Backslash escapes skip the next character
+    inside any string.  ``#`` starts a comment only at top-level.
+
+    It does not attempt to resolve f-string expressions ``{...}``, raw /
+    bytes prefixes as a distinct mode, or ``\\`` line continuation that
+    would carry an ordinary quote across lines — cases that almost never
+    appear in the triple-quoted-string-wrapping-a-fence failure scenario
+    this targets.
 
     Returns ``(in_triple_double, in_triple_single)`` after processing the line.
     """
     i = 0
     n = len(line)
+    # Ordinary quotes are tracked within the line only: Python non-triple
+    # strings do not span lines (without ``\\`` continuation, which we ignore).
+    in_single = False
+    in_double = False
     while i < n:
-        # Skip rest of line when inside a comment (only outside strings).
-        if not in_triple_double and not in_triple_single and line[i] == "#":
+        c = line[i]
+
+        # Inside a triple-quoted string: only look for closer and escapes.
+        if in_triple_double or in_triple_single:
+            if c == "\\":
+                i += 2
+                continue
+            if in_triple_double and i + 2 < n and line[i : i + 3] == '"""':
+                in_triple_double = False
+                i += 3
+                continue
+            if in_triple_single and i + 2 < n and line[i : i + 3] == "'''":
+                in_triple_single = False
+                i += 3
+                continue
+            i += 1
+            continue
+
+        # Inside an ordinary quoted string: skip until closer. Triple-quote
+        # characters and ``#`` are literal content here.
+        if in_single:
+            if c == "\\":
+                i += 2
+                continue
+            if c == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_double = False
+            i += 1
+            continue
+
+        # Top-level: comments, string openers.
+        if c == "#":
             break
 
-        # Backslash escape: skip the next character (only inside a string).
-        if (in_triple_double or in_triple_single) and line[i] == "\\":
-            i += 2
+        # Triple quotes before single (``"""`` is not ``"`` + ``""``).
+        if i + 2 < n and line[i : i + 3] == '"""':
+            in_triple_double = True
+            i += 3
             continue
-
-        # Triple-double-quote — checked before single to avoid mis-parsing
-        # ``"`` followed by ``""`` as two separate events.
-        if i + 2 < n and line[i : i + 3] == '"""' and not in_triple_single:
-            in_triple_double = not in_triple_double
+        if i + 2 < n and line[i : i + 3] == "'''":
+            in_triple_single = True
             i += 3
             continue
 
-        # Triple-single-quote.
-        if i + 2 < n and line[i : i + 3] == "'''" and not in_triple_double:
-            in_triple_single = not in_triple_single
-            i += 3
+        if c == "'":
+            in_single = True
+            i += 1
+            continue
+        if c == '"':
+            in_double = True
+            i += 1
             continue
 
         i += 1
@@ -729,6 +776,15 @@ def _extract_codeblocks(
                                 # This closes a nested block, add to content
                                 content_lines.append(line)
                     else:
+                        # Language-tagged fence. Inside a Python triple-quoted
+                        # string this is literal source, not a nested markdown
+                        # opener — incrementing nesting_depth here would leave
+                        # the depth elevated because the matching bare closer
+                        # is also treated as literal (see gptme/gptme#3773).
+                        if _ipython_in_triple_double or _ipython_in_triple_single:
+                            content_lines.append(line)
+                            i += 1
+                            continue
                         # Line has content after backticks - check if it looks like a valid language tag
                         # to determine if it opens a nested block or is just content
                         potential_lang = line[line_fence_len:].strip()

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -550,6 +550,38 @@ def test_scan_ipython_backslash_continued_ordinary_string_hides_triple():
     )
 
 
+def test_scan_ipython_escaped_quote_in_ordinary_string_does_not_desync():
+    """A backslash-escaped quote inside an ordinary string must not close it.
+
+    Consensus-gate finding on gptme/gptme#3773 claimed ``\"`` would close
+    ordinary-double state prematurely. The scanner already skips the escaped
+    character; this pins that so a later ``\"\"\"`` still opens triple-double.
+    """
+    from gptme.codeblock import _scan_ipython_triple_quote
+
+    # ``"a\""`` is a complete ordinary string containing ``a"``. Then ``"""``
+    # opens triple-double.
+    assert _scan_ipython_triple_quote(r'x = "a\""; y = """', False, False) == (
+        True,
+        False,
+        False,
+        False,
+    )
+    assert _scan_ipython_triple_quote(r"x = 'a\''; y = '''", False, False) == (
+        False,
+        True,
+        False,
+        False,
+    )
+    # Escaped quote with more content before the real closer.
+    assert _scan_ipython_triple_quote(r'x = "hello \" world"', False, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+
+
 def test_extract_codeblocks_ipython_ordinary_string_does_not_open_triple():
     """Ordinary quoted strings must not be mistaken for triple-quote openers.
 
@@ -613,6 +645,32 @@ def test_extract_codeblocks_ipython_continued_ordinary_string_hides_triple():
     assert blocks == [
         Codeblock("ipython", 's = \'abc \\\n"""\'\nprint(s)'),
         Codeblock("output", "later"),
+    ]
+
+
+def test_extract_codeblocks_ipython_escaped_quote_in_ordinary_string():
+    """An escaped quote inside an ordinary string must not desync fence matching.
+
+    If ``\"`` closed ordinary-double state, the trailing ``"`` of ``"a\\""``
+    would open a new string and a later triple-quoted fence would be treated
+    as a real closer (or the block would never be emitted).
+    """
+    markdown = '''```ipython
+x = "a\\""
+y = """
+```
+inside
+```
+"""
+print(y)
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock(
+            "ipython",
+            'x = "a\\""\ny = """\n```\ninside\n```\n"""\nprint(y)',
+        ),
     ]
 
 

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -475,6 +475,95 @@ output
     ]
 
 
+def test_scan_ipython_ordinary_string_hides_triple_quotes():
+    """Ordinary quoted strings must not be mistaken for triple-quote openers."""
+    from gptme.codeblock import _scan_ipython_triple_quote
+
+    assert _scan_ipython_triple_quote('value = \'"""\'', False, False) == (
+        False,
+        False,
+    )
+    assert _scan_ipython_triple_quote('prefix = "#"; text = """', False, False) == (
+        True,
+        False,
+    )
+    assert _scan_ipython_triple_quote('x = """hello"""', False, False) == (False, False)
+    assert _scan_ipython_triple_quote("value = \"'''\"", False, False) == (False, False)
+
+
+def test_extract_codeblocks_ipython_ordinary_string_does_not_open_triple():
+    """Ordinary quoted strings must not be mistaken for triple-quote openers.
+
+    Regression for gptme/gptme#3773 (Greptile P1): ``value = '\"\"\"'`` used
+    to open triple-double state, so the real block closer was retained as
+    source and later Markdown was swallowed.
+    """
+    markdown = '''```ipython
+value = '"""'
+print(value)
+```
+
+```output
+"""
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("ipython", 'value = \'"""\'\nprint(value)'),
+        Codeblock("output", '"""'),
+    ]
+
+
+def test_extract_codeblocks_ipython_hash_in_string_does_not_hide_triple_opener():
+    """A ``#`` inside an ordinary string must not stop the triple-quote scan.
+
+    Regression for gptme/gptme#3773 (Greptile P1): ``prefix = "#"; text = \"\"\"``
+    used to treat ``#`` as a comment, never see the real opener, then close
+    the IPython block at the first fence inside that string.
+    """
+    markdown = '''```ipython
+prefix = "#"; text = """
+```
+inside
+```
+"""
+print(text)
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock(
+            "ipython",
+            'prefix = "#"; text = """\n```\ninside\n```\n"""\nprint(text)',
+        ),
+    ]
+
+
+def test_extract_codeblocks_ipython_tagged_fence_inside_triple_quote_is_literal():
+    """A language-tagged fence inside a triple-quoted string is literal content.
+
+    Regression for gptme/gptme#3773 (Greptile P1): `` ```python `` inside
+    ``\"\"\"...\"\"\"`` incremented nesting_depth, but the matching bare
+    closer was treated as literal, so the IPython block was never emitted.
+    """
+    markdown = '''```ipython
+text = """
+```python
+print("hi")
+```
+"""
+print(text)
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock(
+            "ipython",
+            'text = """\n```python\nprint("hi")\n```\n"""\nprint(text)',
+        ),
+    ]
+
+
 def test_extract_codeblocks_ipython_fence_outside_triple_quote_still_closes():
     """A bare fence that is NOT inside a triple-quoted string still closes the block."""
     markdown = """```ipython

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -409,6 +409,89 @@ output here
     ]
 
 
+def test_extract_codeblocks_ipython_triple_double_quote_contains_fence():
+    """A bare fence inside an IPython triple-double-quoted string is literal content.
+
+    Regression for gptme/gptme#3704: before this fix the closing ``` of the
+    triple-quoted string was treated as the block closer, so the ipython command
+    was truncated and the trailing print + closing fence were lost.
+    """
+    markdown = '''```ipython
+text = """
+```
+some markdown
+```
+"""
+print(text)
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock(
+            "ipython",
+            'text = """\n```\nsome markdown\n```\n"""\nprint(text)',
+        )
+    ]
+
+
+def test_extract_codeblocks_ipython_triple_single_quote_contains_fence():
+    """A bare fence inside an IPython triple-single-quoted string is literal content."""
+    markdown = """```ipython
+text = '''
+```
+markdown here
+```
+'''
+result = text
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock(
+            "ipython",
+            "text = '''\n```\nmarkdown here\n```\n'''\nresult = text",
+        )
+    ]
+
+
+def test_extract_codeblocks_ipython_triple_quote_single_line_does_not_keep_open():
+    """A triple-quoted string that opens and closes on the same line leaves state clean.
+
+    After ``x = \"\"\"hello\"\"\"`` the parser must NOT treat subsequent bare fences
+    as inside a triple-quoted string — the string closed on the same line.
+    """
+    markdown = '''```ipython
+x = """hello"""
+```
+output
+```
+'''
+    blocks = Codeblock.iter_from_markdown(markdown)
+    # The ipython block closes at the first bare ```, then "output" is prose and
+    # the trailing ``` opens a block with no closing fence → only the ipython
+    # block is emitted.
+    assert blocks == [
+        Codeblock("ipython", 'x = """hello"""'),
+    ]
+
+
+def test_extract_codeblocks_ipython_fence_outside_triple_quote_still_closes():
+    """A bare fence that is NOT inside a triple-quoted string still closes the block."""
+    markdown = """```ipython
+x = 1 + 1
+```
+prose after
+```
+"""
+    blocks = Codeblock.iter_from_markdown(markdown)
+    # The ipython block closes correctly at the bare ```.  "prose after" is
+    # prose; the trailing ``` opens a block with no closing fence so it is not
+    # emitted.
+    assert blocks == [
+        Codeblock("ipython", "x = 1 + 1"),
+    ]
+
+
 def test_extract_codeblocks_shift_operand_alone_is_not_a_heredoc():
     """A shift operand that later appears alone on a line must not mint a
     phantom heredoc terminator and swallow the closing fence.

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -482,13 +482,72 @@ def test_scan_ipython_ordinary_string_hides_triple_quotes():
     assert _scan_ipython_triple_quote('value = \'"""\'', False, False) == (
         False,
         False,
+        False,
+        False,
     )
     assert _scan_ipython_triple_quote('prefix = "#"; text = """', False, False) == (
         True,
         False,
+        False,
+        False,
     )
-    assert _scan_ipython_triple_quote('x = """hello"""', False, False) == (False, False)
-    assert _scan_ipython_triple_quote("value = \"'''\"", False, False) == (False, False)
+    assert _scan_ipython_triple_quote('x = """hello"""', False, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+    assert _scan_ipython_triple_quote("value = \"'''\"", False, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+
+
+def test_scan_ipython_backslash_continued_ordinary_string_hides_triple():
+    """A backslash-continued ordinary string must not open triple-quote state.
+
+    Regression for gptme/gptme#3773 (Greptile P1): after ``s = 'abc \\`` the
+    next line's ``\"\"\"`` is still ordinary-string content.
+    """
+    from gptme.codeblock import _scan_ipython_triple_quote
+
+    # Trailing unescaped backslash keeps ordinary-single state.
+    assert _scan_ipython_triple_quote("s = 'abc \\", False, False) == (
+        False,
+        False,
+        True,
+        False,
+    )
+    # Carried ordinary-single makes ``"""`` literal; no closer → reset after line.
+    assert _scan_ipython_triple_quote('"""', False, False, True, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+    # Same, but the continuation line closes the ordinary string.
+    assert _scan_ipython_triple_quote('"""\'', False, False, True, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+    # Unterminated ordinary string WITHOUT continuation must not persist.
+    assert _scan_ipython_triple_quote("s = 'hello", False, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
+    # Even number of trailing backslashes is a literal backslash, not continuation.
+    assert _scan_ipython_triple_quote("s = 'abc \\\\", False, False) == (
+        False,
+        False,
+        False,
+        False,
+    )
 
 
 def test_extract_codeblocks_ipython_ordinary_string_does_not_open_triple():
@@ -536,6 +595,24 @@ print(text)
             "ipython",
             'prefix = "#"; text = """\n```\ninside\n```\n"""\nprint(text)',
         ),
+    ]
+
+
+def test_extract_codeblocks_ipython_continued_ordinary_string_hides_triple():
+    """A backslash-continued ordinary string must not open triple-quote state.
+
+    Regression for gptme/gptme#3773 (Greptile P1): after ``s = 'abc \\`` the
+    next line's ``\"\"\"`` is still ordinary-string content. Treating it as a
+    triple-double opener used to retain the real closer as source (the IPython
+    block was never emitted) and swallow later Markdown.
+    """
+    markdown = (
+        '```ipython\ns = \'abc \\\n"""\'\nprint(s)\n```\n\n```output\nlater\n```\n'
+    )
+    blocks = Codeblock.iter_from_markdown(markdown)
+    assert blocks == [
+        Codeblock("ipython", 's = \'abc \\\n"""\'\nprint(s)'),
+        Codeblock("output", "later"),
     ]
 
 


### PR DESCRIPTION
Bare fences inside Python triple-quoted strings (`"""..."""` or `'''...'''`) inside an ipython block are literal Python source, not markdown block delimiters. Without this fix, the exec-lang bare-fence-is-always-closer rule added in #3703 treats the first ` ``` ` inside a triple-quoted string as the ipython block closer, truncating the rest of the block.

## Changes

- Add `_scan_ipython_triple_quote()` to scan one line of IPython content and return updated triple-double / triple-single state, respecting backslash escapes and `#` comments.
- Wire the scanner into the inner loop under `elif lang == "ipython":`, mirroring the existing `if lang in _SHELL_LANGS:` branch that calls `_find_heredoc_terminator`.
- Extend the bare-fence guard and the streaming fast-close condition with the two new flags.

## Tests

Four new cases in `tests/test_codeblock.py`:
1. Bare fence inside `"""..."""` is treated as literal content.
2. Bare fence inside `'''...'''` is treated as literal content.
3. A single-line `"""hello"""` does not leave the state open (triple-quote scanner clears correctly on the same line).
4. A bare fence outside any triple-quoted string still closes the block normally.

All 90 codeblock tests pass.