### PR TITLE
fix(docs/cli): mention subscription auth in no-provider error paths

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -53,6 +53,8 @@ This will start an interactive chat session with the AI assistant.
 
 If you haven't set a :doc:`LLM provider <providers>` API key in the environment or :doc:`configuration <config>`, you will be prompted for one which will be saved in the configuration file.
 
+If you already subscribe to ChatGPT Plus/Pro or SuperGrok, you can sign in directly — no separate API key purchase required. See :ref:`subscriptions` below.
+
 For detailed usage instructions, see :doc:`usage`.
 
 You can also try the :doc:`examples`.
@@ -83,6 +85,32 @@ Here are some compelling examples to get you started:
 
     # Resume conversations
     gptme -r
+
+.. _subscriptions:
+
+Subscriptions (ChatGPT Plus/Pro, SuperGrok)
+--------------------------------------------
+
+If you already pay for a ChatGPT Plus/Pro or SuperGrok subscription, gptme can
+use it directly — no separate API key purchase needed.
+
+.. code-block:: bash
+
+    # Authenticate with your ChatGPT Plus/Pro subscription (opens browser)
+    gptme-auth openai-subscription
+
+    # Authenticate with your SuperGrok subscription (reuses grok CLI token)
+    gptme-auth grok-subscription
+
+After sign-in, gptme automatically uses the subscription as the default provider.
+You can also reach the same flow from the interactive setup wizard:
+
+.. code-block:: bash
+
+    gptme-onboard
+
+See :doc:`providers` for the full list of supported subscription providers and
+per-model options.
 
 .. _local-models:
 

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -303,20 +303,23 @@ def _run_wizard(check_only: bool = False) -> int:
     available_providers = [p for p, (has_key, _) in providers.items() if has_key]
 
     if not available_providers:
-        console.print("\n[red]❌ No API keys detected![/red]")
-        console.print("\nTo use gptme, you need at least one API key.")
+        console.print("\n[red]❌ No provider configured![/red]")
+        console.print("\nTo use gptme, sign in with a subscription or set an API key.")
         console.print(
-            "\n[bold]Quick start[/bold] — set one of these environment variables:"
+            "\n[bold]Option 1[/bold] — sign in with a subscription you already pay for:"
         )
+        console.print(
+            "  [cyan]gptme-auth openai-subscription[/cyan]    # ChatGPT Plus/Pro"
+        )
+        console.print("  [cyan]gptme-auth grok-subscription[/cyan]      # SuperGrok")
+        console.print("\n[bold]Option 2[/bold] — set an API key:")
         console.print("  export ANTHROPIC_API_KEY='sk-ant-...'")
         console.print("  export OPENAI_API_KEY='sk-...'")
         console.print("  export OPENROUTER_API_KEY='sk-or-...'")
         console.print(
             "\nThen re-run [bold]gptme-onboard[/bold] or just start with [bold]gptme[/bold]."
         )
-        console.print(
-            "\nFull guide: https://gptme.org/docs/getting-started.html#api-keys"
-        )
+        console.print("\nFull guide: https://gptme.org/docs/getting-started.html")
         return 1
 
     if check_only:

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -145,8 +145,11 @@ def init_model(
     # fail with actionable guidance
     if not model:
         raise ValueError(
-            "No API key found, couldn't auto-detect provider.\n\n"
-            "To get started, set an API key for one of these providers:\n"
+            "No provider configured, couldn't auto-detect model.\n\n"
+            "Sign in with a subscription you already pay for:\n"
+            "  gptme-auth openai-subscription    # ChatGPT Plus/Pro\n"
+            "  gptme-auth grok-subscription      # SuperGrok (reuses grok CLI login)\n\n"
+            "Or set an API key:\n"
             "  export ANTHROPIC_API_KEY='sk-ant-...'\n"
             "  export OPENAI_API_KEY='sk-...'\n"
             "  export OPENROUTER_API_KEY='sk-or-...'\n\n"

--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -299,8 +299,8 @@ def oauth_authenticate() -> SubscriptionAuth:
     )
     server.timeout = 120  # 2 minutes should be sufficient for browser auth
 
-    print("\n🔐 Opening browser for OpenAI authentication...")
-    print(f"   If browser doesn't open, visit:\n   {auth_url}")
+    print("\n🔐 Opening browser for OpenAI authentication...", flush=True)
+    print(f"   If browser doesn't open, visit:\n   {auth_url}", flush=True)
 
     def open_browser() -> None:
         time.sleep(0.5)
@@ -308,7 +308,10 @@ def oauth_authenticate() -> SubscriptionAuth:
 
     threading.Thread(target=open_browser, daemon=True).start()
 
-    print(f"   Waiting for authentication callback on port {OAUTH_CALLBACK_PORT}...")
+    print(
+        f"   Waiting for authentication callback on port {OAUTH_CALLBACK_PORT}...",
+        flush=True,
+    )
     try:
         while (
             _OAuthCallbackHandler.authorization_code is None
@@ -324,7 +327,7 @@ def oauth_authenticate() -> SubscriptionAuth:
     if not _OAuthCallbackHandler.authorization_code:
         raise ValueError("No authorization code received")
 
-    print("   Exchanging authorization code for tokens...")
+    print("   Exchanging authorization code for tokens...", flush=True)
     token_response = requests.post(
         OAUTH_TOKEN_URL,
         data={
@@ -362,7 +365,7 @@ def oauth_authenticate() -> SubscriptionAuth:
 
     _save_tokens(auth)
 
-    print("✅ Authentication successful!")
+    print("✅ Authentication successful!", flush=True)
     return auth
 
 

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -402,6 +402,8 @@ def get_recommended_model(provider: Provider) -> str:  # pragma: no cover
         return "claude-sonnet-4-6"
     if provider == "xai":
         return "grok-4"
+    if provider == "grok-subscription":
+        return "grok-4.6"
     if provider == "gptme":
         return "claude-sonnet-4-6"
     if provider == "deepseek":

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -461,6 +461,44 @@ class TestInitModelParsing:
     @patch("gptme.init.set_default_model")
     @patch("gptme.init.get_model")
     @patch("gptme.init.init_llm")
+    @patch("gptme.init.guess_provider_from_config", return_value="grok-subscription")
+    @patch("gptme.init.is_custom_provider", return_value=False)
+    @patch("gptme.init.get_config")
+    @patch("gptme.init.console")
+    def test_grok_subscription_auto_detect_uses_recommended_model(
+        self,
+        mock_console,
+        mock_config_fn,
+        mock_custom,
+        mock_guess,
+        mock_init_llm,
+        mock_get_model,
+        mock_set_default,
+        dummy_model_meta,
+    ):
+        """Bare grok-subscription after auth must resolve grok-4.6, not raise.
+
+        Regression: get_recommended_model() had no grok-subscription case, so
+        `gptme` after `gptme-auth grok-subscription` failed with
+        "Provider 'grok-subscription' requires specifying a model".
+        """
+        from gptme.init import init_model
+
+        config = MagicMock()
+        config.user.models.default = None
+        config.chat = MagicMock(model=None)
+        config.get_env.return_value = None
+        mock_config_fn.return_value = config
+        mock_get_model.return_value = dummy_model_meta
+
+        init_model(model=None, interactive=False)
+
+        mock_init_llm.assert_called_once_with("grok-subscription")
+        mock_get_model.assert_called_once_with("grok-subscription/grok-4.6")
+
+    @patch("gptme.init.set_default_model")
+    @patch("gptme.init.get_model")
+    @patch("gptme.init.init_llm")
     @patch("gptme.init.get_recommended_model")
     @patch("gptme.init.is_custom_provider", return_value=False)
     @patch("gptme.init.get_config")
@@ -934,8 +972,10 @@ class TestInitModelConfig:
         config.get_env.return_value = None
         mock_config_fn.return_value = config
 
-        with pytest.raises(ValueError, match="No API key found"):
+        with pytest.raises(ValueError, match="No provider configured") as exc:
             init_model(model=None, interactive=False)
+        assert "gptme-auth openai-subscription" in str(exc.value)
+        assert "gptme-auth grok-subscription" in str(exc.value)
 
     @patch("gptme.init.set_default_model")
     @patch("gptme.init.get_model")
@@ -1419,7 +1459,7 @@ class TestInitModelInteractive:
         config.get_env.return_value = None
         mock_config_fn.return_value = config
 
-        with pytest.raises(ValueError, match="No API key found"):
+        with pytest.raises(ValueError, match="No provider configured"):
             init_model(model=None, interactive=False)
 
         mock_ask.assert_not_called()

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -397,7 +397,7 @@ class TestJSONRuntimeSuppression:
         monkeypatch.setattr(gptme_init, "set_default_model", lambda _model: None)
 
         # init_model raises ValueError when no keys are available
-        with pytest.raises(ValueError, match="No API key found"):
+        with pytest.raises(ValueError, match="No provider configured"):
             gptme_init.init_model(None, interactive=False)
 
         captured = capfd.readouterr()

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -246,6 +246,7 @@ def test_get_model_openrouter_subprovider_suffix_not_in_static():
         ("deepseek", "deepseek-chat"),
         ("groq", "llama-3.3-70b-versatile"),
         ("openai-subscription", "gpt-5.6-sol"),
+        ("grok-subscription", "grok-4.6"),
     ],
 )
 def test_get_recommended_model(provider, expected_model):


### PR DESCRIPTION
Fixes #3774.

## Summary

Fresh-install users with ChatGPT Plus/Pro or SuperGrok subscriptions were directed to buy an API key. Three places fixed:

### 1. `gptme/init.py` — non-interactive error copy

The `ValueError` raised when no provider is configured now leads with the subscription sign-in commands:

```
Sign in with a subscription you already pay for:
  gptme-auth openai-subscription    # ChatGPT Plus/Pro
  gptme-auth grok-subscription      # SuperGrok (reuses grok CLI login)

Or set an API key:
  export ANTHROPIC_API_KEY='sk-ant-...'
  ...
```

### 2. `gptme/cli/onboard.py` — `gptme-onboard --check` failure block

Updated from `❌ No API keys detected!` + bare env-var list to a two-option layout: Option 1 = subscription sign-in, Option 2 = API key.

### 3. `gptme/llm/llm_openai_subscription.py` — `flush=True` on OAuth prints

All `print()` calls during the browser OAuth flow now pass `flush=True` so the callback URL appears immediately on non-TTY stdout (containers, piped output). Matches the Rich-based `grok-subscription` flow which already flushed. Repro: `timeout 25 gptme-auth openai-subscription` in a non-TTY — user was stuck waiting with no URL visible.

### 4. `docs/getting-started.rst` — add Subscriptions section

New `.. _subscriptions:` section before local-models, with commands for both `gptme-auth openai-subscription` and `gptme-auth grok-subscription`. Added a one-liner pointer in the Usage paragraph that links to it. This is the URL the old error message sent people to, which had zero subscription coverage.

## Testing

- 122 CLI tests pass (pre-existing eval test failure unrelated: `model_capability_registry` missing, fails on master too)
- RST formatting hook passes
- mypy passes

<!-- gptme-id:v1:gai_SbBqNbloHMHVM98Clt62pJYTbDhAihJSeLdjI4PS2iC -->