### PR TITLE
fix(mcp): run TOOL_CONFIRM guardrails on MCP tool.execute()

### DIFF
--- a/gptme/hooks/confirm.py
+++ b/gptme/hooks/confirm.py
@@ -11,6 +11,8 @@ Usage:
 """
 
 import logging
+from collections.abc import Generator
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
@@ -32,6 +34,26 @@ logger = logging.getLogger(__name__)
 
 _auto_override: ContextVar[bool] = ContextVar("auto_override", default=False)
 _auto_count: ContextVar[int] = ContextVar("auto_count", default=0)
+# Identity of a ToolUse already confirmed by a direct executor (MCP). Nested
+# get_confirmation() calls from tool.execute() must not re-dispatch hooks.
+_preconfirmed_tool_use: ContextVar["ToolUse | None"] = ContextVar(
+    "preconfirmed_tool_use", default=None
+)
+
+
+@contextmanager
+def preconfirmed(tool_use: "ToolUse") -> Generator[None, None, None]:
+    """Mark *tool_use* as already confirmed for nested get_confirmation() calls.
+
+    Direct executors (the MCP server) confirm once at the boundary, then call
+    ``tool.execute()`` which may confirm again internally. Wrap the execute so
+    TOOL_CONFIRM hooks fire exactly once per operation.
+    """
+    token = _preconfirmed_tool_use.set(tool_use)
+    try:
+        yield
+    finally:
+        _preconfirmed_tool_use.reset(token)
 
 
 def set_auto_confirm(count: int | None = None) -> None:
@@ -194,6 +216,10 @@ def get_confirmation(
                 return ConfirmationResult.confirm()
             logger.debug("No tool_use in context, auto-skipping")
             return ConfirmationResult.skip("No tool context available")
+
+    if _preconfirmed_tool_use.get() is tool_use:
+        logger.debug("ToolUse already confirmed, skipping TOOL_CONFIRM re-dispatch")
+        return ConfirmationResult.confirm()
 
     # Get registered TOOL_CONFIRM hooks
     hooks = get_hooks(HookType.TOOL_CONFIRM)

--- a/gptme/hooks/tests/test_confirm.py
+++ b/gptme/hooks/tests/test_confirm.py
@@ -7,6 +7,7 @@ from gptme.hooks.confirm import (
     ConfirmAction,
     ConfirmationResult,
     get_confirmation,
+    preconfirmed,
 )
 from gptme.tools.base import ToolUse
 
@@ -412,6 +413,52 @@ class TestHookFallthrough:
         finally:
             registry.hooks.clear()
             registry.hooks.update(original_hooks)
+
+
+class TestPreconfirmed:
+    """Nested get_confirmation() must not re-dispatch after a boundary confirm."""
+
+    def test_preconfirmed_skips_hook_redispatch(self):
+        calls: list[str] = []
+
+        def counting_hook(tool_use, preview=None, workspace=None):
+            calls.append(tool_use.tool)
+            return ConfirmationResult.confirm()
+
+        register_hook(
+            "count-confirm", HookType.TOOL_CONFIRM, counting_hook, priority=50
+        )
+        try:
+            tool_use = ToolUse(tool="shell", args=[], content="echo hi")
+            first = get_confirmation(tool_use)
+            assert first.action == ConfirmAction.CONFIRM
+            assert calls == ["shell"]
+            with preconfirmed(tool_use):
+                nested = get_confirmation(tool_use)
+            assert nested.action == ConfirmAction.CONFIRM
+            assert calls == ["shell"]
+        finally:
+            unregister_hook("count-confirm", HookType.TOOL_CONFIRM)
+
+    def test_preconfirmed_does_not_skip_other_tool_use(self):
+        calls: list[str] = []
+
+        def counting_hook(tool_use, preview=None, workspace=None):
+            calls.append(tool_use.tool)
+            return ConfirmationResult.confirm()
+
+        register_hook(
+            "count-confirm", HookType.TOOL_CONFIRM, counting_hook, priority=50
+        )
+        try:
+            first_use = ToolUse(tool="shell", args=[], content="echo hi")
+            other = ToolUse(tool="read", args=["/tmp/x"], content=None)
+            with preconfirmed(first_use):
+                result = get_confirmation(other)
+            assert result.action == ConfirmAction.CONFIRM
+            assert calls == ["read"]
+        finally:
+            unregister_hook("count-confirm", HookType.TOOL_CONFIRM)
 
 
 class TestShellAllowlistHook:

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -123,6 +123,11 @@ class GptmeMCPServer:
         # on first use; injected into each executor thread via _shell_var so that
         # stateful tools (shell, ipython) retain state between MCP requests.
         self._shell_session: ShellSession | None = None
+        # Hook registry from _init_tools. run_in_executor threads get a fresh
+        # ContextVar default (empty registry), so we inject this object there
+        # the same way we inject _shell_session. Without it, TOOL_CONFIRM
+        # hooks never run and get_confirmation auto-confirms.
+        self._hook_registry: Any = None
         # Serialize tool calls to prevent concurrent access to stateful tools
         # (shell subprocess, IPython REPL) from racing on shared session state.
         self._tool_call_lock = asyncio.Lock()
@@ -168,22 +173,43 @@ class GptmeMCPServer:
 
             # Call tool.execute() directly with kwargs — avoids thread-local registry
             # lookup in ToolUse.execute(). Auto-confirm is handled by the registered
-            # hook (register_auto_confirm called in _init_tools).
+            # hook (register_auto_confirm called in _init_tools). Bind a ToolUse so
+            # TOOL_CONFIRM hooks (guardrails) still dispatch instead of auto-confirming.
+            from ..hooks.registry import get_registry
+
+            hook_registry = self._hook_registry or get_registry()
+
             def _run_tool() -> str:
                 # run_in_executor copies the async context via copy_context(), so
                 # _shell_var resets to None in each new thread — every call would
                 # spawn a fresh subprocess, breaking the advertised shell persistence.
                 # Pre-seed the ContextVar with the server's persistent session so
                 # get_shell() reuses it instead of creating a new one.
+                # Same for the hook registry: a fresh thread would otherwise
+                # auto-confirm without running TOOL_CONFIRM (guardrails).
+                from ..hooks import ConfirmAction, get_confirmation
+                from ..hooks.registry import set_registry
+                from ..tools.base import ToolUse, using_current_tool_use
                 from ..tools.shell import _shell_var as _shell_ctxvar
 
+                set_registry(hook_registry)
                 _shell_ctxvar.set(self._get_or_create_shell_session())
 
-                result = tool.execute(None, None, kwargs)  # type: ignore[misc]
-                if hasattr(result, "__iter__"):
-                    output = _collect_tool_output(result)  # type: ignore[arg-type]
-                else:
-                    output = str(result.content) if result and result.content else ""
+                tool_use = ToolUse(tool=name, args=None, content=None, kwargs=kwargs)
+                with using_current_tool_use(tool_use):
+                    preview = "\n".join(kwargs.values()) or None
+                    confirmation = get_confirmation(
+                        tool_use=tool_use, preview=preview, default_confirm=True
+                    )
+                    if confirmation.action != ConfirmAction.CONFIRM:
+                        return confirmation.message or "Operation aborted"
+                    result = tool.execute(None, None, kwargs)  # type: ignore[misc]
+                    if hasattr(result, "__iter__"):
+                        output = _collect_tool_output(result)  # type: ignore[arg-type]
+                    else:
+                        output = (
+                            str(result.content) if result and result.content else ""
+                        )
 
                 # Sync back any session replaced during execution (e.g. by set_shell).
                 updated = _shell_ctxvar.get()
@@ -205,8 +231,15 @@ class GptmeMCPServer:
     def _init_tools(self) -> None:
         """Initialize gptme tools and register auto-confirm for non-interactive use."""
         from ..hooks.auto_confirm import register as register_auto_confirm
+        from ..hooks.guardrails import register as register_guardrails
 
+        # Guardrails (priority 200) must run before auto_confirm (priority 0)
+        # so MCP's non-interactive path still enforces GPTME_GUARDRAILS.
+        register_guardrails()
         register_auto_confirm()
+        from ..hooks.registry import get_registry
+
+        self._hook_registry = get_registry()
         self._loaded_tools = init_tools(self._tool_names)
         logger.info(
             "Loaded tools: %s", [t.name for t in self._loaded_tools if t.execute]

--- a/gptme/mcp/server.py
+++ b/gptme/mcp/server.py
@@ -188,6 +188,7 @@ class GptmeMCPServer:
                 # Same for the hook registry: a fresh thread would otherwise
                 # auto-confirm without running TOOL_CONFIRM (guardrails).
                 from ..hooks import ConfirmAction, get_confirmation
+                from ..hooks.confirm import preconfirmed
                 from ..hooks.registry import set_registry
                 from ..tools.base import ToolUse, using_current_tool_use
                 from ..tools.shell import _shell_var as _shell_ctxvar
@@ -203,13 +204,17 @@ class GptmeMCPServer:
                     )
                     if confirmation.action != ConfirmAction.CONFIRM:
                         return confirmation.message or "Operation aborted"
-                    result = tool.execute(None, None, kwargs)  # type: ignore[misc]
-                    if hasattr(result, "__iter__"):
-                        output = _collect_tool_output(result)  # type: ignore[arg-type]
-                    else:
-                        output = (
-                            str(result.content) if result and result.content else ""
-                        )
+                    # Shell/save/ipython confirm internally via get_confirmation().
+                    # Mark this ToolUse preconfirmed so those nested calls do not
+                    # re-dispatch TOOL_CONFIRM (hooks must fire once per MCP op).
+                    with preconfirmed(tool_use):
+                        result = tool.execute(None, None, kwargs)  # type: ignore[misc]
+                        if hasattr(result, "__iter__"):
+                            output = _collect_tool_output(result)  # type: ignore[arg-type]
+                        else:
+                            output = (
+                                str(result.content) if result and result.content else ""
+                            )
 
                 # Sync back any session replaced during execution (e.g. by set_shell).
                 updated = _shell_ctxvar.get()

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -10,6 +10,7 @@ import re
 import types
 import xml.etree.ElementTree as _ElementTree
 from collections.abc import Callable, Generator, Sequence
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -148,6 +149,22 @@ _current_tool_use: ContextVar[ToolUse | None] = ContextVar(
 def get_current_tool_use() -> ToolUse | None:
     """Get the currently executing ToolUse from context."""
     return _current_tool_use.get()
+
+
+@contextmanager
+def using_current_tool_use(tool_use: ToolUse) -> Generator[ToolUse, None, None]:
+    """Bind *tool_use* as the currently executing ToolUse for this context.
+
+    Direct executors (the MCP server, tests) that call ``tool.execute()``
+    instead of ``ToolUse.execute()`` must wrap the call so
+    ``get_confirmation()`` dispatches TOOL_CONFIRM instead of auto-confirming
+    when no ToolUse is in context.
+    """
+    token = _current_tool_use.set(tool_use)
+    try:
+        yield tool_use
+    finally:
+        _current_tool_use.reset(token)
 
 
 def set_tool_format(new_format: ToolFormat):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,7 +21,7 @@ from gptme.mcp.server import (
     _toolspec_to_mcp_tool,
     create_server,
 )
-from gptme.tools.base import Parameter, ToolSpec
+from gptme.tools.base import Parameter, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -332,6 +332,120 @@ class TestMCPServerHandlers:
         assert captured_sessions[1] is mock_session, (
             "Second call must reuse the same session"
         )
+
+    @pytest.mark.asyncio
+    async def test_call_tool_binds_current_tool_use(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """MCP must bind a ToolUse so TOOL_CONFIRM (guardrails) can dispatch."""
+        import mcp.types as types
+
+        from gptme.message import Message
+        from gptme.tools.base import get_current_tool_use
+
+        captured: list[ToolUse | None] = []
+
+        def spy(code, args, kwargs):
+            captured.append(get_current_tool_use())
+            yield Message("system", "ok")
+
+        server_with_mock_tools._loaded_tools[0] = ToolSpec(
+            name="shell",
+            desc="Shell.",
+            execute=spy,
+            block_types=["shell"],
+            parameters=[Parameter(name="command", type="string", required=True)],
+        )
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="shell", arguments={"command": "echo test"}
+            ),
+        )
+        await server_with_mock_tools._server.request_handlers[types.CallToolRequest](
+            req
+        )
+
+        assert captured, "spy must run"
+        tu = captured[0]
+        assert tu is not None
+        assert tu.tool == "shell"
+        assert tu.kwargs == {"command": "echo test"}
+
+    @pytest.mark.asyncio
+    async def test_mcp_shell_enforces_guardrails(self, monkeypatch) -> None:
+        """MCP shell must run TOOL_CONFIRM before calling the executor."""
+        import mcp.types as types
+
+        from gptme.message import Message
+        from gptme.tools.shell import tool as shell_tool
+
+        monkeypatch.setenv("GPTME_GUARDRAILS", "enforce")
+        executed = False
+
+        def execution_spy(code, args, kwargs):
+            nonlocal executed
+            executed = True
+            yield Message("system", "executed")
+
+        server = GptmeMCPServer(tool_names=["shell"])
+        server._init_tools()
+        server._loaded_tools = [
+            ToolSpec(
+                name=shell_tool.name,
+                desc=shell_tool.desc,
+                execute=execution_spy,
+                block_types=shell_tool.block_types,
+                parameters=shell_tool.parameters,
+            )
+        ]
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="shell", arguments={"command": "cat ~/.ssh/id_rsa"}
+            ),
+        )
+        result = await server._server.request_handlers[types.CallToolRequest](req)
+        assert isinstance(result.root, types.CallToolResult)
+        text = " ".join(
+            c.text for c in result.root.content if hasattr(c, "text") and c.text
+        )
+        assert not executed
+        assert "guardrail" in text.lower(), f"Expected guardrail skip; got: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_mcp_read_enforces_guardrails(self, monkeypatch) -> None:
+        """MCP read of a secret path must skip under GPTME_GUARDRAILS=enforce."""
+        import mcp.types as types
+
+        from gptme.hooks.auto_confirm import register as register_auto_confirm
+        from gptme.hooks.guardrails import register as register_guardrails
+        from gptme.tools.read import tool as read_tool
+
+        monkeypatch.setenv("GPTME_GUARDRAILS", "enforce")
+        register_guardrails()
+        register_auto_confirm()
+
+        server = GptmeMCPServer(tool_names=["read"])
+        server._loaded_tools = [read_tool]
+        from gptme.hooks.registry import get_registry
+
+        server._hook_registry = get_registry()
+
+        req = types.CallToolRequest(
+            method="tools/call",
+            params=types.CallToolRequestParams(
+                name="read", arguments={"path": "/nonexistent/.ssh/id_rsa"}
+            ),
+        )
+        result = await server._server.request_handlers[types.CallToolRequest](req)
+        assert isinstance(result.root, types.CallToolResult)
+        text = " ".join(
+            c.text for c in result.root.content if hasattr(c, "text") and c.text
+        )
+        assert "guardrail" in text.lower(), f"Expected guardrail skip; got: {text!r}"
 
 
 class TestMCPServerCLI:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -447,8 +447,61 @@ class TestMCPServerHandlers:
         )
         assert "guardrail" in text.lower(), f"Expected guardrail skip; got: {text!r}"
 
+    @pytest.mark.asyncio
+    async def test_mcp_confirm_hooks_run_once(
+        self, server_with_mock_tools: GptmeMCPServer
+    ) -> None:
+        """MCP confirms at the boundary; inner tool confirmation must not re-dispatch."""
+        import mcp.types as types
 
-class TestMCPServerCLI:
+        from gptme.hooks import (
+            HookType,
+            get_confirmation,
+            register_hook,
+            unregister_hook,
+        )
+        from gptme.hooks.registry import get_registry
+        from gptme.message import Message
+
+        calls: list[str] = []
+
+        def counting_hook(tool_use, preview=None, workspace=None):
+            calls.append(tool_use.tool)
+
+        register_hook(
+            "count-confirm", HookType.TOOL_CONFIRM, counting_hook, priority=50
+        )
+        server_with_mock_tools._hook_registry = get_registry()
+        try:
+
+            def spy(code, args, kwargs):
+                inner = get_confirmation()
+                assert inner.action.value == "confirm"
+                yield Message("system", "ok")
+
+            server_with_mock_tools._loaded_tools[0] = ToolSpec(
+                name="shell",
+                desc="Shell.",
+                execute=spy,
+                block_types=["shell"],
+                parameters=[Parameter(name="command", type="string", required=True)],
+            )
+
+            req = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name="shell", arguments={"command": "echo test"}
+                ),
+            )
+            result = await server_with_mock_tools._server.request_handlers[
+                types.CallToolRequest
+            ](req)
+            assert isinstance(result.root, types.CallToolResult)
+            assert not result.root.isError
+            assert calls == ["shell"], f"TOOL_CONFIRM must fire once, got {calls!r}"
+        finally:
+            unregister_hook("count-confirm", HookType.TOOL_CONFIRM)
+
     """Tests for the gptme-mcp-server CLI command."""
 
     def test_cli_help(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #3765. MCP still called `tool.execute()` in a `run_in_executor` thread with an empty hook-registry ContextVar, so `GPTME_GUARDRAILS=enforce` did not apply to shell (and `is_guardrail_active()` was false for reads).

This was the remaining gap vs closed #3695, called out on #3765 before merge.

## What this changes

- Inject the parent hook registry into MCP executor threads (same pattern as the persistent shell session).
- Bind a `ToolUse` and run `get_confirmation()` before `tool.execute()`, so `TOOL_CONFIRM` (guardrails at priority 200, then `auto_confirm`) actually dispatches.
- Register the guardrails hook next to `auto_confirm` in `GptmeMCPServer._init_tools()`.
- Add `using_current_tool_use()` for direct executors that skip `ToolUse.execute()`.

## Test plan

- [x] `tests/test_mcp_server.py` — 29 passed (3 new: ToolUse binding, shell enforce, read enforce)
- [x] ruff + mypy on the changed files

Related: #3765, #3598
