### PR TITLE
fix(llm): fold non-leading system messages for models that reject them (fixes #3779)

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -20,6 +20,7 @@ from .models import (
     CustomProvider,
     ModelMeta,
     Provider,
+    infer_supports_mid_system,
     is_custom_provider,
 )
 from .openai_responses import (
@@ -2156,6 +2157,7 @@ def _openai_compatible_model_to_modelmeta(
         supports_streaming=model_data.get("supports_streaming", True),
         supports_vision=supports_vision,
         supports_reasoning=model_data.get("supports_reasoning", False),
+        supports_mid_system=infer_supports_mid_system(model_id),
         price_input=0,  # pricing unknown for dynamically discovered models
         price_output=0,
         default_tool_format="tool",  # custom providers are openai-compat

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -678,6 +678,40 @@ def _prep_o1(msgs: Iterable[Message]) -> Generator[Message, None, None]:
         yield msg
 
 
+def _fold_mid_system(msgs: list[Message]) -> Generator[Message, None, None]:
+    """Fold non-leading system messages into user messages for models/servers
+    that reject system messages anywhere except the first position.
+
+    The first system message is kept as-is; every subsequent system message
+    (without a call_id — those are tool results handled separately) is wrapped
+    in ``<system>…</system>`` and re-emitted as a user message, exactly like
+    ``_prep_o1`` does.  This handles Qwen3.5 and any other chat template that
+    raises ``System message must be at the beginning`` on non-leading system
+    messages.
+
+    Activation: ``ModelMeta.supports_mid_system = False`` **or** the env var
+    ``GPTME_FOLD_SYSTEM_MESSAGES=1``.
+    """
+    leading_system_seen = False
+    for msg in msgs:
+        if msg.role == "system" and msg.call_id is None:
+            if not leading_system_seen:
+                # Keep the very first system message in place
+                leading_system_seen = True
+                yield msg
+            else:
+                # Fold subsequent system messages into user-role wrapper
+                yield msg.replace(
+                    role="user", content=f"<system>\n{msg.content}\n</system>"
+                )
+        else:
+            if msg.role != "system":
+                # Once we've seen a non-system message, all future system
+                # messages are definitely non-leading
+                leading_system_seen = True
+            yield msg
+
+
 def _merge_consecutive(msgs: Iterable[Message]) -> Generator[Message, None, None]:
     # if consecutive messages from same role, merge them
     last_message = None
@@ -2200,6 +2234,14 @@ def _prepare_messages_for_api(
         or model_meta.supports_reasoning
     ):
         messages = list(_prep_deepseek_reasoner(messages))
+    # For models/servers that only accept system messages at the leading position
+    # (e.g. Qwen3.5 on vLLM), fold non-leading system messages into user messages.
+    # Triggered by ModelMeta.supports_mid_system=False or GPTME_FOLD_SYSTEM_MESSAGES=1.
+    elif (
+        not model_meta.supports_mid_system
+        or os.environ.get("GPTME_FOLD_SYSTEM_MESSAGES") == "1"
+    ):
+        messages = list(_fold_mid_system(messages))
 
     # Process message dicts - _process_msgs handles both regular and tool response messages
     # For tool responses with images, it emits a follow-up user message

--- a/gptme/llm/models/__init__.py
+++ b/gptme/llm/models/__init__.py
@@ -39,6 +39,7 @@ from .types import (
     Provider,
     ProviderPlugin,
     _ModelDictMeta,
+    infer_supports_mid_system,
     is_custom_provider,
 )
 
@@ -50,6 +51,7 @@ __all__ = [
     "Provider",
     "ProviderPlugin",
     "_ModelDictMeta",
+    "infer_supports_mid_system",
     # Constants
     "MODEL_ALIASES",
     "PROVIDER_ALIASES",

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -46,6 +46,8 @@ def model_to_dict(model: ModelMeta) -> dict[str, Any]:
         d["default_tool_format"] = model.default_tool_format
     if model.supports_strict_tools:
         d["supports_strict_tools"] = True
+    if not model.supports_mid_system:
+        d["supports_mid_system"] = False
     return d
 
 

--- a/gptme/llm/models/listing.py
+++ b/gptme/llm/models/listing.py
@@ -46,7 +46,8 @@ def model_to_dict(model: ModelMeta) -> dict[str, Any]:
         d["default_tool_format"] = model.default_tool_format
     if model.supports_strict_tools:
         d["supports_strict_tools"] = True
-    if not model.supports_mid_system:
+    # Duck-typed models (CLI tests, plugins) may omit newer optional fields.
+    if not getattr(model, "supports_mid_system", True):
         d["supports_mid_system"] = False
     return d
 

--- a/gptme/llm/models/resolution.py
+++ b/gptme/llm/models/resolution.py
@@ -15,6 +15,7 @@ from .types import (
     ModelMeta,
     Provider,
     _ModelDictMeta,
+    infer_supports_mid_system,
 )
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,13 @@ def _find_closest_model_properties(
 
 
 def get_model(model: str) -> ModelMeta:
+    meta = _resolve_model(model)
+    if meta.supports_mid_system and not infer_supports_mid_system(meta.model, model):
+        return replace(meta, supports_mid_system=False)
+    return meta
+
+
+def _resolve_model(model: str) -> ModelMeta:
     # Apply provider aliases (e.g. "gptme.ai" -> "gptme")
     if "/" in model:
         prefix, rest = model.split("/", 1)

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -131,6 +131,7 @@ class ModelMeta:
         False  # models that can emit multiple tool calls in a single response
     )
     supports_strict_tools: bool = False  # models that support strict=True in tool schemas (OpenAI structured outputs)
+    supports_mid_system: bool = True  # whether the model/server accepts system messages that are not the first message in the conversation; set False for Qwen3.5 and similar chat templates that raise on non-leading system messages
 
     # price in USD per 1M tokens
     # if price is not set, it is assumed to be 0
@@ -262,6 +263,7 @@ class _ModelDictMeta(TypedDict):
     supports_responses_api: NotRequired[bool]
     supports_parallel_tool_calls: NotRequired[bool]
     supports_strict_tools: NotRequired[bool]
+    supports_mid_system: NotRequired[bool]
 
     knowledge_cutoff: NotRequired[datetime]
     deprecated: NotRequired[bool]

--- a/gptme/llm/models/types.py
+++ b/gptme/llm/models/types.py
@@ -117,6 +117,20 @@ PROVIDERS_OPENAI = [
 ]
 
 
+def infer_supports_mid_system(*names: str) -> bool:
+    """Whether these model identifiers accept non-leading system messages.
+
+    Qwen3.5's stock chat template raises ``System message must be at the beginning.``
+    Match ``qwen3.5`` / ``qwen3_5`` only — not the earlier Qwen3 family.
+    Returns False if any name looks like Qwen3.5.
+    """
+    for name in names:
+        normalized = name.lower().replace("_", ".")
+        if "qwen3.5" in normalized:
+            return False
+    return True
+
+
 @dataclass(frozen=True)
 class ModelMeta:
     provider: Provider | Literal["unknown"]

--- a/tests/test_fold_mid_system.py
+++ b/tests/test_fold_mid_system.py
@@ -1,0 +1,251 @@
+"""Tests for _fold_mid_system — folding non-leading system messages for
+models/servers (e.g. Qwen3.5 on vLLM) that reject system messages anywhere
+except the leading position.
+
+See: https://github.com/gptme/gptme/issues/3779
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gptme.llm.llm_openai import _fold_mid_system
+from gptme.message import Message
+
+
+def _sys(content: str) -> Message:
+    return Message(role="system", content=content)
+
+
+def _user(content: str) -> Message:
+    return Message(role="user", content=content)
+
+
+def _assistant(content: str) -> Message:
+    return Message(role="assistant", content=content)
+
+
+def _tool_result(content: str, call_id: str = "call-abc") -> Message:
+    """A system-role message that is actually a tool result (has call_id)."""
+    return Message(role="system", content=content, call_id=call_id)
+
+
+# ---------------------------------------------------------------------------
+# Core folding behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_fold_mid_system_no_system_messages():
+    """Conversations without system messages pass through unchanged."""
+    msgs = [_user("hello"), _assistant("hi")]
+    result = list(_fold_mid_system(msgs))
+    assert [(m.role, m.content) for m in result] == [
+        ("user", "hello"),
+        ("assistant", "hi"),
+    ]
+
+
+def test_fold_mid_system_leading_only():
+    """A single leading system message is kept as-is."""
+    msgs = [_sys("You are a helpful assistant."), _user("hello")]
+    result = list(_fold_mid_system(msgs))
+    assert result[0].role == "system"
+    assert result[0].content == "You are a helpful assistant."
+    assert result[1].role == "user"
+
+
+def test_fold_mid_system_folds_second_system():
+    """A second system message (after a user turn) is folded to user-role."""
+    msgs = [
+        _sys("Initial system prompt."),
+        _user("hello"),
+        _sys("Injected context."),
+        _assistant("response"),
+    ]
+    result = list(_fold_mid_system(msgs))
+    assert result[0].role == "system", "leading system kept"
+    assert result[1].role == "user"
+    assert result[2].role == "user", "mid-conversation system folded to user"
+    assert "<system>" in result[2].content
+    assert "Injected context." in result[2].content
+    assert result[3].role == "assistant"
+
+
+def test_fold_mid_system_multiple_mid_system():
+    """All non-leading system messages are folded, not just the second one."""
+    msgs = [
+        _sys("Initial."),
+        _user("turn 1"),
+        _sys("Injected 1."),
+        _user("turn 2"),
+        _sys("Injected 2."),
+    ]
+    result = list(_fold_mid_system(msgs))
+    roles = [m.role for m in result]
+    assert roles == ["system", "user", "user", "user", "user"]
+    assert "<system>" in result[2].content
+    assert "<system>" in result[4].content
+
+
+def test_fold_mid_system_wrapping_format():
+    """Folded messages are wrapped in <system>…</system>."""
+    msgs = [_sys("A"), _user("hi"), _sys("B")]
+    result = list(_fold_mid_system(msgs))
+    folded = result[2]
+    assert folded.content == "<system>\nB\n</system>"
+
+
+def test_fold_mid_system_tool_results_unaffected():
+    """System messages with call_id (tool results) are passed through as-is."""
+    msgs = [
+        _sys("System prompt."),
+        _user("run tool"),
+        _tool_result("tool output", call_id="call-1"),
+    ]
+    result = list(_fold_mid_system(msgs))
+    # tool result keeps system role and is not wrapped
+    tool_msg = result[2]
+    assert tool_msg.role == "system"
+    assert tool_msg.call_id == "call-1"
+    assert "<system>" not in tool_msg.content
+
+
+def test_fold_mid_system_no_leading_system():
+    """When there is no leading system message, the first system encountered
+    mid-conversation is still folded (it is non-leading)."""
+    msgs = [_user("hello"), _sys("Injected."), _assistant("hi")]
+    result = list(_fold_mid_system(msgs))
+    assert result[0].role == "user"
+    assert result[1].role == "user"
+    assert "<system>" in result[1].content
+    assert result[2].role == "assistant"
+
+
+def test_fold_mid_system_consecutive_leading_systems():
+    """Back-to-back system messages at the very start: only the first is kept
+    as system; subsequent ones are folded (they are non-leading once there is
+    already a leading system message)."""
+    msgs = [
+        _sys("First."),
+        _sys("Second."),  # still at front, but not THE leading one
+        _user("hello"),
+    ]
+    result = list(_fold_mid_system(msgs))
+    assert result[0].role == "system"
+    # second system is folded because leading_system_seen is True
+    assert result[1].role == "user"
+    assert "<system>" in result[1].content
+
+
+# ---------------------------------------------------------------------------
+# ModelMeta.supports_mid_system flag
+# ---------------------------------------------------------------------------
+
+
+def test_model_meta_default_supports_mid_system():
+    """ModelMeta defaults to supports_mid_system=True (no change for existing models)."""
+    from gptme.llm.models import get_model
+
+    model = get_model("openai/gpt-4o")
+    assert model.supports_mid_system is True
+
+
+def test_model_meta_supports_mid_system_field():
+    """ModelMeta can be instantiated with supports_mid_system=False."""
+    from gptme.llm.models import ModelMeta
+
+    m = ModelMeta(
+        provider="local",
+        model="Qwen/Qwen3.5-0.8B",
+        context=32_768,
+        supports_mid_system=False,
+    )
+    assert m.supports_mid_system is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: _prepare_messages_for_api respects the flag and env var
+# ---------------------------------------------------------------------------
+
+
+def _make_qwen_model_meta():
+    """Return a ModelMeta that mimics a Qwen3.5 local model."""
+    from gptme.llm.models import ModelMeta
+
+    return ModelMeta(
+        provider="local",
+        model="Qwen/Qwen3.5-0.8B",
+        context=32_768,
+        supports_mid_system=False,
+    )
+
+
+def _msgs_with_mid_system() -> list[Message]:
+    return [
+        _sys("System prompt."),
+        _user("hello"),
+        _sys("Injected context."),
+        _user("follow-up"),
+    ]
+
+
+@pytest.mark.parametrize("env_value", ["1"])
+def test_prepare_messages_folds_via_env_var(env_value, monkeypatch):
+    """GPTME_FOLD_SYSTEM_MESSAGES=1 triggers folding regardless of ModelMeta."""
+    from gptme.llm.llm_openai import _prepare_messages_for_api
+    from gptme.llm.models import ModelMeta
+
+    # a plain model that normally supports mid-system
+    model_meta = ModelMeta(
+        provider="local",
+        model="some-local-model",
+        context=32_768,
+        supports_mid_system=True,
+    )
+
+    monkeypatch.setenv("GPTME_FOLD_SYSTEM_MESSAGES", env_value)
+    with patch("gptme.llm.models.get_model", return_value=model_meta):
+        result_dicts, _ = _prepare_messages_for_api(
+            _msgs_with_mid_system(), "local/some-local-model", tools=None
+        )
+
+    roles = [d["role"] for d in result_dicts]
+    # The third message (originally system, non-leading) should now be user
+    assert roles[2] == "user", f"expected user at index 2, got {roles}"
+
+
+def test_prepare_messages_folds_via_model_meta_flag():
+    """ModelMeta.supports_mid_system=False triggers folding."""
+    from gptme.llm.llm_openai import _prepare_messages_for_api
+
+    model_meta = _make_qwen_model_meta()
+
+    with patch("gptme.llm.models.get_model", return_value=model_meta):
+        result_dicts, _ = _prepare_messages_for_api(
+            _msgs_with_mid_system(), "local/Qwen/Qwen3.5-0.8B", tools=None
+        )
+
+    roles = [d["role"] for d in result_dicts]
+    assert roles[2] == "user", f"expected user at index 2, got {roles}"
+
+
+def test_prepare_messages_no_fold_when_supported(monkeypatch):
+    """When supports_mid_system=True (default) and env var unset, no folding."""
+    from gptme.llm.llm_openai import _prepare_messages_for_api
+    from gptme.llm.models import ModelMeta
+
+    model_meta = ModelMeta(
+        provider="local",
+        model="some-local-model",
+        context=32_768,
+        supports_mid_system=True,
+    )
+
+    monkeypatch.delenv("GPTME_FOLD_SYSTEM_MESSAGES", raising=False)
+    with patch("gptme.llm.models.get_model", return_value=model_meta):
+        result_dicts, _ = _prepare_messages_for_api(
+            _msgs_with_mid_system(), "local/some-local-model", tools=None
+        )
+
+    roles = [d["role"] for d in result_dicts]
+    assert roles[2] == "system", f"expected system at index 2, got {roles}"

--- a/tests/test_fold_mid_system.py
+++ b/tests/test_fold_mid_system.py
@@ -163,6 +163,28 @@ def test_model_meta_supports_mid_system_field():
     assert m.supports_mid_system is False
 
 
+def test_get_model_infers_qwen35_does_not_support_mid_system():
+    """Resolving a local Qwen3.5 id sets supports_mid_system=False without mocks.
+
+    This is the activation path for vLLM/local endpoints (gptme/gptme#3779):
+    no static registry entry exists, so inference has to fire on the fallback.
+    """
+    from gptme.llm.models import get_model, infer_supports_mid_system
+
+    assert infer_supports_mid_system("Qwen/Qwen3.5-0.8B") is False
+    assert infer_supports_mid_system("qwen3_5-4b") is False
+    assert infer_supports_mid_system("qwen/qwen3-32b") is True
+    assert infer_supports_mid_system("llama-3") is True
+
+    model = get_model("local/Qwen/Qwen3.5-0.8B")
+    assert model.provider == "local"
+    assert model.supports_mid_system is False
+
+    # Earlier Qwen3 family is unaffected
+    qwen3 = get_model("local/Qwen/Qwen3-8B")
+    assert qwen3.supports_mid_system is True
+
+
 # ---------------------------------------------------------------------------
 # Integration: _prepare_messages_for_api respects the flag and env var
 # ---------------------------------------------------------------------------
@@ -227,6 +249,33 @@ def test_prepare_messages_folds_via_model_meta_flag():
 
     roles = [d["role"] for d in result_dicts]
     assert roles[2] == "user", f"expected user at index 2, got {roles}"
+
+
+def test_prepare_messages_folds_via_real_qwen35_resolution(monkeypatch):
+    """Unmocked get_model('local/Qwen/Qwen3.5-0.8B') activates folding."""
+    from gptme.llm.llm_openai import _prepare_messages_for_api
+
+    monkeypatch.delenv("GPTME_FOLD_SYSTEM_MESSAGES", raising=False)
+    result_dicts, _ = _prepare_messages_for_api(
+        _msgs_with_mid_system(), "local/Qwen/Qwen3.5-0.8B", tools=None
+    )
+
+    roles = [d["role"] for d in result_dicts]
+    assert roles[0] == "system", "leading system kept"
+    assert roles[2] == "user", f"expected folded user at index 2, got {roles}"
+
+
+def test_openai_compat_listing_infers_qwen35_flag():
+    """Dynamic OpenAI-compat listing stamps supports_mid_system from the model id."""
+    from gptme.llm.llm_openai import _openai_compatible_model_to_modelmeta
+
+    qwen = _openai_compatible_model_to_modelmeta(
+        {"id": "Qwen/Qwen3.5-0.8B", "context_length": 32768}, "local"
+    )
+    assert qwen.supports_mid_system is False
+
+    llama = _openai_compatible_model_to_modelmeta({"id": "llama-3"}, "local")
+    assert llama.supports_mid_system is True
 
 
 def test_prepare_messages_no_fold_when_supported(monkeypatch):

--- a/tests/test_llm_models_resolution.py
+++ b/tests/test_llm_models_resolution.py
@@ -687,6 +687,21 @@ class TestModelToDict:
         d = model_to_dict(m)
         assert d["supports_reasoning"] is True
 
+    def test_supports_mid_system_excluded_when_true(self):
+        m = ModelMeta(provider="openai", model="test", context=128_000)
+        d = model_to_dict(m)
+        assert "supports_mid_system" not in d
+
+    def test_supports_mid_system_included_when_false(self):
+        m = ModelMeta(
+            provider="local",
+            model="Qwen/Qwen3.5-0.8B",
+            context=32_000,
+            supports_mid_system=False,
+        )
+        d = model_to_dict(m)
+        assert d["supports_mid_system"] is False
+
 
 # ── _apply_model_filters ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Qwen3.5's chat template raises `System message must be at the beginning.` for any system message that is not the first in the conversation. gptme injects tool results and context as `system` messages mid-conversation, causing every request to a Qwen3.5-on-vLLM endpoint to fail with HTTP 400.

Observed: 580/580 requests rejected during a gptme-eval run against `Qwen/Qwen3.5-0.8B` on vLLM 0.28. Other model families with the same template restriction are affected too.

## Fix

Adds `_fold_mid_system()` (modelled after the existing `_prep_o1`) and a `ModelMeta.supports_mid_system` flag (default `True` — backward-compatible):

- The **first** system message is kept as `system`.
- Every **subsequent** system message without a `call_id` is re-emitted as a `user` message wrapped in `<system>…</system>`, matching what `_prep_o1` does for OpenAI O1.
- Tool-result messages (system role + `call_id`) are **not** affected.

**Activation** (either works independently):
- `ModelMeta.supports_mid_system = False` for a known-restrictive model in the registry or a custom provider definition
- `GPTME_FOLD_SYSTEM_MESSAGES=1` env var for any custom/local endpoint without changing config

## Changes

- `gptme/llm/models/types.py`: add `supports_mid_system: bool = True` to `ModelMeta` and `_ModelDictMeta`
- `gptme/llm/llm_openai.py`: add `_fold_mid_system()`, wire into `_prepare_messages_for_api`
- `gptme/llm/models/listing.py`: serialize `supports_mid_system=False` in `model_to_dict`
- `tests/test_fold_mid_system.py`: 13 tests covering the folding logic, ModelMeta flag, env var activation, and integration with `_prepare_messages_for_api`

Fixes #3779

<!-- gptme-id:v1:gai_HQ6z8m3xmAGJ7buov8ZGlQXbPNH3owZ3eRwIz49bE7l -->