### PR TITLE
fix(server): detect 'No provider configured' as config error in server fallback

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -154,7 +154,9 @@ def init_model(
         # auto-detect depending on if OPENAI_API_KEY or ANTHROPIC_API_KEY is set
         model = guess_provider_from_config()
         if not model and not is_output_json():
-            console.print("[yellow]No API keys set, no provider available.[/yellow]")
+            console.print(
+                "[yellow]No provider configured, no provider available.[/yellow]"
+            )
 
     # ask user for API key
     if not model and interactive:

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -328,6 +328,7 @@ def serve(
         error_msg = str(e)
         is_config_error = (
             "No API key found" in error_msg
+            or "No provider configured" in error_msg
             or "No model specified" in error_msg
             or "not set in env or config" in error_msg
         )


### PR DESCRIPTION
## Summary

PR #3775 changed the `ValueError` in `gptme/init.py` from:
> No API key found…

to:
> No provider configured, couldn't auto-detect model…

But `gptme/server/cli.py` still only checked for `"No API key found"` when deciding whether to enter degraded fallback mode. After #3775 merged, a fresh-install `gptme-server` with no provider configured would **re-raise** the `ValueError` (crashing the server) instead of starting in degraded mode so the user can configure a provider via the WebUI.

## Fixes

### `gptme/server/cli.py` — detect new error text in `is_config_error`

The server's config-error guard now also matches `"No provider configured"`:

```python
is_config_error = (
    "No API key found" in error_msg
    or "No provider configured" in error_msg  # ← added
    or "No model specified" in error_msg
    or "not set in env or config" in error_msg
)
```

### `gptme/init.py` — update stale warning copy

The yellow warning on the non-interactive path (line 157) still said `"No API keys set"`. Updated to `"No provider configured"` for consistency with the `ValueError` below it.

## Testing

- 122 CLI tests pass, 8 skipped
- `mypy gptme/init.py gptme/server/cli.py` → no issues

Closes #3774

<!-- gptme-id:v1:gai_RVt5jSAWMvl037BKlFJabIejwmu2AIkfOaqLB1vJL3p -->