### PR TITLE
feat(skills): record server and TUI invocation outcomes

### DIFF
--- a/docs/skills.rst
+++ b/docs/skills.rst
@@ -234,12 +234,28 @@ event from a caller with execution evidence; terminal transitions are idempotent
 
 On CLI exit, unresolved invocations from that run become ``abandoned``. This means
 no completion evidence was recorded, and does not establish that the skill's work
-failed. Nested and resumed runs have separate UUIDs. Server/TUI terminal adapters,
-automatic completion evidence, abrupt-process recovery, cost attribution, and OTEL
-metrics remain future work; server/TUI command records currently retain the
-conversation path as their session identity. Storage failures are logged and never
-prevent skill execution. Malformed ledgers are preserved and refuse further writes
-until repaired, rather than risking duplicate terminal events.
+failed. Nested and resumed CLI runs and each TUI app have separate UUIDs.
+
+The TUI records ``completed`` when its worker produces a nonempty final response
+with no runnable tools, or receives the explicit session-complete signal. Errors
+record ``failed``; interruption, declined tools, step limits, cancellation, and
+app exit abandon unfinished invocations. A response containing tools keeps the
+invocation open until the tool loop reaches a final response.
+
+The native V2 server tracks invocation ownership per conversation session across
+generation and tool-confirmation workers. A nonempty, tool-free response completes
+an invocation only after pending and executing tools have drained. Generation/tool
+exceptions fail it; skipped tools, interrupts, session removal, and expiry abandon
+it. Revoked generation epochs cannot finalize a replacement worker's invocation.
+Server admission records retain the conversation path as their session identity;
+execution ownership is scoped to the invocation IDs in the latest user turn.
+
+``completed`` describes the runtime response boundary, not independent verification
+that the skill achieved its goal. ACP execution, queued server commands that never
+reach a step, abrupt-process recovery, cost attribution, and OTEL metrics remain
+follow-up work. Storage failures are logged and never prevent skill execution.
+Malformed ledgers are preserved and refuse further writes until repaired, rather
+than risking duplicate terminal events.
 
 Creating Skills
 ---------------

--- a/gptme/lessons/skill_events.py
+++ b/gptme/lessons/skill_events.py
@@ -190,14 +190,25 @@ def abandon_skill_invocations(logdir: Path, session_id: str) -> None:
 
 
 @contextmanager
+def skill_invocation_owner(logdir: Path, session_id: str) -> Iterator[None]:
+    """Bind admission to an owner whose lifetime may span threads or requests.
+
+    The owner must reconcile its invocations when it closes. Unlike
+    ``skill_session``, leaving this context does not end the run.
+    """
+    token = _session.set((logdir.resolve(), session_id))
+    try:
+        yield
+    finally:
+        _session.reset(token)
+
+
+@contextmanager
 def skill_session(logdir: Path) -> Iterator[str]:
     """Give CLI invocations a run identity and reconcile them on every exit path."""
     session_id = str(uuid4())
-    token = _session.set((logdir.resolve(), session_id))
-    try:
-        yield session_id
-    finally:
+    with skill_invocation_owner(logdir, session_id):
         try:
-            abandon_skill_invocations(logdir, session_id)
+            yield session_id
         finally:
-            _session.reset(token)
+            abandon_skill_invocations(logdir, session_id)

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -735,6 +735,7 @@ def api_conversation_tool_confirm(conversation_id: str):
             skip_step_seq = session.step_seq
             try:
                 current_tool.status = ToolStatus.SKIPPED
+                session.finish_skill_turn("abandoned")
                 session.pending_tools.pop(tool_id)
 
                 # Persist the skip before the continuation can load the log.
@@ -1177,6 +1178,7 @@ def api_conversation_interrupt(conversation_id: str):
                     # Revoke every worker queued under the previous epoch, even
                     # when a later explicit /step clears the boolean marker.
                     sess.step_seq += 1
+                    sess.finish_skill_turn("abandoned")
                     sess.pending_tools.clear()
 
     if not interrupted:

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -11,9 +11,12 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..hooks import HookType, trigger_hook
+from ..lessons.skill_events import SkillPhase, record_skill_phase
+from ..message import Message
 from ..session import BaseSession
 from ..tools import ToolUse
 from .api_v2_common import EventType
@@ -102,6 +105,12 @@ class ConversationSession(BaseSession):
     # Tool workers compare their captured epoch before releasing or continuing.
     step_seq: int = 0
 
+    # Invocation ownership follows this session across generation/tool workers.
+    # Access these fields only while holding step_lock.
+    skill_invocation_ids: set[str] = field(default_factory=set)
+    skill_logdir: Path | None = None
+    skill_branch: str | None = None
+
     # ACP-backed subprocess session (opt-in via use_acp=True in step request)
     use_acp: bool = False
     acp_runtime: "AcpSessionRuntime | None" = field(default=None, repr=False)
@@ -114,6 +123,38 @@ class ConversationSession(BaseSession):
     # At ~200 bytes/event, 10K events ≈ 2MB. We trim to keep_last when exceeded.
     _MAX_EVENTS = 10_000
     _KEEP_EVENTS = 1_000
+
+    def track_skill_turn(
+        self, logdir: Path, branch: str, messages: list[Message]
+    ) -> None:
+        """Own only skill prompts in the latest user turn, never the whole ledger."""
+        invocation_ids: set[str] = set()
+        seen_user = False
+        for msg in reversed(messages):
+            if msg.role == "assistant" and seen_user:
+                break
+            if msg.role == "user":
+                seen_user = True
+                if msg.metadata and (
+                    invocation_id := msg.metadata.get("skill_invocation_id")
+                ):
+                    invocation_ids.add(invocation_id)
+        if self.skill_branch != branch or self.skill_invocation_ids != invocation_ids:
+            self.finish_skill_turn("abandoned")
+        self.skill_logdir = logdir
+        self.skill_branch = branch
+        self.skill_invocation_ids = invocation_ids
+
+    def finish_skill_turn(
+        self, phase: SkillPhase, *, error_type: str | None = None
+    ) -> None:
+        """Record evidence for this owner's invocations; caller holds step_lock."""
+        if self.skill_logdir is not None:
+            for invocation_id in self.skill_invocation_ids:
+                record_skill_phase(
+                    self.skill_logdir, invocation_id, phase, error_type=error_type
+                )
+        self.skill_invocation_ids.clear()
 
     @property
     def events_count(self) -> int:
@@ -263,8 +304,10 @@ class SessionManager:
         cutoff = now - timedelta(minutes=max_age_minutes)
         stuck_cutoff = now - timedelta(minutes=cls._STUCK_GENERATING_TIMEOUT_MINUTES)
 
-        # Collect post-lock work: (conversation_id, is_last, acp_runtime)
-        deferred: list[tuple[str, bool, AcpSessionRuntime | None]] = []
+        # Collect post-lock cleanup work, including each session's skill ownership.
+        deferred: list[
+            tuple[str, bool, AcpSessionRuntime | None, ConversationSession]
+        ] = []
 
         with cls._lock:
             to_remove: list[str] = []
@@ -306,10 +349,12 @@ class SessionManager:
 
                 acp_rt = session.acp_runtime
                 del cls._sessions[session_id]
-                deferred.append((conversation_id, is_last, acp_rt))
+                deferred.append((conversation_id, is_last, acp_rt, session))
 
         # Phase 2: outside lock — long-running side-effects
-        for conversation_id, is_last, acp_rt in deferred:
+        for conversation_id, is_last, acp_rt, session in deferred:
+            with session.step_lock:
+                session.finish_skill_turn("abandoned")
             if is_last:
                 try:
                     from ..logmanager import LogManager
@@ -364,6 +409,8 @@ class SessionManager:
             del cls._sessions[session_id]
 
         # Phase 2: outside lock — long-running side-effects
+        with session.step_lock:
+            session.finish_skill_turn("abandoned")
         if is_last_session:
             try:
                 from ..logmanager import LogManager

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -40,6 +40,7 @@ from .session_models import (
 )
 
 if TYPE_CHECKING:
+    from ..lessons.skill_events import SkillPhase
     from .acp_session_runtime import AcpSessionRuntime
 
 logger = logging.getLogger(__name__)
@@ -689,6 +690,10 @@ def step(
     # this line could see the epoch of a replacement step if interrupt + /step
     # ran while the thread was descheduled.
     my_step_seq = step_seq if step_seq is not None else session.step_seq
+    with session.step_lock:
+        if session.step_seq != my_step_seq or session.interrupted:
+            return
+        session.track_skill_turn(manager.logdir, branch, manager.log.messages)
 
     # Fail cleanly if the configured workspace is missing (e.g. an external
     # symlinked workspace that was moved/deleted). step() runs in a daemon
@@ -704,6 +709,7 @@ def step(
         session.last_error = str(e)
         with session.step_lock:
             if session.step_seq == my_step_seq:
+                session.finish_skill_turn("failed")
                 session.generating = False
                 session.generating_since = None
         return
@@ -790,6 +796,7 @@ def step(
         SessionManager.add_event(conversation_id, error_event)
         with session.step_lock:
             if session.step_seq == my_step_seq:
+                session.finish_skill_turn("failed")
                 session.generating = False
                 session.generating_since = None
         return
@@ -802,6 +809,8 @@ def step(
     if tool_format == "tool":
         tools = [t for t in get_tools() if t.is_runnable]
 
+    skill_outcome: SkillPhase | None = None
+    skill_error_type = None
     try:
         # Stream tokens from the model
         output = ""
@@ -851,7 +860,11 @@ def step(
 
         for token in (char for chunk in chunks for char in chunk):
             # check if interrupted
-            if not session.generating:
+            if (
+                not session.generating
+                or session.interrupted
+                or session.step_seq != my_step_seq
+            ):
                 output += " [INTERRUPTED]"
                 break
 
@@ -964,6 +977,11 @@ def step(
                 if first_auto_id is None:
                     first_auto_id = tool_id
 
+        # A tool-free response ends the invocation only after prior tools have
+        # drained. TURN_POST and generation_complete happen before this boundary.
+        if not tooluses and not session.pending_tools and not session._executing_tools:
+            skill_outcome = "completed" if output.strip() else "abandoned"
+
         # Start execution for only the first auto-confirm tool.
         # execute_tool_thread will chain remaining auto-confirm tools serially.
         if first_auto_id is not None:
@@ -978,6 +996,8 @@ def step(
             )
 
     except Exception as e:
+        skill_outcome = "failed"
+        skill_error_type = type(e).__name__
         logger.exception(f"Error during step execution: {e}")
         error_message = str(e) or "Generation failed"
         session.last_error = error_message
@@ -998,6 +1018,12 @@ def step(
         # handoff.
         with session.step_lock:
             if session.step_seq == my_step_seq:
+                if session.interrupted or not session.generating:
+                    session.finish_skill_turn("abandoned")
+                elif skill_outcome is not None:
+                    session.finish_skill_turn(
+                        skill_outcome, error_type=skill_error_type
+                    )
                 session.generating = False
                 session.generating_since = None
             else:
@@ -1179,6 +1205,11 @@ def start_tool_execution(
                     except Exception as e:
                         logger.exception(f"Error executing tool {tooluse.tool}: {e}")
                         tool_exec.status = ToolStatus.FAILED
+                        with session.step_lock:
+                            if session.step_seq == my_seq:
+                                session.finish_skill_turn(
+                                    "failed", error_type=type(e).__name__
+                                )
 
                         with SessionManager.conversation_lock(conversation_id):
                             manager = LogManager.load(
@@ -1304,7 +1335,10 @@ def start_tool_execution(
                             session.generating = False
                             session.generating_since = None
                     raise
-        except Exception:
+        except Exception as e:
+            with session.step_lock:
+                if session.step_seq == my_seq:
+                    session.finish_skill_turn("failed", error_type=type(e).__name__)
             logger.exception(
                 f"Unhandled error in tool execution thread for {conversation_id}"
             )
@@ -1388,16 +1422,22 @@ def _start_step_thread(
 
         current_conversation_id.set(conversation_id)
         current_session_id.set(session.id)
-        step(
-            conversation_id=conversation_id,
-            session=session,
-            model=model,
-            workspace=workspace,
-            branch=branch,
-            auto_confirm=auto_confirm,
-            stream=stream,
-            step_seq=step_seq,
-        )
+        try:
+            step(
+                conversation_id=conversation_id,
+                session=session,
+                model=model,
+                workspace=workspace,
+                branch=branch,
+                auto_confirm=auto_confirm,
+                stream=stream,
+                step_seq=step_seq,
+            )
+        except Exception as e:
+            with session.step_lock:
+                if session.step_seq == step_seq:
+                    session.finish_skill_turn("failed", error_type=type(e).__name__)
+            raise
 
     # Propagate ContextVars (model, config) from the caller into the step thread.
     # Each thread gets its own copy so mutations stay isolated between sessions.

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -1556,6 +1556,18 @@ class GptmeApp(App):
                         self._show_info,
                         f"Reached max steps limit ({max_steps}), stopping.",
                     )
+                    # Mirror the natural-exit check: a step-boundary exit on a
+                    # nonempty final response (no pending runnable tools) is a
+                    # completion, not an abandonment.
+                    if (
+                        response is not None
+                        and response.content.strip()
+                        and not any(
+                            t.is_runnable
+                            for t in ToolUse.iter_from_content(response.content)
+                        )
+                    ):
+                        outcome = "completed"
                     break
                 # continue stepping while the last assistant msg has runnable tools
                 if response is None:

--- a/gptme/tui/app.py
+++ b/gptme/tui/app.py
@@ -21,6 +21,7 @@ except ImportError:
 import threading
 from pathlib import Path
 from typing import IO, cast
+from uuid import uuid4
 
 from rich.console import Console as RichConsole
 from rich.control import Control
@@ -53,6 +54,12 @@ from ..dirs import get_pt_history_file
 from ..hooks import HookType, register_hook, trigger_hook, unregister_hook
 from ..hooks.cli_confirm import _get_lang_for_tool
 from ..hooks.confirm import ConfirmationResult
+from ..lessons.skill_events import (
+    SkillPhase,
+    abandon_skill_invocations,
+    record_skill_phase,
+    skill_invocation_owner,
+)
 from ..llm.models import ModelMeta, get_default_model
 from ..logmanager import LogManager
 from ..message import Message
@@ -1046,6 +1053,8 @@ class GptmeApp(App):
         # (exclusive=True), so reusing one Context is safe, and mutations
         # (e.g. /model-style changes) persist across turns.
         self._chat_ctx = contextvars.copy_context()
+        self._skill_session_id = str(uuid4())
+        self._active_skill_invocation_id: str | None = None
         self.prompt_queue: list[str | Message] = []
         self._queued_widgets: list[Widget] = []
         self.generating = False
@@ -1129,6 +1138,12 @@ class GptmeApp(App):
         self.set_interval(0.5, self._restore_terminal)
 
     def on_unmount(self) -> None:
+        self._quitting = True
+        self._interrupt_event.set()
+        abandon_skill_invocations(self.manager.logdir, self._skill_session_id)
+        record_skill_phase(
+            self.manager.logdir, self._active_skill_invocation_id, "abandoned"
+        )
         unregister_hook("tui_confirm", HookType.TOOL_CONFIRM)
         if self._real_stdout is not None:
             sys.stdout = self._real_stdout
@@ -1373,7 +1388,13 @@ class GptmeApp(App):
             with contextlib.redirect_stdout(buf):
                 # run inside the chat context so state changes (e.g. /model
                 # switching the default-model ContextVar) are seen by workers
-                handled = self._chat_ctx.run(execute_cmd, msg, self.manager)
+                def execute_owned_command() -> bool:
+                    with skill_invocation_owner(
+                        self.manager.logdir, self._skill_session_id
+                    ):
+                        return execute_cmd(msg, self.manager)
+
+                handled = self._chat_ctx.run(execute_owned_command)
         except SystemExit:  # /exit
             self.exit()
             return
@@ -1457,6 +1478,13 @@ class GptmeApp(App):
 
     def _start_generation(self) -> None:
         logger.debug("starting generation worker")
+        # Snapshot the submitted prompt before hooks or generation mutate the log.
+        prompt = next((m for m in reversed(self.manager.log) if m.role == "user"), None)
+        self._active_skill_invocation_id = (
+            prompt.metadata.get("skill_invocation_id")
+            if prompt and prompt.metadata
+            else None
+        )
         self.generating = True
         self._interrupt_event.clear()
         self._set_state("generating")
@@ -1476,6 +1504,9 @@ class GptmeApp(App):
             with contextlib.suppress(ValueError):
                 max_steps = int(max_steps_str)
         step_count = 0
+        invocation_id = self._active_skill_invocation_id
+        outcome: SkillPhase = "abandoned"
+        error_type: str | None = None
         try:
             # Same boundary as the CLI chat loop: TURN_PRE after the user
             # prompt is in the log, before the first generation step.
@@ -1486,6 +1517,7 @@ class GptmeApp(App):
                 self.call_from_thread(self._begin_stream)
                 interrupted = False
                 declined = False
+                response: Message | None = None
                 try:
                     for msg in step(
                         manager.log,
@@ -1502,6 +1534,8 @@ class GptmeApp(App):
                         # confirmations in the same step get a sane terminal
                         self._restore_terminal()
                         manager.append(msg)
+                        if msg.role == "assistant":
+                            response = msg
                         if msg.content == DECLINED_CONTENT:
                             declined = True
                         self.call_from_thread(self._on_step_message, msg)
@@ -1524,21 +1558,30 @@ class GptmeApp(App):
                     )
                     break
                 # continue stepping while the last assistant msg has runnable tools
-                last_content = next(
-                    (m.content for m in reversed(manager.log) if m.role == "assistant"),
-                    "",
-                )
+                if response is None:
+                    break
                 if not any(
-                    t.is_runnable for t in ToolUse.iter_from_content(last_content)
+                    t.is_runnable for t in ToolUse.iter_from_content(response.content)
                 ):
+                    if response.content.strip():
+                        outcome = "completed"
                     break
         except SessionCompleteException:
             # complete tool is filtered out in interactive TUI mode, but a
             # resumed autonomous conversation may still have it loaded
+            outcome = "completed"
             self.call_from_thread(self._show_info, "Session marked complete.")
         except Exception as e:
+            outcome = "failed"
+            error_type = type(e).__name__
             logger.exception("Error in generation worker")
             self.call_from_thread(self._show_info, f"Error: {e}", True)
+        finally:
+            if self._interrupt_event.is_set() or self._quitting:
+                outcome = "abandoned"
+            record_skill_phase(
+                manager.logdir, invocation_id, outcome, error_type=error_type
+            )
         # NOTE: completion handling (queue dispatch etc.) happens in
         # on_worker_state_changed, which fires only after this thread has
         # fully exited self._chat_ctx — dispatching from here would make the
@@ -1644,6 +1687,12 @@ class GptmeApp(App):
             await self._generation_done()
 
     async def _generation_done(self) -> None:
+        # Cancellation can prevent the worker body from running at all. Successful
+        # and failed turns already have a terminal event; this is then a no-op.
+        record_skill_phase(
+            self.manager.logdir, self._active_skill_invocation_id, "abandoned"
+        )
+        self._active_skill_invocation_id = None
         self.generating = False
         # stream may have ended without a final message (interrupt mid-stream)
         self._clear_stream_view()
@@ -1651,6 +1700,13 @@ class GptmeApp(App):
         if self._interrupt_event.is_set() and self.prompt_queue:
             # user interrupted: hand queued text back instead of auto-submitting
             text = "\n".join(_queued_prompt_text(item) for item in self.prompt_queue)
+            for item in self.prompt_queue:
+                if isinstance(item, Message) and item.metadata:
+                    record_skill_phase(
+                        self.manager.logdir,
+                        item.metadata.get("skill_invocation_id"),
+                        "abandoned",
+                    )
             self.prompt_queue.clear()
             for w in self._queued_widgets:
                 w.remove()

--- a/tests/test_server_skill_events.py
+++ b/tests/test_server_skill_events.py
@@ -1,0 +1,236 @@
+"""Server skill ownership across generation, tools, and revoked epochs."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("flask")
+
+from gptme.config import ChatConfig
+from gptme.lessons.index import LessonIndex, clear_cache
+from gptme.lessons.skill_commands import (
+    register_skill_commands,
+    unregister_skill_commands,
+)
+from gptme.lessons.skill_events import (
+    read_skill_events,
+    record_skill_phase,
+    start_skill_invocation,
+)
+from gptme.logmanager import LogManager
+from gptme.message import Message
+from gptme.server.session_models import SessionManager
+from gptme.server.session_step import start_tool_execution, step
+
+
+@pytest.fixture
+def skill_conversation(client, tmp_path, monkeypatch):
+    name = f"test-skill-{uuid4().hex}"
+    result = client.put(
+        f"/api/v2/conversations/{name}",
+        json={
+            "prompt": "Be helpful.",
+            "config": {"chat": {"workspace": str(tmp_path)}},
+        },
+    )
+    assert result.status_code == 200
+    session = SessionManager.get_session(result.get_json()["session_id"])
+    assert session is not None
+    manager = LogManager.load(name, lock=False)
+    invocation_id = start_skill_invocation(
+        manager.logdir, "demo", tmp_path / "SKILL.md"
+    )
+    assert invocation_id
+    record_skill_phase(manager.logdir, invocation_id, "queued")
+    manager.append(
+        Message(
+            "user", "Run the skill", metadata={"skill_invocation_id": invocation_id}
+        )
+    )
+    manager.write()
+    monkeypatch.setattr("gptme.server.session_step.trigger_hook", lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "gptme.server.session_step._try_auto_name_and_notify", lambda *a, **kw: None
+    )
+    yield name, session, manager
+    SessionManager.remove_session(session.id)
+
+
+def run_step(conversation, monkeypatch, output="Done."):
+    name, session, manager = conversation
+    monkeypatch.setattr(
+        "gptme.server.session_step._chat_complete", lambda *a, **kw: (output, None)
+    )
+    session.generating = True
+    session.step_seq += 1
+    step(
+        name,
+        session,
+        "openai/gpt-4o-mini",
+        manager.workspace,
+        stream=False,
+        step_seq=session.step_seq,
+    )
+
+
+def phases(manager):
+    return [e.phase for e in read_skill_events(manager.logdir)]
+
+
+def test_server_command_queue_is_not_completion(client, tmp_path, monkeypatch):
+    skill = tmp_path / "skills" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("---\nname: demo\ndescription: demo\n---\nSay hello.")
+    monkeypatch.setattr(
+        LessonIndex, "_default_dirs", staticmethod(lambda: [skill.parent.parent])
+    )
+    clear_cache()
+    register_skill_commands()
+    name = f"test-skill-command-{uuid4().hex}"
+    response = client.put(
+        f"/api/v2/conversations/{name}", json={"prompt": "Be helpful."}
+    )
+    session = SessionManager.get_session(response.get_json()["session_id"])
+    assert session
+    try:
+        response = client.post(
+            f"/api/v2/conversations/{name}",
+            json={"role": "user", "content": "/skill:demo"},
+        )
+        assert response.status_code == 200
+        manager = LogManager.load(name, lock=False)
+        assert phases(manager) == ["started", "queued"]
+        monkeypatch.setattr(
+            "gptme.server.session_step.trigger_hook", lambda *a, **kw: []
+        )
+        monkeypatch.setattr(
+            "gptme.server.session_step._try_auto_name_and_notify", lambda *a, **kw: None
+        )
+        run_step((name, session, manager), monkeypatch)
+        assert phases(manager) == ["started", "queued", "completed"]
+        SessionManager.remove_session(session.id)
+        assert phases(manager) == ["started", "queued", "completed"]
+    finally:
+        SessionManager.remove_session(session.id)
+        unregister_skill_commands()
+        clear_cache()
+
+
+def test_server_tools_wait_for_final_response(skill_conversation, monkeypatch):
+    name, session, manager = skill_conversation
+    run_step(skill_conversation, monkeypatch, "```shell\nprintf hello\n```\n")
+    assert phases(manager) == ["started", "queued"]
+    assert session.pending_tools
+    # Execute the real shell tool, but control when the continuation starts.
+    monkeypatch.setattr(
+        "gptme.server.session_step._start_step_thread", lambda *a, **kw: True
+    )
+    tool_id = next(iter(session.pending_tools))
+    thread = start_tool_execution(
+        name,
+        session,
+        tool_id,
+        None,
+        "openai/gpt-4o-mini",
+        ChatConfig.load_or_create(manager.logdir, ChatConfig()),
+    )
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert not session.pending_tools
+    assert not session._executing_tools
+    assert phases(manager) == ["started", "queued"]
+    run_step(skill_conversation, monkeypatch)
+    assert phases(manager) == ["started", "queued", "completed"]
+
+
+def test_server_generation_error(skill_conversation, monkeypatch):
+    name, session, manager = skill_conversation
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr("gptme.server.session_step._chat_complete", fail)
+    session.generating = True
+    step(name, session, "openai/gpt-4o-mini", manager.workspace, stream=False)
+    assert phases(manager) == ["started", "queued", "failed"]
+    assert read_skill_events(manager.logdir)[-1].error_type == "RuntimeError"
+
+
+def test_server_interrupt_revokes_stale_worker(skill_conversation, client, monkeypatch):
+    name, session, manager = skill_conversation
+    old_seq = session.step_seq
+    session.generating = True
+
+    def interrupt_during_reply(*args, **kwargs):
+        response = client.post(
+            f"/api/v2/conversations/{name}/interrupt", json={"session_id": session.id}
+        )
+        assert response.status_code == 200
+        # Simulate a replacement dispatch before the old worker finishes.
+        session.generating = True
+        session.interrupted = False
+        session.step_seq += 1
+        return "Old response", None
+
+    monkeypatch.setattr(
+        "gptme.server.session_step._chat_complete", interrupt_during_reply
+    )
+    step(
+        name,
+        session,
+        "openai/gpt-4o-mini",
+        manager.workspace,
+        stream=False,
+        step_seq=old_seq,
+    )
+    assert phases(manager) == ["started", "queued", "abandoned"]
+    assert session.generating
+    # Even a fresh replay cannot overwrite the terminal event.
+    run_step(skill_conversation, monkeypatch)
+    assert phases(manager) == ["started", "queued", "abandoned"]
+
+
+@pytest.mark.parametrize("reason", ["skip", "remove", "expire"])
+def test_server_abandons_owned_invocation(
+    skill_conversation, client, monkeypatch, reason
+):
+    name, session, manager = skill_conversation
+    unrelated = start_skill_invocation(
+        manager.logdir, "other", manager.logdir / "OTHER.md", session_id="other-run"
+    )
+    run_step(skill_conversation, monkeypatch, "```shell\nprintf hello\n```\n")
+    if reason == "skip":
+        monkeypatch.setattr(
+            "gptme.server.api_v2_sessions._start_step_thread", lambda *a, **kw: True
+        )
+        response = client.post(
+            f"/api/v2/conversations/{name}/tool/confirm",
+            json={
+                "session_id": session.id,
+                "tool_id": next(iter(session.pending_tools)),
+                "action": "skip",
+            },
+        )
+        assert response.status_code == 200
+    elif reason == "remove":
+        SessionManager.remove_session(session.id)
+    else:
+        session.last_activity = datetime.now(timezone.utc) - timedelta(hours=2)
+        SessionManager.clean_inactive_sessions()
+    events = read_skill_events(manager.logdir)
+    assert [e.phase for e in events if e.invocation_id != unrelated] == [
+        "started",
+        "queued",
+        "abandoned",
+    ]
+    assert [e.phase for e in events if e.invocation_id == unrelated] == ["started"]
+
+
+def test_server_latest_user_turn_only(skill_conversation, monkeypatch):
+    name, session, manager = skill_conversation
+    manager.append(Message("assistant", "Previous response"))
+    manager.append(Message("user", "Unrelated new prompt"))
+    manager.write()
+    run_step(skill_conversation, monkeypatch)
+    assert phases(manager) == ["started", "queued"]

--- a/tests/test_tui_skill_events.py
+++ b/tests/test_tui_skill_events.py
@@ -1,0 +1,171 @@
+"""TUI lifecycle evidence must describe execution, not queue admission."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from gptme.constants import DECLINED_CONTENT
+from gptme.lessons.index import LessonIndex, clear_cache
+from gptme.lessons.skill_commands import (
+    register_skill_commands,
+    unregister_skill_commands,
+)
+from gptme.lessons.skill_events import (
+    read_skill_events,
+    record_skill_phase,
+    start_skill_invocation,
+)
+from gptme.logmanager import LogManager
+from gptme.message import Message
+from gptme.tools.complete import SessionCompleteException
+from gptme.tui.app import GptmeApp
+
+
+@pytest.mark.asyncio
+async def test_tui_real_command_has_one_terminal_event(tmp_path, monkeypatch):
+    """Exercise command admission, durable queue, worker dispatch, and teardown."""
+    skill = tmp_path / "skills" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("---\nname: demo\ndescription: demo\n---\nSay hello.")
+    monkeypatch.setattr(
+        LessonIndex, "_default_dirs", staticmethod(lambda: [skill.parent.parent])
+    )
+    monkeypatch.setattr("gptme.tui.app.trigger_hook", lambda *a, **kw: [])
+
+    def reply(*args, **kwargs):
+        yield Message("assistant", "Hello.")
+
+    monkeypatch.setattr("gptme.tui.app.step", reply)
+    clear_cache()
+    register_skill_commands()
+    manager = LogManager([], logdir=tmp_path / "conversation", lock=False)
+    app = GptmeApp(manager, workspace=tmp_path)
+    try:
+        async with app.run_test() as pilot:
+            app._handle_command("/skill:demo")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            events = read_skill_events(manager.logdir)
+            assert [e.phase for e in events] == ["started", "queued", "completed"]
+            assert len({e.invocation_id for e in events}) == 1
+            assert events[0].session_id != str(manager.logdir.resolve())
+        assert read_skill_events(manager.logdir) == events
+    finally:
+        unregister_skill_commands()
+        clear_cache()
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("reply", "completed"),
+        ("tools_then_reply", "completed"),
+        ("complete_tool", "completed"),
+        ("error", "failed"),
+        ("interrupt", "abandoned"),
+        ("declined", "abandoned"),
+        ("limit", "abandoned"),
+        ("empty", "abandoned"),
+    ],
+)
+def test_tui_terminal_evidence(tmp_path: Path, monkeypatch, mode, expected):
+    manager = LogManager([], logdir=tmp_path / "conversation", lock=False)
+    invocation_id = start_skill_invocation(
+        manager.logdir, "demo", tmp_path / "SKILL.md"
+    )
+    assert invocation_id
+    record_skill_phase(manager.logdir, invocation_id, "queued")
+    manager.append(
+        Message("user", "run skill", metadata={"skill_invocation_id": invocation_id})
+    )
+    app = GptmeApp(manager, workspace=tmp_path)
+    app._active_skill_invocation_id = invocation_id
+    monkeypatch.setattr(app, "call_from_thread", lambda *a, **kw: None)
+    monkeypatch.setattr(app, "_restore_terminal", lambda: None)
+    monkeypatch.setattr("gptme.tui.app.trigger_hook", lambda *a, **kw: [])
+    monkeypatch.delenv("GPTME_MAX_STEPS", raising=False)
+    calls = 0
+
+    def reply(*args, **kwargs) -> Iterator[Message]:
+        nonlocal calls
+        calls += 1
+        if mode == "error":
+            raise RuntimeError("provider unavailable")
+        if mode == "interrupt":
+            raise KeyboardInterrupt
+        if mode == "complete_tool":
+            raise SessionCompleteException
+        if mode == "empty":
+            return
+        if mode == "declined":
+            yield Message("system", DECLINED_CONTENT)
+        elif mode in ("limit", "tools_then_reply") and calls == 1:
+            yield Message("assistant", "```shell\necho 1\n```")
+            yield Message("system", "1")
+        else:
+            # The tool-bearing step is not itself completion.
+            assert read_skill_events(manager.logdir)[-1].phase == "queued"
+            yield Message("assistant", "Done.")
+
+    if mode == "limit":
+        monkeypatch.setenv("GPTME_MAX_STEPS", "1")
+    monkeypatch.setattr("gptme.tui.app.step", reply)
+    app._generation_body()
+    events = read_skill_events(manager.logdir)
+    assert [e.phase for e in events] == ["started", "queued", expected]
+    assert events[-1].error_type == ("RuntimeError" if mode == "error" else None)
+    assert events[-1].duration_seconds is not None
+    if mode == "tools_then_reply":
+        assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_tui_interrupted_queue_loses_identity_only_after_abandonment(tmp_path):
+    from gptme.tui.app import ChatInput
+
+    manager = LogManager([], logdir=tmp_path / "conversation", lock=False)
+    invocation_id = start_skill_invocation(
+        manager.logdir, "demo", tmp_path / "SKILL.md"
+    )
+    assert invocation_id
+    record_skill_phase(manager.logdir, invocation_id, "queued")
+    app = GptmeApp(manager, workspace=tmp_path)
+    async with app.run_test():
+        app.prompt_queue.append(
+            Message(
+                "user", "queued skill", metadata={"skill_invocation_id": invocation_id}
+            )
+        )
+        app._interrupt_event.set()
+        await app._generation_done()
+        assert [e.phase for e in read_skill_events(manager.logdir)] == [
+            "started",
+            "queued",
+            "abandoned",
+        ]
+        assert app.query_one("#input", ChatInput).text == "queued skill"
+        assert not app.prompt_queue
+
+
+@pytest.mark.asyncio
+async def test_tui_exit_abandons_only_its_run(tmp_path, monkeypatch):
+    from gptme.lessons.skill_events import skill_invocation_owner
+
+    manager = LogManager([], logdir=tmp_path / "conversation", lock=False)
+    app = GptmeApp(manager, workspace=tmp_path)
+    other = start_skill_invocation(
+        manager.logdir, "other", tmp_path / "OTHER.md", session_id="other"
+    )
+    with skill_invocation_owner(manager.logdir, app._skill_session_id):
+        ours = start_skill_invocation(manager.logdir, "ours", tmp_path / "OURS.md")
+    async with app.run_test():
+        pass
+    events = read_skill_events(manager.logdir)
+    assert [e.phase for e in events if e.invocation_id == ours] == [
+        "started",
+        "abandoned",
+    ]
+    assert [e.phase for e in events if e.invocation_id == other] == ["started"]

--- a/tests/test_tui_skill_events.py
+++ b/tests/test_tui_skill_events.py
@@ -68,6 +68,7 @@ async def test_tui_real_command_has_one_terminal_event(tmp_path, monkeypatch):
         ("interrupt", "abandoned"),
         ("declined", "abandoned"),
         ("limit", "abandoned"),
+        ("limit_final", "completed"),
         ("empty", "abandoned"),
     ],
 )
@@ -105,12 +106,17 @@ def test_tui_terminal_evidence(tmp_path: Path, monkeypatch, mode, expected):
         elif mode in ("limit", "tools_then_reply") and calls == 1:
             yield Message("assistant", "```shell\necho 1\n```")
             yield Message("system", "1")
+        elif mode == "limit_final":
+            # Final response (no runnable tools) exactly at the step boundary.
+            yield Message("assistant", "Done.")
         else:
             # The tool-bearing step is not itself completion.
             assert read_skill_events(manager.logdir)[-1].phase == "queued"
             yield Message("assistant", "Done.")
 
     if mode == "limit":
+        monkeypatch.setenv("GPTME_MAX_STEPS", "1")
+    elif mode == "limit_final":
         monkeypatch.setenv("GPTME_MAX_STEPS", "1")
     monkeypatch.setattr("gptme.tui.app.step", reply)
     app._generation_body()


### PR DESCRIPTION
Explicit skill commands in the server and TUI currently record `started → queued` without recording how execution ends. This adds terminal adapters that keep an invocation open through tool execution and record one `completed`, `failed`, or `abandoned` event from the observed runtime outcome.

- TUI commands use an app-run identity. Final responses and explicit completion close the invocation; errors fail it; interruption, declined tools, limits, cancellation, and app exit abandon unfinished work. Queued prompts are abandoned before being returned as plain input text.
- Native V2 sessions retain ownership across tool-confirmation workers. Finalization checks the generation epoch, and skips, interrupts, removal, and expiry abandon only owned invocations.

`completed` means the runtime reached its final response, not independent proof that the skill achieved its goal. ACP, server commands that never reach a step, crash recovery, token/cost attribution, and OTEL remain follow-up scope.

Validation: reproduced the missing terminal event on master through the actual TUI command/queue/worker path; added frontend lifecycle tests covering tool continuations, errors, interruptions, stale workers, skipped tools, expiry, and run isolation. The server continuation test executes a real shell tool. Model responses are controlled fixtures. Scoped mypy and all commit hooks pass. Full `make typecheck` reports five ACP SDK compatibility errors in unchanged files.

Follow-up to gptme/gptme#3750.

Broader regression run: 553 passed, 3 skipped, two 10-second timeouts under parallel load; both timed-out tests passed standalone (2 passed in 6.42s). All 19 new adapter tests pass.

Live-provider smoke: both the TUI and native V2 server invoked `/skill:lifecycle-smoke` using `openrouter/openai/gpt-4o-mini`, returned exactly `SKILL_LIFECYCLE_OK`, and persisted one `started → queued → completed` lifecycle each (TUI: 1.76 seconds; server: 9.01 seconds). Neither run mocked the model response.
