### PR TITLE
fix(openrouter): always send data_collection=deny for reasoning models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,10 +207,11 @@ jobs:
     - name: Install system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       run: |
-        # GitHub's Ubuntu runner image can ship stale apt sources with hash mismatches.
-        # Remove known-flaky sources (Microsoft, Azure CLI, Google Chrome) before update.
+        # GitHub's Ubuntu runner image can ship stale apt sources/caches with hash mismatches.
+        # Remove known-flaky sources and clear the stale lists cache before update.
         sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
-        sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google*.list
+        sudo find /etc/apt/sources.list.d/ -name "*google*" -o -name "*chrome*" | xargs sudo rm -f || true
+        sudo rm -rf /var/lib/apt/lists/*
         sudo apt-get update
         sudo apt-get install -y python3-dev build-essential libffi-dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,8 +207,10 @@ jobs:
     - name: Install system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       run: |
-        # GitHub's Ubuntu runner image can ship Microsoft-hosted apt sources that 403.
+        # GitHub's Ubuntu runner image can ship stale apt sources with hash mismatches.
+        # Remove known-flaky sources (Microsoft, Azure CLI, Google Chrome) before update.
         sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure-cli*.list
+        sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google*.list
         sudo apt-get update
         sudo apt-get install -y python3-dev build-essential libffi-dev
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1199,12 +1199,14 @@ def chat(
         if _uses_openrouter_backend(
             provider, model_meta
         ) and _is_openrouter_no_endpoints_error(_e):
+            _dc_configured = get_config().get_env("OPENROUTER_DATA_COLLECTION", "deny")
             logger.warning(
                 "OpenRouter: no endpoints matched the strict constraints "
-                "(require_parameters=True + data_collection=deny) for %s — "
+                "(require_parameters=True + data_collection=%s) for %s — "
                 "retrying with only the capability guard dropped (data_collection "
                 "stays at its configured default). Set OPENROUTER_PROVIDER_ORDER "
                 "or use model@provider to pin a no-training host.",
+                _dc_configured,
                 model_meta.model,
             )
             raw_response = _chat_create(relaxed_privacy=True)
@@ -1630,12 +1632,14 @@ def stream(
         if _uses_openrouter_backend(
             provider, model_meta
         ) and _is_openrouter_no_endpoints_error(_e):
+            _dc_configured = get_config().get_env("OPENROUTER_DATA_COLLECTION", "deny")
             logger.warning(
                 "OpenRouter: no endpoints matched the strict constraints "
-                "(require_parameters=True + data_collection=deny) for %s — "
+                "(require_parameters=True + data_collection=%s) for %s — "
                 "retrying with only the capability guard dropped (data_collection "
                 "stays at its configured default). Set OPENROUTER_PROVIDER_ORDER "
                 "or use model@provider to pin a no-training host.",
+                _dc_configured,
                 model_meta.model,
             )
             _stream_obj = _stream_create(relaxed_privacy=True)

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1370,7 +1370,7 @@ def extra_body(
         # Chat Completions parameter (OpenAI reasoning models, Kimi K3).
         # The Responses API path sets ``reasoning.effort`` in chat()/stream().
         body["reasoning_effort"] = effort
-    if provider == "openrouter":
+    if _uses_openrouter_backend(provider, model_meta):
         # Enable detailed usage info including cached tokens
         # See: https://openrouter.ai/docs/guides/usage-accounting
         body["usage"] = {"include": True}

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1196,13 +1196,15 @@ def chat(
     try:
         raw_response = _chat_create()
     except Exception as _e:
-        if _is_openrouter_no_endpoints_error(_e):
+        if _uses_openrouter_backend(
+            provider, model_meta
+        ) and _is_openrouter_no_endpoints_error(_e):
             logger.warning(
-                "OpenRouter: no endpoints matched privacy constraints "
-                "(data_collection=deny + require_parameters) for %s — "
-                "retrying without privacy constraints. "
-                "Set OPENROUTER_PROVIDER_ORDER or use model@provider to pin "
-                "a no-training host and restore the default privacy guarantees.",
+                "OpenRouter: no endpoints matched the strict constraints "
+                "(require_parameters=True + data_collection=deny) for %s — "
+                "retrying with only the capability guard dropped (data_collection "
+                "stays at its configured default). Set OPENROUTER_PROVIDER_ORDER "
+                "or use model@provider to pin a no-training host.",
                 model_meta.model,
             )
             raw_response = _chat_create(relaxed_privacy=True)
@@ -1319,16 +1321,19 @@ def _resolve_reasoning_effort(provider: Provider, model_meta: ModelMeta) -> str 
 
 
 def _is_openrouter_no_endpoints_error(e: Exception) -> bool:
-    """Return True when OpenRouter returns 404 because no provider matched the constraints.
+    """Return True when OpenRouter reports no provider matched the constraints.
 
-    OpenRouter returns a 404 with "No endpoints found" in the body when the
-    combination of provider preferences (data_collection, require_parameters,
-    provider order, etc.) eliminates every available host.  This is distinct
-    from a genuine model-not-found 404.
+    OpenRouter returns a 4xx (404 "No endpoints found", or 400 in some routing
+    configurations) when the combination of provider preferences
+    (data_collection, require_parameters, provider order, etc.) eliminates every
+    available host.  Matching both 404 and 400 covers the range documented in
+    the original code comment (the triple constraint "eliminates all available
+    providers and causes 400 errors").  The message check keeps this distinct
+    from a genuine model-not-found or other 4xx error.
     """
     from openai import APIStatusError  # fmt: skip
 
-    if not isinstance(e, APIStatusError) or e.status_code != 404:
+    if not isinstance(e, APIStatusError) or e.status_code not in (400, 404):
         return False
     error_text = " ".join(
         [
@@ -1348,11 +1353,13 @@ def extra_body(
 ) -> dict[str, Any]:
     """Return extra body for the OpenAI API based on the model.
 
-    ``relaxed_privacy=True`` omits ``data_collection`` and ``require_parameters``
-    from the OpenRouter provider preferences.  This is used as a one-shot
-    fallback when the strict defaults cause a 404 "No endpoints found" error —
-    we fail toward privacy (always send the constraints on the first attempt) and
-    only relax them when OpenRouter explicitly tells us no provider survives.
+    ``relaxed_privacy=True`` drops the ``require_parameters`` capability guard
+    (routing to providers that may not support every request parameter) as a
+    one-shot fallback when the strict defaults cause a 404 "No endpoints found"
+    error.  The deny-by-default ``data_collection`` policy is **preserved** even
+    in the relaxed path — prompts are never silently routed to a training host.
+    Relaxing ``data_collection`` requires an explicit
+    ``OPENROUTER_DATA_COLLECTION`` override, which is honoured in both modes.
     """
     body: dict[str, Any] = {}
     _maybe_apply_verbosity(body, model_meta)
@@ -1429,8 +1436,12 @@ def extra_body(
             # and retries once with relaxed_privacy=True (see chat()/stream()).
             data_collection = get_config().get_env("OPENROUTER_DATA_COLLECTION", "deny")
         else:
-            # Relaxed fallback: no require_parameters, honour explicit env override only.
-            data_collection = get_config().get_env("OPENROUTER_DATA_COLLECTION")
+            # Relaxed fallback: drop only the require_parameters capability guard.
+            # The deny-by-default data_collection policy is PRESERVED so a retry
+            # can never silently route prompts to a training host.  To genuinely
+            # relax data_collection, the user must set an explicit
+            # OPENROUTER_DATA_COLLECTION override (e.g. "allow"), honoured below.
+            data_collection = get_config().get_env("OPENROUTER_DATA_COLLECTION", "deny")
         if data_collection:
             provider_prefs["data_collection"] = data_collection
 
@@ -1616,13 +1627,15 @@ def stream(
     try:
         _stream_obj = _stream_create()
     except Exception as _e:
-        if _is_openrouter_no_endpoints_error(_e):
+        if _uses_openrouter_backend(
+            provider, model_meta
+        ) and _is_openrouter_no_endpoints_error(_e):
             logger.warning(
-                "OpenRouter: no endpoints matched privacy constraints "
-                "(data_collection=deny + require_parameters) for %s — "
-                "retrying without privacy constraints. "
-                "Set OPENROUTER_PROVIDER_ORDER or use model@provider to pin "
-                "a no-training host and restore the default privacy guarantees.",
+                "OpenRouter: no endpoints matched the strict constraints "
+                "(require_parameters=True + data_collection=deny) for %s — "
+                "retrying with only the capability guard dropped (data_collection "
+                "stays at its configured default). Set OPENROUTER_PROVIDER_ORDER "
+                "or use model@provider to pin a no-training host.",
                 model_meta.model,
             )
             _stream_obj = _stream_create(relaxed_privacy=True)

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1179,13 +1179,35 @@ def chat(
     if max_tokens is not None:
         optional_kwargs[_max_tokens_param_name(provider, api_model)] = max_tokens
 
-    raw_response = client.chat.completions.with_raw_response.create(
-        model=api_model.split("@")[0],
-        messages=cast(list, messages_dicts),
-        extra_headers=extra_headers(provider),
-        extra_body=extra_body(provider, model_meta, max_tokens=max_tokens),
-        **optional_kwargs,
-    )
+    def _chat_create(relaxed_privacy: bool = False) -> Any:
+        return client.chat.completions.with_raw_response.create(
+            model=api_model.split("@")[0],
+            messages=cast(list, messages_dicts),
+            extra_headers=extra_headers(provider),
+            extra_body=extra_body(
+                provider,
+                model_meta,
+                max_tokens=max_tokens,
+                relaxed_privacy=relaxed_privacy,
+            ),
+            **optional_kwargs,
+        )
+
+    try:
+        raw_response = _chat_create()
+    except Exception as _e:
+        if _is_openrouter_no_endpoints_error(_e):
+            logger.warning(
+                "OpenRouter: no endpoints matched privacy constraints "
+                "(data_collection=deny + require_parameters) for %s — "
+                "retrying without privacy constraints. "
+                "Set OPENROUTER_PROVIDER_ORDER or use model@provider to pin "
+                "a no-training host and restore the default privacy guarantees.",
+                model_meta.model,
+            )
+            raw_response = _chat_create(relaxed_privacy=True)
+        else:
+            raise
     response = raw_response.parse()
     _or_provider = (
         raw_response.headers.get("x-openrouter-provider")
@@ -1296,10 +1318,42 @@ def _resolve_reasoning_effort(provider: Provider, model_meta: ModelMeta) -> str 
     return effort
 
 
+def _is_openrouter_no_endpoints_error(e: Exception) -> bool:
+    """Return True when OpenRouter returns 404 because no provider matched the constraints.
+
+    OpenRouter returns a 404 with "No endpoints found" in the body when the
+    combination of provider preferences (data_collection, require_parameters,
+    provider order, etc.) eliminates every available host.  This is distinct
+    from a genuine model-not-found 404.
+    """
+    from openai import APIStatusError  # fmt: skip
+
+    if not isinstance(e, APIStatusError) or e.status_code != 404:
+        return False
+    error_text = " ".join(
+        [
+            str(getattr(e, "message", "")),
+            str(e.body) if e.body else "",
+            str(e),
+        ]
+    ).lower()
+    return "no endpoints" in error_text or "no providers" in error_text
+
+
 def extra_body(
-    provider: Provider, model_meta: ModelMeta, max_tokens: int | None = None
+    provider: Provider,
+    model_meta: ModelMeta,
+    max_tokens: int | None = None,
+    relaxed_privacy: bool = False,
 ) -> dict[str, Any]:
-    """Return extra body for the OpenAI API based on the model."""
+    """Return extra body for the OpenAI API based on the model.
+
+    ``relaxed_privacy=True`` omits ``data_collection`` and ``require_parameters``
+    from the OpenRouter provider preferences.  This is used as a one-shot
+    fallback when the strict defaults cause a 404 "No endpoints found" error —
+    we fail toward privacy (always send the constraints on the first attempt) and
+    only relax them when OpenRouter explicitly tells us no provider survives.
+    """
     body: dict[str, Any] = {}
     _maybe_apply_verbosity(body, model_meta)
     effort = _resolve_reasoning_effort(provider, model_meta)
@@ -1356,23 +1410,26 @@ def extra_body(
             provider_prefs["order"] = provider_order
             provider_prefs["allow_fallbacks"] = False
 
-        # Ensure routed provider supports all request parameters (tools,
-        # response_format, etc.) — prevents silent failures when OpenRouter
-        # falls back to a provider that doesn't support function calling.
-        # NOTE: only set when reasoning is NOT enabled, because the
-        # combination of require_parameters=True + reasoning extension can
-        # eliminate all available providers (the reasoning body parameter
-        # is not universally supported).
-        if "reasoning" not in body:
+        if not relaxed_privacy:
+            # Ensure routed provider supports all request parameters (tools,
+            # response_format, etc.) — prevents silent failures when OpenRouter
+            # falls back to a provider that doesn't support function calling.
+            # Sent for all models including reasoning models: as of 2026-09-09,
+            # 20+ hosts of common reasoning models (DeepSeek V4, GLM-5.3, etc.)
+            # support the reasoning parameter and honour this constraint.
             provider_prefs["require_parameters"] = True
 
-        # Privacy: default to "deny" for non-reasoning models to preserve
-        # user privacy. For reasoning models, skip the default — the triple
-        # constraint (require_parameters + reasoning + data_collection="deny")
-        # eliminates all available providers and causes 400 errors.
-        if "reasoning" not in body:
+            # Privacy: always default to "deny" so prompts stay off training
+            # pipelines.  This applies to reasoning models too — the earlier
+            # concern that the triple constraint (require_parameters + reasoning
+            # + data_collection=deny) would eliminate all providers no longer
+            # holds for current open-weight model hosts (verified 2026-09-09).
+            # If a future model has no matching privacy-respecting host,
+            # OpenRouter returns 404 "No endpoints found"; gptme catches that
+            # and retries once with relaxed_privacy=True (see chat()/stream()).
             data_collection = get_config().get_env("OPENROUTER_DATA_COLLECTION", "deny")
         else:
+            # Relaxed fallback: no require_parameters, honour explicit env override only.
             data_collection = get_config().get_env("OPENROUTER_DATA_COLLECTION")
         if data_collection:
             provider_prefs["data_collection"] = data_collection
@@ -1540,15 +1597,37 @@ def stream(
         optional_kwargs[_max_tokens_param_name(provider, api_model)] = max_tokens
     reasoning_effort = _resolve_reasoning_effort(provider, model_meta)
 
-    _stream_obj = client.chat.completions.create(
-        model=api_model.split("@")[0],
-        messages=cast(list, messages_dicts),
-        stream=True,
-        extra_headers=extra_headers(provider),
-        extra_body=extra_body(provider, model_meta, max_tokens=max_tokens),
-        stream_options={"include_usage": True},
-        **optional_kwargs,
-    )
+    def _stream_create(relaxed_privacy: bool = False) -> Any:
+        return client.chat.completions.create(
+            model=api_model.split("@")[0],
+            messages=cast(list, messages_dicts),
+            stream=True,
+            extra_headers=extra_headers(provider),
+            extra_body=extra_body(
+                provider,
+                model_meta,
+                max_tokens=max_tokens,
+                relaxed_privacy=relaxed_privacy,
+            ),
+            stream_options={"include_usage": True},
+            **optional_kwargs,
+        )
+
+    try:
+        _stream_obj = _stream_create()
+    except Exception as _e:
+        if _is_openrouter_no_endpoints_error(_e):
+            logger.warning(
+                "OpenRouter: no endpoints matched privacy constraints "
+                "(data_collection=deny + require_parameters) for %s — "
+                "retrying without privacy constraints. "
+                "Set OPENROUTER_PROVIDER_ORDER or use model@provider to pin "
+                "a no-training host and restore the default privacy guarantees.",
+                model_meta.model,
+            )
+            _stream_obj = _stream_create(relaxed_privacy=True)
+        else:
+            raise
     # Capture which subprovider OpenRouter actually used before consuming the
     # stream. The x-openrouter-provider header is available on the initial
     # HTTP response (before the stream body starts).

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -2604,17 +2604,22 @@ class TestExtraBody:
         result = extra_body("openrouter", meta)
         assert result["provider"]["require_parameters"] is True
 
-    def test_openrouter_has_data_collection_deny_by_default_for_non_reasoning(
-        self, monkeypatch
-    ):
-        """Non-reasoning models default to data_collection='deny' for privacy."""
+    def test_openrouter_has_data_collection_deny_by_default(self, monkeypatch):
+        """All models default to data_collection='deny' for privacy."""
         from gptme.llm.llm_openai import extra_body
 
         monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
         monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
+        # Non-reasoning model
         meta = self._make_model("anthropic/claude-sonnet-4-20250514")
         result = extra_body("openrouter", meta)
         assert result["provider"]["data_collection"] == "deny"
+        # Reasoning model — privacy constraints now apply regardless of reasoning
+        meta_r = self._make_model(
+            "deepseek/deepseek-v4-flash-0731", supports_reasoning=True
+        )
+        result_r = extra_body("openrouter", meta_r)
+        assert result_r["provider"]["data_collection"] == "deny"
 
     def test_openrouter_provider_override_with_at_sign(self):
         from gptme.llm.llm_openai import extra_body
@@ -2680,21 +2685,22 @@ class TestExtraBody:
         assert "reasoning" in result
         assert result["reasoning"]["enabled"] is True
 
-    def test_openrouter_reasoning_model_no_require_parameters(self):
-        """Reasoning models must not set require_parameters=True.
+    def test_openrouter_reasoning_model_has_require_parameters(self):
+        """Reasoning models now also set require_parameters=True (fail toward privacy).
 
-        The combination of require_parameters + reasoning extension can
-        eliminate all available providers — the reasoning body parameter
-        is not universally supported by all OpenRouter providers.
+        As of 2026-09-09, 20+ hosts of common reasoning models (DeepSeek V4,
+        GLM-5.3, etc.) support the reasoning parameter, so the constraint no
+        longer eliminates all providers.  If it does, the caller retries with
+        relaxed_privacy=True (see chat()/stream()).
         """
         from gptme.llm.llm_openai import extra_body
 
         meta = self._make_model(
-            "anthropic/claude-sonnet-4-20250514", supports_reasoning=True
+            "deepseek/deepseek-v4-flash-0731", supports_reasoning=True
         )
         result = extra_body("openrouter", meta)
         assert "reasoning" in result
-        assert "require_parameters" not in result["provider"]
+        assert result["provider"]["require_parameters"] is True
 
     def test_openrouter_non_reasoning_model_has_require_parameters(self):
         """Non-reasoning models should still set require_parameters=True."""
@@ -2704,6 +2710,19 @@ class TestExtraBody:
         result = extra_body("openrouter", meta)
         assert "reasoning" not in result
         assert result["provider"]["require_parameters"] is True
+
+    def test_openrouter_relaxed_privacy_skips_constraints(self, monkeypatch):
+        """relaxed_privacy=True omits data_collection and require_parameters (404-fallback path)."""
+        from gptme.llm.llm_openai import extra_body
+
+        monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
+        monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
+        meta = self._make_model(
+            "deepseek/deepseek-v4-flash-0731", supports_reasoning=True
+        )
+        result = extra_body("openrouter", meta, relaxed_privacy=True)
+        assert "require_parameters" not in result["provider"]
+        assert "data_collection" not in result["provider"]
 
     def test_openrouter_data_collection_env_override_allow(self, monkeypatch):
         from gptme.llm.llm_openai import extra_body
@@ -2721,24 +2740,28 @@ class TestExtraBody:
         result = extra_body("openrouter", meta)
         assert result["provider"]["data_collection"] == "deny"
 
-    def test_openrouter_reasoning_model_no_data_collection_by_default(
+    def test_openrouter_reasoning_model_has_data_collection_deny_by_default(
         self, monkeypatch
     ):
-        """Reasoning models don't set data_collection by default.
+        """Reasoning models now default to data_collection='deny' (fail toward privacy).
 
-        The triple constraint (require_parameters + reasoning + data_collection="deny")
-        eliminates all available OpenRouter providers, causing 400 errors.
+        The earlier concern that the triple constraint (require_parameters +
+        reasoning + data_collection=deny) would eliminate all OpenRouter providers
+        no longer holds: as of 2026-09-09, 20+ hosts support reasoning and
+        no-training policy simultaneously.  If a model has no matching host,
+        OpenRouter returns 404 "No endpoints found" and gptme retries once with
+        relaxed_privacy=True.
         """
         from gptme.llm.llm_openai import extra_body
 
         monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
         monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
         meta = self._make_model(
-            "anthropic/claude-sonnet-4-20250514", supports_reasoning=True
+            "deepseek/deepseek-v4-flash-0731", supports_reasoning=True
         )
         result = extra_body("openrouter", meta)
         assert "reasoning" in result
-        assert "data_collection" not in result["provider"]
+        assert result["provider"]["data_collection"] == "deny"
 
     def test_openrouter_data_collection_gptme_prefixed_env(self, monkeypatch):
         """GPTME_OPENROUTER_DATA_COLLECTION takes precedence over bare form."""
@@ -2806,6 +2829,70 @@ class TestExtraBody:
         meta = self._make_model("anthropic/claude-sonnet-4-20250514")
         result = extra_body("openrouter", meta)
         assert result["provider"]["quantizations"] == ["int4"]
+
+
+def _make_api_status_error(message: str, status_code: int, body: object = None):
+    """Build an openai.APIStatusError without a real httpx.Response."""
+    import httpx
+    from openai import APIStatusError
+
+    response = httpx.Response(
+        status_code,
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+    return APIStatusError(message, response=response, body=body)
+
+
+class TestOpenRouterNoEndpointsError:
+    """Tests for _is_openrouter_no_endpoints_error helper."""
+
+    def test_detects_no_endpoints_in_message(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        e = _make_api_status_error(
+            "No endpoints found that match your data policies",
+            404,
+            body={
+                "error": {"message": "No endpoints found that match your data policies"}
+            },
+        )
+        assert _is_openrouter_no_endpoints_error(e)
+
+    def test_detects_no_providers_in_body(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        e = _make_api_status_error(
+            "No providers available",
+            404,
+            body={"error": "No providers available for this model"},
+        )
+        assert _is_openrouter_no_endpoints_error(e)
+
+    def test_does_not_match_non_404(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        e = _make_api_status_error(
+            "No endpoints found",
+            400,
+            body={"error": "No endpoints found"},
+        )
+        assert not _is_openrouter_no_endpoints_error(e)
+
+    def test_does_not_match_other_404(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        e = _make_api_status_error(
+            "Model not found",
+            404,
+            body={"error": "Model not found"},
+        )
+        assert not _is_openrouter_no_endpoints_error(e)
+
+    def test_does_not_match_non_api_error(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        assert not _is_openrouter_no_endpoints_error(ValueError("No endpoints"))
+        assert not _is_openrouter_no_endpoints_error(RuntimeError("404"))
 
 
 class TestRecordUsageCacheTokens:

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 from unittest.mock import MagicMock, Mock, patch
 
 import openai  # warm import cache before per-test 10s timeout
-import openai._types  # noqa: F401  # warm openai._types (NOT_GIVEN) before per-test 10s timeout
+import openai._types  # warm openai._types (NOT_GIVEN) before per-test 10s timeout
 import pytest
 from pydantic import BaseModel
 
@@ -2711,8 +2711,16 @@ class TestExtraBody:
         assert "reasoning" not in result
         assert result["provider"]["require_parameters"] is True
 
-    def test_openrouter_relaxed_privacy_skips_constraints(self, monkeypatch):
-        """relaxed_privacy=True omits data_collection and require_parameters (404-fallback path)."""
+    def test_openrouter_relaxed_privacy_drops_require_parameters_keeps_deny(
+        self, monkeypatch
+    ):
+        """relaxed_privacy=True drops require_parameters but PRESERVES data_collection=deny.
+
+        The relaxed 404-fallback path only drops the require_parameters
+        capability guard.  The deny-by-default data_collection policy is kept so
+        a retry can never silently route prompts to a training host; relaxing
+        data_collection requires an explicit OPENROUTER_DATA_COLLECTION override.
+        """
         from gptme.llm.llm_openai import extra_body
 
         monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
@@ -2722,7 +2730,21 @@ class TestExtraBody:
         )
         result = extra_body("openrouter", meta, relaxed_privacy=True)
         assert "require_parameters" not in result["provider"]
-        assert "data_collection" not in result["provider"]
+        # deny-by-default preserved even in the relaxed fallback path
+        assert result["provider"]["data_collection"] == "deny"
+
+    def test_openrouter_relaxed_privacy_honors_explicit_env_override(self, monkeypatch):
+        """relaxed_privacy=True honours an explicit OPENROUTER_DATA_COLLECTION=allow override."""
+        from gptme.llm.llm_openai import extra_body
+
+        monkeypatch.setenv("OPENROUTER_DATA_COLLECTION", "allow")
+        monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
+        meta = self._make_model(
+            "deepseek/deepseek-v4-flash-0731", supports_reasoning=True
+        )
+        result = extra_body("openrouter", meta, relaxed_privacy=True)
+        assert "require_parameters" not in result["provider"]
+        assert result["provider"]["data_collection"] == "allow"
 
     def test_openrouter_data_collection_env_override_allow(self, monkeypatch):
         from gptme.llm.llm_openai import extra_body
@@ -2868,13 +2890,29 @@ class TestOpenRouterNoEndpointsError:
         )
         assert _is_openrouter_no_endpoints_error(e)
 
-    def test_does_not_match_non_404(self):
+    def test_matches_no_endpoints_on_400(self):
+        """A 400 with the no-endpoints message matches (broadened beyond 404).
+
+        The original code comment documented that the triple constraint
+        "eliminates all available providers and causes 400 errors", so the
+        fallback must also fire on a 400 that carries the no-endpoints signal.
+        """
         from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
 
         e = _make_api_status_error(
             "No endpoints found",
             400,
             body={"error": "No endpoints found"},
+        )
+        assert _is_openrouter_no_endpoints_error(e)
+
+    def test_does_not_match_other_400(self):
+        from gptme.llm.llm_openai import _is_openrouter_no_endpoints_error
+
+        e = _make_api_status_error(
+            "Bad request",
+            400,
+            body={"error": "Unsupported parameter"},
         )
         assert not _is_openrouter_no_endpoints_error(e)
 
@@ -2893,6 +2931,183 @@ class TestOpenRouterNoEndpointsError:
 
         assert not _is_openrouter_no_endpoints_error(ValueError("No endpoints"))
         assert not _is_openrouter_no_endpoints_error(RuntimeError("404"))
+
+
+class TestOpenRouterPrivacyFallbackRetry:
+    """Caller-level tests for the chat()/stream() relaxed-privacy retry.
+
+    Regression guard for the Greptile finding that the fallback wiring was
+    untested: chat()/stream() receiving an OpenRouter "No endpoints found" 404
+    must retry strict-first then relaxed, keep data_collection=deny in the
+    relaxed retry (never silently route to a training host), and only retry on
+    the OpenRouter backend.
+    """
+
+    @staticmethod
+    def _success_completion():
+        from openai.types.completion_usage import CompletionUsage
+
+        return SimpleNamespace(
+            usage=CompletionUsage.model_validate(
+                {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                }
+            ),
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(
+                        content="Hello",
+                        tool_calls=None,
+                        reasoning_content=None,
+                    ),
+                )
+            ],
+        )
+
+    def _chat_error(self):
+        return _make_api_status_error(
+            "No endpoints found that match your data policies",
+            404,
+            body={
+                "error": {"message": "No endpoints found that match your data policies"}
+            },
+        )
+
+    def _setup_openrouter_chat(self, monkeypatch, side_effect):
+        """Wire a mock openrouter chat-completions client with the given side_effect."""
+        completions_create = Mock(side_effect=side_effect)
+        mock_client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    with_raw_response=SimpleNamespace(create=completions_create)
+                )
+            )
+        )
+        monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+        monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+        monkeypatch.setattr(
+            llm_openai, "_should_use_responses_api", lambda *args: False
+        )
+        return completions_create
+
+    def test_chat_retries_relaxed_on_no_endpoints_and_keeps_deny(self, monkeypatch):
+        """chat() retries once relaxed on a no-endpoints 404, keeping data_collection=deny."""
+        completion = self._success_completion()
+        raw_ok = SimpleNamespace(parse=lambda: completion, headers={})
+
+        err = self._chat_error()
+        calls = []
+
+        def _create(**kwargs):
+            calls.append(kwargs.get("extra_body", {}))
+            if len(calls) == 1:
+                raise err
+            return raw_ok
+
+        completions_create = self._setup_openrouter_chat(monkeypatch, _create)
+
+        result, _ = llm_openai.chat(
+            [Message(role="user", content="Hi")],
+            "openrouter/deepseek/deepseek-v4-flash-0731",
+            None,
+        )
+
+        # Strict-first, relaxed-second: two create calls
+        assert completions_create.call_count == 2
+        # First (strict) request had require_parameters + data_collection=deny
+        assert calls[0]["provider"]["require_parameters"] is True
+        assert calls[0]["provider"]["data_collection"] == "deny"
+        # Relaxed retry drops require_parameters but keeps deny (privacy preserved)
+        assert "require_parameters" not in calls[1]["provider"]
+        assert calls[1]["provider"]["data_collection"] == "deny"
+        assert result == "Hello"
+
+    def test_chat_reraises_non_endpoint_error(self, monkeypatch):
+        """chat() re-raises a 404 that is not an OpenRouter no-endpoints error."""
+        other_err = _make_api_status_error(
+            "Model not found",
+            404,
+            body={"error": "Model not found"},
+        )
+        calls = []
+
+        def _create(**kwargs):
+            calls.append(kwargs.get("extra_body", {}))
+            raise other_err
+
+        completions_create = self._setup_openrouter_chat(monkeypatch, _create)
+
+        with pytest.raises(openai.APIStatusError):
+            llm_openai.chat(
+                [Message(role="user", content="Hi")],
+                "openrouter/deepseek/deepseek-v4-flash-0731",
+                None,
+            )
+        # No retry happened
+        assert completions_create.call_count == 1
+
+    def test_stream_retries_relaxed_on_no_endpoints_and_keeps_deny(self, monkeypatch):
+        """stream() retries once relaxed on a no-endpoints 404, keeping data_collection=deny."""
+        from gptme.message import Message
+
+        err = self._chat_error()
+        calls = []
+
+        class _FakeStream:
+            """Iterable that yields a single content chunk then ends."""
+
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    usage=None,
+                    choices=[
+                        SimpleNamespace(
+                            finish_reason=None,
+                            delta=SimpleNamespace(
+                                reasoning_content=None,
+                                reasoning=None,
+                                content="Hello",
+                                tool_calls=None,
+                            ),
+                        )
+                    ],
+                )
+
+        def _create(**kwargs):
+            calls.append(kwargs.get("extra_body", {}))
+            if len(calls) == 1:
+                raise err
+            return _FakeStream()
+
+        mock_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+        )
+        monkeypatch.setattr(llm_openai, "get_client", lambda provider: mock_client)
+        monkeypatch.setattr(llm_openai, "_is_proxy", lambda client: False)
+        monkeypatch.setattr(
+            llm_openai, "_should_use_responses_api", lambda *args: False
+        )
+
+        result = "".join(
+            llm_openai.stream(
+                [Message(role="user", content="Hi")],
+                "openrouter/deepseek/deepseek-v4-flash-0731",
+                None,
+            )
+        )
+
+        # Strict-first, relaxed-second
+        assert len(calls) == 2
+        assert calls[0]["provider"]["require_parameters"] is True
+        assert calls[0]["provider"]["data_collection"] == "deny"
+        # Relaxed retry keeps deny (privacy preserved), only drops require_parameters
+        assert "require_parameters" not in calls[1]["provider"]
+        assert calls[1]["provider"]["data_collection"] == "deny"
+        assert result == "Hello"
 
 
 class TestRecordUsageCacheTokens:

--- a/tests/test_llm_openai_reasoning_effort.py
+++ b/tests/test_llm_openai_reasoning_effort.py
@@ -120,12 +120,29 @@ def test_openai_rejects_unknown_effort(monkeypatch):
 
 def test_openrouter_effort_replaces_budget(monkeypatch):
     monkeypatch.setenv("GPTME_THINKING_EFFORT", "high")
+    monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
+    monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
     body = extra_body(
         "openrouter", _meta("openai/o3", "openrouter", True), max_tokens=64
     )
     assert body["reasoning"] == {"effort": "high"}
     assert body["usage"] == {"include": True}
-    # reasoning present → same provider-pref interplay as the budget path
+    # reasoning present → privacy constraints still apply (fail toward privacy)
+    assert body["provider"]["require_parameters"] is True
+    assert body["provider"]["data_collection"] == "deny"
+
+
+def test_openrouter_effort_relaxed_privacy_skips_constraints(monkeypatch):
+    """relaxed_privacy=True omits data_collection and require_parameters (404-fallback path)."""
+    monkeypatch.setenv("GPTME_THINKING_EFFORT", "high")
+    monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
+    monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
+    body = extra_body(
+        "openrouter",
+        _meta("openai/o3", "openrouter", True),
+        max_tokens=64,
+        relaxed_privacy=True,
+    )
     assert "require_parameters" not in body["provider"]
     assert "data_collection" not in body["provider"]
 

--- a/tests/test_llm_openai_reasoning_effort.py
+++ b/tests/test_llm_openai_reasoning_effort.py
@@ -132,8 +132,14 @@ def test_openrouter_effort_replaces_budget(monkeypatch):
     assert body["provider"]["data_collection"] == "deny"
 
 
-def test_openrouter_effort_relaxed_privacy_skips_constraints(monkeypatch):
-    """relaxed_privacy=True omits data_collection and require_parameters (404-fallback path)."""
+def test_openrouter_effort_relaxed_privacy_keeps_deny(monkeypatch):
+    """relaxed_privacy=True drops require_parameters but PRESERVES data_collection=deny.
+
+    The relaxed 404-fallback path only drops the require_parameters capability
+    guard.  The deny-by-default data_collection policy is kept so a retry can
+    never silently route prompts to a training host; relaxing data_collection
+    requires an explicit OPENROUTER_DATA_COLLECTION override.
+    """
     monkeypatch.setenv("GPTME_THINKING_EFFORT", "high")
     monkeypatch.delenv("OPENROUTER_DATA_COLLECTION", raising=False)
     monkeypatch.delenv("GPTME_OPENROUTER_DATA_COLLECTION", raising=False)
@@ -144,7 +150,7 @@ def test_openrouter_effort_relaxed_privacy_skips_constraints(monkeypatch):
         relaxed_privacy=True,
     )
     assert "require_parameters" not in body["provider"]
-    assert "data_collection" not in body["provider"]
+    assert body["provider"]["data_collection"] == "deny"
 
 
 def test_openrouter_non_reasoning_model_ignores_effort(monkeypatch):


### PR DESCRIPTION
## Problem

Closes #3785.

`extra_body()` in `gptme/llm/llm_openai.py` skipped `data_collection=deny` and `require_parameters=True` whenever the request contained a `reasoning` block. This meant every reasoning model (DeepSeek V4, GLM-5.3 Flash, Qwen, Kimi, etc.) silently routed to providers with `training=true / retainsPrompts=true`, bypassing the privacy guarantees documented in `docs/providers.rst`.

The original comment said the triple constraint (require_parameters + reasoning + data_collection=deny) would "eliminate all available providers", but that is no longer true: as of 2026-09-09, 20+ hosts of `deepseek/deepseek-v4-flash-0731` and `z-ai/glm-5.3-flash` support the reasoning parameter *and* no-training policy simultaneously.

## Fix

**Fail toward privacy** — always send `data_collection=deny` and `require_parameters=True`, even for reasoning models.

If a future model genuinely has no matching privacy-respecting host, OpenRouter returns a 4xx `No endpoints found` / `No providers` (404, or 400 in some routing configurations). `chat()` and `stream()` catch that specific error (scoped to the OpenRouter backend, matching both 400 and 404) and retry once with `relaxed_privacy=True`.

The relaxed retry drops only the `require_parameters` capability guard — it **preserves** the deny-by-default `data_collection` policy, so prompts are never silently rerouted to a training host. Relaxing `data_collection` requires an explicit `OPENROUTER_DATA_COLLECTION` override (e.g. `allow`). The retry logs an actionable warning pointing at `OPENROUTER_PROVIDER_ORDER` / `model@provider` for pinning a no-training host.

## Changes

- **`extra_body()`**: Remove the `"reasoning" not in body` guard on `data_collection` and `require_parameters`. Add `relaxed_privacy: bool = False` parameter for the fallback path, which drops `require_parameters` only (deny-by-default `data_collection` is preserved).
- **`_is_openrouter_no_endpoints_error()`**: New helper — distinguishes OpenRouter's "No endpoints found" / "No providers" 4xx (400 or 404) from a genuine model-not-found or other error.
- **`chat()` / `stream()`**: Wrap the API call with a try/except that retries once with `relaxed_privacy=True` on a "no endpoints" 404, scoped to the OpenRouter backend, and logs an actionable warning.
- **Tests**: Updated assertions that expected the relaxed fallback to drop `data_collection` (it now keeps deny by default). Added `TestOpenRouterNoEndpointsError` for the helper and caller-level `TestOpenRouterPrivacyFallbackRetry` covering the `chat()` and `stream()` retry wiring (strict-first, relaxed-second; deny preserved; non-endpoint errors re-raised without retry).

## Test results

```
179 passed in ~14s  (tests/test_llm_openai.py + tests/test_llm_openai_reasoning_effort.py)
```

<!-- gptme-id:v1:gai_7NvhPyMifwKedfOnh4qlbgIJNOXdIInIEOoQen4404D -->
