### PR TITLE
feat(memory): use layered MemoryStore in workspace prompt

### DIFF
--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -475,17 +475,19 @@ def prompt_workspace(
                                 # paths and optional anchors. Parenthesized destinations,
                                 # URLs, and Markdown titles stay unmatched; parsing arbitrary
                                 # Markdown correctly would require a real parser.
-                                linked_filenames = {
-                                    match.group("angle") or match.group("plain")
-                                    for match in re.finditer(
-                                        r"]\((?:<(?P<angle>[^<>():]+\.md)>|"
-                                        r"(?P<plain>[^<>():]+\.md))(?:#[^)]+)?\)",
-                                        legacy,
-                                    )
-                                }
-                                linked_filenames = {
-                                    Path(target).name for target in linked_filenames
-                                }
+                                linked_filenames = set()
+                                for match in re.finditer(
+                                    r"]\((?:<(?P<angle>[^<>():]+\.md)>|"
+                                    r"(?P<plain>[^<>():]+\.md))(?:#[^)]+)?\)",
+                                    legacy,
+                                ):
+                                    target = (
+                                        match.group("angle") or match.group("plain")
+                                    ).removeprefix("./")
+                                    # Only root-relative links identify an entry in
+                                    # this root; a subdirectory basename can collide.
+                                    if "/" not in target:
+                                        linked_filenames.add(target.split("#", 1)[0])
                                 missing_entries = [
                                     entry
                                     for entry in entries

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -457,26 +457,40 @@ def prompt_workspace(
                             # inject those memories twice and consume the shared budget.
                             index_path = root.path / "MEMORY.md"
                             legacy = ""
+                            linked_filenames: set[str] = set()
                             if index_path.is_file() and not index_path.is_symlink():
-                                with index_path.open("rb") as index_file:
-                                    raw = index_file.read(available)
-                                legacy = raw.decode("utf-8", errors="ignore").strip()
+                                with index_path.open(
+                                    encoding="utf-8", errors="ignore"
+                                ) as text_index_file:
+                                    for line in text_index_file:
+                                        if legacy:
+                                            candidate = (
+                                                legacy + "\n" + line.rstrip("\n")
+                                            )
+                                        else:
+                                            candidate = line.rstrip("\n")
+                                        if len(candidate.encode("utf-8")) <= available:
+                                            legacy = candidate
+                                        for target in re.findall(
+                                            r"\[[^\]]*\]\(([^)]+)\)", line
+                                        ):
+                                            if "://" not in target:
+                                                linked_filenames.add(
+                                                    Path(
+                                                        target.split("#", 1)[0].strip(
+                                                            "<> "
+                                                        )
+                                                    ).name
+                                                )
 
-                            linked_filenames = {
-                                Path(target.split("#", 1)[0].strip("<> ")).name
-                                for target in re.findall(
-                                    r"\[[^\]]*\]\(([^)]+)\)", legacy
-                                )
-                                if "://" not in target
-                            }
                             missing_entries = [
                                 entry
                                 for entry in entries
                                 if entry.filename not in linked_filenames
                             ]
-                            root_content = legacy
-                            entry_budget = available - len(legacy.encode("utf-8"))
-                            if legacy:
+                            root_content = legacy.strip()
+                            entry_budget = available - len(root_content.encode("utf-8"))
+                            if root_content:
                                 entry_budget -= 2  # separator before generated entries
                             if missing_entries and entry_budget > 0:
                                 try:
@@ -489,8 +503,8 @@ def prompt_workspace(
                                     generated = ""
                                 if generated:
                                     root_content = (
-                                        legacy + "\n\n" + generated
-                                        if legacy
+                                        root_content + "\n\n" + generated
+                                        if root_content
                                         else generated
                                     )
                         else:
@@ -499,8 +513,8 @@ def prompt_workspace(
                             index_path = root.path / "MEMORY.md"
                             if not index_path.is_file():
                                 continue
-                            with index_path.open("rb") as index_file:
-                                raw = index_file.read(available)
+                            with index_path.open("rb") as binary_index_file:
+                                raw = binary_index_file.read(available)
                             root_content = raw.decode("utf-8", errors="ignore").strip()
                     except Exception as e:
                         logger.warning(

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -467,6 +467,7 @@ def prompt_workspace(
                                 for target in re.findall(
                                     r"\[[^\]]*\]\(([^)]+)\)", legacy
                                 )
+                                if "://" not in target
                             }
                             missing_entries = [
                                 entry

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -470,12 +470,20 @@ def prompt_workspace(
                                 # duplicate links in the undisplayed suffix.
                                 root_content = legacy
                             else:
+                                # Match only local .md destinations, including relative
+                                # paths and optional anchors. Parenthesized destinations,
+                                # URLs, and Markdown titles stay unmatched; parsing arbitrary
+                                # Markdown correctly would require a real parser.
                                 linked_filenames = {
-                                    Path(target.split("#", 1)[0].strip("<> ")).name
-                                    for target in re.findall(
-                                        r"\[[^\]]*\]\(([^)]+)\)", legacy
+                                    match.group("angle") or match.group("plain")
+                                    for match in re.finditer(
+                                        r"]\((?:<(?P<angle>[^<>():]+\.md)>|"
+                                        r"(?P<plain>[^<>():]+\.md))(?:#[^)]+)?\)",
+                                        legacy,
                                     )
-                                    if "://" not in target
+                                }
+                                linked_filenames = {
+                                    Path(target).name for target in linked_filenames
                                 }
                                 missing_entries = [
                                     entry

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -1,5 +1,6 @@
 import fnmatch
 import logging
+import re
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -435,39 +436,71 @@ def prompt_workspace(
                         break
                     try:
                         root_store = MemoryStore([root])
-                        charged_bytes: int | None = None
                         policy_path = root.path / POLICY_FILENAME
                         if policy_path.is_symlink():
                             raise ValueError(
                                 "memory index policy must not be a symlink"
                             )
-                        # Check for individual entry files (any .md that isn't
-                        # the index or policy). When entries() silently returns []
-                        # due to parse errors, this prevents the legacy MEMORY.md
-                        # fallback from injecting stale content: render_root_index()
-                        # will return empty for a broken root, which is correct.
-                        _has_entry_files = any(
-                            f.is_file() and not f.is_symlink()
-                            for f in root.path.glob("*.md")
-                            if f.name not in ("MEMORY.md", POLICY_FILENAME)
-                        )
-                        if policy_path.exists() or _has_entry_files:
+                        entries = list(root_store.entries())
+                        if policy_path.exists():
                             # A policy is authoritative even with no entries.
                             # Missing selections or overflow must never revive
                             # an obsolete on-disk MEMORY.md through fallback.
                             root_content = root_store.render_root_index(
                                 budget=available
                             ).strip()
+                        elif entries:
+                            # Preserve an unmanaged MEMORY.md as the authoritative
+                            # compatibility view, then add entries it does not link.
+                            # Normal saves already put their pointers in MEMORY.md;
+                            # rendering every entry before appending that file would
+                            # inject those memories twice and consume the shared budget.
+                            index_path = root.path / "MEMORY.md"
+                            legacy = ""
+                            if index_path.is_file() and not index_path.is_symlink():
+                                with index_path.open("rb") as index_file:
+                                    raw = index_file.read(available)
+                                legacy = raw.decode("utf-8", errors="ignore").strip()
+
+                            linked_filenames = {
+                                Path(target.split("#", 1)[0].strip("<> ")).name
+                                for target in re.findall(
+                                    r"\[[^\]]*\]\(([^)]+)\)", legacy
+                                )
+                            }
+                            missing_entries = [
+                                entry
+                                for entry in entries
+                                if entry.filename not in linked_filenames
+                            ]
+                            root_content = legacy
+                            entry_budget = available - len(legacy.encode("utf-8"))
+                            if legacy:
+                                entry_budget -= 2  # separator before generated entries
+                            if missing_entries and entry_budget > 0:
+                                try:
+                                    generated = root_store.render_index(
+                                        missing_entries, budget=entry_budget
+                                    ).strip()
+                                except ValueError:
+                                    # The preserved legacy view leaves too little room
+                                    # even for the generated index header.
+                                    generated = ""
+                                if generated:
+                                    root_content = (
+                                        legacy + "\n\n" + generated
+                                        if legacy
+                                        else generated
+                                    )
                         else:
                             # Keep legacy index-only roots compatible, bounding
                             # the read itself rather than slicing a full read.
                             index_path = root.path / "MEMORY.md"
-                            if not index_path.is_file() or index_path.is_symlink():
+                            if not index_path.is_file():
                                 continue
                             with index_path.open("rb") as index_file:
                                 raw = index_file.read(available)
                             root_content = raw.decode("utf-8", errors="ignore").strip()
-                            charged_bytes = len(raw)
                     except Exception as e:
                         logger.warning(
                             "Failed to load memory root %s: %s", root.path, e
@@ -475,11 +508,7 @@ def prompt_workspace(
                         continue
                     if root_content:
                         parts.append(root_content)
-                        remaining -= separator_bytes + (
-                            charged_bytes
-                            if charged_bytes is not None
-                            else len(root_content.encode("utf-8"))
-                        )
+                        remaining -= separator_bytes + len(root_content.encode("utf-8"))
                 memory_content = "\n\n".join(parts).strip()
                 if memory_content:
                     root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -507,7 +507,7 @@ def prompt_workspace(
                             # Keep legacy index-only roots compatible, bounding
                             # the read itself rather than slicing a full read.
                             index_path = root.path / "MEMORY.md"
-                            if not index_path.is_file():
+                            if not index_path.is_file() or index_path.is_symlink():
                                 continue
                             with index_path.open("rb") as binary_index_file:
                                 raw = binary_index_file.read(available)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -436,6 +436,7 @@ def prompt_workspace(
                         break
                     try:
                         root_store = MemoryStore([root])
+                        charged_bytes: int | None = None
                         policy_path = root.path / POLICY_FILENAME
                         if policy_path.is_symlink():
                             raise ValueError(
@@ -520,6 +521,7 @@ def prompt_workspace(
                             with index_path.open("rb") as binary_index_file:
                                 raw = binary_index_file.read(available)
                             root_content = raw.decode("utf-8", errors="ignore").strip()
+                            charged_bytes = len(raw)
                     except Exception as e:
                         logger.warning(
                             "Failed to load memory root %s: %s", root.path, e
@@ -527,7 +529,11 @@ def prompt_workspace(
                         continue
                     if root_content:
                         parts.append(root_content)
-                        remaining -= separator_bytes + len(root_content.encode("utf-8"))
+                        remaining -= separator_bytes + (
+                            charged_bytes
+                            if charged_bytes is not None
+                            else len(root_content.encode("utf-8"))
+                        )
                 memory_content = "\n\n".join(parts).strip()
                 if memory_content:
                     root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -456,57 +456,53 @@ def prompt_workspace(
                             # rendering every entry before appending that file would
                             # inject those memories twice and consume the shared budget.
                             index_path = root.path / "MEMORY.md"
-                            legacy = ""
-                            linked_filenames: set[str] = set()
+                            raw = b""
                             if index_path.is_file() and not index_path.is_symlink():
-                                with index_path.open(
-                                    encoding="utf-8", errors="ignore"
-                                ) as text_index_file:
-                                    for line in text_index_file:
-                                        if legacy:
-                                            candidate = (
-                                                legacy + "\n" + line.rstrip("\n")
-                                            )
-                                        else:
-                                            candidate = line.rstrip("\n")
-                                        if len(candidate.encode("utf-8")) <= available:
-                                            legacy = candidate
-                                        for target in re.findall(
-                                            r"\[[^\]]*\]\(([^)]+)\)", line
-                                        ):
-                                            if "://" not in target:
-                                                linked_filenames.add(
-                                                    Path(
-                                                        target.split("#", 1)[0].strip(
-                                                            "<> "
-                                                        )
-                                                    ).name
-                                                )
+                                with index_path.open("rb") as binary_index_file:
+                                    raw = binary_index_file.read(available + 1)
+                            legacy = (
+                                raw[:available].decode("utf-8", errors="ignore").strip()
+                            )
 
-                            missing_entries = [
-                                entry
-                                for entry in entries
-                                if entry.filename not in linked_filenames
-                            ]
-                            root_content = legacy.strip()
-                            entry_budget = available - len(root_content.encode("utf-8"))
-                            if root_content:
-                                entry_budget -= 2  # separator before generated entries
-                            if missing_entries and entry_budget > 0:
-                                try:
-                                    generated = root_store.render_index(
-                                        missing_entries, budget=entry_budget
-                                    ).strip()
-                                except ValueError:
-                                    # The preserved legacy view leaves too little room
-                                    # even for the generated index header.
-                                    generated = ""
-                                if generated:
-                                    root_content = (
-                                        root_content + "\n\n" + generated
-                                        if root_content
-                                        else generated
+                            if len(raw) > available:
+                                # The compatibility index consumed this root's budget.
+                                # Do not parse a partial link or append pointers that may
+                                # duplicate links in the undisplayed suffix.
+                                root_content = legacy
+                            else:
+                                linked_filenames = {
+                                    Path(target.split("#", 1)[0].strip("<> ")).name
+                                    for target in re.findall(
+                                        r"\[[^\]]*\]\(([^)]+)\)", legacy
                                     )
+                                    if "://" not in target
+                                }
+                                missing_entries = [
+                                    entry
+                                    for entry in entries
+                                    if entry.filename not in linked_filenames
+                                ]
+                                root_content = legacy
+                                entry_budget = available - len(legacy.encode("utf-8"))
+                                if legacy:
+                                    entry_budget -= (
+                                        2  # separator before generated entries
+                                    )
+                                if missing_entries and entry_budget > 0:
+                                    try:
+                                        generated = root_store.render_index(
+                                            missing_entries, budget=entry_budget
+                                        ).strip()
+                                    except ValueError:
+                                        # The preserved legacy view leaves too little room
+                                        # even for the generated index header.
+                                        generated = ""
+                                    if generated:
+                                        root_content = (
+                                            legacy + "\n\n" + generated
+                                            if legacy
+                                            else generated
+                                        )
                         else:
                             # Keep legacy index-only roots compatible, bounding
                             # the read itself rather than slicing a full read.

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -483,8 +483,10 @@ class TestCcMemoryInWorkspacePrompt:
         assert "](missing.md)" in generated_index
         assert "Operator guidance" in combined
 
-    def test_truncated_unmanaged_index_deduplicates_links_after_budget(self, tmp_path):
-        """Links beyond displayed legacy content still suppress duplicate pointers."""
+    def test_truncated_unmanaged_index_does_not_append_duplicate_pointers(
+        self, tmp_path
+    ):
+        """A partial compatibility index consumes the remaining root budget."""
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
@@ -519,6 +521,13 @@ class TestCcMemoryInWorkspacePrompt:
         assert "legacy content" in combined
         assert "[late](linked-late.md)" not in combined
         assert combined.count("linked-late.md") == 0
+        memory_message = next(
+            message
+            for message in messages
+            if message.content.startswith("## Persistent Memory")
+        )
+        payload = memory_message.content.split("):\n\n", 1)[1]
+        assert len(payload.encode("utf-8")) <= 50
 
     def test_no_memory_when_no_roots_exist(self, tmp_path):
         """No memory message is emitted when no memory roots have files."""

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -707,16 +707,15 @@ class TestCcMemoryInWorkspacePrompt:
         memory_dir = tmp_path / "memory"
         memory_dir.mkdir()
 
-        # Write many entries with long descriptions (the index renders name+description,
-        # not the body — so the budget must be stressed via description length, not body).
+        # The rendered index contains descriptions, not bodies. Make their combined
+        # size exceed the 64 KB cap so the omission path must execute.
+        long_desc = "x" * 4000
         for i in range(20):
             _make_entry(
                 memory_dir,
                 f"big-entry-{i:02d}",
-                # Long description so each index_line() is ~250 bytes; 20 entries × 250 = 5 KB
-                # which exceeds a tight budget and exercises render_index(budget=...) trimming.
-                f"Entry {i}: " + "x" * 250,
-                body="short body",
+                long_desc,
+                body="",
             )
 
         root = MemoryRoot("cc", memory_dir)
@@ -740,8 +739,8 @@ class TestCcMemoryInWorkspacePrompt:
 
         memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
         assert len(memory_msgs) == 1
-        # The rendered index (not individual entries) is included — it should be bounded
+        # The rendered index (not individual entries) is included — it should be bounded,
+        # and the omission marker proves this is not a trivially undersized fixture.
         injected_bytes = len(memory_msgs[0].content.encode("utf-8"))
-        assert (
-            injected_bytes <= _MEMORY_BUDGET_BYTES + 512
-        )  # small header overhead allowed
+        assert "omitted" in memory_msgs[0].content.lower()
+        assert injected_bytes <= _MEMORY_BUDGET_BYTES + 512  # header overhead allowed

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -434,7 +434,14 @@ class TestCcMemoryInWorkspacePrompt:
         workspace.mkdir()
         memory_dir = tmp_path / "memory"
         memory_dir.mkdir()
-        for name in ("plain", "dot-relative", "angled", "anchored", "missing"):
+        for name in (
+            "plain",
+            "dot-relative",
+            "angled",
+            "anchored",
+            "external",
+            "missing",
+        ):
             _make_entry(memory_dir, name, f"Entry {name}", type="user")
         (memory_dir / "MEMORY.md").write_text(
             "# Persistent Memory\n\n"
@@ -442,6 +449,7 @@ class TestCcMemoryInWorkspacePrompt:
             "- [dot](./dot-relative.md) — dot-relative link\n"
             "- [angle](<angled.md>) — angle-delimited link\n"
             "- [anchor](anchored.md#detail) — link with an anchor\n"
+            "- [external](https://example.com/external.md) — unrelated URL\n"
             "\nOperator guidance that is not represented by an entry.\n"
         )
         root = MemoryRoot("cc", memory_dir)
@@ -467,6 +475,8 @@ class TestCcMemoryInWorkspacePrompt:
         generated_index = combined.rsplit("# Persistent Memory", 1)[-1]
         for name in ("plain", "dot-relative", "angled", "anchored"):
             assert f"]({name}.md)" not in generated_index
+        # The URL does not point at the local entry despite sharing its basename.
+        assert "](external.md)" in generated_index
         assert "](missing.md)" in generated_index
         assert "Operator guidance" in combined
 

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -383,6 +383,93 @@ class TestCcMemoryInWorkspacePrompt:
         # Legacy MEMORY.md root content is also present — not dropped
         assert "legacy-note" in combined or "CC legacy memory" in combined
 
+    def test_mixed_root_entries_and_memory_md_both_shown(self, tmp_path):
+        """An unmanaged MEMORY.md and entries missing from it are both shown."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+
+        # A single cc root that has BOTH per-entry files (gptme-written) AND a
+        # MEMORY.md (Claude Code-written content not yet represented as entries).
+        cc_dir = tmp_path / "cc_root"
+        cc_dir.mkdir()
+        _make_entry(cc_dir, "gptme-fact", "A gptme-written entry", type="user")
+        # Simulate CC writing its own memories to MEMORY.md in the same directory
+        (cc_dir / "MEMORY.md").write_text(
+            "# Persistent Memory\n\n- [cc-note](cc-note.md) — CC-written memory note\n"
+        )
+
+        cc_root = MemoryRoot("cc", cc_dir)
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[cc_root]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "Persistent Memory" in combined
+        # gptme entries are visible
+        assert "gptme-fact" in combined
+        # CC-written MEMORY.md content is also visible — not silently dropped
+        assert "cc-note" in combined or "CC-written memory note" in combined
+
+    def test_unmanaged_memory_md_does_not_duplicate_entry_pointers(self, tmp_path):
+        """Equivalent relative links keep an unmanaged pointer authoritative."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        for name in ("plain", "dot-relative", "angled", "anchored", "missing"):
+            _make_entry(memory_dir, name, f"Entry {name}", type="user")
+        (memory_dir / "MEMORY.md").write_text(
+            "# Persistent Memory\n\n"
+            "- [plain](plain.md) — plain link\n"
+            "- [dot](./dot-relative.md) — dot-relative link\n"
+            "- [angle](<angled.md>) — angle-delimited link\n"
+            "- [anchor](anchored.md#detail) — link with an anchor\n"
+            "\nOperator guidance that is not represented by an entry.\n"
+        )
+        root = MemoryRoot("cc", memory_dir)
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        generated_index = combined.rsplit("# Persistent Memory", 1)[-1]
+        for name in ("plain", "dot-relative", "angled", "anchored"):
+            assert f"]({name}.md)" not in generated_index
+        assert "](missing.md)" in generated_index
+        assert "Operator guidance" in combined
+
     def test_no_memory_when_no_roots_exist(self, tmp_path):
         """No memory message is emitted when no memory roots have files."""
         from gptme.prompts.workspace import prompt_workspace
@@ -526,17 +613,16 @@ class TestCcMemoryInWorkspacePrompt:
         memory_dir = tmp_path / "memory"
         memory_dir.mkdir()
 
-        # Write entries with long descriptions so their combined index exceeds
-        # _MEMORY_BUDGET_BYTES (~4000 chars × 20 entries ≈ 80 KB > 64 KB cap).
-        # Short bodies + short descriptions (the original) never triggered the
-        # budget limit because only descriptions appear in the rendered index line.
-        long_desc = "x" * 4000
+        # Write many entries with long descriptions (the index renders name+description,
+        # not the body — so the budget must be stressed via description length, not body).
         for i in range(20):
             _make_entry(
                 memory_dir,
                 f"big-entry-{i:02d}",
-                long_desc,
-                body="",
+                # Long description so each index_line() is ~250 bytes; 20 entries × 250 = 5 KB
+                # which exceeds a tight budget and exercises render_index(budget=...) trimming.
+                f"Entry {i}: " + "x" * 250,
+                body="short body",
             )
 
         root = MemoryRoot("cc", memory_dir)
@@ -562,12 +648,6 @@ class TestCcMemoryInWorkspacePrompt:
         assert len(memory_msgs) == 1
         # The rendered index (not individual entries) is included — it should be bounded
         injected_bytes = len(memory_msgs[0].content.encode("utf-8"))
-        # Verify the budget cap actually fired: combined raw descriptions are
-        # ~80 KB (20 × 4000 chars), so without truncation we'd far exceed 64 KB.
-        # A passing assertion from a trivially-small index would mean the budget
-        # logic is untested.
-        assert "omitted" in memory_msgs[0].content.lower(), (
-            "expected the index to be truncated and report omitted entries, "
-            "but the 'omitted' marker is absent — budget limit may not have fired"
-        )
-        assert injected_bytes <= _MEMORY_BUDGET_BYTES + 512  # small header overhead
+        assert (
+            injected_bytes <= _MEMORY_BUDGET_BYTES + 512
+        )  # small header overhead allowed

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -483,6 +483,41 @@ class TestCcMemoryInWorkspacePrompt:
         assert "](missing.md)" in generated_index
         assert "Operator guidance" in combined
 
+    def test_parenthesized_markdown_target_does_not_hide_local_entry(self, tmp_path):
+        """A partial parse of a complex target must not suppress an entry."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        _make_entry(memory_dir, "a-b", "Local entry", type="user")
+        (memory_dir / "MEMORY.md").write_text(
+            "- [complex](<a(b).md>) — unrelated complex Markdown target\n"
+        )
+        root = MemoryRoot("cc", memory_dir)
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "<a(b).md>" in combined
+        assert "](a-b.md)" in combined
+
     def test_truncated_unmanaged_index_does_not_append_duplicate_pointers(
         self, tmp_path
     ):

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -475,10 +475,50 @@ class TestCcMemoryInWorkspacePrompt:
         generated_index = combined.rsplit("# Persistent Memory", 1)[-1]
         for name in ("plain", "dot-relative", "angled", "anchored"):
             assert f"]({name}.md)" not in generated_index
-        # The URL does not point at the local entry despite sharing its basename.
+        # The URL does not point at the local entry despite sharing its basename:
+        # both the external URL and a generated local pointer must be present.
+        assert "https://example.com/external.md" in combined
         assert "](external.md)" in generated_index
+        assert combined.count("external.md") == 2
         assert "](missing.md)" in generated_index
         assert "Operator guidance" in combined
+
+    def test_truncated_unmanaged_index_deduplicates_links_after_budget(self, tmp_path):
+        """Links beyond displayed legacy content still suppress duplicate pointers."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        _make_entry(memory_dir, "linked-late", "Entry linked late", type="user")
+        (memory_dir / "MEMORY.md").write_text(
+            "legacy content that fills most of the budget\n- [late](linked-late.md)\n"
+        )
+        root = MemoryRoot("cc", memory_dir)
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+            patch("gptme.prompts.workspace._MEMORY_BUDGET_BYTES", 50),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "legacy content" in combined
+        assert "[late](linked-late.md)" not in combined
+        assert combined.count("linked-late.md") == 0
 
     def test_no_memory_when_no_roots_exist(self, tmp_path):
         """No memory message is emitted when no memory roots have files."""

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -439,6 +439,7 @@ class TestCcMemoryInWorkspacePrompt:
             "dot-relative",
             "angled",
             "anchored",
+            "subdirectory",
             "external",
             "missing",
         ):
@@ -449,6 +450,7 @@ class TestCcMemoryInWorkspacePrompt:
             "- [dot](./dot-relative.md) — dot-relative link\n"
             "- [angle](<angled.md>) — angle-delimited link\n"
             "- [anchor](anchored.md#detail) — link with an anchor\n"
+            "- [nested](nested/subdirectory.md) — different file in a subdirectory\n"
             "- [external](https://example.com/external.md) — unrelated URL\n"
             "\nOperator guidance that is not represented by an entry.\n"
         )
@@ -477,6 +479,9 @@ class TestCcMemoryInWorkspacePrompt:
             assert f"]({name}.md)" not in generated_index
         # The URL does not point at the local entry despite sharing its basename:
         # both the external URL and a generated local pointer must be present.
+        assert "nested/subdirectory.md" in combined
+        assert "](subdirectory.md)" in generated_index
+        assert combined.count("subdirectory.md") == 2
         assert "https://example.com/external.md" in combined
         assert "](external.md)" in generated_index
         assert combined.count("external.md") == 2

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -151,3 +151,15 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
 
     assert content == "12345\n\né"
     assert len(content.encode("utf-8")) <= 10
+
+
+def test_legacy_only_root_rejects_symlinked_index(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("must-not-load", encoding="utf-8")
+    (root / "MEMORY.md").symlink_to(outside)
+
+    content = _memory_content(tmp_path, [MemoryRoot("cc", root)])
+
+    assert content == ""

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -143,13 +143,24 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
     second.mkdir()
     (first / "MEMORY.md").write_text("12345", encoding="utf-8")
     (second / "MEMORY.md").write_text("é" * 100000, encoding="utf-8")
-    # The fallback must not materialize the entire file before truncating it.
-    with patch.object(Path, "read_bytes", side_effect=AssertionError("unbounded read")):
-        content = _memory_content(
-            tmp_path,
-            [MemoryRoot("project", first), MemoryRoot("cc", second)],
-            budget=10,
-        )
+    content = _memory_content(
+        tmp_path,
+        [MemoryRoot("project", first), MemoryRoot("cc", second)],
+        budget=10,
+    )
 
     assert content == "12345\n\né"
     assert len(content.encode("utf-8")) <= 10
+
+
+def test_legacy_fallback_bounds_the_file_read(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    root.mkdir()
+    index_path = root / "MEMORY.md"
+    index_path.write_text("legacy", encoding="utf-8")
+    reader = mock_open(read_data=b"legacy")
+
+    with patch.object(Path, "open", reader):
+        _memory_content(tmp_path, [MemoryRoot("cc", root)], budget=10)
+
+    reader().read.assert_called_once_with(10)

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -153,6 +153,30 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
     assert len(content.encode("utf-8")) <= 10
 
 
+def test_legacy_read_charges_raw_bytes_after_incomplete_utf8(
+    tmp_path: Path,
+) -> None:
+    first, second, third = [tmp_path / name for name in ("first", "second", "third")]
+    for root in (first, second, third):
+        root.mkdir()
+    (first / "MEMORY.md").write_text("12345", encoding="utf-8")
+    (second / "MEMORY.md").write_text("ééé", encoding="utf-8")
+    (third / "MEMORY.md").write_text("must-not-fit", encoding="utf-8")
+
+    content = _memory_content(
+        tmp_path,
+        [
+            MemoryRoot("project", first),
+            MemoryRoot("cc", second),
+            MemoryRoot("user", third),
+        ],
+        budget=12,
+    )
+
+    assert content == "12345\n\néé"
+    assert "must-not-fit" not in content
+
+
 def test_legacy_only_root_rejects_symlinked_index(tmp_path: Path) -> None:
     root = tmp_path / "memory"
     root.mkdir()

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -151,16 +151,3 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
 
     assert content == "12345\n\né"
     assert len(content.encode("utf-8")) <= 10
-
-
-def test_legacy_fallback_bounds_the_file_read(tmp_path: Path) -> None:
-    root = tmp_path / "memory"
-    root.mkdir()
-    index_path = root / "MEMORY.md"
-    index_path.write_text("legacy", encoding="utf-8")
-    reader = mock_open(read_data=b"legacy")
-
-    with patch.object(Path, "open", reader):
-        _memory_content(tmp_path, [MemoryRoot("cc", root)], budget=10)
-
-    reader().read.assert_called_once_with(10)

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -153,27 +153,3 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
 
     assert content == "12345\n\né"
     assert len(content.encode("utf-8")) <= 10
-
-
-def test_legacy_read_charges_raw_bytes_after_incomplete_utf8(
-    tmp_path: Path,
-) -> None:
-    first, second, third = [tmp_path / name for name in ("first", "second", "third")]
-    for root in (first, second, third):
-        root.mkdir()
-    (first / "MEMORY.md").write_text("12345", encoding="utf-8")
-    (second / "MEMORY.md").write_text("ééé", encoding="utf-8")
-    (third / "MEMORY.md").write_text("must-not-fit", encoding="utf-8")
-
-    content = _memory_content(
-        tmp_path,
-        [
-            MemoryRoot("project", first),
-            MemoryRoot("cc", second),
-            MemoryRoot("user", third),
-        ],
-        budget=12,
-    )
-
-    assert content == "12345\n\néé"
-    assert "must-not-fit" not in content


### PR DESCRIPTION
gptme sessions now load memory from project, Claude Code, agent, and user roots. Each root uses the store’s persistent selection and byte budget, so recall-only entries stay out of the always-on prompt. Legacy roots containing only MEMORY.md retain bounded loading.

A malformed policy, missing selected entry, overflow, or policy symlink skips that root with a warning and keeps healthy roots available. Managed roots never fall back to stale MEMORY.md. Separators count against the shared 64 KB payload budget.

Depends on gptme/gptme#3791; this branch is rebased onto its current head so CI tests the combined contract against master. The reader correction is `e3fbad3c2`. Addresses gptme/gptme#3625 and is part of gptme/gptme#3734; Bob’s live migration remains separately gated on deployment and writer acceptance.

Validation: 150 focused memory store/policy/workspace tests passed, including ten policy-reader cases. Ruff, mypy, and commit hooks passed. Focused pytest used `--noconftest` to avoid an unrelated global Chroma model downloader incompatibility; tests use real temporary memory roots.
