### PR TITLE
fix(memory): read index entries under the root lock

### DIFF
--- a/gptme/memory/store.py
+++ b/gptme/memory/store.py
@@ -551,9 +551,9 @@ class MemoryStore:
         self, scope: str | None = None, *, budget: int | None = None
     ) -> Path:
         root = self.root(scope)
-        text = self.render_index(self.index_entries(scope), budget=budget)
         path = root.path / INDEX_FILENAME
         with _locked_root(root.path):
+            text = self.render_index(self.index_entries(scope), budget=budget)
             _atomic_write(path, text)
         return path
 

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -4,6 +4,10 @@ import importlib
 import multiprocessing
 import os
 import stat
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -286,6 +290,50 @@ class TestStore:
             os.umask(previous)
 
         assert stat.S_IMODE(index.stat().st_mode) == 0o600
+
+    @pytest.mark.parametrize("mutation", ["save", "supersede"])
+    def test_write_index_reads_after_acquiring_root_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation: str
+    ) -> None:
+        from gptme.memory import store as store_module
+
+        store = self._store(tmp_path)
+        store.save("old", "Old belief", scope="project")
+        store.save("new", "New belief", scope="project")
+        main_thread = threading.current_thread()
+        index_waiting = threading.Event()
+        mutation_done = threading.Event()
+        locked_root = store_module._locked_root
+
+        @contextmanager
+        def pause_before_index_lock(root: Path) -> Iterator[None]:
+            if threading.current_thread() is not main_thread:
+                index_waiting.set()
+                assert mutation_done.wait(10), "concurrent mutation did not finish"
+            with locked_root(root):
+                yield
+
+        monkeypatch.setattr(store_module, "_locked_root", pause_before_index_lock)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            pending = executor.submit(store.write_index, scope="project")
+            try:
+                assert index_waiting.wait(10), "index writer did not reach the lock"
+                # Complete a real mutation in the window before the index writer
+                # acquires its root lock. A pre-lock snapshot would now be stale.
+                if mutation == "save":
+                    store.save("latest", "Latest belief", scope="project")
+                else:
+                    store.supersede("old", "new", scope="project")
+            finally:
+                mutation_done.set()
+            pending.result(timeout=10)
+
+        assert store.check_index(scope="project")
+        index = store.index_path("project").read_text()
+        if mutation == "save":
+            assert "latest.md" in index
+        else:
+            assert "old.md" not in index
 
     def test_supersede_rejects_cross_root_entries(self, tmp_path):
         store = self._store(tmp_path)


### PR DESCRIPTION
When `memory index --write` waits for the root lock, a concurrent `save` or `supersede` can finish after its entries were read. The index writer then publishes the stale snapshot, hiding the saved entry or restoring a superseded entry in MEMORY.md.

Move entry reading and rendering inside the existing root lock so generation sees mutations completed before it acquires the lock. Two event-synchronized regressions exercise actual save and supersede operations in that window; both fail before the fix.

Validation: `tests/test_memory_store.py` and `tests/test_cc_memory.py`: 101 passed, 1 skipped. Commit hooks passed. Related to gptme/gptme#3734; this fixes one concurrency prerequisite and does not complete the broader memory migration.
