### PR TITLE
feat(memory): preserve writer provenance through CLI metadata

### DIFF
--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -184,4 +184,5 @@ Harness wrappers can preserve their session identity through the shared writer::
 
 ``--metadata`` accepts a JSON object and merges its keys into existing entry
 metadata. Omitted keys survive updates; lifecycle fields and root index policy
-remain governed by the store. Invalid JSON or a non-object fails before writing.
+remain governed by the store. The reserved ``type`` key must use ``--type``
+instead. Invalid JSON, a non-object, or a reserved key fails before writing.

--- a/docs/memory.rst
+++ b/docs/memory.rst
@@ -173,3 +173,15 @@ gptme's session-start workspace prompt and Claude Code's native
 ``MEMORY.md`` auto-load only the Claude Code root. Pass ``--scope cc``
 when the memory must appear on that auto-load path without running
 recall.
+
+Writer provenance
+-----------------
+
+Harness wrappers can preserve their session identity through the shared writer::
+
+    gptme-util memory save decision "Reviewed decision" --type reference \
+      --metadata '{"originSessionId":"session-123","node_type":"memory"}' < body.md
+
+``--metadata`` accepts a JSON object and merges its keys into existing entry
+metadata. Omitted keys survive updates; lifecycle fields and root index policy
+remain governed by the store. Invalid JSON or a non-object fails before writing.

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -172,6 +172,8 @@ def memory_save(
         body = sys.stdin.read()
     else:
         body = ""
+    from ..memory.schema import MemoryParseError  # fmt: skip
+
     store = _store()
     try:
         path = store.save(
@@ -183,7 +185,7 @@ def memory_save(
             title=title,
             metadata=parsed_metadata,
         )
-    except (KeyError, OSError, ValueError) as e:
+    except (KeyError, OSError, ValueError, MemoryParseError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
     if as_json:
@@ -297,9 +299,11 @@ def memory_recall(
 @click.option("--scope", help="Root containing both entries (default: write root).")
 def memory_supersede(old_name: str, new_name: str, scope: str | None):
     """Mark OLD_NAME superseded by NEW_NAME and link both entries."""
+    from ..memory.schema import MemoryParseError  # fmt: skip
+
     try:
         old, new = _store().supersede(old_name, new_name, scope=scope)
-    except (KeyError, OSError, ValueError) as e:
+    except (KeyError, OSError, ValueError, MemoryParseError) as e:
         raise click.ClickException(str(e)) from e
     click.echo(f"Superseded {_clean(old.name)} -> {_clean(new.name)}")
 
@@ -340,6 +344,8 @@ def memory_index(scope: str | None, write: bool, check: bool, budget: int | None
     Prints to stdout by default so a hand-curated MEMORY.md is never
     overwritten by accident; pass --write to replace it, --check to verify.
     """
+    from ..memory.schema import MemoryParseError  # fmt: skip
+
     store = _store()
     try:
         if check:
@@ -357,6 +363,6 @@ def memory_index(scope: str | None, write: bool, check: bool, budget: int | None
             ),
             nl=False,
         )
-    except (KeyError, OSError, ValueError) as e:
+    except (KeyError, OSError, ValueError, MemoryParseError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -161,6 +161,10 @@ def memory_save(
             ) from exc
         if not isinstance(parsed_metadata, dict):
             raise click.BadParameter("must be a JSON object", param_hint="--metadata")
+        if "type" in parsed_metadata:
+            raise click.BadParameter(
+                "type is reserved; use --type", param_hint="--metadata"
+            )
     if body_file:
         with open(body_file, encoding="utf-8") as f:
             body = f.read()

--- a/gptme/cli/cmd_memory.py
+++ b/gptme/cli/cmd_memory.py
@@ -125,6 +125,9 @@ def memory_show(name: str, as_json: bool):
 )
 @click.option("--title", help="Index link text (defaults to the name).")
 @click.option(
+    "--metadata", help="JSON object merged into entry metadata (e.g. provenance)."
+)
+@click.option(
     "--body-file",
     type=click.Path(exists=True, dir_okay=False),
     help="Read the body from this file instead of stdin.",
@@ -136,6 +139,7 @@ def memory_save(
     type_: str | None,
     scope: str | None,
     title: str | None,
+    metadata: str | None,
     body_file: str | None,
     as_json: bool,
 ):
@@ -147,6 +151,16 @@ def memory_save(
         gptme-util memory save prefer-short-answers \\
           "User prefers short, direct answers." --type feedback < body.md
     """
+    parsed_metadata = None
+    if metadata is not None:
+        try:
+            parsed_metadata = json.loads(metadata)
+        except ValueError as exc:
+            raise click.BadParameter(
+                "must be a JSON object", param_hint="--metadata"
+            ) from exc
+        if not isinstance(parsed_metadata, dict):
+            raise click.BadParameter("must be a JSON object", param_hint="--metadata")
     if body_file:
         with open(body_file, encoding="utf-8") as f:
             body = f.read()
@@ -156,7 +170,15 @@ def memory_save(
         body = ""
     store = _store()
     try:
-        path = store.save(name, description, body, type=type_, scope=scope, title=title)
+        path = store.save(
+            name,
+            description,
+            body,
+            type=type_,
+            scope=scope,
+            title=title,
+            metadata=parsed_metadata,
+        )
     except (KeyError, OSError, ValueError) as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)

--- a/gptme/memory/policy.py
+++ b/gptme/memory/policy.py
@@ -25,8 +25,11 @@ class IndexPolicy:
     @classmethod
     def read(cls, root: Path) -> IndexPolicy | None:
         """Missing policy keeps legacy behavior; malformed policy never does."""
+        path = root / POLICY_FILENAME
+        if path.is_symlink():
+            raise ValueError(f"memory index policy {path} must not be a symlink")
         try:
-            text = (root / POLICY_FILENAME).read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return None
         try:

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -435,6 +435,7 @@ def prompt_workspace(
                         break
                     try:
                         root_store = MemoryStore([root])
+                        charged_bytes: int | None = None
                         policy_path = root.path / POLICY_FILENAME
                         if policy_path.is_symlink():
                             raise ValueError(
@@ -466,6 +467,7 @@ def prompt_workspace(
                             with index_path.open("rb") as index_file:
                                 raw = index_file.read(available)
                             root_content = raw.decode("utf-8", errors="ignore").strip()
+                            charged_bytes = len(raw)
                     except Exception as e:
                         logger.warning(
                             "Failed to load memory root %s: %s", root.path, e
@@ -473,7 +475,11 @@ def prompt_workspace(
                         continue
                     if root_content:
                         parts.append(root_content)
-                        remaining -= separator_bytes + len(root_content.encode("utf-8"))
+                        remaining -= separator_bytes + (
+                            charged_bytes
+                            if charged_bytes is not None
+                            else len(root_content.encode("utf-8"))
+                        )
                 memory_content = "\n\n".join(parts).strip()
                 if memory_content:
                     root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..config import config_path, get_config, get_project_config
-from ..dirs import get_cc_memory_file
+from ..memory import MemoryStore, resolve_roots
 from ..message import Message
 from ..util.context import md_codeblock
 from ..util.context_dedup import _content_hash
@@ -16,7 +16,7 @@ from . import AGENT_FILES, DEFAULT_CONTEXT_FILES, _loaded_agent_files_var
 from .context_cmd import get_project_context_cmd_output
 
 _HASH_PREFIX = "ch:"
-_CC_MEMORY_MAX_BYTES = 64 * 1024  # 64 KB cap to avoid consuming excessive prompt budget
+_MEMORY_BUDGET_BYTES = 64 * 1024  # 64 KB cap to avoid consuming excessive prompt budget
 
 if TYPE_CHECKING:
     from ..util.uri import FilePath
@@ -416,32 +416,36 @@ def prompt_workspace(
             files=valid_context_files,
         )
 
-    # Load Claude Code memory if present — makes CC-written memories accessible in gptme
+    # Load persistent memories from all layered roots (project, CC, agent, user).
+    # This makes memories written by any harness (gptme, Claude Code, Codex) visible
+    # in gptme sessions — the cross-harness read path for #3625.
     if include_user_context:
-        cc_memory_file = get_cc_memory_file(workspace_resolved)
-        if cc_memory_file.exists():
-            try:
-                # Read at most MAX+1 bytes to detect oversized files without loading them fully
-                with open(cc_memory_file, "rb") as _f:
-                    raw = _f.read(_CC_MEMORY_MAX_BYTES + 1)
-                truncated = len(raw) > _CC_MEMORY_MAX_BYTES
-                if truncated:
-                    raw = raw[:_CC_MEMORY_MAX_BYTES]
-                    logger.warning(
-                        f"CC memory file {cc_memory_file} exceeds "
-                        f"{_CC_MEMORY_MAX_BYTES // 1024}KB; truncating"
-                    )
-                memory_content = raw.decode("utf-8", errors="ignore").strip()
-                if memory_content:
-                    yield Message(
-                        "system",
-                        f"## Persistent Memory\n\n"
-                        f"The following memory was saved across sessions "
-                        f"(from `{cc_memory_file}`):\n\n{memory_content}",
-                    )
-                    logger.debug(f"Loaded CC memory from {cc_memory_file}")
-            except OSError as e:
-                logger.debug(f"Failed to read CC memory file {cc_memory_file}: {e}")
+        try:
+            roots = resolve_roots(workspace_resolved)
+            existing_roots = [r for r in roots if r.exists]
+            if existing_roots:
+                store = MemoryStore(existing_roots)
+                entries = list(store.entries())
+                if entries:
+                    memory_content = MemoryStore.render_index(
+                        entries, budget=_MEMORY_BUDGET_BYTES
+                    ).strip()
+                    if memory_content:
+                        root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)
+                        yield Message(
+                            "system",
+                            f"## Persistent Memory\n\n"
+                            f"The following memories are shared across sessions "
+                            f"(from {root_paths}):\n\n{memory_content}",
+                        )
+                        logger.debug(
+                            "Loaded %d memory entries from %d root(s): %s",
+                            len(entries),
+                            len(existing_roots),
+                            [r.scope for r in existing_roots],
+                        )
+        except Exception as e:
+            logger.debug(f"Failed to load layered memory: {e}")
 
     # Computed context last (changes most often, least cacheable)
     if (

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from ..config import config_path, get_config, get_project_config
 from ..memory import MemoryStore, resolve_roots
+from ..memory.policy import POLICY_FILENAME
 from ..message import Message
 from ..util.context import md_codeblock
 from ..util.context_dedup import _content_hash
@@ -424,40 +425,45 @@ def prompt_workspace(
             roots = resolve_roots(workspace_resolved)
             existing_roots = [r for r in roots if r.exists]
             if existing_roots:
-                # Evaluate each root independently: use per-entry files when
-                # present, fall back to MEMORY.md for roots that have none.
-                # This prevents a mixed workspace (one root with entry files,
-                # another with only MEMORY.md) from silently dropping the
-                # legacy root's memories.
-                all_entries: list = []
                 parts: list[str] = []
                 remaining = _MEMORY_BUDGET_BYTES
                 for root in existing_roots:
-                    if remaining <= 0:
+                    # Separators count against the shared prompt budget too.
+                    separator_bytes = 2 if parts else 0
+                    available = remaining - separator_bytes
+                    if available <= 0:
                         break
-                    root_store = MemoryStore([root])
-                    root_entries = list(root_store.entries())
-                    if root_entries:
-                        all_entries.extend(root_entries)
-                        root_content = MemoryStore.render_index(
-                            root_entries, budget=remaining
-                        ).strip()
-                        if root_content:
-                            parts.append(root_content)
-                            remaining -= len(root_content.encode("utf-8"))
-                    else:
-                        # Fallback for roots that contain only MEMORY.md (no
-                        # individual entry files) — e.g. a CC root written by
-                        # an older harness or hand-authored index.  Preserves
-                        # the behaviour from #3626 on a per-root basis so that
-                        # a mixed workspace doesn't silently drop these roots.
-                        index_path = root.path / "MEMORY.md"
-                        if index_path.is_file():
-                            raw = index_path.read_bytes()[:remaining]
-                            text = raw.decode("utf-8", errors="ignore").strip()
-                            if text:
-                                parts.append(text)
-                                remaining -= len(raw)
+                    try:
+                        root_store = MemoryStore([root])
+                        policy_path = root.path / POLICY_FILENAME
+                        if policy_path.is_symlink():
+                            raise ValueError(
+                                "memory index policy must not be a symlink"
+                            )
+                        if policy_path.exists() or any(root_store.entries()):
+                            # A policy is authoritative even with no entries.
+                            # Missing selections or overflow must never revive
+                            # an obsolete on-disk MEMORY.md through fallback.
+                            root_content = root_store.render_root_index(
+                                budget=available
+                            ).strip()
+                        else:
+                            # Keep legacy index-only roots compatible, bounding
+                            # the read itself rather than slicing a full read.
+                            index_path = root.path / "MEMORY.md"
+                            if not index_path.is_file():
+                                continue
+                            with index_path.open("rb") as index_file:
+                                raw = index_file.read(available)
+                            root_content = raw.decode("utf-8", errors="ignore").strip()
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to load memory root %s: %s", root.path, e
+                        )
+                        continue
+                    if root_content:
+                        parts.append(root_content)
+                        remaining -= separator_bytes + len(root_content.encode("utf-8"))
                 memory_content = "\n\n".join(parts).strip()
                 if memory_content:
                     root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)
@@ -468,8 +474,8 @@ def prompt_workspace(
                         f"(from {root_paths}):\n\n{memory_content}",
                     )
                     logger.debug(
-                        "Loaded %d memory entries from %d root(s): %s",
-                        len(all_entries),
+                        "Loaded %d memory indexes from %d root(s): %s",
+                        len(parts),
                         len(existing_roots),
                         [r.scope for r in existing_roots],
                     )

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -430,20 +430,37 @@ def prompt_workspace(
                     memory_content = MemoryStore.render_index(
                         entries, budget=_MEMORY_BUDGET_BYTES
                     ).strip()
-                    if memory_content:
-                        root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)
-                        yield Message(
-                            "system",
-                            f"## Persistent Memory\n\n"
-                            f"The following memories are shared across sessions "
-                            f"(from {root_paths}):\n\n{memory_content}",
-                        )
-                        logger.debug(
-                            "Loaded %d memory entries from %d root(s): %s",
-                            len(entries),
-                            len(existing_roots),
-                            [r.scope for r in existing_roots],
-                        )
+                else:
+                    # Fallback for roots that contain only MEMORY.md (no individual
+                    # entry files) — e.g. a CC root written by an older harness or
+                    # hand-authored before the per-entry format was introduced.
+                    # This preserves the behaviour from #3626 so existing CC memories
+                    # are not silently dropped when upgrading.
+                    parts: list[str] = []
+                    remaining = _MEMORY_BUDGET_BYTES
+                    for root in existing_roots:
+                        index_path = root.path / "MEMORY.md"
+                        if index_path.is_file() and remaining > 0:
+                            raw = index_path.read_bytes()[:remaining]
+                            text = raw.decode("utf-8", errors="ignore").strip()
+                            if text:
+                                parts.append(text)
+                                remaining -= len(raw)
+                    memory_content = "\n\n".join(parts).strip()
+                if memory_content:
+                    root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)
+                    yield Message(
+                        "system",
+                        f"## Persistent Memory\n\n"
+                        f"The following memories are shared across sessions "
+                        f"(from {root_paths}):\n\n{memory_content}",
+                    )
+                    logger.debug(
+                        "Loaded %d memory entries from %d root(s): %s",
+                        len(entries),
+                        len(existing_roots),
+                        [r.scope for r in existing_roots],
+                    )
         except Exception as e:
             logger.debug(f"Failed to load layered memory: {e}")
 

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -440,7 +440,17 @@ def prompt_workspace(
                             raise ValueError(
                                 "memory index policy must not be a symlink"
                             )
-                        if policy_path.exists() or any(root_store.entries()):
+                        # Check for individual entry files (any .md that isn't
+                        # the index or policy). When entries() silently returns []
+                        # due to parse errors, this prevents the legacy MEMORY.md
+                        # fallback from injecting stale content: render_root_index()
+                        # will return empty for a broken root, which is correct.
+                        _has_entry_files = any(
+                            f.is_file() and not f.is_symlink()
+                            for f in root.path.glob("*.md")
+                            if f.name not in ("MEMORY.md", POLICY_FILENAME)
+                        )
+                        if policy_path.exists() or _has_entry_files:
                             # A policy is authoritative even with no entries.
                             # Missing selections or overflow must never revive
                             # an obsolete on-disk MEMORY.md through fallback.
@@ -451,7 +461,7 @@ def prompt_workspace(
                             # Keep legacy index-only roots compatible, bounding
                             # the read itself rather than slicing a full read.
                             index_path = root.path / "MEMORY.md"
-                            if not index_path.is_file():
+                            if not index_path.is_file() or index_path.is_symlink():
                                 continue
                             with index_path.open("rb") as index_file:
                                 raw = index_file.read(available)

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -424,29 +424,41 @@ def prompt_workspace(
             roots = resolve_roots(workspace_resolved)
             existing_roots = [r for r in roots if r.exists]
             if existing_roots:
-                store = MemoryStore(existing_roots)
-                entries = list(store.entries())
-                if entries:
-                    memory_content = MemoryStore.render_index(
-                        entries, budget=_MEMORY_BUDGET_BYTES
-                    ).strip()
-                else:
-                    # Fallback for roots that contain only MEMORY.md (no individual
-                    # entry files) — e.g. a CC root written by an older harness or
-                    # hand-authored before the per-entry format was introduced.
-                    # This preserves the behaviour from #3626 so existing CC memories
-                    # are not silently dropped when upgrading.
-                    parts: list[str] = []
-                    remaining = _MEMORY_BUDGET_BYTES
-                    for root in existing_roots:
+                # Evaluate each root independently: use per-entry files when
+                # present, fall back to MEMORY.md for roots that have none.
+                # This prevents a mixed workspace (one root with entry files,
+                # another with only MEMORY.md) from silently dropping the
+                # legacy root's memories.
+                all_entries: list = []
+                parts: list[str] = []
+                remaining = _MEMORY_BUDGET_BYTES
+                for root in existing_roots:
+                    if remaining <= 0:
+                        break
+                    root_store = MemoryStore([root])
+                    root_entries = list(root_store.entries())
+                    if root_entries:
+                        all_entries.extend(root_entries)
+                        root_content = MemoryStore.render_index(
+                            root_entries, budget=remaining
+                        ).strip()
+                        if root_content:
+                            parts.append(root_content)
+                            remaining -= len(root_content.encode("utf-8"))
+                    else:
+                        # Fallback for roots that contain only MEMORY.md (no
+                        # individual entry files) — e.g. a CC root written by
+                        # an older harness or hand-authored index.  Preserves
+                        # the behaviour from #3626 on a per-root basis so that
+                        # a mixed workspace doesn't silently drop these roots.
                         index_path = root.path / "MEMORY.md"
-                        if index_path.is_file() and remaining > 0:
+                        if index_path.is_file():
                             raw = index_path.read_bytes()[:remaining]
                             text = raw.decode("utf-8", errors="ignore").strip()
                             if text:
                                 parts.append(text)
                                 remaining -= len(raw)
-                    memory_content = "\n\n".join(parts).strip()
+                memory_content = "\n\n".join(parts).strip()
                 if memory_content:
                     root_paths = ", ".join(f"`{r.path}`" for r in existing_roots)
                     yield Message(
@@ -457,7 +469,7 @@ def prompt_workspace(
                     )
                     logger.debug(
                         "Loaded %d memory entries from %d root(s): %s",
-                        len(entries),
+                        len(all_entries),
                         len(existing_roots),
                         [r.scope for r in existing_roots],
                     )

--- a/gptme/tools/memory.py
+++ b/gptme/tools/memory.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from ..dirs import get_cc_memory_dir, get_workspace
 from ..memory import MemoryEntry, MemoryRoot, MemoryStore, slugify, update_index_line
+from ..memory.schema import MemoryParseError
 from ..message import Message
 from ..util.ask_execute import execute_with_confirmation
 from .base import ToolSpec, ToolUse
@@ -132,7 +133,7 @@ def execute_memory(
         try:
             file_path = save_memory(name, save_content)
             yield Message("system", f"Memory '{name}' saved to `{file_path}`.")
-        except (OSError, ValueError) as e:
+        except (OSError, ValueError, MemoryParseError) as e:
             yield Message("system", f"Error saving memory '{name}': {e}")
 
     target_path = _get_path(code, args, kwargs)

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -332,6 +332,57 @@ class TestCcMemoryInWorkspacePrompt:
         assert "cc-fact" in combined
         assert "gptme-fact" in combined
 
+    def test_mixed_roots_entry_files_and_legacy_memory_md(self, tmp_path):
+        """A root with per-entry files and a root with only MEMORY.md are both shown.
+
+        Regression test: before the per-root fallback, when any root had entry
+        files the combined `entries` list was non-empty and the else-branch
+        (MEMORY.md fallback) was skipped entirely, silently dropping the legacy
+        root's content. The fix evaluates each root independently.
+        """
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+
+        # Root A: modern per-entry files (e.g. gptme project root)
+        proj_dir = workspace / "memory"
+        proj_dir.mkdir()
+        _make_entry(proj_dir, "gptme-fact", "Written by gptme", type="project")
+
+        # Root B: legacy CC root with only MEMORY.md, no individual entry files
+        cc_dir = tmp_path / "cc_root"
+        cc_dir.mkdir()
+        (cc_dir / "MEMORY.md").write_text(
+            "# Persistent Memory\n\n- [legacy-note](legacy-note.md) — CC legacy memory\n"
+        )
+
+        roots = [MemoryRoot("project", proj_dir), MemoryRoot("cc", cc_dir)]
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=roots),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "Persistent Memory" in combined
+        # Per-entry root content is present
+        assert "gptme-fact" in combined
+        # Legacy MEMORY.md root content is also present — not dropped
+        assert "legacy-note" in combined or "CC legacy memory" in combined
+
     def test_no_memory_when_no_roots_exist(self, tmp_path):
         """No memory message is emitted when no memory roots have files."""
         from gptme.prompts.workspace import prompt_workspace

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -391,16 +391,58 @@ class TestCcMemoryInWorkspacePrompt:
         combined = "\n".join(m.content for m in messages)
         assert "Persistent Memory" not in combined
 
-    def test_skips_dir_with_no_parseable_entries(self, tmp_path):
-        """A memory dir containing only the index file produces no memory message."""
+    def test_falls_back_to_memory_md_when_no_entry_files(self, tmp_path):
+        """A CC root with only MEMORY.md (no individual entry files) still shows
+        its content via the legacy fallback path.
+
+        Regression test: the layered-store path (MemoryStore.entries()) skips
+        MEMORY.md by design; without the fallback, existing CC memories written
+        by older harnesses or hand-authored indexes are silently dropped.
+        """
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
         workspace.mkdir()
         memory_dir = tmp_path / "memory"
         memory_dir.mkdir()
-        # Only MEMORY.md — no actual entry files
-        (memory_dir / "MEMORY.md").write_text("# Persistent Memory\n\n")
+        # Only MEMORY.md — no individual entry files (legacy CC format)
+        (memory_dir / "MEMORY.md").write_text(
+            "# Persistent Memory\n\n- [my-note](my-note.md) — a legacy memory\n"
+        )
+
+        root = MemoryRoot("cc", memory_dir)
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "Persistent Memory" in combined
+        assert "legacy memory" in combined
+
+    def test_skips_dir_with_empty_memory_md(self, tmp_path):
+        """A memory dir whose MEMORY.md contains only whitespace produces no output."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        # Blank MEMORY.md and no individual entry files
+        (memory_dir / "MEMORY.md").write_text("\n\n")
 
         root = MemoryRoot("cc", memory_dir)
 

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -1,10 +1,12 @@
 """Tests for Claude Code memory integration in gptme workspace context."""
 
 import re
+import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
 from gptme.dirs import _claude_project_dirname, get_cc_memory_dir, get_cc_memory_file
+from gptme.memory import MemoryRoot
 
 
 class TestClaudeProjectDirname:
@@ -171,29 +173,63 @@ class TestGetCcMemoryFile:
         assert cc_file.parent == get_cc_memory_dir(workspace)
 
 
+def _make_entry(
+    memory_dir: Path, name: str, description: str, body: str = "", type: str = "project"
+) -> Path:
+    """Write a minimal CC-compatible memory entry file and return its path."""
+    slug = name.replace(" ", "-").lower()
+    path = memory_dir / f"{slug}.md"
+    content = textwrap.dedent(f"""\
+        ---
+        name: {slug}
+        description: "{description}"
+        metadata:
+          type: {type}
+        ---
+
+        {body or description}
+    """)
+    path.write_text(content)
+    return path
+
+
+def _common_patches(mock_roots=None):
+    """Return context manager stack for workspace prompt unit tests.
+
+    Patches out external I/O (git, config) and optionally mocks resolve_roots
+    to return a controlled set of MemoryRoot objects.
+    """
+    patches = [
+        patch("gptme.prompts.workspace.get_config"),
+        patch("gptme.prompts.workspace.get_project_config", return_value=None),
+        patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+        patch("gptme.prompts.workspace._get_git_status", return_value=None),
+        patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+    ]
+    if mock_roots is not None:
+        patches.insert(
+            0, patch("gptme.prompts.workspace.resolve_roots", return_value=mock_roots)
+        )
+    return patches
+
+
 class TestCcMemoryInWorkspacePrompt:
-    """Tests for CC memory loading in prompt_workspace."""
+    """Tests for layered memory loading in prompt_workspace (gptme/gptme#3625)."""
 
     def test_loads_cc_memory_when_present(self, tmp_path):
-        """CC memory is included in workspace context when MEMORY.md exists."""
+        """CC-scoped memory entries are included in workspace context."""
         from gptme.prompts.workspace import prompt_workspace
 
-        # Create a fake CC memory file
         workspace = tmp_path / "myproject"
         workspace.mkdir()
-        workspace_hash = str(workspace.resolve()).replace("/", "-")
-        cc_memory_dir = (
-            tmp_path / "home" / ".claude" / "projects" / workspace_hash / "memory"
-        )
-        cc_memory_dir.mkdir(parents=True)
-        cc_memory_file = cc_memory_dir / "MEMORY.md"
-        cc_memory_file.write_text("# Memory\n\n- Key insight about this project\n")
+        memory_dir = tmp_path / "cc_memory"
+        memory_dir.mkdir()
+        _make_entry(memory_dir, "key-insight", "Key insight about this project")
+
+        cc_root = MemoryRoot("cc", memory_dir)
 
         with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file",
-                return_value=cc_memory_file,
-            ),
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[cc_root]),
             patch("gptme.prompts.workspace.get_config") as mock_config,
             patch("gptme.prompts.workspace.get_project_config", return_value=None),
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
@@ -209,23 +245,28 @@ class TestCcMemoryInWorkspacePrompt:
                 )
             )
 
-        contents = [m.content for m in messages]
-        combined = "\n".join(contents)
+        combined = "\n".join(m.content for m in messages)
         assert "Persistent Memory" in combined
-        assert "Key insight about this project" in combined
+        assert "key-insight" in combined
 
-    def test_no_memory_when_file_missing(self, tmp_path):
-        """No memory message is emitted when CC MEMORY.md doesn't exist."""
+    def test_loads_from_project_memory_dir(self, tmp_path):
+        """Project-scoped memory/ entries are auto-loaded into workspace context.
+
+        This is the core feature of #3625: memories written by any harness to
+        the project memory/ dir become visible in the next gptme session.
+        """
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
         workspace.mkdir()
-        nonexistent = tmp_path / "nonexistent" / "MEMORY.md"
+        memory_dir = workspace / "memory"
+        memory_dir.mkdir()
+        _make_entry(memory_dir, "project-fact", "A key project fact", type="project")
+
+        project_root = MemoryRoot("project", memory_dir)
 
         with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file", return_value=nonexistent
-            ),
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[project_root]),
             patch("gptme.prompts.workspace.get_config") as mock_config,
             patch("gptme.prompts.workspace.get_project_config", return_value=None),
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
@@ -241,24 +282,97 @@ class TestCcMemoryInWorkspacePrompt:
                 )
             )
 
-        contents = [m.content for m in messages]
-        combined = "\n".join(contents)
+        combined = "\n".join(m.content for m in messages)
+        assert "Persistent Memory" in combined
+        assert "project-fact" in combined
+
+    def test_cross_harness_both_roots_visible(self, tmp_path):
+        """Memories from project and CC roots both appear in a single session.
+
+        This verifies the cross-harness round-trip: CC writes to cc root, gptme
+        writes to project root, both are visible in a subsequent gptme session.
+        """
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+
+        # Simulate CC writing to its root
+        cc_dir = tmp_path / "cc_root"
+        cc_dir.mkdir()
+        _make_entry(cc_dir, "cc-fact", "Written by Claude Code", type="feedback")
+
+        # Simulate gptme writing to project root
+        proj_dir = workspace / "memory"
+        proj_dir.mkdir()
+        _make_entry(proj_dir, "gptme-fact", "Written by gptme", type="project")
+
+        roots = [MemoryRoot("project", proj_dir), MemoryRoot("cc", cc_dir)]
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=roots),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
+        assert "Persistent Memory" in combined
+        # Both harnesses' entries are present
+        assert "cc-fact" in combined
+        assert "gptme-fact" in combined
+
+    def test_no_memory_when_no_roots_exist(self, tmp_path):
+        """No memory message is emitted when no memory roots have files."""
+        from gptme.prompts.workspace import prompt_workspace
+
+        workspace = tmp_path / "myproject"
+        workspace.mkdir()
+        # No roots — resolve_roots returns empty list
+
+        with (
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[]),
+            patch("gptme.prompts.workspace.get_config") as mock_config,
+            patch("gptme.prompts.workspace.get_project_config", return_value=None),
+            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+            patch("gptme.prompts.workspace._get_git_status", return_value=None),
+            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        ):
+            mock_config.return_value.user = None
+            messages = list(
+                prompt_workspace(
+                    workspace=workspace,
+                    include_user_context=True,
+                    include_context_cmd=False,
+                )
+            )
+
+        combined = "\n".join(m.content for m in messages)
         assert "Persistent Memory" not in combined
 
     def test_skips_memory_when_include_user_context_false(self, tmp_path):
-        """CC memory is not loaded when include_user_context=False (e.g. eval mode)."""
+        """Layered memory is not loaded when include_user_context=False (e.g. eval mode)."""
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
         workspace.mkdir()
-        cc_memory_file = tmp_path / "MEMORY.md"
-        cc_memory_file.write_text("# Memory\n\n- Some insight\n")
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        _make_entry(memory_dir, "some-fact", "Some insight")
+        root = MemoryRoot("cc", memory_dir)
 
         with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file",
-                return_value=cc_memory_file,
-            ),
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
             patch("gptme.prompts.workspace.get_config") as mock_config,
             patch("gptme.prompts.workspace.get_project_config", return_value=None),
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
@@ -274,24 +388,24 @@ class TestCcMemoryInWorkspacePrompt:
                 )
             )
 
-        contents = [m.content for m in messages]
-        combined = "\n".join(contents)
+        combined = "\n".join(m.content for m in messages)
         assert "Persistent Memory" not in combined
 
-    def test_skips_empty_memory_file(self, tmp_path):
-        """Empty MEMORY.md produces no memory message."""
+    def test_skips_dir_with_no_parseable_entries(self, tmp_path):
+        """A memory dir containing only the index file produces no memory message."""
         from gptme.prompts.workspace import prompt_workspace
 
         workspace = tmp_path / "myproject"
         workspace.mkdir()
-        cc_memory_file = tmp_path / "MEMORY.md"
-        cc_memory_file.write_text("   \n   ")  # whitespace only
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        # Only MEMORY.md — no actual entry files
+        (memory_dir / "MEMORY.md").write_text("# Persistent Memory\n\n")
+
+        root = MemoryRoot("cc", memory_dir)
 
         with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file",
-                return_value=cc_memory_file,
-            ),
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
             patch("gptme.prompts.workspace.get_config") as mock_config,
             patch("gptme.prompts.workspace.get_project_config", return_value=None),
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
@@ -307,30 +421,31 @@ class TestCcMemoryInWorkspacePrompt:
                 )
             )
 
-        contents = [m.content for m in messages]
-        combined = "\n".join(contents)
+        combined = "\n".join(m.content for m in messages)
         assert "Persistent Memory" not in combined
 
-    def test_non_utf8_memory_drops_invalid_bytes(self, tmp_path):
-        """Non-UTF-8 bytes in MEMORY.md are silently dropped (errors='ignore').
-
-        Using errors='replace' would expand each invalid byte to 3-byte U+FFFD,
-        allowing 64KB of input to produce ~192KB of decoded text — exceeding the
-        intended size cap. errors='ignore' keeps the decoded size bounded.
-        """
-        from gptme.prompts.workspace import prompt_workspace
+    def test_budget_limits_injected_content(self, tmp_path):
+        """render_index budget caps the memory block to _MEMORY_BUDGET_BYTES."""
+        from gptme.prompts.workspace import _MEMORY_BUDGET_BYTES, prompt_workspace
 
         workspace = tmp_path / "myproject"
         workspace.mkdir()
-        cc_memory_file = tmp_path / "MEMORY.md"
-        # Latin-1 encoded text: "café" — 0xe9 is invalid UTF-8 lead byte
-        cc_memory_file.write_bytes(b"# Memory\n\ncaf\xe9\n")
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+
+        # Write many large entries
+        for i in range(20):
+            _make_entry(
+                memory_dir,
+                f"big-entry-{i:02d}",
+                f"Entry {i}",
+                body="x" * 5000,
+            )
+
+        root = MemoryRoot("cc", memory_dir)
 
         with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file",
-                return_value=cc_memory_file,
-            ),
+            patch("gptme.prompts.workspace.resolve_roots", return_value=[root]),
             patch("gptme.prompts.workspace.get_config") as mock_config,
             patch("gptme.prompts.workspace.get_project_config", return_value=None),
             patch("gptme.prompts.workspace.get_tree_output", return_value=None),
@@ -348,70 +463,8 @@ class TestCcMemoryInWorkspacePrompt:
 
         memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
         assert len(memory_msgs) == 1
-        content = memory_msgs[0].content
-        # The invalid byte is dropped; valid prefix survives
-        assert "caf" in content
-        # No U+FFFD replacement chars (that would indicate errors='replace')
-        assert "�" not in content
-
-    def test_oversized_memory_is_truncated(self, tmp_path):
-        """Memory files exceeding the size cap are truncated before injection.
-
-        Critically, the file must NOT be fully read — only _CC_MEMORY_MAX_BYTES+1
-        bytes should be consumed so that multi-MB MEMORY.md files cannot stall
-        prompt construction.
-        """
-        from gptme.prompts.workspace import _CC_MEMORY_MAX_BYTES, prompt_workspace
-
-        workspace = tmp_path / "myproject"
-        workspace.mkdir()
-        cc_memory_file = tmp_path / "MEMORY.md"
-        big_content = "# Memory\n\n" + ("x" * (_CC_MEMORY_MAX_BYTES + 10_000))
-        cc_memory_file.write_text(big_content, encoding="utf-8")
-
-        max_bytes_read = []
-
-        real_open = open
-
-        def tracking_open(path, mode="r", **kw):
-            fh = real_open(path, mode, **kw)
-            if str(path) == str(cc_memory_file) and "b" in mode:
-                real_read = fh.read
-
-                def bounded_read(n=-1):
-                    data = real_read(n)
-                    max_bytes_read.append(len(data))
-                    return data
-
-                fh.read = bounded_read
-            return fh
-
-        with (
-            patch(
-                "gptme.prompts.workspace.get_cc_memory_file",
-                return_value=cc_memory_file,
-            ),
-            patch("gptme.prompts.workspace.get_config") as mock_config,
-            patch("gptme.prompts.workspace.get_project_config", return_value=None),
-            patch("gptme.prompts.workspace.get_tree_output", return_value=None),
-            patch("gptme.prompts.workspace._get_git_status", return_value=None),
-            patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
-            patch("builtins.open", side_effect=tracking_open),
-        ):
-            mock_config.return_value.user = None
-            messages = list(
-                prompt_workspace(
-                    workspace=workspace,
-                    include_user_context=True,
-                    include_context_cmd=False,
-                )
-            )
-
-        memory_msgs = [m for m in messages if "Persistent Memory" in m.content]
-        assert len(memory_msgs) == 1
-        injected = memory_msgs[0].content.encode("utf-8")
-        # Output is bounded
-        assert len(injected) <= _CC_MEMORY_MAX_BYTES * 2
-        # The file was read with a size bound, not in full
-        assert max_bytes_read, "open() was not called on the memory file in binary mode"
-        assert max(max_bytes_read) <= _CC_MEMORY_MAX_BYTES + 1
+        # The rendered index (not individual entries) is included — it should be bounded
+        injected_bytes = len(memory_msgs[0].content.encode("utf-8"))
+        assert (
+            injected_bytes <= _MEMORY_BUDGET_BYTES + 512
+        )  # small header overhead allowed

--- a/tests/test_cc_memory.py
+++ b/tests/test_cc_memory.py
@@ -526,13 +526,17 @@ class TestCcMemoryInWorkspacePrompt:
         memory_dir = tmp_path / "memory"
         memory_dir.mkdir()
 
-        # Write many large entries
+        # Write entries with long descriptions so their combined index exceeds
+        # _MEMORY_BUDGET_BYTES (~4000 chars × 20 entries ≈ 80 KB > 64 KB cap).
+        # Short bodies + short descriptions (the original) never triggered the
+        # budget limit because only descriptions appear in the rendered index line.
+        long_desc = "x" * 4000
         for i in range(20):
             _make_entry(
                 memory_dir,
                 f"big-entry-{i:02d}",
-                f"Entry {i}",
-                body="x" * 5000,
+                long_desc,
+                body="",
             )
 
         root = MemoryRoot("cc", memory_dir)
@@ -558,6 +562,12 @@ class TestCcMemoryInWorkspacePrompt:
         assert len(memory_msgs) == 1
         # The rendered index (not individual entries) is included — it should be bounded
         injected_bytes = len(memory_msgs[0].content.encode("utf-8"))
-        assert (
-            injected_bytes <= _MEMORY_BUDGET_BYTES + 512
-        )  # small header overhead allowed
+        # Verify the budget cap actually fired: combined raw descriptions are
+        # ~80 KB (20 × 4000 chars), so without truncation we'd far exceed 64 KB.
+        # A passing assertion from a trivially-small index would mean the budget
+        # logic is untested.
+        assert "omitted" in memory_msgs[0].content.lower(), (
+            "expected the index to be truncated and report omitted entries, "
+            "but the 'omitted' marker is absent — budget limit may not have fired"
+        )
+        assert injected_bytes <= _MEMORY_BUDGET_BYTES + 512  # small header overhead

--- a/tests/test_memory_cli_metadata.py
+++ b/tests/test_memory_cli_metadata.py
@@ -65,3 +65,29 @@ def test_invalid_metadata_does_not_write(
     assert result.exit_code != 0
     assert "--metadata" in result.output and "JSON object" in result.output
     assert not root.exists()
+
+
+def test_metadata_cannot_override_canonical_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GPTME_MEMORY_DIRS", str(tmp_path))
+    store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+    path = store.save("kept", "Original", type="feedback")
+    before = path.read_bytes()
+    result = CliRunner().invoke(
+        util_main,
+        [
+            "memory",
+            "save",
+            "kept",
+            "Changed",
+            "--type",
+            "feedback",
+            "--metadata",
+            '{"type":"project"}',
+        ],
+        input="Changed body",
+    )
+    assert result.exit_code != 0
+    assert "--type" in result.output
+    assert path.read_bytes() == before

--- a/tests/test_memory_cli_metadata.py
+++ b/tests/test_memory_cli_metadata.py
@@ -91,3 +91,30 @@ def test_metadata_cannot_override_canonical_type(
     assert result.exit_code != 0
     assert "--type" in result.output
     assert path.read_bytes() == before
+
+
+def test_save_over_malformed_existing_entry_shows_friendly_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI must not traceback when the existing entry has malformed YAML frontmatter.
+
+    store.save() calls parse_entry(..., strict=True) on the existing path and
+    raises MemoryFrontmatterError (a MemoryParseError subclass, not ValueError).
+    Without the fix, the CLI's except clause silently misses it and the process
+    exits with a raw traceback.
+    """
+    monkeypatch.setenv("GPTME_MEMORY_DIRS", str(tmp_path))
+    broken = tmp_path / "broken-entry.md"
+    broken.write_text(
+        "---\nname: broken-entry\ntype: [invalid yaml: unclosed\n---\n\nBody.\n"
+    )
+    result = CliRunner().invoke(
+        util_main,
+        ["memory", "save", "broken-entry", "New description"],
+        input="New body",
+    )
+    assert result.exit_code != 0
+    # Must be a friendly error message, not a raw Python traceback
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "MemoryFrontmatterError" not in (result.output or "")
+    assert "Traceback" not in (result.output or "")

--- a/tests/test_memory_cli_metadata.py
+++ b/tests/test_memory_cli_metadata.py
@@ -1,0 +1,67 @@
+"""Harness wrappers must retain provenance through the public save command."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import main as util_main
+from gptme.memory import MemoryRoot, MemoryStore
+
+
+def test_cli_metadata_preserves_other_fields_and_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GPTME_MEMORY_DIRS", str(tmp_path))
+    store = MemoryStore([MemoryRoot("explicit", tmp_path)])
+    store.save(
+        "kept", "Original", title="Curated label", metadata={"source": "operator"}
+    )
+    policy = tmp_path / ".memory-index.json"
+    policy.write_text(
+        json.dumps({"version": 1, "budget": 1000, "selected": ["kept.md"]})
+    )
+    before_policy = policy.read_bytes()
+    result = CliRunner().invoke(
+        util_main,
+        [
+            "memory",
+            "save",
+            "kept",
+            "Updated",
+            "--scope",
+            "explicit",
+            "--type",
+            "feedback",
+            "--metadata",
+            '{"originSessionId":"session-123","node_type":"memory"}',
+        ],
+        input="Body with provenance",
+    )
+    assert result.exit_code == 0, result.output
+    entry = store.get("kept")
+    assert entry is not None
+    assert entry.metadata["source"] == "operator"
+    assert entry.metadata["originSessionId"] == "session-123"
+    assert entry.title == "Curated label"
+    assert entry.type == "feedback"
+    assert entry.body.strip() == "Body with provenance"
+    assert policy.read_bytes() == before_policy
+    assert store.check_index()
+
+
+@pytest.mark.parametrize("metadata", ["[]", "null", '"text"', "123", "{broken"])
+def test_invalid_metadata_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, metadata: str
+) -> None:
+    root = tmp_path / "new-root"
+    monkeypatch.setenv("GPTME_MEMORY_DIRS", str(root))
+    result = CliRunner().invoke(
+        util_main,
+        ["memory", "save", "entry", "Description", "--metadata", metadata],
+        input="Body",
+    )
+    assert result.exit_code != 0
+    assert "--metadata" in result.output and "JSON object" in result.output
+    assert not root.exists()

--- a/tests/test_memory_index_policy.py
+++ b/tests/test_memory_index_policy.py
@@ -228,6 +228,33 @@ def test_malformed_policy_fails_closed(tmp_path: Path, raw: str) -> None:
         assert _snapshot(tmp_path) == before
 
 
+def test_symlinked_policy_fails_closed_without_mutating_target(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save("old", "Old")
+    store.save("new", "New")
+    target = tmp_path.parent / f"{tmp_path.name}-external-policy.json"
+    target.write_text(
+        json.dumps({"version": 1, "budget": 4096, "selected": ["old.md"]}),
+        encoding="utf-8",
+    )
+    policy = tmp_path / ".memory-index.json"
+    policy.symlink_to(target)
+    before = _snapshot(tmp_path)
+    target_before = target.read_bytes()
+
+    for operation in (
+        store.render_root_index,
+        store.write_index,
+        store.check_index,
+        lambda: store.save("old", "Changed"),
+        lambda: store.supersede("old", "new"),
+    ):
+        with pytest.raises(ValueError, match="policy.*symlink"):
+            operation()
+        assert _snapshot(tmp_path) == before
+        assert target.read_bytes() == target_before
+
+
 @pytest.mark.parametrize("target", ["missing.md", "historical.md"])
 def test_selected_target_must_exist_and_be_living(tmp_path: Path, target: str) -> None:
     store = _store(tmp_path)

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -1,0 +1,155 @@
+"""Policy-aware layered prompt loading, including legacy root compatibility."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gptme.memory import MemoryRoot, MemoryStore
+from gptme.memory.policy import POLICY_FILENAME
+from gptme.prompts.workspace import prompt_workspace
+
+
+def _entry(root: Path, name: str) -> None:
+    (root / f"{name}.md").write_text(
+        f"---\nname: {name}\ndescription: About {name}\ntype: feedback\n---\n"
+        f"Remember {name}.\n",
+        encoding="utf-8",
+    )
+
+
+def _policy(root: Path, selected: list[str], budget: int = 2048) -> None:
+    (root / POLICY_FILENAME).write_text(
+        json.dumps({"version": 1, "budget": budget, "selected": selected}),
+        encoding="utf-8",
+    )
+
+
+def _memory_content(
+    workspace: Path, roots: list[MemoryRoot], budget: int = 65536
+) -> str:
+    with (
+        patch("gptme.prompts.workspace.resolve_roots", return_value=roots),
+        patch("gptme.prompts.workspace.get_config") as config,
+        patch("gptme.prompts.workspace.get_project_config", return_value=None),
+        patch("gptme.prompts.workspace.get_tree_output", return_value=None),
+        patch("gptme.prompts.workspace._get_git_status", return_value=None),
+        patch("gptme.prompts.workspace.find_agent_files_in_tree", return_value=[]),
+        patch("gptme.prompts.workspace._MEMORY_BUDGET_BYTES", budget),
+    ):
+        config.return_value.user = None
+        messages = list(
+            prompt_workspace(
+                workspace=workspace,
+                include_user_context=True,
+                include_context_cmd=False,
+            )
+        )
+    memories = [
+        m.content for m in messages if m.content.startswith("## Persistent Memory")
+    ]
+    return memories[0].split("):\n\n", 1)[1] if memories else ""
+
+
+def test_prompt_uses_stored_selection_without_hiding_recall(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    root.mkdir()
+    _entry(root, "selected")
+    _entry(root, "recall-only")
+    _policy(root, ["selected.md"])
+    (root / "MEMORY.md").write_text("stale-index", encoding="utf-8")
+    roots = [MemoryRoot("project", root)]
+
+    content = _memory_content(tmp_path, roots)
+
+    assert "selected.md" in content
+    assert "recall-only" not in content
+    assert "stale-index" not in content
+    assert {entry.name for entry in MemoryStore(roots).entries()} == {
+        "selected",
+        "recall-only",
+    }
+
+
+@pytest.mark.parametrize(
+    "policy_case",
+    ["empty", "missing", "malformed", "overflow", "unreadable", "symlink", "dangling"],
+)
+def test_policy_never_falls_back_and_healthy_roots_survive(
+    tmp_path: Path, policy_case: str
+) -> None:
+    before, target, after = [tmp_path / name for name in ("before", "target", "after")]
+    for root in (before, target, after):
+        root.mkdir()
+    _entry(before, "healthy-before")
+    _entry(after, "healthy-after")
+    (target / "MEMORY.md").write_text("stale-index", encoding="utf-8")
+    if policy_case == "empty":
+        _policy(target, [])
+    elif policy_case == "missing":
+        _policy(target, ["missing.md"])
+    elif policy_case == "malformed":
+        (target / POLICY_FILENAME).write_text("{broken", encoding="utf-8")
+    elif policy_case == "overflow":
+        _entry(target, "selected")
+        _policy(target, ["selected.md"], budget=1)
+    elif policy_case == "unreadable":
+        (target / POLICY_FILENAME).mkdir()
+    else:
+        _entry(target, "selected")
+        policy_target = tmp_path / "outside-policy.json"
+        if policy_case == "symlink":
+            policy_target.write_text(
+                json.dumps({"version": 1, "budget": 2048, "selected": ["selected.md"]}),
+                encoding="utf-8",
+            )
+        (target / POLICY_FILENAME).symlink_to(policy_target)
+
+    content = _memory_content(
+        tmp_path,
+        [
+            MemoryRoot("project", before),
+            MemoryRoot("cc", target),
+            MemoryRoot("user", after),
+        ],
+    )
+
+    assert "healthy-before.md" in content
+    assert "healthy-after.md" in content
+    assert "stale-index" not in content
+    assert "selected.md" not in content
+
+
+def test_policy_over_shared_budget_skips_only_that_root(tmp_path: Path) -> None:
+    target, healthy = tmp_path / "target", tmp_path / "healthy"
+    target.mkdir()
+    healthy.mkdir()
+    _entry(target, "too-big")
+    _policy(target, ["too-big.md"])
+    (target / "MEMORY.md").write_text("stale-index", encoding="utf-8")
+    (healthy / "MEMORY.md").write_text("healthy", encoding="utf-8")
+
+    content = _memory_content(
+        tmp_path, [MemoryRoot("project", target), MemoryRoot("cc", healthy)], budget=10
+    )
+
+    assert content == "healthy"
+
+
+def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "MEMORY.md").write_text("12345", encoding="utf-8")
+    (second / "MEMORY.md").write_text("é" * 100000, encoding="utf-8")
+    # The fallback must not materialize the entire file before truncating it.
+    with patch.object(Path, "read_bytes", side_effect=AssertionError("unbounded read")):
+        content = _memory_content(
+            tmp_path,
+            [MemoryRoot("project", first), MemoryRoot("cc", second)],
+            budget=10,
+        )
+
+    assert content == "12345\n\né"
+    assert len(content.encode("utf-8")) <= 10

--- a/tests/test_workspace_memory_policy.py
+++ b/tests/test_workspace_memory_policy.py
@@ -153,3 +153,27 @@ def test_legacy_reads_and_separators_obey_byte_budget(tmp_path: Path) -> None:
 
     assert content == "12345\n\né"
     assert len(content.encode("utf-8")) <= 10
+
+
+def test_legacy_read_charges_raw_bytes_after_incomplete_utf8(
+    tmp_path: Path,
+) -> None:
+    first, second, third = [tmp_path / name for name in ("first", "second", "third")]
+    for root in (first, second, third):
+        root.mkdir()
+    (first / "MEMORY.md").write_text("12345", encoding="utf-8")
+    (second / "MEMORY.md").write_text("ééé", encoding="utf-8")
+    (third / "MEMORY.md").write_text("must-not-fit", encoding="utf-8")
+
+    content = _memory_content(
+        tmp_path,
+        [
+            MemoryRoot("project", first),
+            MemoryRoot("cc", second),
+            MemoryRoot("user", third),
+        ],
+        budget=12,
+    )
+
+    assert content == "12345\n\néé"
+    assert "must-not-fit" not in content


### PR DESCRIPTION
Harness wrappers can now save provenance through `gptme-util memory save --metadata JSON`. The CLI validates an object before writing and delegates the metadata merge to `MemoryStore.save`; existing unrelated keys, curated titles, lifecycle, and root policy are preserved.

Depends on gptme/gptme#3791 for update preservation and index policy. The incremental change is commit `437ee0ae5`; the branch includes that prerequisite so CI can test the complete contract against master. Bob’s managed writer needs this to retain `originSessionId` and `node_type` while retiring direct index writes. Part of gptme/gptme#3734.

Validation: 121 focused store/policy/CLI tests passed, including six CLI metadata cases. Ruff, mypy, and commit hooks passed. Focused pytest used `--noconftest` because the workspace’s unrelated global Chroma model downloader calls a removed API; these tests use only built-in fixtures and real temporary stores.
