### PR TITLE
fix(llm): honor Retry-After during transient retries

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -25,7 +25,7 @@ from .retry_policy import (
     DEFAULT_BASE_DELAY,
     SDK_MAX_RETRIES,
     get_max_retries,
-    retry_delay,
+    retry_delay_for_error,
 )
 from .utils import (
     apply_cache_control,
@@ -505,7 +505,7 @@ def _handle_anthropic_transient_error(
     if not should_retry or attempt == max_retries - 1:
         raise e
 
-    delay = retry_delay(attempt, base_delay)
+    delay = retry_delay_for_error(e, attempt, base_delay)
     status_code = getattr(e, "status_code", "unknown")
     logger.warning(
         f"Anthropic API transient error (status {status_code}), "

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -41,7 +41,7 @@ from .retry_policy import (
     DEFAULT_BASE_DELAY,
     SDK_MAX_RETRIES,
     get_max_retries,
-    retry_delay,
+    retry_delay_for_error,
 )
 from .utils import (
     apply_cache_control,
@@ -914,7 +914,7 @@ def _handle_openai_transient_error(
     if not should_retry or attempt == max_retries - 1:
         raise e
 
-    delay = retry_delay(attempt, base_delay)
+    delay = retry_delay_for_error(e, attempt, base_delay)
     status_code = getattr(e, "status_code", "unknown")
     logger.warning(
         f"OpenAI API transient error (status {status_code}), "

--- a/gptme/llm/retry_policy.py
+++ b/gptme/llm/retry_policy.py
@@ -19,6 +19,9 @@ autonomous session. Override with ``GPTME_LLM_MAX_RETRIES``.
 """
 
 import logging
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -61,3 +64,40 @@ def get_max_retries(default: int = DEFAULT_MAX_RETRIES) -> int:
 def retry_delay(attempt: int, base_delay: float = DEFAULT_BASE_DELAY) -> float:
     """Capped exponential backoff delay for a zero-indexed attempt."""
     return min(base_delay * (2**attempt), MAX_RETRY_DELAY)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _retry_after_seconds(error: Any) -> float | None:
+    """Parse a provider response's Retry-After header, if present and valid."""
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    value = headers.get("Retry-After")
+    if not value:
+        return None
+    try:
+        delay = float(value)
+    except (TypeError, ValueError):
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        delay = (retry_at - _utcnow()).total_seconds()
+    return delay if delay >= 0 else None
+
+
+def retry_delay_for_error(
+    error: Any, attempt: int, base_delay: float = DEFAULT_BASE_DELAY
+) -> float:
+    """Return exponential backoff extended by Retry-After, within the delay cap."""
+    exponential = retry_delay(attempt, base_delay)
+    retry_after = _retry_after_seconds(error)
+    if retry_after is None:
+        return exponential
+    return min(max(exponential, retry_after), MAX_RETRY_DELAY)

--- a/gptme/llm/retry_policy.py
+++ b/gptme/llm/retry_policy.py
@@ -19,7 +19,7 @@ autonomous session. Override with ``GPTME_LLM_MAX_RETRIES``.
 """
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
 
@@ -67,7 +67,7 @@ def retry_delay(attempt: int, base_delay: float = DEFAULT_BASE_DELAY) -> float:
 
 
 def _utcnow() -> datetime:
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 def _retry_after_seconds(error: Any) -> float | None:
@@ -87,7 +87,7 @@ def _retry_after_seconds(error: Any) -> float | None:
         except (TypeError, ValueError, OverflowError):
             return None
         if retry_at.tzinfo is None:
-            retry_at = retry_at.replace(tzinfo=UTC)
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
         delay = (retry_at - _utcnow()).total_seconds()
     return delay if delay >= 0 else None
 

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -323,6 +323,29 @@ def test_boundary_keeps_dynamic_context_out_of_static_system_prompt():
 # Updated tests for generator retry behavior
 
 
+def test_anthropic_rate_limit_honors_retry_after():
+    """Anthropic rate-limit retries use the provider's requested cooldown."""
+    from unittest.mock import patch
+
+    from anthropic import RateLimitError
+    from httpx import Request, Response
+
+    from gptme.llm.llm_anthropic import _handle_anthropic_transient_error
+
+    response = Response(
+        429,
+        headers={"Retry-After": "12"},
+        request=Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+    error = RateLimitError("Rate limit exceeded", response=response, body=None)
+
+    with patch("gptme.llm.llm_anthropic.backoff_wait", return_value=False) as mock_wait:
+        _handle_anthropic_transient_error(
+            error, attempt=0, max_retries=3, base_delay=0.1
+        )
+    mock_wait.assert_called_once_with(12, None)
+
+
 def test_retry_generator_only_retries_before_yield():
     """Test that retry_generator_on_overloaded only retries if no content has been yielded.
 

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1745,6 +1745,30 @@ class TestOpenAIRetryLogic:
                 error, attempt=0, max_retries=3, base_delay=0.1
             )
 
+    def test_handle_openai_transient_error_honors_retry_after(self):
+        """Rate-limit retries use the provider's requested cooldown."""
+        from unittest.mock import patch
+
+        import httpx
+        from openai import RateLimitError
+
+        from gptme.llm.llm_openai import _handle_openai_transient_error
+
+        response = httpx.Response(
+            429,
+            headers={"Retry-After": "12"},
+            request=httpx.Request("POST", "https://example.test/v1/chat"),
+        )
+        error = RateLimitError("Rate limit exceeded", response=response, body=None)
+
+        with patch(
+            "gptme.llm.llm_openai.backoff_wait", return_value=False
+        ) as mock_wait:
+            _handle_openai_transient_error(
+                error, attempt=0, max_retries=3, base_delay=0.1
+            )
+        mock_wait.assert_called_once_with(12, None)
+
     def test_handle_openai_transient_error_server_error(self):
         """Test that 5xx server errors trigger retry."""
         from unittest.mock import MagicMock, patch

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -53,9 +53,9 @@ def test_retry_after_does_not_shorten_exponential_delay():
 
 
 def test_retry_after_http_date_is_honored(monkeypatch):
-    from datetime import UTC, datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    now = datetime(2026, 9, 10, 6, 0, tzinfo=UTC)
+    now = datetime(2026, 9, 10, 6, 0, tzinfo=timezone.utc)
     error = _status_error_with_retry_after(format_datetime(now + timedelta(seconds=23)))
     monkeypatch.setattr("gptme.llm.retry_policy._utcnow", lambda: now)
     assert retry_delay_for_error(error, attempt=0) == 23

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -6,6 +6,9 @@ became sdk_retries * max_retries requests), and the backoff window was too
 short to outlast a brief upstream rate-limit.
 """
 
+from email.utils import format_datetime
+
+import httpx
 import pytest
 
 from gptme.llm.retry_policy import (
@@ -15,6 +18,7 @@ from gptme.llm.retry_policy import (
     SDK_MAX_RETRIES,
     get_max_retries,
     retry_delay,
+    retry_delay_for_error,
 )
 
 
@@ -24,6 +28,48 @@ def test_backoff_is_exponential_then_capped():
     assert retry_delay(2) == 4 * DEFAULT_BASE_DELAY
     # Without a cap, attempt 10 would sleep for over 17 minutes
     assert retry_delay(10) == MAX_RETRY_DELAY
+
+
+def _status_error_with_retry_after(value: str | None):
+    from openai import RateLimitError
+
+    headers = {"Retry-After": value} if value is not None else {}
+    response = httpx.Response(
+        429,
+        headers=headers,
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+    )
+    return RateLimitError("rate limited", response=response, body=None)
+
+
+def test_retry_after_seconds_overrides_shorter_exponential_delay():
+    error = _status_error_with_retry_after("17")
+    assert retry_delay_for_error(error, attempt=0) == 17
+
+
+def test_retry_after_does_not_shorten_exponential_delay():
+    error = _status_error_with_retry_after("1")
+    assert retry_delay_for_error(error, attempt=5) == 32
+
+
+def test_retry_after_http_date_is_honored(monkeypatch):
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime(2026, 9, 10, 6, 0, tzinfo=UTC)
+    error = _status_error_with_retry_after(format_datetime(now + timedelta(seconds=23)))
+    monkeypatch.setattr("gptme.llm.retry_policy._utcnow", lambda: now)
+    assert retry_delay_for_error(error, attempt=0) == 23
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-delay", "-4"])
+def test_missing_or_invalid_retry_after_falls_back_to_exponential(value):
+    error = _status_error_with_retry_after(value)
+    assert retry_delay_for_error(error, attempt=2) == 4
+
+
+def test_retry_after_is_capped_to_the_per_attempt_limit():
+    error = _status_error_with_retry_after("600")
+    assert retry_delay_for_error(error, attempt=0) == MAX_RETRY_DELAY
 
 
 def test_default_retry_window_is_about_five_minutes():


### PR DESCRIPTION
## Summary

- parse `Retry-After` as delay-seconds or an HTTP date
- extend (never shorten) exponential retry backoff while retaining the 60-second per-attempt cap
- apply the shared policy to both OpenAI-compatible and Anthropic provider paths

## Context

The broad retry/resume lane was already largely implemented by #3669 and the harness resume path. Static tracing found one remaining upstream gap: provider `Retry-After` headers were ignored even though the shared policy owns retry timing. This PR closes that gap without changing the existing ~5-minute default retry budget or retrying after streaming output begins.

## Verification

- `275 passed` across `test_llm_retry_policy.py`, `test_llm_retry_abort.py`, `test_llm_openai.py`, and `test_llm_anthropic.py`
- ruff check + format check pass
- pre-commit hooks pass

Related to the retry/resume follow-up tracked from gptme/gptme#3668.