### PR TITLE
fix(llm): keep tool_call pairing for unavailable tools; dedupe auto-naming threads

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -57,6 +57,36 @@ logger = logging.getLogger(__name__)
 
 # logdir -> in-flight auto-naming thread (see the naming block in step loop)
 _naming_threads: dict[Path, threading.Thread] = {}
+_naming_threads_lock = threading.Lock()
+
+
+def _start_auto_naming_thread(
+    logdir: Path,
+    chat_config: ChatConfig,
+    messages: list[Message],
+    model: str,
+) -> None:
+    """Start at most one auto-naming worker for *logdir*."""
+
+    def _run() -> None:
+        try:
+            try_auto_name(chat_config, messages, model)
+        finally:
+            with _naming_threads_lock:
+                if _naming_threads.get(logdir) is threading.current_thread():
+                    del _naming_threads[logdir]
+
+    with _naming_threads_lock:
+        if logdir in _naming_threads:
+            return
+        thread = threading.Thread(target=_run, daemon=True)
+        _naming_threads[logdir] = thread
+        try:
+            thread.start()
+        except Exception:
+            del _naming_threads[logdir]
+            raise
+
 
 # Store an immutable int. copy_context() (server/TUI/ACP step threads) copies
 # the binding, not the value: a list would be shared by reference and a child
@@ -565,19 +595,13 @@ def _process_message_conversation(
             # guard every step before the first name lands spawns another
             # thread and the log shows three "Auto-generated conversation
             # name" lines for one conversation.
-            inflight = _naming_threads.get(manager.logdir)
-            if not chat_config.name and not (inflight and inflight.is_alive()):
-                thread = threading.Thread(
-                    target=try_auto_name,
-                    args=(
-                        chat_config,
-                        copy.deepcopy(manager.log.messages),
-                        current_model.full,
-                    ),
-                    daemon=True,
+            if not chat_config.name:
+                _start_auto_naming_thread(
+                    manager.logdir,
+                    chat_config,
+                    copy.deepcopy(manager.log.messages),
+                    current_model.full,
                 )
-                _naming_threads[manager.logdir] = thread
-                thread.start()
 
         # Check step limit (GPTME_MAX_STEPS)
         step_count += 1

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -55,6 +55,9 @@ from .util.terminal import flush_stdin, set_current_conv_name, terminal_state_ti
 
 logger = logging.getLogger(__name__)
 
+# logdir -> in-flight auto-naming thread (see the naming block in step loop)
+_naming_threads: dict[Path, threading.Thread] = {}
+
 # Store an immutable int. copy_context() (server/TUI/ACP step threads) copies
 # the binding, not the value: a list would be shared by reference and a child
 # step() would mutate the parent's running total. Rebinding via .set() keeps
@@ -557,7 +560,13 @@ def _process_message_conversation(
         assistant_count = sum(1 for m in manager.log.messages if m.role == "assistant")
         if current_model and 1 <= assistant_count <= MAX_ASSISTANT_MSGS_FOR_NAMING:
             chat_config = ChatConfig.from_logdir(manager.logdir)
-            if not chat_config.name:
+            # One naming call per conversation: the thread runs across several
+            # loop iterations (each tool step re-enters here), so without this
+            # guard every step before the first name lands spawns another
+            # thread and the log shows three "Auto-generated conversation
+            # name" lines for one conversation.
+            inflight = _naming_threads.get(manager.logdir)
+            if not chat_config.name and not (inflight and inflight.is_alive()):
                 thread = threading.Thread(
                     target=try_auto_name,
                     args=(
@@ -567,6 +576,7 @@ def _process_message_conversation(
                     ),
                     daemon=True,
                 )
+                _naming_threads[manager.logdir] = thread
                 thread.start()
 
         # Check step limit (GPTME_MAX_STEPS)

--- a/gptme/config/chat.py
+++ b/gptme/config/chat.py
@@ -4,13 +4,15 @@ ChatConfig manages per-conversation settings including model selection,
 tool configuration, workspace paths, and agent settings.
 """
 
+import importlib
 import logging
 import os
 import sys
 import tempfile
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field, fields, replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import tomlkit
 from tomlkit.exceptions import TOMLKitError
@@ -34,6 +36,40 @@ if TYPE_CHECKING:
     from ..tools.base import ToolFormat
 
 logger = logging.getLogger(__name__)
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    msvcrt: Any = importlib.import_module("msvcrt")
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
+
+
+@contextmanager
+def chat_config_lock(logdir: Path):
+    """Serialize config.toml read-modify-write operations for one chat."""
+    lock_path = logdir / ".config.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock:
+        if fcntl is not None:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            if lock.seek(0, os.SEEK_END) == 0:
+                lock.write(b"\0")
+                lock.flush()
+            lock.seek(0)
+            msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 def _coerce_config_path(value: object, field_name: str) -> Path:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1782,15 +1782,38 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
     # and re-emit after the tool responses are flushed.
     pending_system: list[dict] = []
     pending_tool_call_ids: set[str] = set()
+    seen_tool_call_ids: set[str] = set()
     after_tool_calls = False
 
     for message in message_dicts:
         # Format tool result as expected by the model
         if message["role"] == "system" and "call_id" in message:
+            tool_call_id = message["call_id"]
+            if tool_call_id not in seen_tool_call_ids:
+                # Orphan: a tool result whose call never appeared in a
+                # preceding assistant tool_calls list (e.g. an old log where
+                # the assistant turn lost the call). Strict providers reject a
+                # `tool` message without its `tool_calls` parent, so demote it
+                # to plain text instead of poisoning every later request.
+                logger.warning(
+                    "Orphan tool result for call_id %s (no preceding tool_call); "
+                    "sending it as a user message instead of role=tool.",
+                    tool_call_id,
+                )
+                demoted = {k: v for k, v in message.items() if k != "call_id"}
+                demoted["role"] = "user"
+                if after_tool_calls:
+                    pending_system.append(demoted)
+                else:
+                    for buffered in pending_system:
+                        yield buffered
+                    pending_system = []
+                    yield demoted
+                continue
             # Convert system+call_id to tool message (conforms to MessageDict)
             modified_message = dict(message)
             modified_message["role"] = "tool"
-            tool_call_id = modified_message.pop("call_id")
+            modified_message.pop("call_id")
             modified_message["tool_call_id"] = tool_call_id
             yield modified_message
             pending_tool_call_ids.discard(tool_call_id)
@@ -1837,6 +1860,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                 modified_message["tool_calls"] = tool_calls
 
             pending_tool_call_ids = {call["id"] for call in tool_calls if call["id"]}
+            seen_tool_call_ids |= pending_tool_call_ids
             after_tool_calls = bool(tool_calls)
             yield modified_message
         else:

--- a/gptme/llm/utils.py
+++ b/gptme/llm/utils.py
@@ -51,10 +51,18 @@ def extract_tool_uses_from_assistant_message(
         for line in message_part["text"].split("\n"):
             text += line + "\n"
 
+            # Keep every structured tool call (it has a call_id: the API
+            # actually emitted it as a tool_call), even when the tool is not
+            # loaded. The executor answers such calls with a paired error
+            # tool_result; dropping the call here would leave that result an
+            # orphan and strict providers (DeepSeek) then 400 every later
+            # request: "Messages with role 'tool' must be a response to a
+            # preceding message with 'tool_calls'". Markdown blocks (no
+            # call_id) still require a runnable tool.
             tooluses = [
                 tooluse
                 for tooluse in ToolUse.iter_from_content(text, tool_format_override)
-                if tooluse.is_runnable
+                if tooluse.is_runnable or tooluse.call_id
             ]
             if not tooluses:
                 continue

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -20,6 +20,7 @@ from typing import Any
 import tomlkit
 
 from ..config import ChatConfig, get_project_config
+from ..config.chat import chat_config_lock
 from ..dirs import get_logs_dir
 from .manager import Log
 
@@ -527,24 +528,24 @@ def rename_conversation(conv_id: str, new_name: str) -> bool:
     conv_dir = conv_path.parent
     config_path = conv_dir / "config.toml"
 
-    # Load existing config or create fresh — update only the name field.
-    # We avoid ChatConfig.save() here because it also manages the workspace
-    # symlink, which would create an unintended symlink pointing to cwd for
-    # conversations that have no pre-existing workspace configuration.
-    if config_path.exists():
-        with open(config_path) as f:
-            config_data = tomlkit.load(f)
-    else:
-        config_data = tomlkit.document()
+    # Share the auto-namer's lock so its compare-and-save cannot overwrite a
+    # user rename. Update only the name field: ChatConfig.save() also manages
+    # workspace symlinks, which is unwanted for legacy conversations.
+    with chat_config_lock(conv_dir):
+        if config_path.exists():
+            with open(config_path) as f:
+                config_data = tomlkit.load(f)
+        else:
+            config_data = tomlkit.document()
 
-    if "chat" not in config_data:
-        config_data.add("chat", tomlkit.table())
-    chat_section = config_data["chat"]
-    assert isinstance(chat_section, dict)
-    chat_section["name"] = new_name
+        if "chat" not in config_data:
+            config_data.add("chat", tomlkit.table())
+        chat_section = config_data["chat"]
+        assert isinstance(chat_section, dict)
+        chat_section["name"] = new_name
 
-    with open(config_path, "w") as f:
-        tomlkit.dump(config_data, f)
+        with open(config_path, "w") as f:
+            tomlkit.dump(config_data, f)
 
     return True
 

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -308,6 +308,21 @@ def auto_generate_display_name(messages: list[Message], model: str) -> str | Non
     return generate_conversation_name(strategy="llm", messages=messages, model=model)
 
 
+def _config_has_name_on_disk(config: ChatConfig) -> bool:
+    """Re-read *config* from its logdir; True if a name was saved meanwhile."""
+    from pathlib import Path  # runtime use; avoids the config import cycle
+
+    from ..config import ChatConfig as _ChatConfig
+
+    logdir = getattr(config, "_logdir", None)
+    if not logdir:
+        return False
+    try:
+        return bool(_ChatConfig.from_logdir(Path(logdir)).name)
+    except Exception:  # pragma: no cover - never block naming on a read error
+        return False
+
+
 def try_auto_name(
     config: ChatConfig,
     messages: list[Message],
@@ -332,6 +347,12 @@ def try_auto_name(
     try:
         display_name = auto_generate_display_name(messages, model)
         if display_name:
+            # Another caller (a concurrent naming thread, the server, or the
+            # user via /rename) may have named the conversation while the
+            # LLM call was in flight; the first name wins.
+            if _config_has_name_on_disk(config):
+                logger.debug("Conversation was named concurrently; keeping it")
+                return None
             config.name = display_name
             config.save()
             logger.info(f"Auto-generated conversation name: {display_name}")

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ..message import Message
@@ -11,8 +12,6 @@ from ..telemetry import trace_function
 from .generate_name import generate_name
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from ..config import ChatConfig
 
 logger = logging.getLogger(__name__)
@@ -308,21 +307,6 @@ def auto_generate_display_name(messages: list[Message], model: str) -> str | Non
     return generate_conversation_name(strategy="llm", messages=messages, model=model)
 
 
-def _config_has_name_on_disk(config: ChatConfig) -> bool:
-    """Re-read *config* from its logdir; True if a name was saved meanwhile."""
-    from pathlib import Path  # runtime use; avoids the config import cycle
-
-    from ..config import ChatConfig as _ChatConfig
-
-    logdir = getattr(config, "_logdir", None)
-    if not logdir:
-        return False
-    try:
-        return bool(_ChatConfig.from_logdir(Path(logdir)).name)
-    except Exception:  # pragma: no cover - never block naming on a read error
-        return False
-
-
 def try_auto_name(
     config: ChatConfig,
     messages: list[Message],
@@ -347,14 +331,22 @@ def try_auto_name(
     try:
         display_name = auto_generate_display_name(messages, model)
         if display_name:
-            # Another caller (a concurrent naming thread, the server, or the
-            # user via /rename) may have named the conversation while the
-            # LLM call was in flight; the first name wins.
-            if _config_has_name_on_disk(config):
-                logger.debug("Conversation was named concurrently; keeping it")
-                return None
-            config.name = display_name
-            config.save()
+            logdir = getattr(config, "_logdir", None)
+            if logdir:
+                from ..config import ChatConfig as _ChatConfig
+                from ..config.chat import chat_config_lock
+
+                with chat_config_lock(Path(logdir)):
+                    current = _ChatConfig.from_logdir(Path(logdir))
+                    if current.name:
+                        logger.debug("Conversation was named concurrently; keeping it")
+                        return None
+                    current.name = display_name
+                    current.save()
+                    config.name = display_name
+            else:
+                config.name = display_name
+                config.save()
             logger.info(f"Auto-generated conversation name: {display_name}")
             return display_name
         logger.debug("Auto-naming returned no result, will retry on next message")

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -341,9 +341,8 @@ def try_auto_name(
                     if current.name:
                         logger.debug("Conversation was named concurrently; keeping it")
                         return None
-                    current.name = display_name
-                    current.save()
                     config.name = display_name
+                    config.save()
             else:
                 config.name = display_name
                 config.save()

--- a/tests/test_auto_naming.py
+++ b/tests/test_auto_naming.py
@@ -349,3 +349,33 @@ def test_generate_conversation_name_returns_none_on_llm_failure():
         "generate_conversation_name should not fall back to random names when "
         "LLM strategy is explicitly requested."
     )
+
+
+def test_try_auto_name_keeps_name_saved_concurrently(tmp_path, monkeypatch):
+    """A name saved on disk while the LLM call was in flight wins.
+
+    Several naming threads can race (one per step before the first name
+    lands); the second result must not overwrite the first.
+    """
+    from gptme.config import ChatConfig
+    from gptme.message import Message
+    from gptme.util import auto_naming
+
+    config = ChatConfig(_logdir=tmp_path)
+    messages = [
+        Message("user", "Help me debug a Python script"),
+        Message("assistant", "Sure, what's the error?"),
+    ]
+
+    def _slow_name(_messages, _model):
+        # Simulate a sibling thread finishing first
+        other = ChatConfig(_logdir=tmp_path)
+        other.name = "First Name"
+        other.save()
+        return "Second Name"
+
+    monkeypatch.setattr(auto_naming, "auto_generate_display_name", _slow_name)
+
+    result = auto_naming.try_auto_name(config, messages, "test/model")
+    assert result is None
+    assert ChatConfig.from_logdir(tmp_path).name == "First Name"

--- a/tests/test_auto_naming.py
+++ b/tests/test_auto_naming.py
@@ -352,11 +352,7 @@ def test_generate_conversation_name_returns_none_on_llm_failure():
 
 
 def test_try_auto_name_keeps_name_saved_concurrently(tmp_path, monkeypatch):
-    """A name saved on disk while the LLM call was in flight wins.
-
-    Several naming threads can race (one per step before the first name
-    lands); the second result must not overwrite the first.
-    """
+    """A name saved on disk while the LLM call was in flight wins."""
     from gptme.config import ChatConfig
     from gptme.message import Message
     from gptme.util import auto_naming
@@ -378,4 +374,5 @@ def test_try_auto_name_keeps_name_saved_concurrently(tmp_path, monkeypatch):
 
     result = auto_naming.try_auto_name(config, messages, "test/model")
     assert result is None
+    assert config.name is None
     assert ChatConfig.from_logdir(tmp_path).name == "First Name"

--- a/tests/test_auto_naming.py
+++ b/tests/test_auto_naming.py
@@ -376,3 +376,30 @@ def test_try_auto_name_keeps_name_saved_concurrently(tmp_path, monkeypatch):
     assert result is None
     assert config.name is None
     assert ChatConfig.from_logdir(tmp_path).name == "First Name"
+
+
+def test_try_auto_name_persists_in_memory_config_overrides(tmp_path, monkeypatch):
+    """Auto-naming preserves unsaved settings on the caller's config."""
+    from gptme.config import ChatConfig
+    from gptme.message import Message
+    from gptme.util import auto_naming
+
+    config = ChatConfig(_logdir=tmp_path, model="test/original")
+    config.save()
+    config.model = "test/override"
+    config.tools = ["shell"]
+    messages = [
+        Message("user", "Help me debug a Python script"),
+        Message("assistant", "Sure, what's the error?"),
+    ]
+    monkeypatch.setattr(
+        auto_naming, "auto_generate_display_name", lambda *_: "Debug Python"
+    )
+
+    result = auto_naming.try_auto_name(config, messages, "test/model")
+
+    assert result == "Debug Python"
+    saved = ChatConfig.from_logdir(tmp_path)
+    assert saved.name == "Debug Python"
+    assert saved.model == "test/override"
+    assert saved.tools == ["shell"]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1255,3 +1255,36 @@ def test_get_user_input_cancels_on_include_paths_interrupt(monkeypatch):
     result = _get_user_input(Log(messages=[Message("assistant", "ok")]), None)
     assert result is None
     assert _interruptible_var.get() is False
+
+
+def test_auto_naming_thread_registry_cleans_up_and_deduplicates(tmp_path, monkeypatch):
+    """The registry owns one live worker and drops it after completion."""
+    import threading
+
+    import gptme.chat as chat_module
+    from gptme.config import ChatConfig
+    from gptme.message import Message
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def _try_auto_name(*_args):
+        started.set()
+        assert release.wait(timeout=2)
+
+    monkeypatch.setattr(chat_module, "try_auto_name", _try_auto_name)
+    chat_module._naming_threads.clear()
+    config = ChatConfig(_logdir=tmp_path)
+    messages = [Message("assistant", "hello")]
+
+    chat_module._start_auto_naming_thread(tmp_path, config, messages, "test/model")
+    assert started.wait(timeout=2)
+    first = chat_module._naming_threads[tmp_path]
+
+    chat_module._start_auto_naming_thread(tmp_path, config, messages, "test/model")
+    assert chat_module._naming_threads[tmp_path] is first
+
+    release.set()
+    first.join(timeout=2)
+    assert not first.is_alive()
+    assert tmp_path not in chat_module._naming_threads

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1259,11 +1259,14 @@ def test_get_user_input_cancels_on_include_paths_interrupt(monkeypatch):
 
 def test_auto_naming_thread_registry_cleans_up_and_deduplicates(tmp_path, monkeypatch):
     """The registry owns one live worker and drops it after completion."""
+    import sys
     import threading
 
-    import gptme.chat as chat_module
+    import gptme.chat  # noqa: F401
     from gptme.config import ChatConfig
     from gptme.message import Message
+
+    chat_module = sys.modules["gptme.chat"]
 
     started = threading.Event()
     release = threading.Event()

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -3896,9 +3896,10 @@ def test_handle_tools_demotes_orphan_tool_result_to_user_text():
 
     messages = [
         Message(role="user", content="hi"),
-        # Result whose assistant call was lost (old log / interrupted turn)
+        Message(role="assistant", content='@shell(call_live): {"command": "true"}'),
+        # Result whose assistant call was lost (old log / interrupted turn).
+        # Put it after an unrelated tool call to cover the buffered path.
         Message(role="system", content="stale output", call_id="call_gone"),
-        Message(role="assistant", content="ok"),
     ]
 
     tool_shell = get_tool("shell")
@@ -3906,10 +3907,9 @@ def test_handle_tools_demotes_orphan_tool_result_to_user_text():
     model = get_model("openai/gpt-4o")
     messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
 
-    roles = [m["role"] for m in messages_dicts]
-    assert "tool" not in roles
+    assert [m["role"] for m in messages_dicts] == ["user", "assistant", "user"]
     assert all("tool_call_id" not in m for m in messages_dicts)
-    demoted = messages_dicts[1]
+    demoted = messages_dicts[-1]
     assert demoted["role"] == "user"
     content = demoted["content"]
     text: str | None

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -3853,3 +3853,71 @@ class TestIsProxy:
         client.base_url = "http://127.0.0.1:8080/messages/"
         assert not _is_proxy(client)
         _is_proxy.cache_clear()
+
+
+def test_handle_tools_keeps_pairing_for_unavailable_tool_call():
+    """A structured call to a tool that is not loaded must still become a tool_call.
+
+    gptme answers such a call with a paired error tool_result ("Tool 'read' is
+    not available for execution"). If the extractor dropped the call because
+    the tool is not runnable, that result would be an orphan `tool` message and
+    strict providers (DeepSeek) 400 every later request: "Messages with role
+    'tool' must be a response to a preceding message with 'tool_calls'".
+    """
+    init_tools(allowlist=["shell"])
+    assert get_tool("read") is None
+
+    messages = [
+        Message(role="user", content="Read calc.py"),
+        Message(role="assistant", content='@read(call_007): {"path": "calc.py"}'),
+        Message(
+            role="system",
+            content="Tool 'read' is not available for execution.",
+            call_id="call_007",
+        ),
+    ]
+
+    tool_shell = get_tool("shell")
+    assert tool_shell
+    model = get_model("openai/gpt-4o")
+    messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
+
+    assert messages_dicts[1]["role"] == "assistant"
+    tool_calls = messages_dicts[1].get("tool_calls")
+    assert tool_calls and tool_calls[0]["id"] == "call_007"
+    assert tool_calls[0]["function"]["name"] == "read"
+    assert messages_dicts[2]["role"] == "tool"
+    assert messages_dicts[2]["tool_call_id"] == "call_007"
+
+
+def test_handle_tools_demotes_orphan_tool_result_to_user_text():
+    """A tool result with no preceding tool_call is sent as plain text, not role=tool."""
+    init_tools(allowlist=["shell"])
+
+    messages = [
+        Message(role="user", content="hi"),
+        # Result whose assistant call was lost (old log / interrupted turn)
+        Message(role="system", content="stale output", call_id="call_gone"),
+        Message(role="assistant", content="ok"),
+    ]
+
+    tool_shell = get_tool("shell")
+    assert tool_shell
+    model = get_model("openai/gpt-4o")
+    messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
+
+    roles = [m["role"] for m in messages_dicts]
+    assert "tool" not in roles
+    assert all("tool_call_id" not in m for m in messages_dicts)
+    demoted = messages_dicts[1]
+    assert demoted["role"] == "user"
+    content = demoted["content"]
+    text: str | None
+    if isinstance(content, list):
+        first = content[0]
+        assert isinstance(first, dict)
+        text = first["text"]
+    else:
+        text = content
+    assert isinstance(text, str)
+    assert "stale output" in text

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -3891,15 +3891,17 @@ def test_handle_tools_keeps_pairing_for_unavailable_tool_call():
 
 
 def test_handle_tools_demotes_orphan_tool_result_to_user_text():
-    """A tool result with no preceding tool_call is sent as plain text, not role=tool."""
+    """A buffered orphan result is moved after the valid tool-response run."""
     init_tools(allowlist=["shell"])
 
     messages = [
         Message(role="user", content="hi"),
         Message(role="assistant", content='@shell(call_live): {"command": "true"}'),
         # Result whose assistant call was lost (old log / interrupted turn).
-        # Put it after an unrelated tool call to cover the buffered path.
+        # Put it before the valid result to exercise the buffered path without
+        # leaving the live call unanswered in the API transcript.
         Message(role="system", content="stale output", call_id="call_gone"),
+        Message(role="system", content="live output", call_id="call_live"),
     ]
 
     tool_shell = get_tool("shell")
@@ -3907,9 +3909,15 @@ def test_handle_tools_demotes_orphan_tool_result_to_user_text():
     model = get_model("openai/gpt-4o")
     messages_dicts, _ = _prepare_messages_for_api(messages, model.full, [tool_shell])
 
-    assert [m["role"] for m in messages_dicts] == ["user", "assistant", "user"]
-    assert all("tool_call_id" not in m for m in messages_dicts)
+    assert [m["role"] for m in messages_dicts] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+    ]
+    assert messages_dicts[2]["tool_call_id"] == "call_live"
     demoted = messages_dicts[-1]
+    assert "tool_call_id" not in demoted
     assert demoted["role"] == "user"
     content = demoted["content"]
     text: str | None


### PR DESCRIPTION
## What

Two bugs from one DeepSeek V4.1 Flash session (reported by Erik, 2026-09-10):

**1. Orphan tool result → provider 400 that kills the session.** When the model called a tool that is not loaded (`read` without `--tools +read`), `extract_tool_uses_from_assistant_message` dropped the call (`is_runnable` filter) while `execute_msg` still emitted the paired error result (`Tool 'read' is not available for execution.`, with `call_id`). The next request carried a `tool` message with no `tool_calls` parent; DeepSeek rejects that on every subsequent request:

```
Messages with role 'tool' must be a response to a preceding message with 'tool_calls'
```

Fix: keep every tool use that carries a `call_id` (the API emitted it as a real tool_call), whether or not the tool is runnable; markdown blocks (no `call_id`) still require a runnable tool. Belt and braces: `_handle_tools` demotes any tool result whose `call_id` never appeared in a preceding `tool_calls` list to a `user` message instead of sending it as `role=tool`.

**2. Three auto-generated names for one conversation.** `chat.py` spawned a new naming thread on every step until the first name was saved, so a conversation with a few quick tool steps logged `Auto-generated conversation name:` three times with three different names. Fix: one in-flight naming thread per logdir; `try_auto_name` re-reads the config from disk before saving so the first name wins.

## Tests

- `test_handle_tools_keeps_pairing_for_unavailable_tool_call`
- `test_handle_tools_demotes_orphan_tool_result_to_user_text`
- `test_try_auto_name_keeps_name_saved_concurrently`

`tests/test_llm_openai.py tests/test_llm_utils.py tests/test_auto_naming.py tests/test_tools.py`: 275 passed, 1 skipped. ruff + mypy clean on the changed files.

Same strict-ordering class as #3422.

https://claude.ai/code/session_01Kk96ga5Fqt7412xr74yww9
