### PR TITLE
fix(shell): bound captured subprocess output bytes (GPTME_SHELL_MAX_OUTPUT_BYTES)

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -969,12 +969,17 @@ class ShellSession:
                     with cap_lock:
                         cap_state["bytes"] += len(raw)
                         over = cap_state["bytes"] > max_output_bytes
+                        if over:
+                            # Flag the cap BEFORE enqueueing the chunk so the
+                            # consumer cannot dequeue an over-cap chunk that
+                            # carries the delimiter while `over` is still
+                            # False and return the real code (Greptile P1 /
+                            # bob-ai-review P1 race).
+                            cap_state["over"] = True
                     queue.put(data)
                     if over:
                         # Stop producing more data; the consumer detects the
                         # cap and performs the kill + marker.
-                        with cap_lock:
-                            cap_state["over"] = True
                         break
                 except BlockingIOError:
                     time.sleep(0.01)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -21,6 +21,15 @@ Configuration:
     truncation path fire on smaller outputs, which surfaces savings telemetry
     in `context-savings.jsonl` and the `/context` command. Invalid values fall
     back to defaults.
+
+    GPTME_SHELL_MAX_OUTPUT_BYTES: Hard cap on the total bytes (stdout + stderr
+        combined) captured into the in-process buffer before the subprocess is
+        killed and the output is truncated. Accepts a plain byte count or a
+        binary suffix (e.g. "32M", "1G"). Default: 32 MiB. This prevents a
+        runaway ``cat`` of a multi-GiB file from exhausting gptme's RSS.
+        The process receives SIGTERM then SIGKILL; the returned output contains
+        a ``[output truncated at N MiB, process killed]`` marker. Token-level
+        truncation (GPTME_SHELL_TRUNC_*) is applied on top as a second stage.
 """
 
 import atexit
@@ -172,6 +181,10 @@ _TRUNC_STDERR_PRE_TOKENS_DEFAULT = 2000
 _TRUNC_STDERR_POST_TOKENS_DEFAULT = 2000
 _GIT_LOG_PREVIEW_LINES = 20
 _GH_LIST_PREVIEW_LINES = 10
+
+# Default byte cap for captured subprocess output (32 MiB). Configurable via
+# GPTME_SHELL_MAX_OUTPUT_BYTES (or [env] SHELL_MAX_OUTPUT_BYTES in config.toml).
+_DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024  # 32 MiB
 
 
 candidates = (
@@ -355,6 +368,37 @@ def _get_memory_limit() -> int | None:
             exc,
         )
         return None
+    return limit
+
+
+def _get_max_output_bytes() -> int:
+    """Read the output byte cap in bytes (default 32 MiB).
+
+    Knob is ``GPTME_SHELL_MAX_OUTPUT_BYTES`` (env) or
+    ``[env] SHELL_MAX_OUTPUT_BYTES`` (config.toml). Accepts a plain byte count
+    or a binary-suffixed size (e.g. ``"32M"``). Unparseable or non-positive
+    values fall back to the 32 MiB default so a misconfiguration never disables
+    the cap entirely.
+    """
+    from ..config import get_config  # deferred: avoid import cycle
+
+    raw = get_config().get_env("SHELL_MAX_OUTPUT_BYTES")
+    if not raw:
+        return _DEFAULT_MAX_OUTPUT_BYTES
+    try:
+        limit = _parse_size(str(raw))
+    except (ValueError, AttributeError):
+        logger.warning(
+            "Ignoring invalid GPTME_SHELL_MAX_OUTPUT_BYTES=%r (expected e.g. '32M')",
+            raw,
+        )
+        return _DEFAULT_MAX_OUTPUT_BYTES
+    if limit <= 0:
+        logger.warning(
+            "GPTME_SHELL_MAX_OUTPUT_BYTES=%r is not positive; using default 32 MiB",
+            raw,
+        )
+        return _DEFAULT_MAX_OUTPUT_BYTES
     return limit
 
 
@@ -856,6 +900,7 @@ class ShellSession:
         stderr: list[str] = []
         return_code: int | None = None
         start_time = time.time() if timeout else None
+        max_output_bytes = _get_max_output_bytes()
 
         if _is_windows:
             return self._read_output_windows(
@@ -868,6 +913,7 @@ class ShellSession:
                 start_marker_pattern,
                 start_time,
                 timeout,
+                max_output_bytes,
             )
         return self._read_output_unix(
             command,
@@ -879,6 +925,7 @@ class ShellSession:
             start_marker_pattern,
             start_time,
             timeout,
+            max_output_bytes,
         )
 
     def _read_output_windows(
@@ -892,6 +939,7 @@ class ShellSession:
         start_marker_pattern: str,
         start_time: float | None,
         timeout: float | None,
+        max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
     ) -> tuple[int | None, str, str]:
         """Read command output on Windows using threads with non-blocking I/O."""
         from queue import Empty, Queue
@@ -926,6 +974,7 @@ class ShellSession:
         t_stderr.start()
 
         re_returncode = re.compile(r"ReturnCode:(\d+)")
+        captured_bytes = 0
 
         try:
             while not stop_event.is_set():
@@ -1008,8 +1057,29 @@ class ShellSession:
                             )
 
                         stdout.append(line)
+                        captured_bytes += len(line)
                         if output:
                             print(line, end="", file=sys.stdout)
+                        if captured_bytes > max_output_bytes:
+                            cap_mib = max_output_bytes / (1024 * 1024)
+                            trunc_msg = (
+                                f"\n[output truncated at {cap_mib:.0f} MiB,"
+                                f" process killed]\n"
+                            )
+                            stdout.append(trunc_msg)
+                            if output:
+                                print(trunc_msg, end="", file=sys.stdout)
+                            logger.warning(
+                                "Shell output cap (%d MiB) exceeded; killing process",
+                                int(cap_mib),
+                            )
+                            self._terminate_process()
+                            stop_event.set()
+                            return (
+                                -125,
+                                trim_blank_lines("".join(stdout)),
+                                trim_blank_lines("".join(stderr)),
+                            )
                 except Empty:
                     pass
 
@@ -1019,8 +1089,29 @@ class ShellSession:
                     lines = data.splitlines(keepends=True)
                     for line in lines:
                         stderr.append(line)
+                        captured_bytes += len(line)
                         if output:
                             print(line, end="", file=sys.stderr)
+                        if captured_bytes > max_output_bytes:
+                            cap_mib = max_output_bytes / (1024 * 1024)
+                            trunc_msg = (
+                                f"\n[output truncated at {cap_mib:.0f} MiB,"
+                                f" process killed]\n"
+                            )
+                            stderr.append(trunc_msg)
+                            if output:
+                                print(trunc_msg, end="", file=sys.stderr)
+                            logger.warning(
+                                "Shell output cap (%d MiB) exceeded; killing process",
+                                int(cap_mib),
+                            )
+                            self._terminate_process()
+                            stop_event.set()
+                            return (
+                                -125,
+                                trim_blank_lines("".join(stdout)),
+                                trim_blank_lines("".join(stderr)),
+                            )
                 except Empty:
                     pass
 
@@ -1057,9 +1148,11 @@ class ShellSession:
         start_marker_pattern: str,
         start_time: float | None,
         timeout: float | None,
+        max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
     ) -> tuple[int | None, str, str]:
         """Read command output on Unix using select()."""
         assert select is not None
+        captured_bytes = 0
         try:
             while True:
                 # Calculate remaining timeout
@@ -1200,12 +1293,44 @@ class ShellSession:
                             )
                         if fd == self.stdout_fd:
                             stdout.append(line)
+                            captured_bytes += len(line)
                             if output:
                                 print(line, end="", file=sys.stdout)
                         elif fd == self.stderr_fd:
                             stderr.append(line)
+                            captured_bytes += len(line)
                             if output:
                                 print(line, end="", file=sys.stderr)
+
+                        if captured_bytes > max_output_bytes:
+                            cap_mib = max_output_bytes / (1024 * 1024)
+                            trunc_msg = (
+                                f"\n[output truncated at {cap_mib:.0f} MiB,"
+                                f" process killed]\n"
+                            )
+                            stdout.append(trunc_msg)
+                            if output:
+                                print(trunc_msg, end="", file=sys.stdout)
+                            logger.warning(
+                                "Shell output cap (%d MiB) exceeded; killing process",
+                                int(cap_mib),
+                            )
+                            try:
+                                pgid = os.getpgid(self.process.pid)
+                                os.killpg(pgid, signal.SIGTERM)
+                                time.sleep(0.1)
+                                if self.process.poll() is None:
+                                    os.killpg(pgid, signal.SIGKILL)
+                            except Exception as e:
+                                logger.warning(
+                                    "Error killing process after byte cap exceeded: %s",
+                                    e,
+                                )
+                            return (
+                                -125,
+                                trim_blank_lines("".join(stdout)),
+                                trim_blank_lines("".join(stderr)),
+                            )
         except KeyboardInterrupt:
             # Clear line after ^C to avoid leaving a hanging line
             print()
@@ -1625,6 +1750,7 @@ def _format_shell_output(
     timed_out: bool = False,
     timeout_value: float | None = None,
     logdir: Path | None = None,
+    byte_cap_exceeded: bool = False,
 ) -> str:
     """Format shell command output into a message."""
     # Strip ANSI escape sequences from output
@@ -1638,6 +1764,7 @@ def _format_shell_output(
         and not stderr
         and not interrupted
         and not timed_out
+        and not byte_cap_exceeded
         and _matches_git_log_oneline(cmd)
     ):
         try:
@@ -1651,6 +1778,7 @@ def _format_shell_output(
         and not stderr
         and not interrupted
         and not timed_out
+        and not byte_cap_exceeded
         and _matches_gh_list(cmd)
     ):
         try:
@@ -1659,7 +1787,12 @@ def _format_shell_output(
             logger.warning("Failed to format compact shell output: %s", e)
 
     if compact_stdout is None and (
-        returncode == 0 and stdout and not stderr and not interrupted and not timed_out
+        returncode == 0
+        and stdout
+        and not stderr
+        and not interrupted
+        and not timed_out
+        and not byte_cap_exceeded
     ):
         try:
             compact_stdout = _format_query_pruned_output(cmd, stdout, logdir)
@@ -1696,7 +1829,10 @@ def _format_shell_output(
         )
 
     # Format header
-    if timed_out:
+    if byte_cap_exceeded:
+        cap_mib = _DEFAULT_MAX_OUTPUT_BYTES / (1024 * 1024)
+        header = f"Command killed (output exceeded {cap_mib:.0f} MiB cap)"
+    elif timed_out:
         header = (
             f"Command timed out (after {timeout_value}s)"
             if timeout_value
@@ -1728,7 +1864,9 @@ def _format_shell_output(
     if stderr:
         msg += _format_block_smart("", stderr, "stderr").lstrip() + "\n\n"
     if not compact_stdout and not stdout and not stderr:
-        if timed_out:
+        if byte_cap_exceeded:
+            msg += "No output before byte cap\n"
+        elif timed_out:
             msg += "No output before timeout\n"
         elif interrupted:
             msg += "No output before interruption\n"
@@ -1741,6 +1879,8 @@ def _format_shell_output(
             msg += f"Process interrupted (return code: {returncode})\n"
         else:
             msg += "Process interrupted\n"
+    elif byte_cap_exceeded or timed_out:
+        pass  # Header already describes the termination; return code is synthetic
     elif returncode:
         msg += f"Return code: {returncode}\n"
 
@@ -1759,6 +1899,7 @@ def execute_shell_impl(
         returncode, stdout, stderr = shell.run(cmd, timeout=timeout)
         interrupted = False
         timed_out = returncode == -124  # Our timeout return code
+        byte_cap_exceeded = returncode == -125  # Output byte cap return code
     except KeyboardInterrupt as e:
         # Extract partial output and handle subprocess termination
         stdout = stderr = ""
@@ -1770,6 +1911,7 @@ def execute_shell_impl(
         returncode = shell.process.returncode
         interrupted = True
         timed_out = False
+        byte_cap_exceeded = False
     except Exception as e:
         raise ValueError(f"Shell error: {e}") from None
     duration = time.monotonic() - start_time
@@ -1785,6 +1927,7 @@ def execute_shell_impl(
         timed_out,
         timeout_value=timeout,
         logdir=logdir,
+        byte_cap_exceeded=byte_cap_exceeded,
     )
     # Workspace-awareness: notify when cd enters a directory with gptme.toml.
     # Append hint text directly to the command output (single yield) so no

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -402,6 +402,27 @@ def _get_max_output_bytes() -> int:
     return limit
 
 
+def _strip_shell_return_marker(raw: bytes, delimiter: str) -> bytes:
+    """Strip the shell-injected return marker from a raw output chunk.
+
+    The marker is echoed on a single line — ``ReturnCode:$? <delimiter>`` —
+    immediately after the command. We remove it (and anything after it) from
+    the byte-accounting stream, but only when both ``ReturnCode:`` and the
+    delimiter share the *same* line. Command output that merely contains
+    ``ReturnCode:`` and later ``END_OF_COMMAND_OUTPUT`` on separate lines must
+    be counted in full, otherwise such output can undercount and bypass the
+    output byte cap (Greptile P1: marker text bypasses cap).
+    """
+    delimiter_pos = raw.rfind(b"ReturnCode:")
+    if delimiter_pos >= 0:
+        rest = raw[delimiter_pos:]
+        line_end = rest.find(b"\n")
+        delimiter_line = rest if line_end < 0 else rest[:line_end]
+        if delimiter.encode() in delimiter_line:
+            return raw[:delimiter_pos]
+    return raw
+
+
 def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
     """Return the subset of `fds` that are readable, waiting up to `timeout` seconds.
 
@@ -1307,12 +1328,9 @@ class ShellSession:
                                 if marker_end >= 0
                                 else b""
                             )
-                        delimiter_pos = captured_raw.rfind(b"ReturnCode:")
-                        if (
-                            delimiter_pos >= 0
-                            and self.delimiter.encode() in captured_raw[delimiter_pos:]
-                        ):
-                            captured_raw = captured_raw[:delimiter_pos]
+                        captured_raw = _strip_shell_return_marker(
+                            captured_raw, self.delimiter
+                        )
                     captured_bytes += len(captured_raw)
 
                     for line in lines:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1288,12 +1288,32 @@ class ShellSession:
                     # 2**12 = 4096
                     # 2**16 = 65536
                     raw = os.read(fd, 2**16)
-                    # Count the raw bytes actually read so multibyte UTF-8 output
-                    # cannot exceed the cap by 3-4x (byte count, not character count).
-                    captured_bytes += len(raw)
                     data = raw.decode("utf-8", errors="replace")
                     lines = data.splitlines(keepends=True)
                     re_returncode = re.compile(r"ReturnCode:(\d+)")
+
+                    # Count raw subprocess output bytes, excluding the shell's
+                    # injected start/return markers. A command just below the cap
+                    # must not be killed merely because its delimiter shares the
+                    # final read chunk (bob-ai-review P2).
+                    captured_raw = raw
+                    if fd == self.stdout_fd:
+                        marker_bytes = start_marker_pattern.encode()
+                        marker_pos = captured_raw.find(marker_bytes)
+                        if not seen_start_marker and marker_pos >= 0:
+                            marker_end = captured_raw.find(b"\n", marker_pos)
+                            captured_raw = (
+                                captured_raw[marker_end + 1 :]
+                                if marker_end >= 0
+                                else b""
+                            )
+                        delimiter_pos = captured_raw.rfind(b"ReturnCode:")
+                        if (
+                            delimiter_pos >= 0
+                            and self.delimiter.encode() in captured_raw[delimiter_pos:]
+                        ):
+                            captured_raw = captured_raw[:delimiter_pos]
+                    captured_bytes += len(captured_raw)
 
                     for line in lines:
                         # Issue #408: Skip stdout until we see the start marker

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1414,24 +1414,38 @@ class ShellSession:
             pgid = os.getpgid(self.process.pid)
             os.killpg(pgid, signal.SIGTERM)
             time.sleep(0.1)
-            if self.process.poll() is None:
-                os.killpg(pgid, signal.SIGKILL)
+            # SIGKILL the whole process group unconditionally. If the shell
+            # leader exits after SIGTERM while a descendant retains an
+            # inherited output pipe, a descendant could keep emitting and the
+            # unbounded drain below would recreate the memory exhaustion this
+            # cap is meant to prevent (Greptile P1 Security).
+            os.killpg(pgid, signal.SIGKILL)
         except Exception as e:
             logger.warning("Error killing process after byte cap exceeded: %s", e)
         # Drain any remaining data from both pipes so it does not bleed into the
-        # next command's output (Greptile P1).
+        # next command's output, BUT keep the drain bounded (Greptile P1).
+        # After a group SIGKILL there is only kernel-buffered data left; guard
+        # both the total drained bytes and the drain duration so a surviving
+        # descendant cannot keep the loop live and grow memory.
+        drain_budget = max_output_bytes  # at most one cap's worth more
+        drain_deadline = time.monotonic() + 1.0  # hard time bound
         for drain_fd in (self.stdout_fd, self.stderr_fd):
             drain_empty_count = 0
-            while drain_empty_count < 2:
+            while (
+                drain_empty_count < 2
+                and drain_budget > 0
+                and time.monotonic() < drain_deadline
+            ):
                 drain_rlist = _wait_readable([drain_fd], 0.1)
                 if not drain_rlist:
                     drain_empty_count += 1
                     continue
-                drain_raw = os.read(drain_fd, 2**16)
+                drain_raw = os.read(drain_fd, min(2**16, drain_budget))
                 if not drain_raw:
                     drain_empty_count += 1
                     continue
                 drain_empty_count = 0
+                drain_budget -= len(drain_raw)
                 drain_data = drain_raw.decode("utf-8", errors="replace")
                 if drain_fd == self.stdout_fd:
                     stdout.append(drain_data)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -948,17 +948,34 @@ class ShellSession:
         stderr_queue: Queue[str] = Queue()
         stop_event = threading.Event()
 
+        # Shared byte counter so the producer threads stop enqueueing once the
+        # cap is reached — otherwise a fast-output command can buffer unbounded
+        # data in the queues ahead of the consumer (Greptile P1). Bytes, not
+        # decoded characters, so multibyte UTF-8 cannot exceed the cap 3-4x.
+        cap_state = {"bytes": 0, "over": False}
+        cap_lock = threading.Lock()
+
         def read_stream(fd: int, queue: Queue[str]) -> None:
             try:
                 os.set_blocking(fd, False)
             except OSError:
                 pass
-            while not stop_event.is_set():
+            while not stop_event.is_set() and not cap_state["over"]:
                 try:
-                    data = os.read(fd, 2**16).decode("utf-8", errors="replace")
-                    if not data:
+                    raw = os.read(fd, 2**16)
+                    if not raw:
                         break
+                    data = raw.decode("utf-8", errors="replace")
+                    with cap_lock:
+                        cap_state["bytes"] += len(raw)
+                        over = cap_state["bytes"] > max_output_bytes
                     queue.put(data)
+                    if over:
+                        # Stop producing more data; the consumer detects the
+                        # cap and performs the kill + marker.
+                        with cap_lock:
+                            cap_state["over"] = True
+                        break
                 except BlockingIOError:
                     time.sleep(0.01)
                 except OSError:
@@ -974,7 +991,6 @@ class ShellSession:
         t_stderr.start()
 
         re_returncode = re.compile(r"ReturnCode:(\d+)")
-        captured_bytes = 0
 
         try:
             while not stop_event.is_set():
@@ -1057,10 +1073,9 @@ class ShellSession:
                             )
 
                         stdout.append(line)
-                        captured_bytes += len(line)
                         if output:
                             print(line, end="", file=sys.stdout)
-                        if captured_bytes > max_output_bytes:
+                        if cap_state["over"]:
                             cap_mib = max_output_bytes / (1024 * 1024)
                             trunc_msg = (
                                 f"\n[output truncated at {cap_mib:.0f} MiB,"
@@ -1089,18 +1104,20 @@ class ShellSession:
                     lines = data.splitlines(keepends=True)
                     for line in lines:
                         stderr.append(line)
-                        captured_bytes += len(line)
                         if output:
                             print(line, end="", file=sys.stderr)
-                        if captured_bytes > max_output_bytes:
+                        # Marker is always appended to stdout (consistent with the
+                        # Unix path and documented behavior), even when the cap
+                        # was tripped by a stderr line.
+                        if cap_state["over"]:
                             cap_mib = max_output_bytes / (1024 * 1024)
                             trunc_msg = (
                                 f"\n[output truncated at {cap_mib:.0f} MiB,"
                                 f" process killed]\n"
                             )
-                            stderr.append(trunc_msg)
+                            stdout.append(trunc_msg)
                             if output:
-                                print(trunc_msg, end="", file=sys.stderr)
+                                print(trunc_msg, end="", file=sys.stdout)
                             logger.warning(
                                 "Shell output cap (%d MiB) exceeded; killing process",
                                 int(cap_mib),
@@ -1196,7 +1213,11 @@ class ShellSession:
                     # spaces at the boundary
                     # 2**12 = 4096
                     # 2**16 = 65536
-                    data = os.read(fd, 2**16).decode("utf-8", errors="replace")
+                    raw = os.read(fd, 2**16)
+                    # Count the raw bytes actually read so multibyte UTF-8 output
+                    # cannot exceed the cap by 3-4x (byte count, not character count).
+                    captured_bytes += len(raw)
+                    data = raw.decode("utf-8", errors="replace")
                     lines = data.splitlines(keepends=True)
                     re_returncode = re.compile(r"ReturnCode:(\d+)")
                     for line in lines:
@@ -1293,12 +1314,10 @@ class ShellSession:
                             )
                         if fd == self.stdout_fd:
                             stdout.append(line)
-                            captured_bytes += len(line)
                             if output:
                                 print(line, end="", file=sys.stdout)
                         elif fd == self.stderr_fd:
                             stderr.append(line)
-                            captured_bytes += len(line)
                             if output:
                                 print(line, end="", file=sys.stderr)
 
@@ -1326,6 +1345,31 @@ class ShellSession:
                                     "Error killing process after byte cap exceeded: %s",
                                     e,
                                 )
+                            # Drain any remaining data from both pipes so it does
+                            # not bleed into the next command's output (Greptile P1).
+                            for drain_fd in (self.stdout_fd, self.stderr_fd):
+                                drain_empty_count = 0
+                                while drain_empty_count < 2:
+                                    drain_rlist = _wait_readable([drain_fd], 0.1)
+                                    if not drain_rlist:
+                                        drain_empty_count += 1
+                                        continue
+                                    drain_raw = os.read(drain_fd, 2**16)
+                                    if not drain_raw:
+                                        drain_empty_count += 1
+                                        continue
+                                    drain_empty_count = 0
+                                    drain_data = drain_raw.decode(
+                                        "utf-8", errors="replace"
+                                    )
+                                    if drain_fd == self.stdout_fd:
+                                        stdout.append(drain_data)
+                                        if output:
+                                            print(drain_data, end="", file=sys.stdout)
+                                    else:
+                                        stderr.append(drain_data)
+                                        if output:
+                                            print(drain_data, end="", file=sys.stderr)
                             return (
                                 -125,
                                 trim_blank_lines("".join(stdout)),
@@ -1751,6 +1795,7 @@ def _format_shell_output(
     timeout_value: float | None = None,
     logdir: Path | None = None,
     byte_cap_exceeded: bool = False,
+    cap_bytes: int | None = None,
 ) -> str:
     """Format shell command output into a message."""
     # Strip ANSI escape sequences from output
@@ -1830,7 +1875,8 @@ def _format_shell_output(
 
     # Format header
     if byte_cap_exceeded:
-        cap_mib = _DEFAULT_MAX_OUTPUT_BYTES / (1024 * 1024)
+        cap_bytes = cap_bytes or _DEFAULT_MAX_OUTPUT_BYTES
+        cap_mib = cap_bytes / (1024 * 1024)
         header = f"Command killed (output exceeded {cap_mib:.0f} MiB cap)"
     elif timed_out:
         header = (
@@ -1928,6 +1974,7 @@ def execute_shell_impl(
         timeout_value=timeout,
         logdir=logdir,
         byte_cap_exceeded=byte_cap_exceeded,
+        cap_bytes=_get_max_output_bytes() if byte_cap_exceeded else None,
     )
     # Workspace-awareness: notify when cd enters a directory with gptme.toml.
     # Append hint text directly to the command output (single yield) so no

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1010,6 +1010,29 @@ class ShellSession:
                 # Drain stdout queue
                 try:
                     data = stdout_queue.get(timeout=0.1)
+                    # Check the cap at the chunk level, before the delimiter
+                    # branch, so a chunk that both exceeds the cap and carries
+                    # the delimiter cannot bypass the cap (Greptile P1).
+                    if cap_state["over"]:
+                        cap_mib = max_output_bytes / (1024 * 1024)
+                        trunc_msg = (
+                            f"\n[output truncated at {cap_mib:.0f} MiB,"
+                            f" process killed]\n"
+                        )
+                        stdout.append(trunc_msg)
+                        if output:
+                            print(trunc_msg, end="", file=sys.stdout)
+                        logger.warning(
+                            "Shell output cap (%d MiB) exceeded; killing process",
+                            int(cap_mib),
+                        )
+                        self._terminate_process()
+                        stop_event.set()
+                        return (
+                            -125,
+                            trim_blank_lines("".join(stdout)),
+                            trim_blank_lines("".join(stderr)),
+                        )
                     lines = data.splitlines(keepends=True)
                     for line in lines:
                         if not seen_start_marker:
@@ -1101,6 +1124,28 @@ class ShellSession:
                 # Drain stderr queue
                 try:
                     data = stderr_queue.get_nowait()
+                    if cap_state["over"]:
+                        # Marker is always appended to stdout (consistent with
+                        # the Unix path and documented behavior).
+                        cap_mib = max_output_bytes / (1024 * 1024)
+                        trunc_msg = (
+                            f"\n[output truncated at {cap_mib:.0f} MiB,"
+                            f" process killed]\n"
+                        )
+                        stdout.append(trunc_msg)
+                        if output:
+                            print(trunc_msg, end="", file=sys.stdout)
+                        logger.warning(
+                            "Shell output cap (%d MiB) exceeded; killing process",
+                            int(cap_mib),
+                        )
+                        self._terminate_process()
+                        stop_event.set()
+                        return (
+                            -125,
+                            trim_blank_lines("".join(stdout)),
+                            trim_blank_lines("".join(stderr)),
+                        )
                     lines = data.splitlines(keepends=True)
                     for line in lines:
                         stderr.append(line)
@@ -1220,6 +1265,7 @@ class ShellSession:
                     data = raw.decode("utf-8", errors="replace")
                     lines = data.splitlines(keepends=True)
                     re_returncode = re.compile(r"ReturnCode:(\d+)")
+
                     for line in lines:
                         # Issue #408: Skip stdout until we see the start marker
                         # Only apply to stdout - stderr should pass through unfiltered
@@ -1288,6 +1334,14 @@ class ShellSession:
                                 else:
                                     os.chdir(pwd.strip())
 
+                            # If the byte cap was already exceeded in this chunk
+                            # (delimiter line present), do not return the real
+                            # code — enforce the cap (Greptile P1 race).
+                            if captured_bytes > max_output_bytes:
+                                return self._kill_for_byte_cap(
+                                    stdout, stderr, output, max_output_bytes
+                                )
+
                             # Issue #408: Drain any remaining stderr before
                             # returning. Use multiple attempts to ensure stderr
                             # has time to arrive from bash.
@@ -1322,58 +1376,8 @@ class ShellSession:
                                 print(line, end="", file=sys.stderr)
 
                         if captured_bytes > max_output_bytes:
-                            cap_mib = max_output_bytes / (1024 * 1024)
-                            trunc_msg = (
-                                f"\n[output truncated at {cap_mib:.0f} MiB,"
-                                f" process killed]\n"
-                            )
-                            stdout.append(trunc_msg)
-                            if output:
-                                print(trunc_msg, end="", file=sys.stdout)
-                            logger.warning(
-                                "Shell output cap (%d MiB) exceeded; killing process",
-                                int(cap_mib),
-                            )
-                            try:
-                                pgid = os.getpgid(self.process.pid)
-                                os.killpg(pgid, signal.SIGTERM)
-                                time.sleep(0.1)
-                                if self.process.poll() is None:
-                                    os.killpg(pgid, signal.SIGKILL)
-                            except Exception as e:
-                                logger.warning(
-                                    "Error killing process after byte cap exceeded: %s",
-                                    e,
-                                )
-                            # Drain any remaining data from both pipes so it does
-                            # not bleed into the next command's output (Greptile P1).
-                            for drain_fd in (self.stdout_fd, self.stderr_fd):
-                                drain_empty_count = 0
-                                while drain_empty_count < 2:
-                                    drain_rlist = _wait_readable([drain_fd], 0.1)
-                                    if not drain_rlist:
-                                        drain_empty_count += 1
-                                        continue
-                                    drain_raw = os.read(drain_fd, 2**16)
-                                    if not drain_raw:
-                                        drain_empty_count += 1
-                                        continue
-                                    drain_empty_count = 0
-                                    drain_data = drain_raw.decode(
-                                        "utf-8", errors="replace"
-                                    )
-                                    if drain_fd == self.stdout_fd:
-                                        stdout.append(drain_data)
-                                        if output:
-                                            print(drain_data, end="", file=sys.stdout)
-                                    else:
-                                        stderr.append(drain_data)
-                                        if output:
-                                            print(drain_data, end="", file=sys.stderr)
-                            return (
-                                -125,
-                                trim_blank_lines("".join(stdout)),
-                                trim_blank_lines("".join(stderr)),
+                            return self._kill_for_byte_cap(
+                                stdout, stderr, output, max_output_bytes
                             )
         except KeyboardInterrupt:
             # Clear line after ^C to avoid leaving a hanging line
@@ -1383,6 +1387,65 @@ class ShellSession:
             partial_stdout = trim_blank_lines("".join(stdout))
             partial_stderr = trim_blank_lines("".join(stderr))
             raise KeyboardInterrupt((partial_stdout, partial_stderr)) from None
+
+    def _kill_for_byte_cap(
+        self,
+        stdout: list[str],
+        stderr: list[str],
+        output: bool,
+        max_output_bytes: int,
+    ) -> tuple[int | None, str, str]:
+        """Kill the process for exceeding the byte cap, drain pipes, return -125.
+
+        Appends the truncation marker to stdout, terminates the process group,
+        drains any remaining output from both pipes (so it does not bleed into
+        the next command), and returns the synthetic -125 tuple.
+        """
+        cap_mib = max_output_bytes / (1024 * 1024)
+        trunc_msg = f"\n[output truncated at {cap_mib:.0f} MiB, process killed]\n"
+        stdout.append(trunc_msg)
+        if output:
+            print(trunc_msg, end="", file=sys.stdout)
+        logger.warning(
+            "Shell output cap (%d MiB) exceeded; killing process",
+            int(cap_mib),
+        )
+        try:
+            pgid = os.getpgid(self.process.pid)
+            os.killpg(pgid, signal.SIGTERM)
+            time.sleep(0.1)
+            if self.process.poll() is None:
+                os.killpg(pgid, signal.SIGKILL)
+        except Exception as e:
+            logger.warning("Error killing process after byte cap exceeded: %s", e)
+        # Drain any remaining data from both pipes so it does not bleed into the
+        # next command's output (Greptile P1).
+        for drain_fd in (self.stdout_fd, self.stderr_fd):
+            drain_empty_count = 0
+            while drain_empty_count < 2:
+                drain_rlist = _wait_readable([drain_fd], 0.1)
+                if not drain_rlist:
+                    drain_empty_count += 1
+                    continue
+                drain_raw = os.read(drain_fd, 2**16)
+                if not drain_raw:
+                    drain_empty_count += 1
+                    continue
+                drain_empty_count = 0
+                drain_data = drain_raw.decode("utf-8", errors="replace")
+                if drain_fd == self.stdout_fd:
+                    stdout.append(drain_data)
+                    if output:
+                        print(drain_data, end="", file=sys.stdout)
+                else:
+                    stderr.append(drain_data)
+                    if output:
+                        print(drain_data, end="", file=sys.stderr)
+        return (
+            -125,
+            trim_blank_lines("".join(stdout)),
+            trim_blank_lines("".join(stderr)),
+        )
 
     def _terminate_process(self) -> None:
         """Terminate the shell process, platform-aware."""

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -976,6 +976,12 @@ class ShellSession:
         cap_state = {"bytes": 0, "over": False}
         cap_lock = threading.Lock()
 
+        # Track the start marker for the stdout producer so it does not count
+        # the shell-injected START_OF_COMMAND_OUTPUT line (and any pre-marker
+        # output) against the cap.  Mirrors the Unix path's marker exclusion.
+        # Use a list so the closure can mutate it from the producer thread.
+        _producer_seen_start = [False]
+
         def read_stream(fd: int, queue: Queue[str]) -> None:
             try:
                 os.set_blocking(fd, False)
@@ -987,8 +993,36 @@ class ShellSession:
                     if not raw:
                         break
                     data = raw.decode("utf-8", errors="replace")
+
+                    # Exclude shell protocol markers from byte accounting on
+                    # stdout (mirrors the Unix path).  Pre-marker bytes (e.g.
+                    # leftover output from a prior command, the start-marker
+                    # line itself) are not counted so a command whose real
+                    # output is exactly max_output_bytes does not trip the cap
+                    # on Windows when Unix would not (bob-ai-review P2).
+                    if fd == self.stdout_fd:
+                        countable = raw
+                        if not _producer_seen_start[0]:
+                            if start_marker_pattern in data:
+                                _producer_seen_start[0] = True
+                                raw_marker = start_marker_pattern.encode()
+                                marker_pos = countable.find(raw_marker)
+                                if marker_pos >= 0:
+                                    nl_pos = countable.find(b"\n", marker_pos)
+                                    countable = (
+                                        countable[nl_pos + 1 :] if nl_pos >= 0 else b""
+                                    )
+                            else:
+                                countable = b""  # pre-marker; not user output
+                        countable = _strip_shell_return_marker(
+                            countable, self.delimiter
+                        )
+                        bytes_to_count = len(countable)
+                    else:
+                        bytes_to_count = len(raw)
+
                     with cap_lock:
-                        cap_state["bytes"] += len(raw)
+                        cap_state["bytes"] += bytes_to_count
                         over = cap_state["bytes"] > max_output_bytes
                         if over:
                             # Flag the cap BEFORE enqueueing the chunk so the

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1094,6 +1094,30 @@ class ShellSession:
                                         print(err_data, end="", file=sys.stderr)
                                 except Empty:
                                     break
+                            # If the cap was tripped (producer set the flag) we
+                            # must not return the real code — enforce the cap
+                            # (bob-ai-review P1 ordering race).
+                            if cap_state["over"]:
+                                cap_mib = max_output_bytes / (1024 * 1024)
+                                trunc_msg = (
+                                    f"\n[output truncated at {cap_mib:.0f} MiB,"
+                                    f" process killed]\n"
+                                )
+                                stdout.append(trunc_msg)
+                                if output:
+                                    print(trunc_msg, end="", file=sys.stdout)
+                                logger.warning(
+                                    "Shell output cap (%d MiB) exceeded;"
+                                    " killing process",
+                                    int(cap_mib),
+                                )
+                                self._terminate_process()
+                                stop_event.set()
+                                return (
+                                    -125,
+                                    trim_blank_lines("".join(stdout)),
+                                    trim_blank_lines("".join(stderr)),
+                                )
                             return (
                                 return_code,
                                 trim_blank_lines("".join(stdout)),
@@ -1349,23 +1373,33 @@ class ShellSession:
 
                             # Issue #408: Drain any remaining stderr before
                             # returning. Use multiple attempts to ensure stderr
-                            # has time to arrive from bash.
+                            # has time to arrive from bash. Bound the drain by
+                            # the byte cap as well — a command that floods
+                            # stderr after signalling completion must not
+                            # bypass the cap (bob-ai-review P1).
                             drain_empty_count = 0
-                            while drain_empty_count < 2:
+                            while (
+                                drain_empty_count < 2
+                                and captured_bytes <= max_output_bytes
+                            ):
                                 drain_rlist = _wait_readable([self.stderr_fd], 0.1)
                                 if not drain_rlist:
                                     drain_empty_count += 1
                                     continue
-                                drain_data = os.read(self.stderr_fd, 2**16).decode(
-                                    "utf-8", errors="replace"
-                                )
-                                if not drain_data:
+                                drain_raw = os.read(self.stderr_fd, 2**16)
+                                if not drain_raw:
                                     drain_empty_count += 1
                                     continue
                                 drain_empty_count = 0
+                                captured_bytes += len(drain_raw)
+                                drain_data = drain_raw.decode("utf-8", errors="replace")
                                 stderr.append(drain_data)
                                 if output:
                                     print(drain_data, end="", file=sys.stderr)
+                            if captured_bytes > max_output_bytes:
+                                return self._kill_for_byte_cap(
+                                    stdout, stderr, output, max_output_bytes
+                                )
                             return (
                                 return_code,
                                 trim_blank_lines("".join(stdout)),

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -46,6 +46,15 @@ def reset_default_model():
     set_default_model(default_model)
 
 
+@pytest.fixture(autouse=True)
+def reset_verbosity_warning_flag():
+    """Reset the _verbosity_warned flag before each test to prevent cross-test interference."""
+    original_flag = llm_openai._verbosity_warned
+    llm_openai._verbosity_warned = False
+    yield
+    llm_openai._verbosity_warned = original_flag
+
+
 def _collect_stream_result(generator):
     chunks: list[str] = []
     while True:

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -175,3 +175,48 @@ def test_cap_counts_bytes_not_characters(shell):
         f"Multibyte output ({captured} bytes) exceeds byte cap ({cap} bytes) "
         "by more than one chunk"
     )
+
+
+def test_cap_drain_is_byte_bounded(shell, monkeypatch):
+    """The post-kill drain must be byte-bounded (Greptile P1 Security).
+
+    Regression for the unbounded-drain-after-termination finding: when a
+    descendant retains an inherited output pipe and keeps writing, the drain
+    loop must stop at a bounded number of bytes instead of growing memory
+    without limit. We simulate persistent readability on the pipe and assert
+    _kill_for_byte_cap returns promptly with total output bounded by the cap.
+    """
+    from gptme.tools import shell as shell_mod
+
+    # Force the drain to always see readable data: the loop reads a chunk,
+    # drains the "budget", and stops. Without the bound it would loop forever.
+    monkeypatch.setattr(shell_mod, "_wait_readable", lambda fds, timeout: list(fds))
+    # Never report EOF so only the byte/time bound can stop the loop.
+    real_read = os.read
+    monkeypatch.setattr(
+        shell_mod.os,
+        "read",
+        lambda fd, n: (
+            real_read(fd, n)
+            if fd not in (shell.stdout_fd, shell.stderr_fd)
+            else b"x" * n
+        ),
+    )
+
+    cap = 32 * 1024  # 32 KiB — small for a fast unit test
+    with patch("gptme.tools.shell._get_max_output_bytes", return_value=cap):
+        returncode, stdout, stderr = shell._kill_for_byte_cap(
+            [], [], output=False, max_output_bytes=cap
+        )
+
+    assert returncode == -125
+    # Total drained output (excluding the truncation marker) must be at most
+    # one cap's worth — the byte budget. The old code had no bound.
+    total = len(stdout.encode("utf-8", errors="replace")) + len(
+        stderr.encode("utf-8", errors="replace")
+    )
+    # marker is ~50 bytes; allow a small slack
+    assert total < cap + 256, (
+        f"Drain unbounded: captured {total} bytes with a {cap} byte budget"
+    )
+    assert "[output truncated" in stdout

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -210,13 +210,20 @@ def test_cap_drain_is_byte_bounded(shell, monkeypatch):
         )
 
     assert returncode == -125
-    # Total drained output (excluding the truncation marker) must be at most
-    # one cap's worth — the byte budget. The old code had no bound.
-    total = len(stdout.encode("utf-8", errors="replace")) + len(
-        stderr.encode("utf-8", errors="replace")
-    )
-    # marker is ~50 bytes; allow a small slack
-    assert total < cap + 256, (
-        f"Drain unbounded: captured {total} bytes with a {cap} byte budget"
-    )
     assert "[output truncated" in stdout
+    marker = "[output truncated"
+    marker_idx = stdout.find(marker)
+    assert marker_idx >= 0
+    # Everything after the marker was drained from the pipes. The drain must
+    # actually have consumed data (proving the loop ran and was stopped by the
+    # bound, not exited on first pass) AND the total drained output must stay
+    # within the one-cap byte budget (proving it is not unbounded).
+    drained = stdout[marker_idx + len(marker) :] + stderr
+    drained_bytes = len(drained.encode("utf-8", errors="replace"))
+    assert drained_bytes > 0, "Drain consumed no data — bound not exercised"
+    # Bound: total drained output (both pipes, sharing one budget) is at most
+    # one cap's worth. The pre-fix code had no limit and would drain forever.
+    assert drained_bytes <= cap + 256, (
+        f"Drain not bounded by budget: captured {drained_bytes} bytes with a "
+        f"{cap} byte budget"
+    )

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -144,10 +144,18 @@ def test_cap_kills_large_output(shell):
 
 @pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
 def test_cap_total_output_size_bounded(shell):
-    """The total captured output must not exceed the cap by more than one read chunk.
+    """The total captured output stays within the theoretical maximum.
 
-    Uses a 256 KiB cap and ``yes`` to generate infinite output. The resulting
-    stdout must be well under 1 MiB — proving the cap prevents memory growth.
+    Uses a 256 KiB cap and ``yes`` to generate infinite output.
+
+    The theoretical maximum for captured stdout is:
+      - up to ``cap`` bytes read before the cap was detected, PLUS
+      - up to ``cap`` bytes drained by ``_kill_for_byte_cap`` (drain_budget),
+        PLUS one read chunk that may have already been read.
+
+    The resulting bound is ``2 * cap + chunk``.  This is a tight hermetic bound
+    derived from the implementation, not from the OS pipe-buffer size
+    (bob-ai-review P2: the prior bound was non-hermetic).
     """
     cap = 256 * 1024  # 256 KiB
     chunk = 2**16  # 64 KiB — the read chunk size
@@ -156,10 +164,10 @@ def test_cap_total_output_size_bounded(shell):
         returncode, stdout, stderr = shell.run("yes", timeout=10)
 
     assert returncode == -125, f"Expected -125 (byte cap), got {returncode}"
-    # Output must be capped: at most cap + one extra chunk + truncation marker
+    # Tight hermetic bound: pre-cap output + drain budget + one chunk + marker
     captured = len(stdout.encode("utf-8", errors="replace"))
-    assert captured < cap + 2 * chunk + 1024, (
-        f"Output ({captured} bytes) exceeds cap ({cap} bytes) by more than one chunk"
+    assert captured < 2 * cap + chunk + 1024, (
+        f"Output ({captured} bytes) exceeds 2×cap+chunk bound ({2 * cap + chunk} bytes)"
     )
 
 

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -149,3 +149,29 @@ def test_cap_preserves_partial_output(shell):
     # There should be some actual content before the marker
     marker_pos = stdout.find("[output truncated")
     assert marker_pos > 0, "No content before truncation marker"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_cap_counts_bytes_not_characters(shell):
+    """Multibyte UTF-8 output must be bounded by bytes, not characters.
+
+    Regression for Greptile P1: the cap previously counted decoded Unicode
+    characters, so 3-4 byte UTF-8 output could accumulate ~3-4x the cap before
+    the child was killed. The counter now uses raw bytes read from the pipe.
+    """
+    cap = 64 * 1024  # 64 KiB
+    marker = "\u4e2d" * 100  # 100 three-byte characters → 300 bytes per line
+    # `yes` emits marker repeatedly; at 300 bytes/line the byte counter must
+    # trip the cap at roughly the same point as ASCII-only output.
+    with patch("gptme.tools.shell._get_max_output_bytes", return_value=cap):
+        returncode, stdout, stderr = shell.run(f"yes '{marker}'", timeout=10)
+
+    assert returncode == -125
+    captured = len(stdout.encode("utf-8", errors="replace"))
+    chunk = 2**16
+    # Byte cap: output stays near cap (+ one chunk + marker), never ~3x the cap
+    # which would be the case if the counter were counting characters.
+    assert captured < cap + chunk + 512, (
+        f"Multibyte output ({captured} bytes) exceeds byte cap ({cap} bytes) "
+        "by more than one chunk"
+    )

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -1,0 +1,151 @@
+"""Tests for GPTME_SHELL_MAX_OUTPUT_BYTES — bounded captured subprocess output.
+
+Issue #3798: the shell tool accumulated subprocess output into an unbounded list
+before applying token-level truncation. A ``cat`` of a 2.7 GiB log file pushed
+the gptme process to 3.3 GiB RSS and drained the system swap.
+
+The fix adds a byte cap (default 32 MiB) that kills the child and embeds a
+truncation marker in the output when the cap is exceeded.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gptme.tools.shell import (
+    _DEFAULT_MAX_OUTPUT_BYTES,
+    ShellSession,
+    _get_max_output_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for _get_max_output_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_default_when_env_unset(monkeypatch):
+    """Without any config the default (32 MiB) is returned."""
+    monkeypatch.delenv("GPTME_SHELL_MAX_OUTPUT_BYTES", raising=False)
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = None
+    with patch("gptme.config.get_config", return_value=mock_cfg):
+        result = _get_max_output_bytes()
+    assert result == _DEFAULT_MAX_OUTPUT_BYTES
+
+
+def test_env_override_bytes(monkeypatch):
+    """A plain integer env value is accepted."""
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = "8388608"  # 8 MiB
+    with patch("gptme.config.get_config", return_value=mock_cfg):
+        result = _get_max_output_bytes()
+    assert result == 8 * 1024 * 1024
+
+
+def test_env_override_suffix(monkeypatch):
+    """A suffixed value like '16M' is parsed correctly."""
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = "16M"
+    with patch("gptme.config.get_config", return_value=mock_cfg):
+        result = _get_max_output_bytes()
+    assert result == 16 * 1024 * 1024
+
+
+def test_invalid_env_falls_back_to_default():
+    """An unparseable value logs a warning and returns the default."""
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = "not-a-number"
+    with patch("gptme.config.get_config", return_value=mock_cfg):
+        result = _get_max_output_bytes()
+    assert result == _DEFAULT_MAX_OUTPUT_BYTES
+
+
+def test_zero_env_falls_back_to_default():
+    """A zero or negative value falls back to the default (doesn't disable cap)."""
+    mock_cfg = MagicMock()
+    mock_cfg.get_env.return_value = "0"
+    with patch("gptme.config.get_config", return_value=mock_cfg):
+        result = _get_max_output_bytes()
+    assert result == _DEFAULT_MAX_OUTPUT_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — require a real ShellSession
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def shell():
+    """Provide a fresh ShellSession and close it after the test."""
+    s = ShellSession()
+    yield s
+    s.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_cap_kills_large_output(shell):
+    """Output larger than the cap triggers kill and embeds the truncation marker.
+
+    We set a tiny cap (64 KiB) and run ``yes`` — a program that produces
+    infinite output without consuming memory itself. The shell should stop it
+    quickly and return the marker.
+    """
+    tiny_cap = 64 * 1024  # 64 KiB
+    with patch("gptme.tools.shell._get_max_output_bytes", return_value=tiny_cap):
+        returncode, stdout, stderr = shell.run("yes", timeout=10)
+
+    assert returncode == -125, f"Expected -125 (byte cap), got {returncode}"
+    assert "[output truncated" in stdout, (
+        f"Truncation marker missing from stdout: {stdout[:200]}"
+    )
+    assert "process killed" in stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_cap_total_output_size_bounded(shell):
+    """The total captured output must not exceed the cap by more than one read chunk.
+
+    Uses a 256 KiB cap and ``yes`` to generate infinite output. The resulting
+    stdout must be well under 1 MiB — proving the cap prevents memory growth.
+    """
+    cap = 256 * 1024  # 256 KiB
+    chunk = 2**16  # 64 KiB — the read chunk size
+
+    with patch("gptme.tools.shell._get_max_output_bytes", return_value=cap):
+        returncode, stdout, stderr = shell.run("yes", timeout=10)
+
+    assert returncode == -125, f"Expected -125 (byte cap), got {returncode}"
+    # Output must be capped: at most cap + one extra chunk + truncation marker
+    captured = len(stdout.encode("utf-8", errors="replace"))
+    assert captured < cap + chunk + 512, (
+        f"Output ({captured} bytes) exceeds cap ({cap} bytes) by more than one chunk"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_normal_output_below_cap_unaffected(shell):
+    """Commands producing output well below the cap run normally (no -125)."""
+    with patch(
+        "gptme.tools.shell._get_max_output_bytes",
+        return_value=_DEFAULT_MAX_OUTPUT_BYTES,
+    ):
+        returncode, stdout, stderr = shell.run("echo hello")
+
+    assert returncode == 0, f"stderr: {stderr}"
+    assert "hello" in stdout
+    assert "[output truncated" not in stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_cap_preserves_partial_output(shell):
+    """Some output is captured before the cap fires; it must be in stdout."""
+    cap = 32 * 1024  # 32 KiB
+
+    with patch("gptme.tools.shell._get_max_output_bytes", return_value=cap):
+        returncode, stdout, stderr = shell.run("yes", timeout=10)
+
+    assert returncode == -125
+    # There should be some actual content before the marker
+    marker_pos = stdout.find("[output truncated")
+    assert marker_pos > 0, "No content before truncation marker"

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -17,6 +17,7 @@ from gptme.tools.shell import (
     _DEFAULT_MAX_OUTPUT_BYTES,
     ShellSession,
     _get_max_output_bytes,
+    _strip_shell_return_marker,
 )
 
 # ---------------------------------------------------------------------------
@@ -68,6 +69,45 @@ def test_zero_env_falls_back_to_default():
     with patch("gptme.config.get_config", return_value=mock_cfg):
         result = _get_max_output_bytes()
     assert result == _DEFAULT_MAX_OUTPUT_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _strip_shell_return_marker
+# ---------------------------------------------------------------------------
+
+DELIM = "END_OF_COMMAND_OUTPUT"
+
+
+def test_marker_stripped_when_same_line():
+    """The single-line injected return marker is removed from byte accounting."""
+    chunk = b"hello\nworld\nReturnCode:0 END_OF_COMMAND_OUTPUT\n"
+    assert _strip_shell_return_marker(chunk, DELIM) == b"hello\nworld\n"
+
+
+def test_marker_split_across_lines_not_stripped():
+    """Command output with ReturnCode: and delimiter on SEPARATE lines counts fully.
+
+    Regression for Greptile P1 (marker text bypasses cap): previously anything
+    with ``ReturnCode:`` later followed by the delimiter in the same chunk was
+    stripped from byte accounting, so a command emitting marker-like text on
+    separate lines could undercount and evade the cap.
+    """
+    chunk = b"ReturnCode: 42\nsome output\nEND_OF_COMMAND_OUTPUT here\nmore\n"
+    assert _strip_shell_return_marker(chunk, DELIM) == chunk
+
+
+def test_marker_stripped_only_after_returncode_line():
+    """Command output before the delimiter line is preserved."""
+    chunk = b"data\nReturnCode:0\nEND_OF_COMMAND_OUTPUT\n"
+    # 'ReturnCode:0\n' and 'END_OF_COMMAND_OUTPUT\n' are on separate lines, so
+    # nothing is stripped: this is genuine (non-marker) output text.
+    assert _strip_shell_return_marker(chunk, DELIM) == chunk
+
+
+def test_no_marker_leaves_chunk_untouched():
+    """A chunk without the marker is passed through unchanged."""
+    chunk = b"just stdout data\nwith a ReturnCode: prefix but no delimiter\n"
+    assert _strip_shell_return_marker(chunk, DELIM) == chunk
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -118,7 +118,7 @@ def test_cap_total_output_size_bounded(shell):
     assert returncode == -125, f"Expected -125 (byte cap), got {returncode}"
     # Output must be capped: at most cap + one extra chunk + truncation marker
     captured = len(stdout.encode("utf-8", errors="replace"))
-    assert captured < cap + chunk + 512, (
+    assert captured < cap + 2 * chunk + 1024, (
         f"Output ({captured} bytes) exceeds cap ({cap} bytes) by more than one chunk"
     )
 
@@ -171,7 +171,7 @@ def test_cap_counts_bytes_not_characters(shell):
     chunk = 2**16
     # Byte cap: output stays near cap (+ one chunk + marker), never ~3x the cap
     # which would be the case if the counter were counting characters.
-    assert captured < cap + chunk + 512, (
+    assert captured < cap + 2 * chunk + 1024, (
         f"Multibyte output ({captured} bytes) exceeds byte cap ({cap} bytes) "
         "by more than one chunk"
     )

--- a/tests/test_shell_max_output_bytes.py
+++ b/tests/test_shell_max_output_bytes.py
@@ -138,6 +138,20 @@ def test_normal_output_below_cap_unaffected(shell):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
+def test_delimiter_bytes_do_not_trip_cap(shell):
+    """The shell's injected return marker is not subprocess output."""
+    command_output = "x" * 4096
+    with patch(
+        "gptme.tools.shell._get_max_output_bytes", return_value=len(command_output)
+    ):
+        returncode, stdout, stderr = shell.run(f"printf %s {command_output}")
+
+    assert returncode == 0, f"stderr: {stderr}"
+    assert stdout == command_output
+    assert "[output truncated" not in stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM/SIGKILL are POSIX-only")
 def test_cap_preserves_partial_output(shell):
     """Some output is captured before the cap fires; it must be in stdout."""
     cap = 32 * 1024  # 32 KiB


### PR DESCRIPTION
## Problem

`gptme/tools/shell.py` captured the full subprocess output into an unbounded list (`stdout: list[str]`, `stderr: list[str]`) and only applied token-level truncation after the process exited. A `cat` of a multi-GiB file accumulates all bytes in the gptme process's heap.

**Incident (2026-09-10):** An autonomous PM session ran `cat` on its own 2.7 GiB slot log. gptme reached 3.3 GiB RSS + 1.9 GiB swap inside a `MemoryHigh=3G` systemd unit, drained the box's 4 GiB swap, and parked the whole PM fleet for ~10 minutes. Same class as ErikBjare/bob#151 (2025-11). Related bounded-capture work: #1274, #1724 — the shell tool had no equivalent cap.

## Fix

Add a hard byte cap on the total bytes accumulated in the reader loop, configurable via `GPTME_SHELL_MAX_OUTPUT_BYTES` (env) / `SHELL_MAX_OUTPUT_BYTES` (config.toml). Default: **32 MiB**.

When the cap is exceeded:
1. The subprocess receives SIGTERM then SIGKILL.
2. A `[output truncated at N MiB, process killed]` marker is appended to stdout.
3. Return code `-125` signals the caller (distinct from `-124` = timeout).
4. Header in the tool output: `Command killed (output exceeded N MiB cap)`.
5. Token-level truncation (`GPTME_SHELL_TRUNC_*`) applies on top as a second stage.

Both `_read_output_unix` and `_read_output_windows` are covered.

## Changes

- `gptme/tools/shell.py`: `_DEFAULT_MAX_OUTPUT_BYTES`, `_get_max_output_bytes()`, byte tracking in both read loops, `byte_cap_exceeded` flag through `execute_shell_impl` → `_format_shell_output`
- `tests/test_shell_max_output_bytes.py`: 9 tests — env reader unit tests, live cap behaviour (`yes` as infinite source), size bound proof, normal output unaffected, partial output preserved

## Testing

```
tests/test_shell_max_output_bytes.py  9 passed
tests/test_tools_shell.py            137 passed (0 regressions)
tests/test_shell_memory_limit.py       5 passed
```

Closes #3798

<!-- gptme-id:v1:gai_SVB2ZU1CEEXXbH9Howsj1qypSE4ayAmyrNE6ufqXt7E -->