### PR TITLE
fix(shell): survive command timeouts, restore cwd/env after a shell death, tell the model

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1088,14 +1088,19 @@ class ShellSession:
 
         full_command = f"echo {start_marker_pattern}\n"  # Start marker first
         full_command += f"{command}\n"
-        full_command += f"echo ReturnCode:$? {self.delimiter}\n"
         if self._state_path:
-            # Snapshot cwd + exported env after every command so a restart can
-            # restore them (runs after the delimiter, so it never delays output).
+            # Snapshot cwd + exported env before reporting completion. This
+            # closes the race where run() returned and the shell died before
+            # the state from the successful command reached the snapshot.
             full_command += (
+                "_gptme_rc=$?; "
                 "{ printf 'cd -- %q\\n' \"$PWD\"; export -p; } > "
-                f"{shlex.quote(self._state_path)} 2>/dev/null || true\n"
+                f"{shlex.quote(self._state_path)} 2>/dev/null || true; "
+                f"echo ReturnCode:$_gptme_rc {self.delimiter}; "
+                "unset _gptme_rc\n"
             )
+        else:
+            full_command += f"echo ReturnCode:$? {self.delimiter}\n"
 
         try:
             self.process.stdin.write(full_command)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1583,12 +1583,27 @@ class ShellSession:
                                 return self._kill_for_byte_cap(
                                     stdout, stderr, output, max_output_bytes
                                 )
+                            restored = self._has_state_snapshot()
                             self.restart()
+                            if restored:
+                                note = (
+                                    "cwd and exported variables were restored "
+                                    "from a snapshot"
+                                )
+                            else:
+                                note = "cwd was reset; exported variables are gone"
                             stderr.append(
-                                "\n[gptme] The command closed a persistent shell "
-                                "output pipe, so a fresh shell was started; cwd, "
-                                "variables and `&` jobs from the old shell are "
-                                "gone.\n"
+                                f"\n[gptme] The command closed a persistent shell "
+                                f"output pipe, so a fresh shell was started; {note}. "
+                                f"Shell functions, aliases, unexported variables "
+                                f"and `&` jobs from the old shell are gone.\n"
+                            )
+                            self._restart_notice = (
+                                f"Note: the shell exited (closed its output pipe) "
+                                f"during this command, so gptme started a fresh "
+                                f"shell. {note[0].upper() + note[1:]}. Shell functions, "
+                                f"aliases, unexported variables and background jobs "
+                                f"of the old shell are gone."
                             )
                             return (
                                 -1,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1616,12 +1616,17 @@ class ShellSession:
                                 f"Shell functions, aliases, unexported variables "
                                 f"and `&` jobs from the old shell are gone.\n"
                             )
-                            self._restart_notice = (
+                            restart_notice = (
                                 f"Note: the shell exited (closed its output pipe) "
                                 f"during this command, so gptme started a fresh "
                                 f"shell. {note[0].upper() + note[1:]}. Shell functions, "
                                 f"aliases, unexported variables and background jobs "
                                 f"of the old shell are gone."
+                            )
+                            self._restart_notice = (
+                                restart_notice
+                                if not self._restart_notice
+                                else self._restart_notice + "\n" + restart_notice
                             )
                             return (
                                 -1,

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -557,12 +557,14 @@ class ShellSession:
     _state_path: str | None  # cwd + exported-env snapshot, restored on restart
     _restart_notice: str | None  # pending note for the model about a restart
     _restarting: bool
+    _closed: bool
 
     def __init__(self, cwd: str | None = None) -> None:
         self._cwd = cwd
         self._memory_limit = _get_memory_limit()
         self._restart_notice = None
         self._restarting = False
+        self._closed = False
         self._state_path = self._create_state_file()
         self._init()
 
@@ -993,9 +995,12 @@ class ShellSession:
         # Diagnostic logging for Issue #408: Log command start
         logger.debug(f"Shell: Running command: {command[:200]}")
 
-        # The shell may have died between commands (external kill, OOM, or
-        # closed by the conversation registry from another thread). Nothing has
-        # been sent yet, so restarting here cannot double-execute anything.
+        # The shell may have died between commands (external kill or OOM).
+        # Nothing has been sent yet, so restarting here cannot double-execute
+        # anything. An explicit close is terminal: reviving a shell removed by
+        # SESSION_END would leak an unregistered process.
+        if self._closed:
+            raise RuntimeError("Shell session is closed")
         if self.process.poll() is not None or self.process.stdin.closed:
             self._restart_after_death(self.process.returncode, "before this command")
             assert self.process.stdin
@@ -1940,6 +1945,9 @@ class ShellSession:
             logger.warning(f"Error terminating process: {e}")
 
     def close(self):
+        if not self._restarting:
+            self._closed = True
+
         # Close stdin to signal no more input
         if self.process.stdin:
             self.process.stdin.close()
@@ -1964,6 +1972,7 @@ class ShellSession:
         try:
             self.close()
             self._init()
+            self._closed = False
         finally:
             self._restarting = False
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -672,6 +672,8 @@ class ShellSession:
         Never re-runs the command that was in flight: it may have partially or
         fully executed (e.g. ``git commit && kill -9 $$``).
         """
+        if self._closed:
+            return
         logger.warning(
             "Warning: shell process died (%s, %s), restarting",
             _describe_exit_status(status),
@@ -1589,6 +1591,12 @@ class ShellSession:
                                     stdout, stderr, output, max_output_bytes
                                 )
                             restored = self._has_state_snapshot()
+                            if self._closed:
+                                return (
+                                    -1,
+                                    trim_blank_lines("".join(stdout)),
+                                    trim_blank_lines("".join(stderr)),
+                                )
                             self.restart()
                             if restored:
                                 note = (
@@ -1968,11 +1976,12 @@ class ShellSession:
                 pass
 
     def restart(self):
+        if self._closed:
+            return
         self._restarting = True
         try:
             self.close()
             self._init()
-            self._closed = False
         finally:
             self._restarting = False
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -43,6 +43,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Generator
@@ -480,6 +481,71 @@ def _wait_readable(fds: list[int], timeout: float | None) -> list[int]:
     return [fd for fd, _event in poller.poll(timeout_ms)]
 
 
+def _child_pids(pid: int) -> list[int]:
+    """Return the direct children of ``pid`` (Linux ``/proc``, else ``pgrep``)."""
+    task_dir = f"/proc/{pid}/task"
+    try:
+        children: list[int] = []
+        for tid in os.listdir(task_dir):
+            with open(f"{task_dir}/{tid}/children") as f:
+                children.extend(int(p) for p in f.read().split())
+        return children
+    except (OSError, ValueError):
+        pass
+    try:
+        out = subprocess.run(
+            ["pgrep", "-P", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        ).stdout
+        return [int(p) for p in out.split()]
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return []
+
+
+def _descendant_pids(pid: int) -> list[int]:
+    """Return every live descendant of ``pid`` (breadth-first), excluding ``pid``."""
+    seen: set[int] = set()
+    queue = [pid]
+    while queue:
+        for child in _child_pids(queue.pop()):
+            if child not in seen:
+                seen.add(child)
+                queue.append(child)
+    return sorted(seen)
+
+
+def _kill_descendants(pid: int) -> None:
+    """SIGTERM then SIGKILL every descendant of ``pid`` without touching ``pid``.
+
+    Used on command timeout so the persistent bash survives: killing the whole
+    process group (bash is its leader) would take the shell down with the
+    command, losing cwd/env and triggering a restart on the next command.
+    """
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        for child in _descendant_pids(pid):
+            try:
+                os.kill(child, sig)
+            except (ProcessLookupError, PermissionError):
+                pass
+        if sig == signal.SIGTERM:
+            time.sleep(0.1)
+
+
+def _describe_exit_status(status: int | None) -> str:
+    if status is None:
+        return "closed its stdout/stderr while still running"
+    if status < 0:
+        try:
+            name = signal.Signals(-status).name
+        except ValueError:
+            name = f"signal {-status}"
+        return f"killed by {name}"
+    return f"code {status}"
+
+
 class ShellSession:
     process: subprocess.Popen
     stdout_fd: int
@@ -488,10 +554,16 @@ class ShellSession:
     start_marker: str  # Fix for Issue #408: Add start marker to prevent output mixing
     _cwd: str | None  # Workspace directory for this session (thread-safe)
     _memory_limit: int | None  # Address-space ceiling in bytes (None = off)
+    _state_path: str | None  # cwd + exported-env snapshot, restored on restart
+    _restart_notice: str | None  # pending note for the model about a restart
+    _restarting: bool
 
     def __init__(self, cwd: str | None = None) -> None:
         self._cwd = cwd
         self._memory_limit = _get_memory_limit()
+        self._restart_notice = None
+        self._restarting = False
+        self._state_path = self._create_state_file()
         self._init()
 
         # close on exit
@@ -546,6 +618,16 @@ class ShellSession:
         self.delimiter = "END_OF_COMMAND_OUTPUT"
         self.start_marker = "START_OF_COMMAND_OUTPUT"
 
+        # After a restart, restore cwd and exported variables from the snapshot
+        # taken after the last command the previous shell completed. Must run
+        # first: every run() below rewrites the snapshot with the new shell's state.
+        if self._restarting and self._has_state_snapshot():
+            assert self._state_path is not None
+            self.run(
+                f"source {shlex.quote(self._state_path)} >/dev/null 2>&1 || true",
+                output=False,
+            )
+
         # set GIT_PAGER=cat
         self.run("export PAGER=")
         self.run("export GH_PAGER=")
@@ -556,6 +638,66 @@ class ShellSession:
         self.run("export VISUAL=true")
         # make Python output unbuffered by default for better UX
         self.run("export PYTHONUNBUFFERED=1")
+
+    @staticmethod
+    def _create_state_file() -> str | None:
+        if _is_windows:
+            return None
+        try:
+            fd, path = tempfile.mkstemp(prefix="gptme-shell-state-", suffix=".sh")
+            os.close(fd)
+            return path
+        except OSError as e:
+            logger.warning(f"Could not create shell state snapshot file: {e}")
+            return None
+
+    def _has_state_snapshot(self) -> bool:
+        if not self._state_path:
+            return False
+        try:
+            return os.path.getsize(self._state_path) > 0
+        except OSError:
+            return False
+
+    def consume_restart_notice(self) -> str | None:
+        """Return (and clear) the pending note about a shell restart, if any."""
+        notice, self._restart_notice = self._restart_notice, None
+        return notice
+
+    def _restart_after_death(self, status: int | None, when: str) -> None:
+        """Restart the shell after it died and queue a note for the model.
+
+        Never re-runs the command that was in flight: it may have partially or
+        fully executed (e.g. ``git commit && kill -9 $$``).
+        """
+        logger.warning(
+            "Warning: shell process died (%s, %s), restarting",
+            _describe_exit_status(status),
+            when,
+        )
+        restored = self._has_state_snapshot()
+        self.restart()
+        _, cwd, _ = self.run("pwd", output=False)
+        cwd = cwd.strip()
+        if restored:
+            state = (
+                f"Working directory ({cwd}) and exported variables were "
+                "restored from a snapshot taken after the last completed "
+                "command."
+            )
+        else:
+            state = (
+                f"Working directory was reset to {cwd}; environment variables "
+                "exported by earlier commands are gone."
+            )
+        notice = (
+            f"Note: the shell exited ({_describe_exit_status(status)}) {when}, "
+            f"so gptme started a fresh shell. {state} Shell functions, aliases, "
+            "unexported variables and background jobs of the old shell are gone."
+        )
+        self._restart_notice = (
+            notice if not self._restart_notice else self._restart_notice + "\n" + notice
+        )
 
     def run(
         self, code: str, output=True, timeout: float | None = None
@@ -851,6 +993,13 @@ class ShellSession:
         # Diagnostic logging for Issue #408: Log command start
         logger.debug(f"Shell: Running command: {command[:200]}")
 
+        # The shell may have died between commands (external kill, OOM, or
+        # closed by the conversation registry from another thread). Nothing has
+        # been sent yet, so restarting here cannot double-execute anything.
+        if self.process.poll() is not None or self.process.stdin.closed:
+            self._restart_after_death(self.process.returncode, "before this command")
+            assert self.process.stdin
+
         # Redirect stdin to /dev/null to prevent commands from inheriting bash's pipe stdin
         # Use shlex to properly parse commands and respect quotes
         # Only add for commands that don't already redirect stdin
@@ -933,20 +1082,28 @@ class ShellSession:
         full_command = f"echo {start_marker_pattern}\n"  # Start marker first
         full_command += f"{command}\n"
         full_command += f"echo ReturnCode:$? {self.delimiter}\n"
+        if self._state_path:
+            # Snapshot cwd + exported env after every command so a restart can
+            # restore them (runs after the delimiter, so it never delays output).
+            full_command += (
+                "{ printf 'cd -- %q\\n' \"$PWD\"; export -p; } > "
+                f"{shlex.quote(self._state_path)} 2>/dev/null || true\n"
+            )
+
         try:
             self.process.stdin.write(full_command)
+            self.process.stdin.flush()
         except BrokenPipeError:
-            # process has died
+            # Died between the liveness check and the write: the command was
+            # never received, so a single retry is safe.
             if tries == 0:
-                # log warning and restart, once
-                logger.warning("Warning: shell process died, restarting")
-                self.restart()
+                self._restart_after_death(
+                    self.process.poll(), "before this command was received"
+                )
                 return self._run_pipe(
                     command, output=output, tries=tries + 1, timeout=timeout
                 )
             raise
-
-        self.process.stdin.flush()
 
         # Issue #408: Track whether we've seen the start marker for this command
         seen_start_marker = False
@@ -1333,25 +1490,38 @@ class ShellSession:
         """Read command output on Unix using select()."""
         assert select is not None
         captured_bytes = 0
+        timed_out = False  # children killed; waiting for bash to emit delimiter
+        grace_deadline = 0.0
         try:
             while True:
                 # Calculate remaining timeout
                 select_timeout = None
                 if timeout and start_time:
                     elapsed = time.time() - start_time
-                    if elapsed >= timeout:
-                        # Timeout exceeded
+                    if elapsed >= timeout and not timed_out:
+                        # Timeout exceeded: kill the command's processes but
+                        # keep bash alive (it is the process-group leader, so
+                        # killpg would take it down and lose cwd/env). Bash
+                        # then reports the kill via the delimiter line.
                         logger.info(f"Command timed out after {timeout} seconds")
-                        # Terminate the entire process group (bash + all child processes)
+                        _kill_descendants(self.process.pid)
+                        timed_out = True
+                        grace_deadline = time.time() + 2.0
+                    elif timed_out and time.time() >= grace_deadline:
+                        # Bash itself is stuck (or the command was a builtin):
+                        # fall back to killing the whole group and restarting.
                         try:
                             pgid = os.getpgid(self.process.pid)
                             os.killpg(pgid, signal.SIGTERM)
                             time.sleep(0.1)  # Give it a moment to terminate
                             if self.process.poll() is None:
                                 os.killpg(pgid, signal.SIGKILL)
+                            self.process.wait(timeout=1.0)
                         except Exception as e:
                             logger.warning(f"Error terminating timed-out process: {e}")
-
+                        self._restart_after_death(
+                            self.process.poll(), "after the command timed out"
+                        )
                         partial_stdout = trim_blank_lines("".join(stdout))
                         partial_stderr = trim_blank_lines("".join(stderr))
                         return (
@@ -1360,8 +1530,8 @@ class ShellSession:
                             partial_stderr,
                         )  # Use timeout exit code (124)
 
-                    select_timeout = min(
-                        1.0, timeout - elapsed
+                    select_timeout = (
+                        0.1 if timed_out else min(1.0, timeout - elapsed)
                     )  # Check at least every second
 
                 rlist = _wait_readable([self.stdout_fd, self.stderr_fd], select_timeout)
@@ -1511,6 +1681,8 @@ class ShellSession:
                             rc_matches = re_returncode.findall(line)
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
+                            if timed_out:
+                                return_code = -124  # timeout exit code
                             # if command is cd, update working directory
                             if (
                                 command == "cd" or command.startswith("cd ")
@@ -1638,19 +1810,19 @@ class ShellSession:
             rc: int | None = self.process.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
             rc = None
+        # Drain output still buffered on the unclosed pipe (a diagnostic can
+        # arrive after the EOF-triggering close), enforcing the same byte cap,
+        # then restart and restore cwd/exported env. Never re-run the command.
         captured_bytes = self._drain_closed_shell_pipes(
             stdout, stderr, output, max_output_bytes, captured_bytes
         )
         if captured_bytes > max_output_bytes:
             return self._kill_for_byte_cap(stdout, stderr, output, max_output_bytes)
-        logger.warning(
-            "Shell process exited during command (code %s), restarting shell", rc
-        )
-        self.restart()
+        self._restart_after_death(rc, "during this command")
         stderr.append(
-            f"\n[gptme] The shell exited (code {rc}), so a fresh shell was "
-            "started; cwd, variables and `&` jobs from the old shell are gone. "
-            "Don't run `exit` in the tool shell — it never needs to be exited.\n"
+            f"\n[gptme] The shell exited ({_describe_exit_status(rc)}), so a "
+            "fresh shell was started (see note below). Don't run `exit` in the "
+            "tool shell — it never needs to be exited.\n"
         )
         return (
             rc if rc is not None else -1,
@@ -1766,9 +1938,19 @@ class ShellSession:
         if self.process.stderr:
             self.process.stderr.close()
 
+        if self._state_path and not self._restarting:
+            try:
+                os.unlink(self._state_path)
+            except OSError:
+                pass
+
     def restart(self):
-        self.close()
-        self._init()
+        self._restarting = True
+        try:
+            self.close()
+            self._init()
+        finally:
+            self._restarting = False
 
 
 _shell_var: ContextVar[ShellSession | None] = ContextVar("shell", default=None)
@@ -2338,6 +2520,11 @@ def execute_shell_impl(
             hint = _check_workspace_config()
             if hint:
                 workspace_hint_content = "\n\n" + hint.content
+    # If the shell died and was restarted during this call, tell the model
+    # (same single-yield rule as the workspace hint).
+    restart_notice = shell.consume_restart_notice()
+    if restart_notice:
+        workspace_hint_content += "\n\n" + restart_notice
 
     # stdout/stderr were already streamed live by ShellSession (both the
     # persistent-pipe and the TTY path stream as bytes arrive), so the

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -251,7 +251,9 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
     # A delimiter is a shell word, not necessarily an identifier. Support
     # punctuation commonly used to make delimiters distinctive (for example
     # ``END-TAG``), while stopping unquoted words at shell metacharacters.
-    heredoc_pattern = re.compile(r"<<-?\s*(?:\"([^\"\n]+)\"|'([^'\n]+)'|([^\s;&|<>]+))")
+    heredoc_pattern = re.compile(
+        r"<<(\-?)\s*(?:\"([^\"\n]+)\"|'([^'\n]+)'|([^\s;&|<>]+))"
+    )
 
     quoted_regions = _find_quotes(cmd)
 
@@ -283,7 +285,8 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
         ):
             continue
 
-        delimiter = next(group for group in match.groups() if group is not None)
+        strip_tabs = match.group(1) == "-"
+        delimiter = next(group for group in match.groups()[1:] if group is not None)
 
         # Find where the content starts (after the first newline after the marker)
         search_start = match.end()
@@ -301,15 +304,20 @@ def _find_heredoc_regions(cmd: str) -> list[tuple[int, int]]:
                 # Check if remaining text is the delimiter. Include the
                 # delimiter itself in the safe region: it is shell syntax, not
                 # a command following the heredoc.
-                if cmd[pos:].strip() == delimiter:
+                tail = cmd[pos:].rstrip("\r")
+                if strip_tabs:
+                    tail = tail.lstrip("\t")
+                if tail == delimiter:
                     heredoc_regions.append((content_start, len(cmd)))
                 break
 
             # Check if the line from pos to newline_idx is just the delimiter.
             # Include the terminator line but preserve its newline, so a real
             # command on the following line remains independently visible.
-            line = cmd[pos:newline_idx]
-            if line.strip() == delimiter:
+            line = cmd[pos:newline_idx].rstrip("\r")
+            if strip_tabs:
+                line = line.lstrip("\t")
+            if line == delimiter:
                 heredoc_regions.append((content_start, newline_idx))
                 break
 

--- a/tests/test_shell_restart.py
+++ b/tests/test_shell_restart.py
@@ -95,12 +95,11 @@ def test_killed_between_commands_restarts_before_next_command(shell, tmp_path):
     assert _state(shell)[:2] == (str(tmp_path), "alive")
 
 
-def test_closed_stdin_restarts_instead_of_raising(shell):
-    """close() from another thread must not leave a permanently broken shell."""
+def test_explicitly_closed_shell_stays_closed(shell):
+    """SESSION_END cleanup must not be undone by a stale ContextVar reference."""
     shell.close()
-    rc, out, _ = shell.run("echo back", output=False)
-    assert (rc, out.strip()) == (0, "back")
-    assert "before this command" in (shell.consume_restart_notice() or "")
+    with pytest.raises(RuntimeError, match="Shell session is closed"):
+        shell.run("echo back", output=False)
 
 
 def test_command_that_kills_shell_is_not_rerun(shell, tmp_path):

--- a/tests/test_shell_restart.py
+++ b/tests/test_shell_restart.py
@@ -84,6 +84,20 @@ def test_stdout_closed_but_shell_alive_is_restarted(shell, tmp_path):
     assert (pid != old_pid, cwd, marker) == (True, str(tmp_path), "alive")
 
 
+def test_closed_pipe_preserves_existing_restart_notice(shell):
+    """Two shell deaths before notice consumption must both reach the model."""
+    os.kill(shell.process.pid, signal.SIGKILL)
+    shell.process.wait(timeout=5)
+
+    shell.run("exec 1>&-", output=False, timeout=30)
+
+    notice = shell.consume_restart_notice()
+    assert notice
+    assert "before this command" in notice
+    assert "during this command" in notice
+    assert notice.index("before this command") < notice.index("during this command")
+
+
 def test_killed_between_commands_restarts_before_next_command(shell, tmp_path):
     """External kill (OOM killer, registry close from another thread)."""
     os.kill(shell.process.pid, signal.SIGKILL)

--- a/tests/test_shell_restart.py
+++ b/tests/test_shell_restart.py
@@ -16,6 +16,7 @@ A command timeout must kill the command's processes, not bash itself.
 import os
 import signal
 import sys
+import threading
 import time
 from unittest.mock import patch
 
@@ -100,6 +101,31 @@ def test_explicitly_closed_shell_stays_closed(shell):
     shell.close()
     with pytest.raises(RuntimeError, match="Shell session is closed"):
         shell.run("echo back", output=False)
+
+
+def test_close_racing_with_eof_does_not_restart_shell(shell):
+    """SESSION_END must win when an active read sees the pipes close."""
+    command_started = threading.Event()
+    run_finished = threading.Event()
+
+    def run_command():
+        command_started.set()
+        try:
+            shell.run("sleep 30", output=False)
+        finally:
+            run_finished.set()
+
+    thread = threading.Thread(target=run_command)
+    thread.start()
+    assert command_started.wait(timeout=1)
+    time.sleep(0.1)
+
+    shell.close()
+    thread.join(timeout=5)
+
+    assert run_finished.is_set()
+    assert shell._closed
+    assert shell.process.poll() is not None
 
 
 def test_command_that_kills_shell_is_not_rerun(shell, tmp_path):

--- a/tests/test_shell_restart.py
+++ b/tests/test_shell_restart.py
@@ -1,0 +1,202 @@
+"""Persistent-shell death and restart semantics.
+
+Every way the persistent bash can die (``exit``, ``exec``, ``kill -9 $$``,
+``set -e`` + failure, closing its stdout, an external kill, a command timeout)
+must:
+
+* return promptly instead of spinning on the closed pipe until the timeout,
+* restart the shell with the working directory and exported variables
+  restored from the snapshot taken after the last completed command,
+* queue a note that the tool response shows the model,
+* never re-run the command that killed the shell (it may have executed).
+
+A command timeout must kill the command's processes, not bash itself.
+"""
+
+import os
+import signal
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+from gptme.tools.shell import ShellSession, execute_shell
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX process semantics"
+)
+
+
+@pytest.fixture
+def shell(tmp_path):
+    sh = ShellSession()
+    sh.run(f"cd {tmp_path} && export RESTART_MARKER=alive", output=False)
+    yield sh
+    sh.close()
+
+
+def _state(sh: ShellSession) -> tuple[str, str, int]:
+    rc, out, _ = sh.run("echo $PWD $RESTART_MARKER", output=False)
+    assert rc == 0
+    cwd, _, marker = out.strip().partition(" ")
+    return cwd, marker, sh.process.pid
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expected_rc"),
+    [
+        ("exit 3", 3),
+        ("exec true", 0),
+        ("kill -9 $$", -signal.SIGKILL),
+        ("kill -- -$$", -signal.SIGTERM),
+        ("set -e; false", 1),
+        ("exec 1>&-", 0),
+    ],
+)
+def test_shell_death_restarts_and_restores_state(shell, tmp_path, cmd, expected_rc):
+    old_pid = shell.process.pid
+    start = time.monotonic()
+    rc, _, _ = shell.run(cmd, output=False)  # no timeout: must not spin
+    assert time.monotonic() - start < 6.0
+    assert rc == expected_rc
+
+    cwd, marker, pid = _state(shell)
+    assert pid != old_pid
+    assert cwd == str(tmp_path)
+    assert marker == "alive"
+
+    notice = shell.consume_restart_notice()
+    assert notice and "fresh shell" in notice
+    assert "restored from a snapshot" in notice
+    assert shell.consume_restart_notice() is None
+
+
+def test_stdout_closed_but_shell_alive_is_restarted(shell, tmp_path):
+    """``exec 1>&-; echo`` leaves bash alive but mute: restart instead of wedging."""
+    old_pid = shell.process.pid
+    start = time.monotonic()
+    rc, _, _ = shell.run("exec 1>&-; echo hi", output=False, timeout=30)
+    assert time.monotonic() - start < 8.0
+    assert rc != 0
+    cwd, marker, pid = _state(shell)
+    assert (pid != old_pid, cwd, marker) == (True, str(tmp_path), "alive")
+
+
+def test_killed_between_commands_restarts_before_next_command(shell, tmp_path):
+    """External kill (OOM killer, registry close from another thread)."""
+    os.kill(shell.process.pid, signal.SIGKILL)
+    shell.process.wait(timeout=5)
+
+    rc, out, _ = shell.run("echo alive-again", output=False)
+    assert (rc, out.strip()) == (0, "alive-again")
+    notice = shell.consume_restart_notice()
+    assert notice and "before this command" in notice
+    assert _state(shell)[:2] == (str(tmp_path), "alive")
+
+
+def test_closed_stdin_restarts_instead_of_raising(shell):
+    """close() from another thread must not leave a permanently broken shell."""
+    shell.close()
+    rc, out, _ = shell.run("echo back", output=False)
+    assert (rc, out.strip()) == (0, "back")
+    assert "before this command" in (shell.consume_restart_notice() or "")
+
+
+def test_command_that_kills_shell_is_not_rerun(shell, tmp_path):
+    marker = tmp_path / "ran"
+    rc, _, _ = shell.run(f"{{ echo x >> {marker}; kill -9 $$; }}", output=False)
+    assert rc == -signal.SIGKILL
+    shell.run("true", output=False)
+    assert marker.read_text() == "x\n"
+
+
+def test_timeout_kills_command_but_keeps_shell(shell, tmp_path):
+    pid = shell.process.pid
+    start = time.monotonic()
+    rc, _, _ = shell.run("sleep 30", output=False, timeout=1.0)
+    assert time.monotonic() - start < 5.0
+    assert rc == -124
+    assert shell.process.pid == pid
+    assert shell.process.poll() is None
+    assert _state(shell) == (str(tmp_path), "alive", pid)
+    assert shell.consume_restart_notice() is None
+
+
+def test_timeout_kills_grandchildren_and_term_ignoring_children(shell, tmp_path):
+    # Anchor the pgrep regex so it can't substring-match an unrelated process
+    # (e.g. a concurrent `sleep 300` in a shared CI/agent container).
+    pid = shell.process.pid
+    rc, _, _ = shell.run(
+        "bash -c 'trap \"\" TERM; (sleep 30); sleep 30'", output=False, timeout=1.0
+    )
+    assert rc == -124
+    assert shell.process.pid == pid
+    rc, out, _ = shell.run("pgrep -f 'sleep 30$' | wc -l", output=False)
+    assert out.strip() == "0"
+
+
+def test_timeout_fallback_when_bash_itself_stalls(shell, tmp_path):
+    """A pure-bash busy loop (no child to kill) still ends in a restart."""
+    pid = shell.process.pid
+    start = time.monotonic()
+    rc, _, _ = shell.run("while true; do :; done", output=False, timeout=1.0)
+    assert rc == -124
+    assert time.monotonic() - start < 8.0
+    assert shell.process.pid != pid
+    assert "timed out" in (shell.consume_restart_notice() or "")
+    assert _state(shell)[:2] == (str(tmp_path), "alive")
+
+
+def test_snapshot_failure_does_not_kill_shell_under_set_e(shell):
+    """A failing state-snapshot redirect must not take bash down under `set -e`.
+
+    The snapshot runs at the top level after the delimiter. Without ``|| true``,
+    a failed redirect (read-only tmp dir, full disk) returns non-zero and, with
+    sticky ``set -e``, exits the persistent shell — the exact spurious shell
+    death this PR exists to eliminate.
+    """
+    pid = shell.process.pid
+    shell._state_path = "/nonexistent-dir-xyz/state"  # redirect will fail
+    shell.run("set -e", output=False)
+    rc, _, _ = shell.run("echo after", output=False)
+    assert rc == 0
+    assert shell.process.pid == pid  # same shell, no restart
+    assert shell.consume_restart_notice() is None
+
+
+def test_state_file_removed_on_close():
+    sh = ShellSession()
+    path = sh._state_path
+    assert path and os.path.exists(path)
+    sh.run("true", output=False)
+    sh.restart()
+    assert os.path.exists(path)  # kept across restart
+    sh.close()
+    assert not os.path.exists(path)
+
+
+def test_tool_response_carries_restart_note(tmp_path):
+    from gptme.hooks.confirm import ConfirmationResult
+    from gptme.tools.shell import get_shell
+
+    sh = get_shell()
+    sh.run(f"cd {tmp_path} && export RESTART_MARKER=alive", output=False)
+    try:
+        with patch(
+            "gptme.hooks.get_confirmation",
+            return_value=ConfirmationResult.confirm(),
+        ):
+            content = "\n".join(m.content for m in execute_shell("exit 3", [], None))
+            assert "Return code: 3" in content
+            assert "fresh shell" in content
+            assert str(tmp_path) in content
+
+            content = "\n".join(
+                m.content
+                for m in execute_shell('echo "$PWD" "$RESTART_MARKER"', [], None)
+            )
+            assert f"{tmp_path} alive" in content
+            assert "fresh shell" not in content
+    finally:
+        sh.close()

--- a/tests/test_shell_restart.py
+++ b/tests/test_shell_restart.py
@@ -176,10 +176,9 @@ def test_timeout_fallback_when_bash_itself_stalls(shell, tmp_path):
 def test_snapshot_failure_does_not_kill_shell_under_set_e(shell):
     """A failing state-snapshot redirect must not take bash down under `set -e`.
 
-    The snapshot runs at the top level after the delimiter. Without ``|| true``,
-    a failed redirect (read-only tmp dir, full disk) returns non-zero and, with
-    sticky ``set -e``, exits the persistent shell — the exact spurious shell
-    death this PR exists to eliminate.
+    Without ``|| true``, a failed redirect (read-only tmp dir, full disk)
+    returns non-zero and, with sticky ``set -e``, exits the persistent shell —
+    the exact spurious shell death this PR exists to eliminate.
     """
     pid = shell.process.pid
     shell._state_path = "/nonexistent-dir-xyz/state"  # redirect will fail
@@ -188,6 +187,16 @@ def test_snapshot_failure_does_not_kill_shell_under_set_e(shell):
     assert rc == 0
     assert shell.process.pid == pid  # same shell, no restart
     assert shell.consume_restart_notice() is None
+
+
+def test_snapshot_is_written_before_run_returns(shell, tmp_path):
+    """A successful run must not expose stale state to an immediate restart."""
+    shell.run(f"cd {tmp_path} && export SNAPSHOT_MARKER=current", output=False)
+    assert shell._state_path
+    with open(shell._state_path) as state_file:
+        snapshot = state_file.read()
+    assert f"cd -- {tmp_path}" in snapshot
+    assert 'SNAPSHOT_MARKER="current"' in snapshot
 
 
 def test_state_file_removed_on_close():

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -135,6 +135,20 @@ class TestFindHeredocRegions:
         regions = _find_heredoc_regions(cmd)
         assert len(regions) == 1
 
+    def test_space_indented_delimiter_is_data_for_plain_heredoc(self):
+        cmd = "cat <<EOF\n  EOF\nbg\nEOF"
+        regions = _find_heredoc_regions(cmd)
+        assert len(regions) == 1
+        content = cmd[regions[0][0] : regions[0][1]]
+        assert "bg" in content
+
+    def test_space_indented_delimiter_is_data_for_tab_stripping_heredoc(self):
+        cmd = "cat <<-EOF\n  EOF\nbg\n\tEOF"
+        regions = _find_heredoc_regions(cmd)
+        assert len(regions) == 1
+        content = cmd[regions[0][0] : regions[0][1]]
+        assert "bg" in content
+
     def test_no_content_after_delimiter(self):
         # Heredoc with no newline after marker
         cmd = "cat << EOF"


### PR DESCRIPTION
Stacked on #3802 (uses its `_handle_shell_exit` EOF detection; retarget to master once that merges). Not the same bug as #3803 (`time` script parsing), just the same file.

## Problem

Erik: *"i still see `WARNING Warning: shell process died, restarting` from time to time … around things that break/stall in weird ways … worried this happens in autonomous runs too."*

It does, and far more often than the warning suggests. Every way the persistent bash can die was audited with reproductions through `ShellSession` and the tool layer:

| cause | before | after |
|---|---|---|
| `exit` / `exec` / `kill -9 $$` / `kill -- -$$` / `set -e` + failing step / `exec 1>&-` | spin on the closed pipe until `GPTME_SHELL_TIMEOUT` (20 min default, 120 s in Bob's runs) → `-124` with no explanation; restart only on the *next* command; cwd (server mode) and all exported env silently gone | returns at once with the real status (#3802), shell restarted, cwd + exported vars restored, note in the tool response |
| **command timeout** | `os.killpg(getpgid(bash))` — bash is the group leader, so **every timeout killed the shell**; silent restart on the next command, env gone | descendants get SIGTERM→SIGKILL, bash stays alive and reports the kill; still returns `-124`; group kill + restart only if bash itself is stuck (pure-bash loop) |
| shell died between commands (OOM, external kill, `close()` from the conversation registry on another thread) | `BrokenPipeError` → silent restart, or `Shell error: I/O operation on closed file` forever | liveness check before the write → restart + note |
| stdout closed but bash alive (`exec 1>&-; echo`) | wedged: every later command times out, never restarts | EOF → restart + note |

Bob's autonomous data since 2026-09-01: **977 timeouts in 34,318 shell calls (28 / 1,000), in 38 % of sessions** — each one a shell death pre-fix. 41 % of the timed-out blocks start with `set -euo pipefail`/`set -e` (61 % had `set -e` in that or an earlier block): with errexit sticky in the persistent shell, the first failing step *exits bash* and the model sees a 120 s "timeout". Sessions whose stderr tail contains the warning hit the 50-minute session timeout 68 % of the time vs 0.4 % base rate. Only 4 warnings reached the launch logs (stderr tail is printed on failure only).

## Fix

- **Timeout keeps bash alive**: `_kill_descendants()` walks `/proc/<pid>/task/*/children` (falls back to `pgrep -P`), SIGTERM then SIGKILL; the read loop waits ≤2 s for the delimiter and returns `-124` as before. Fallback to the old group kill + restart when bash does not answer.
- **State restore**: every command appends `{ printf 'cd -- %q\n' "$PWD"; export -p; } > <per-session tmpfile>` after the delimiter (never delays output); `_init()` sources it first on restart. `set -e`, functions, aliases, unexported vars and `&` jobs are intentionally not restored.
- **Model-visible note**: `ShellSession.consume_restart_notice()`; `execute_shell_impl` appends it to the tool response (single yield, same rule as the workspace hint): why the shell died, what was restored, what is gone.
- **No double execution**: a command that killed the shell is never re-run; the only retry left is `BrokenPipeError` on the initial write, where bash never received the statement.
- Windows read loop untouched; snapshot is POSIX-only.

## Tests

`tests/test_shell_restart.py` (15): each death cause restores cwd/env and returns promptly, external kill / closed stdin, no re-run (`{ echo x >> f; kill -9 $$; }` runs once), timeout keeps pid + env and kills TERM-ignoring grandchildren, pure-bash loop fallback, state file lifecycle, tool response carries the note. Existing shell suites: 769 passed; ruff + mypy clean.

Follow-up worth its own PR: warn or scope `set -e` at the top of a block — it is the dominant self-inflicted death and now merely fails fast instead of wedging.

https://claude.ai/code/session_01Kk96ga5Fqt7412xr74yww9
