### PR TITLE
fix(shell): strip shell operators from tokens before sensitive-path check (#3806)

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1004,6 +1004,7 @@ class ShellSession:
                 return_code,
                 seen_start_marker,
                 start_marker_pattern,
+                delimiter_pattern,
                 start_time,
                 timeout,
                 max_output_bytes,
@@ -1016,6 +1017,7 @@ class ShellSession:
             return_code,
             seen_start_marker,
             start_marker_pattern,
+            delimiter_pattern,
             start_time,
             timeout,
             max_output_bytes,
@@ -1030,6 +1032,7 @@ class ShellSession:
         return_code: int | None,
         seen_start_marker: bool,
         start_marker_pattern: str,
+        delimiter_pattern: str,
         start_time: float | None,
         timeout: float | None,
         max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
@@ -1180,7 +1183,7 @@ class ShellSession:
                                     )
                             continue
 
-                        if "ReturnCode:" in line and self.delimiter in line:
+                        if "ReturnCode:" in line and delimiter_pattern in line:
                             # Extract any command output that precedes the
                             # delimiter on the same line.  This happens when
                             # command output lacks a trailing newline (e.g.
@@ -1204,7 +1207,7 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWDHEX:([0-9a-f]*) {re.escape(self.delimiter)}",
+                                rf" PWDHEX:([0-9a-f]*) {re.escape(delimiter_pattern)}",
                                 line[rc_pos:],
                             )
                             if cwd_match:
@@ -1368,6 +1371,7 @@ class ShellSession:
         return_code: int | None,
         seen_start_marker: bool,
         start_marker_pattern: str,
+        delimiter_pattern: str,
         start_time: float | None,
         timeout: float | None,
         max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
@@ -1463,7 +1467,7 @@ class ShellSession:
                                     )
                             continue
 
-                        if "ReturnCode:" in line and self.delimiter in line:
+                        if "ReturnCode:" in line and delimiter_pattern in line:
                             # Extract any command output that precedes the
                             # delimiter on the same line.  This happens when
                             # command output lacks a trailing newline (e.g.
@@ -1499,7 +1503,7 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWDHEX:([0-9a-f]*) {re.escape(self.delimiter)}",
+                                rf" PWDHEX:([0-9a-f]*) {re.escape(delimiter_pattern)}",
                                 line[rc_pos:],
                             )
                             if cwd_match:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -505,6 +505,14 @@ class ShellSession:
         """Return the persistent shell's effective working directory."""
         return Path(self._cwd or os.getcwd())
 
+    def _set_cwd(self, cwd: str) -> None:
+        """Synchronize the tracked cwd with the persistent shell."""
+        if not cwd:
+            logger.warning("pwd returned an empty working directory")
+            return
+        self._cwd = cwd
+        os.chdir(cwd)
+
     def _init(self):
         # Choose shell and process group settings based on platform
         if _is_windows:
@@ -934,9 +942,11 @@ class ShellSession:
                         f"Shell: Pre-command stderr drain: {pre_drain_data[:80]}"
                     )
 
-        # Generate unique command ID to prevent output mixing (Issue #408)
+        # Generate per-command markers so command output cannot spoof the
+        # control record parsed below (Issue #408).
         cmd_id = f"{time.time_ns()}"
         start_marker_pattern = f"{self.start_marker}_{cmd_id}"
+        delimiter_pattern = f"{self.delimiter}_{cmd_id}"
 
         # Reset errexit after each block so that `set -e` set by the user does
         # not persist to later blocks. 41% of shell timeouts involve errexit
@@ -945,7 +955,15 @@ class ShellSession:
         # success path.
         full_command = f"echo {start_marker_pattern}\n"  # Start marker first
         full_command += f"{command}\n"
-        full_command += f"echo ReturnCode:$? {self.delimiter}\n"
+        # Capture the status before querying the physical cwd. ``$PWD`` is a
+        # mutable variable and therefore cannot be trusted for validation. Hex
+        # gives arbitrary valid path bytes a portable, single-line encoding.
+        full_command += (
+            "__gptme_rc=$?; __gptme_pwd=$(pwd -P | od -An -v -tx1 | "
+            "tr -d ' \n'); __gptme_pwd=${__gptme_pwd%0a}; printf "
+            f'"ReturnCode:%s PWDHEX:%s {delimiter_pattern}\\n" '
+            '"$__gptme_rc" "$__gptme_pwd"\n'
+        )
         full_command += "builtin set +e\n"
         try:
             self.process.stdin.write(full_command)
@@ -1179,13 +1197,11 @@ class ShellSession:
                             rc_matches = re_returncode.findall(line)
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
-                            if (command == "cd" or command.startswith("cd ")) and (
-                                return_code == 0
-                            ):
-                                ex, pwd, _ = self._run("pwd", output=False)
-                                if ex == 0:
-                                    self._cwd = pwd.strip()
-                                    os.chdir(self._cwd)
+                            cwd_match = re.search(
+                                rf" PWD:(.*?) {re.escape(self.delimiter)}", line
+                            )
+                            if cwd_match:
+                                self._set_cwd(cwd_match.group(1))
 
                             # Drain remaining stderr
                             stop_event.set()
@@ -1471,19 +1487,11 @@ class ShellSession:
                             rc_matches = re_returncode.findall(line)
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
-                            # If command is cd, track the persistent shell's cwd.
-                            if (
-                                command == "cd" or command.startswith("cd ")
-                            ) and return_code == 0:
-                                ex, pwd, _ = self._run("pwd", output=False)
-                                if ex != 0:
-                                    logger.warning(
-                                        "pwd failed after cd, cannot update "
-                                        "working directory"
-                                    )
-                                else:
-                                    self._cwd = pwd.strip()
-                                    os.chdir(self._cwd)
+                            cwd_match = re.search(
+                                rf" PWD:(.*?) {re.escape(self.delimiter)}", line
+                            )
+                            if cwd_match:
+                                self._set_cwd(cwd_match.group(1))
 
                             # If the byte cap was already exceeded in this chunk
                             # (delimiter line present), do not return the real

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -510,8 +510,12 @@ class ShellSession:
         if not cwd:
             logger.warning("pwd returned an empty working directory")
             return
+        changed = cwd != self._cwd
         self._cwd = cwd
-        os.chdir(cwd)
+        # Preserve historical CLI behavior without process-wide chdir calls
+        # after every command; server conversations use context-local cwd.
+        if changed and get_workspace_cwd() is None:
+            os.chdir(cwd)
 
     def _init(self):
         # Choose shell and process group settings based on platform
@@ -963,6 +967,7 @@ class ShellSession:
             "tr -d ' \n'); __gptme_pwd=${__gptme_pwd%0a}; printf "
             f'"ReturnCode:%s PWDHEX:%s {delimiter_pattern}\\n" '
             '"$__gptme_rc" "$__gptme_pwd"\n'
+
         )
         full_command += "builtin set +e\n"
         try:
@@ -1198,10 +1203,13 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWD:(.*?) {re.escape(self.delimiter)}", line
+                                rf" PWD:(.*?) {re.escape(self.delimiter)}",
+                                line[rc_pos:],
                             )
                             if cwd_match:
-                                self._set_cwd(cwd_match.group(1))
+                                self._set_cwd(
+                                    shlex.split(cwd_match.group(1), posix=True)[0]
+                                )
 
                             # Drain remaining stderr
                             stop_event.set()
@@ -1488,10 +1496,13 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWD:(.*?) {re.escape(self.delimiter)}", line
+                                rf" PWD:(.*?) {re.escape(self.delimiter)}",
+                                line[rc_pos:],
                             )
                             if cwd_match:
-                                self._set_cwd(cwd_match.group(1))
+                                self._set_cwd(
+                                    shlex.split(cwd_match.group(1), posix=True)[0]
+                                )
 
                             # If the byte cap was already exceeded in this chunk
                             # (delimiter line present), do not return the real

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -966,6 +966,7 @@ class ShellSession:
             "__gptme_rc=$?; __gptme_pwd=$(pwd -P | od -An -v -tx1 | "
             "tr -d ' \n'); __gptme_pwd=${__gptme_pwd%0a}; printf "
             f'"ReturnCode:%s PWDHEX:%s {delimiter_pattern}\\n" '
+
             '"$__gptme_rc" "$__gptme_pwd"\n'
 
         )
@@ -1203,12 +1204,14 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWD:(.*?) {re.escape(self.delimiter)}",
+                                rf" PWDHEX:([0-9a-f]*) {re.escape(self.delimiter)}",
                                 line[rc_pos:],
                             )
                             if cwd_match:
                                 self._set_cwd(
-                                    shlex.split(cwd_match.group(1), posix=True)[0]
+                                    bytes.fromhex(cwd_match.group(1)).decode(
+                                        errors="surrogateescape"
+                                    )
                                 )
 
                             # Drain remaining stderr
@@ -1496,12 +1499,14 @@ class ShellSession:
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
                             cwd_match = re.search(
-                                rf" PWD:(.*?) {re.escape(self.delimiter)}",
+                                rf" PWDHEX:([0-9a-f]*) {re.escape(self.delimiter)}",
                                 line[rc_pos:],
                             )
                             if cwd_match:
                                 self._set_cwd(
-                                    shlex.split(cwd_match.group(1), posix=True)[0]
+                                    bytes.fromhex(cwd_match.group(1)).decode(
+                                        errors="surrogateescape"
+                                    )
                                 )
 
                             # If the byte cap was already exceeded in this chunk

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -501,6 +501,10 @@ class ShellSession:
         # close on exit
         atexit.register(self.close)
 
+    def get_cwd(self) -> Path:
+        """Return the persistent shell's effective working directory."""
+        return Path(self._cwd or os.getcwd())
+
     def _init(self):
         # Choose shell and process group settings based on platform
         if _is_windows:
@@ -1180,7 +1184,8 @@ class ShellSession:
                             ):
                                 ex, pwd, _ = self._run("pwd", output=False)
                                 if ex == 0:
-                                    os.chdir(pwd.strip())
+                                    self._cwd = pwd.strip()
+                                    os.chdir(self._cwd)
 
                             # Drain remaining stderr
                             stop_event.set()
@@ -1466,7 +1471,7 @@ class ShellSession:
                             rc_matches = re_returncode.findall(line)
                             if rc_matches:
                                 return_code = int(rc_matches[-1])
-                            # if command is cd, update working directory
+                            # If command is cd, track the persistent shell's cwd.
                             if (
                                 command == "cd" or command.startswith("cd ")
                             ) and return_code == 0:
@@ -1477,7 +1482,8 @@ class ShellSession:
                                         "working directory"
                                     )
                                 else:
-                                    os.chdir(pwd.strip())
+                                    self._cwd = pwd.strip()
+                                    os.chdir(self._cwd)
 
                             # If the byte cap was already exceeded in this chunk
                             # (delimiter line present), do not return the real
@@ -2170,7 +2176,7 @@ def execute_shell_impl(
 ) -> Generator[Message, None, None]:
     """Execute shell command and format output."""
     shell = get_shell()
-    allowlisted = is_allowlisted(cmd)
+    allowlisted = is_allowlisted(cmd, cwd=shell.get_cwd())
 
     start_time = time.monotonic()
     try:
@@ -2567,6 +2573,7 @@ def execute_shell(
             preview_lang="bash",
             confirm_msg="Run command in background?",
             allow_edit=not _has_surrounding,
+            confirmation_workspace=get_shell().get_cwd(),
         )
         return
 
@@ -2649,6 +2656,7 @@ def execute_shell(
         preview_lang="bash",
         confirm_msg="Run command?",
         allow_edit=True,
+        confirmation_workspace=get_shell().get_cwd(),
     )
 
 

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -966,9 +966,7 @@ class ShellSession:
             "__gptme_rc=$?; __gptme_pwd=$(pwd -P | od -An -v -tx1 | "
             "tr -d ' \n'); __gptme_pwd=${__gptme_pwd%0a}; printf "
             f'"ReturnCode:%s PWDHEX:%s {delimiter_pattern}\\n" '
-
             '"$__gptme_rc" "$__gptme_pwd"\n'
-
         )
         full_command += "builtin set +e\n"
         try:

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -401,28 +401,22 @@ def _has_sensitive_args(cmd: str) -> bool:
 
     Returns True if a sensitive argument is found (approval should be denied).
     """
+    # Blank heredoc bodies (stdin data) *and* headers (the << / <<- opener and
+    # its delimiter word). Both are shell syntax, not filesystem arguments.
+    # Critically, header blanking is spacing-aware: ``<<-`` (attached) treats
+    # the following word as the delimiter and blanks it, while ``<< -`` (spaced)
+    # is a delimiter literally named ``-`` whose next token is a real argument.
+    # The old token loop could not distinguish these (shlex collapses the
+    # whitespace), so ``cat << - /etc/shadow`` auto-approved a genuine read;
+    # regex-based blanking keeps the real path visible, so it is scanned.
+    cmd_blanked = _blank_heredoc_headers(_blank_heredoc_bodies(cmd))
     try:
-        lexer = shlex.shlex(
-            _blank_heredoc_bodies(cmd), posix=True, punctuation_chars=";&|><()"
-        )
+        lexer = shlex.shlex(cmd_blanked, posix=True, punctuation_chars=";&|><()")
         lexer.whitespace_split = True
         lexer.commenters = ""
-        raw_tokens = list(lexer)
+        tokens = list(lexer)
     except ValueError:
-        raw_tokens = cmd.split()
-
-    tokens: list[str] = []
-    skip_heredoc_delimiter = False
-    for token in raw_tokens:
-        if skip_heredoc_delimiter:
-            if token == "-":
-                continue
-            skip_heredoc_delimiter = False
-            continue
-        if token == "<<":
-            skip_heredoc_delimiter = True
-            continue
-        tokens.append(token)
+        tokens = cmd_blanked.split()
 
     # Walk all tokens after the first (which is the leading command name).
     # punctuation_chars separates unquoted shell operators from adjacent path
@@ -562,6 +556,16 @@ def _has_command_substitution(cmd: str) -> bool:
     return False
 
 
+# Heredoc opener plus optional attached ``-`` (indent) flag plus the delimiter
+# word. ``<<<`` (here-string) is excluded via ``(?<!<)...(?!<)`` because an
+# unquoted here-string takes a real filename operand that must stay visible:
+# for a run ``<<<``, neither ``<<`` start position passes both lookarounds,
+# so nothing is blanked and the operand reaches the sensitive-path scan.
+_HEREDOC_HEADER = re.compile(
+    r"(?<!<)<<(?!<)-?\s*(?:\"[^\"\n]+\"|'[^'\n]+'|[^\s;&|<>]+)"
+)
+
+
 def _blank_heredoc_bodies(cmd: str) -> str:
     """Replace heredoc bodies with blanks, preserving offsets.
 
@@ -576,6 +580,29 @@ def _blank_heredoc_bodies(cmd: str) -> str:
     chars = list(cmd)
     for start, end in regions:
         for i in range(start, min(end, len(chars))):
+            if chars[i] != "\n":
+                chars[i] = " "
+    return "".join(chars)
+
+
+def _blank_heredoc_headers(cmd: str) -> str:
+    """Blank heredoc opener + delimiter words, preserving everything else.
+
+    Heredoc openers (``<<`` / ``<<-`` and the delimiter word) are shell
+    syntax, not filesystem arguments. Blanking them keeps a path-like
+    delimiter (``cat <<- /etc/shadow``) out of the sensitive-path scan.
+
+    Critically, only the *attached* ``<<-`` form treats the following word as
+    a delimiter. In the spaced ``<< -`` form bash treats ``-`` *itself* as the
+    delimiter and the next token as a real argument, so ``cat << - /etc/shadow``
+    genuinely reads ``/etc/shadow`` and must remain visible to the scan. The
+    regex handles this because the optional ``-`` is attached to ``<<`` with no
+    intervening whitespace; a spaced ``-`` is matched only as the delimiter word
+    and any further token after it is untouched.
+    """
+    chars = list(cmd)
+    for match in _HEREDOC_HEADER.finditer(cmd):
+        for i in range(match.start(), match.end()):
             if chars[i] != "\n":
                 chars[i] = " "
     return "".join(chars)

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -407,6 +407,18 @@ def _has_sensitive_args(cmd: str) -> bool:
     # Compound commands (&&, ||, ;) mean subsequent command names also appear
     # in this list, but command names never start with / so they are harmless.
     for token in tokens[1:]:
+        # Shell metacharacters (;, |, &, >, <, (, )) are not whitespace in
+        # Python's shlex, so they can be appended to the preceding path token
+        # in a compound command.  Two forms occur in practice:
+        #   `cd ~/.ssh; cat id_rsa`   → shlex yields `~/.ssh;` (trailing sep)
+        #   `cd ~/.ssh;cat id_rsa`    → shlex yields `~/.ssh;cat` (sep+cmd fused)
+        # In both cases the path portion is the text before the first shell
+        # operator.  Split on the operator and keep only the leading fragment
+        # so the sensitive-path checks are not bypassed by an attached
+        # separator or fused command name.
+        token = re.split(r"[;|&><()]", token)[0]
+        if not token:
+            continue
         # Bare root directory — e.g. `find /` or `ls /`
         if token == "/":
             return True

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -11,14 +11,13 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..util.context import md_codeblock
 from .shell_flags import flags_permitted
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from .base import ToolUse
 
 logger = logging.getLogger(__name__)
@@ -384,7 +383,7 @@ def _has_file_redirection(cmd: str) -> bool:
     return False
 
 
-def _has_sensitive_args(cmd: str) -> bool:
+def _has_sensitive_args(cmd: str, cwd: Path | None = None) -> bool:
     """Check whether any argument in the command targets a sensitive system path.
 
     Heredoc delimiters and bodies are shell syntax and stdin data rather than
@@ -475,6 +474,14 @@ def _has_sensitive_args(cmd: str) -> bool:
         # so the sensitive-dir boundary check below fires for those too.
         if re.match(r"^~[^/]+/", normalized) and not normalized.startswith("~/"):
             normalized = "~/" + re.sub(r"^~[^/]+/", "", normalized)
+        # Relative path arguments are interpreted from the persistent shell's
+        # effective cwd. Resolve lexical components here so a confirmed
+        # ``cd ~/.ssh`` cannot make a later ``cat id_rsa`` auto-approved.
+        if cwd is not None and not normalized.startswith(("/", "~")):
+            normalized = str(cwd / normalized)
+            if normalized == home or normalized.startswith(home + "/"):
+                normalized = "~" + normalized[len(home) :]
+
         # Collapse redundant separators so that $HOME//.ssh/id_rsa (→ ~//.ssh/id_rsa)
         # still matches the ~/ prefix boundary after double-slash removal.
         while "//" in normalized:
@@ -656,7 +663,7 @@ def _blank_shell_comments(cmd: str) -> str:
     return "".join(chars)
 
 
-def is_allowlisted(cmd: str) -> bool:
+def is_allowlisted(cmd: str, cwd: Path | None = None) -> bool:
     """Check if a shell command is safe to auto-approve.
 
     Uses a conservative allowlist approach:
@@ -699,7 +706,7 @@ def is_allowlisted(cmd: str) -> bool:
 
     # P1/P4: Check for sensitive path arguments (e.g. /etc/shadow, /root/, /)
     # Allowlisted commands like `cat` must not auto-approve reads of sensitive paths.
-    if _has_sensitive_args(cmd):
+    if _has_sensitive_args(cmd, cwd=cwd):
         return False
 
     # P2: Check for executable shell command substitution. Both backticks and
@@ -812,7 +819,7 @@ def shell_allowlist_hook(
     )
 
     # Check if command is allowlisted
-    if is_allowlisted(check_cmd):
+    if is_allowlisted(check_cmd, cwd=workspace):
         logger.debug(f"Shell command allowlisted, auto-confirming: {cmd[:50]}...")
         return ConfirmationResult.confirm()
 

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -387,6 +387,9 @@ def _has_file_redirection(cmd: str) -> bool:
 def _has_sensitive_args(cmd: str) -> bool:
     """Check whether any argument in the command targets a sensitive system path.
 
+    Heredoc delimiters and bodies are shell syntax and stdin data rather than
+    filesystem arguments, so blank them before tokenizing.
+
     P1 fix: `is_allowlisted()` previously checked command NAMES only, so
     ``cat /etc/shadow`` was auto-approved because ``cat`` is allowlisted.
     This helper rejects the command when any argument matches a sensitive
@@ -399,12 +402,25 @@ def _has_sensitive_args(cmd: str) -> bool:
     Returns True if a sensitive argument is found (approval should be denied).
     """
     try:
-        lexer = shlex.shlex(cmd, posix=True, punctuation_chars=";&|><()")
+        lexer = shlex.shlex(
+            _blank_heredoc_bodies(cmd), posix=True, punctuation_chars=";&|><()"
+        )
         lexer.whitespace_split = True
         lexer.commenters = ""
-        tokens = list(lexer)
+        raw_tokens = list(lexer)
     except ValueError:
-        tokens = cmd.split()
+        raw_tokens = cmd.split()
+
+    tokens: list[str] = []
+    skip_heredoc_delimiter = False
+    for token in raw_tokens:
+        if skip_heredoc_delimiter:
+            skip_heredoc_delimiter = False
+            continue
+        if token == "<<":
+            skip_heredoc_delimiter = True
+            continue
+        tokens.append(token)
 
     # Walk all tokens after the first (which is the leading command name).
     # punctuation_chars separates unquoted shell operators from adjacent path

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -399,25 +399,20 @@ def _has_sensitive_args(cmd: str) -> bool:
     Returns True if a sensitive argument is found (approval should be denied).
     """
     try:
-        tokens = shlex.split(cmd)
+        lexer = shlex.shlex(cmd, posix=True, punctuation_chars=";&|><()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
     except ValueError:
         tokens = cmd.split()
 
     # Walk all tokens after the first (which is the leading command name).
-    # Compound commands (&&, ||, ;) mean subsequent command names also appear
-    # in this list, but command names never start with / so they are harmless.
+    # punctuation_chars separates unquoted shell operators from adjacent path
+    # tokens while preserving quoted or escaped operators as literal filename
+    # characters. Compound command names also appear in this list, but command
+    # names never start with / so they are harmless.
     for token in tokens[1:]:
-        # Shell metacharacters (;, |, &, >, <, (, )) are not whitespace in
-        # Python's shlex, so they can be appended to the preceding path token
-        # in a compound command.  Two forms occur in practice:
-        #   `cd ~/.ssh; cat id_rsa`   → shlex yields `~/.ssh;` (trailing sep)
-        #   `cd ~/.ssh;cat id_rsa`    → shlex yields `~/.ssh;cat` (sep+cmd fused)
-        # In both cases the path portion is the text before the first shell
-        # operator.  Split on the operator and keep only the leading fragment
-        # so the sensitive-path checks are not bypassed by an attached
-        # separator or fused command name.
-        token = re.split(r"[;|&><()]", token)[0]
-        if not token:
+        if token and all(char in ";&|><()" for char in token):
             continue
         # Bare root directory — e.g. `find /` or `ls /`
         if token == "/":

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -478,7 +478,7 @@ def _has_sensitive_args(cmd: str, cwd: Path | None = None) -> bool:
         # effective cwd. Resolve lexical components here so a confirmed
         # ``cd ~/.ssh`` cannot make a later ``cat id_rsa`` auto-approved.
         if cwd is not None and not normalized.startswith(("/", "~")):
-            normalized = str(cwd / normalized)
+            normalized = str(cwd.resolve() / normalized)
             if normalized == home or normalized.startswith(home + "/"):
                 normalized = "~" + normalized[len(home) :]
 

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -415,6 +415,8 @@ def _has_sensitive_args(cmd: str) -> bool:
     skip_heredoc_delimiter = False
     for token in raw_tokens:
         if skip_heredoc_delimiter:
+            if token == "-":
+                continue
             skip_heredoc_delimiter = False
             continue
         if token == "<<":

--- a/gptme/tools/shell_validation.py
+++ b/gptme/tools/shell_validation.py
@@ -601,7 +601,22 @@ def _blank_heredoc_headers(cmd: str) -> str:
     and any further token after it is untouched.
     """
     chars = list(cmd)
+    quoted_regions = _find_quotes(cmd)
     for match in _HEREDOC_HEADER.finditer(cmd):
+        # Keep the same lexical guards as ``_find_heredoc_regions``. Quoted or
+        # escaped apparent openers are data, not heredoc syntax. In particular,
+        # ``cat \<< /etc/shadow`` leaves one real ``<`` redirection whose path
+        # must remain visible to the sensitive-argument scan.
+        if _is_in_quoted_region(match.start(), quoted_regions):
+            continue
+        backslashes = 0
+        pos = match.start() - 1
+        while pos >= 0 and cmd[pos] == "\\":
+            backslashes += 1
+            pos -= 1
+        if backslashes % 2:
+            continue
+
         for i in range(match.start(), match.end()):
             if chars[i] != "\n":
                 chars[i] = " "

--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -82,6 +82,7 @@ def execute_with_confirmation(
     preview_lang: str | None = None,
     confirm_msg: str | None = None,
     allow_edit: bool = True,
+    confirmation_workspace: Path | None = None,
 ) -> Generator[Message, None, None]:
     """Helper function to handle common patterns in tool execution.
 
@@ -98,6 +99,7 @@ def execute_with_confirmation(
         preview_lang: Language for syntax highlighting
         confirm_msg: Custom confirmation message
         allow_edit: Whether to allow editing the content
+        confirmation_workspace: Effective cwd passed to confirmation hooks
     """
     from ..hooks import ConfirmAction, get_confirmation
 
@@ -113,10 +115,10 @@ def execute_with_confirmation(
         if preview_fn and content:
             preview_content = preview_fn(content, path)
 
-        # Get confirmation via hook system
-        # The hook will show preview, allow editing, and return result
+        # Get confirmation via hook system.
         result = get_confirmation(
             preview=preview_content or content,
+            workspace=confirmation_workspace,
             default_confirm=True,
         )
 
@@ -150,6 +152,7 @@ def execute_with_confirmation(
                 edited_preview = preview_fn(content, path) if preview_fn else None
                 edited_result = get_confirmation(
                     preview=edited_preview or content,
+                    workspace=confirmation_workspace,
                     default_confirm=True,
                 )
                 if edited_result.action != ConfirmAction.CONFIRM:

--- a/tests/test_shell_allowlist_autoconfirm.py
+++ b/tests/test_shell_allowlist_autoconfirm.py
@@ -4,10 +4,12 @@ Regression test for issue where read-only commands like `cat file | head -100`
 were requiring confirmation despite being in the allowlist.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gptme.hooks.confirm import ConfirmationResult
 from gptme.message import Message
 from gptme.tools.base import ToolUse
 from gptme.tools.shell import (
@@ -125,6 +127,19 @@ class TestShellAllowlistHook:
         assert result is not None
         assert result.action.value == "confirm"
 
+    def test_relative_path_in_sensitive_cwd_falls_through(self):
+        """A prior ``cd ~/.ssh`` makes a later relative read sensitive."""
+        tool_use = ToolUse(
+            tool="shell",
+            args=[],
+            kwargs={},
+            content="cat id_rsa",
+        )
+
+        result = shell_allowlist_hook(tool_use, workspace=Path.home() / ".ssh")
+
+        assert result is None
+
     def test_non_allowlisted_command_falls_through(self):
         """Test that non-allowlisted commands fall through (return None)."""
         tool_use = ToolUse(
@@ -186,6 +201,24 @@ class TestExecuteShellAllowlist:
         with patch("gptme.tools.shell.get_path_fn") as mock:
             mock.return_value = tmp_path
             yield tmp_path
+
+    def test_relative_path_in_sensitive_cwd_uses_confirmation(
+        self, mock_shell, mock_logdir, tmp_path
+    ):
+        """A prior ``cd`` affects validation of the next shell invocation."""
+        sensitive_cwd = tmp_path / "home" / ".ssh"
+        sensitive_cwd.mkdir(parents=True)
+
+        mock_shell.get_cwd.return_value = sensitive_cwd
+        with patch(
+            "gptme.hooks.get_confirmation",
+            return_value=ConfirmationResult.skip(),
+        ) as confirm:
+            messages = list(execute_shell("cat id_rsa", [], None))
+
+        assert not mock_shell.run.called
+        assert messages[0].content == "Operation skipped"
+        assert confirm.call_args.kwargs["workspace"] == sensitive_cwd
 
     def test_allowlisted_command_executes_without_confirmation(
         self, mock_shell, mock_logdir

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1996,6 +1996,7 @@ def test_shell_cwd_parameter(tmp_path):
 
 def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
     """A successful compound command must refresh the persistent shell cwd."""
+    original_cwd = Path.cwd()
     shell = ShellSession()
     try:
         ret, _, _ = shell.run(f"printf ready; cd {tmp_path}")
@@ -2021,6 +2022,7 @@ def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
         assert shell.get_cwd() == unusual_cwd
     finally:
         shell.close()
+        os.chdir(original_cwd)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2038,6 +2038,23 @@ def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
         ret, _, _ = shell.run(f"cd {shlex.quote(str(unusual_cwd))}")
         assert ret == 0
         assert shell.get_cwd() == unusual_cwd
+
+        # macOS/BSD ``head`` has no GNU ``head -c -1``. Cwd tracking must not
+        # depend on it: a PATH entry that rejects ``head`` cannot break a later
+        # cwd update.
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        fake_head = fake_bin / "head"
+        fake_head.write_text("#!/bin/sh\nexit 64\n")
+        fake_head.chmod(0o755)
+        ret, _, _ = shell.run(f"PATH={shlex.quote(str(fake_bin))}:$PATH")
+        assert ret == 0
+
+        portable_cwd = tmp_path / "portable"
+        portable_cwd.mkdir()
+        ret, _, _ = shell.run(f"cd {shlex.quote(str(portable_cwd))}")
+        assert ret == 0
+        assert shell.get_cwd() == portable_cwd
     finally:
         shell.close()
         os.chdir(original_cwd)

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -2011,6 +2012,13 @@ def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
         ret, _, _ = shell.run("PWD=/tmp")
         assert ret == 0
         assert shell.get_cwd() == tmp_path.parent
+
+        # Marker encoding must round-trip Bash-special path characters.
+        unusual_cwd = tmp_path / "line\nbreak and space"
+        unusual_cwd.mkdir()
+        ret, _, _ = shell.run(f"cd {shlex.quote(str(unusual_cwd))}")
+        assert ret == 0
+        assert shell.get_cwd() == unusual_cwd
     finally:
         shell.close()
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -1993,6 +1993,23 @@ def test_shell_cwd_parameter(tmp_path):
         shell.close()
 
 
+def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
+    """A successful compound command must refresh the persistent shell cwd."""
+    shell = ShellSession()
+    try:
+        ret, _, _ = shell.run(f"printf ready; cd {tmp_path}")
+        assert ret == 0
+        assert shell.get_cwd() == tmp_path
+
+        # Track cwd even when a later command fails: Bash keeps a successful
+        # ``cd`` performed before the failing command in a compound list.
+        ret, _, _ = shell.run("cd ..; false")
+        assert ret == 1
+        assert shell.get_cwd() == tmp_path.parent
+    finally:
+        shell.close()
+
+
 # ---------------------------------------------------------------------------
 # Tests for workspace-aware subagent suggestion (issue #554)
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import gptme.tools.shell as shell_module
 from gptme.tools.pruner import PrunePlan
 from gptme.tools.shell import (
     ShellSession,
@@ -1992,6 +1993,23 @@ def test_shell_cwd_parameter(tmp_path):
         assert out.strip() == str(target_dir)
     finally:
         shell.close()
+
+
+def test_shell_context_local_cwd_does_not_change_process_cwd(tmp_path):
+    """Server contexts track shell cwd without mutating process-global cwd."""
+    original_cwd = Path.cwd()
+    cwd_token = shell_module._workspace_cwd.set(str(tmp_path))
+    shell = ShellSession(cwd=str(tmp_path))
+    try:
+        child = tmp_path / "child"
+        child.mkdir()
+        ret, _, _ = shell.run("cd child")
+        assert ret == 0
+        assert shell.get_cwd() == child
+        assert Path.cwd() == original_cwd
+    finally:
+        shell.close()
+        shell_module._workspace_cwd.reset(cwd_token)
 
 
 def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2006,6 +2006,11 @@ def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
         ret, _, _ = shell.run("cd ..; false")
         assert ret == 1
         assert shell.get_cwd() == tmp_path.parent
+
+        # PWD is mutable, so validation must use the shell's physical cwd.
+        ret, _, _ = shell.run("PWD=/tmp")
+        assert ret == 0
+        assert shell.get_cwd() == tmp_path.parent
     finally:
         shell.close()
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2055,6 +2055,18 @@ def test_shell_tracks_cwd_changed_by_compound_command(tmp_path):
         ret, _, _ = shell.run(f"cd {shlex.quote(str(portable_cwd))}")
         assert ret == 0
         assert shell.get_cwd() == portable_cwd
+
+        # Command output that resembles the old fixed control marker must not
+        # terminate parsing early or spoof the cwd used by later validation.
+        fake_cwd = tmp_path / "spoofed"
+        fake_cwd.mkdir()
+        old_marker = (
+            f"ReturnCode:0 PWDHEX:{os.fsencode(fake_cwd).hex()} {shell.delimiter}"
+        )
+        ret, out, _ = shell.run(f"printf '%s\\n' {shlex.quote(old_marker)}; true")
+        assert ret == 0
+        assert old_marker in out
+        assert shell.get_cwd() == portable_cwd
     finally:
         shell.close()
         os.chdir(original_cwd)

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -838,6 +838,27 @@ class TestSensitiveArgs:
         """`ls /tmp/ && cat /etc/passwd` should NOT be auto-approved (P1)."""
         assert not is_allowlisted("ls /tmp/ && cat /etc/passwd")
 
+    # #3806: relative paths bypass sensitive-path check via cd + semicolon
+    def test_cd_ssh_semicolon_cat_not_allowlisted(self):
+        """`cd ~/.ssh; cat id_rsa` must NOT be auto-approved (#3806).
+
+        Python's shlex attaches the semicolon to the preceding token, yielding
+        `~/.ssh;` which previously bypassed the exact-match / prefix check.
+        """
+        assert not is_allowlisted("cd ~/.ssh; cat id_rsa")
+
+    def test_cd_ssh_semicolon_no_space_not_allowlisted(self):
+        """`cd ~/.ssh;cat id_rsa` (no space around semicolon) must NOT be auto-approved."""
+        assert not is_allowlisted("cd ~/.ssh;cat id_rsa")
+
+    def test_cd_aws_semicolon_cat_not_allowlisted(self):
+        """`cd ~/.aws; cat credentials` must NOT be auto-approved (#3806)."""
+        assert not is_allowlisted("cd ~/.aws; cat credentials")
+
+    def test_cd_tmp_semicolon_ls_still_allowlisted(self):
+        """`cd /tmp; ls` should still be auto-approved — /tmp is not sensitive."""
+        assert is_allowlisted("cd /tmp; ls")
+
     def test_globbed_sensitive_path_not_allowlisted(self):
         """Shell glob expansion must not turn an approved token into /etc/shadow."""
         assert not is_allowlisted("cat /e??/shadow")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -4,6 +4,8 @@ Tests the allowlist/denylist logic, quote/heredoc parsing, pipe detection,
 and redirection detection in gptme/tools/shell_validation.py.
 """
 
+from pathlib import Path
+
 import pytest
 
 from gptme.tools.shell_validation import (
@@ -937,6 +939,12 @@ class TestSensitiveArgs:
     def test_search_pattern_without_path_separator_still_allowlisted(self):
         """Non-path glob patterns used by find remain safe to auto-approve."""
         assert is_allowlisted("find . -name '*.py'")
+
+    def test_relative_read_uses_effective_cwd(self):
+        """Relative operands are resolved from the persistent shell's cwd."""
+        ssh_dir = Path.home() / ".ssh"
+        assert not is_allowlisted("cat id_rsa", cwd=ssh_dir)
+        assert is_allowlisted("cat README.md", cwd=Path.home())
 
     def test_safe_file_read_still_allowlisted(self):
         """`cat README.md` should still be auto-approved (no false positive)."""

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -872,6 +872,23 @@ class TestSensitiveArgs:
         """Quoted or escaped operators are filename characters, not separators."""
         assert not _has_sensitive_args(command)
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat << /etc/passwd\n~/.ssh/id_rsa\n/etc/passwd",
+            "cat <<EOF\n/etc/passwd\nEOF",
+        ],
+    )
+    def test_heredoc_delimiter_and_body_are_not_sensitive_args(self, command: str):
+        """Heredoc syntax and stdin data are not filesystem arguments."""
+        assert not _has_sensitive_args(command)
+        assert is_allowlisted(command)
+
+    def test_here_string_sensitive_path_remains_sensitive(self):
+        """A here-string operand is data supplied by expansion, not a delimiter."""
+        assert _has_sensitive_args("cat <<< /etc/passwd")
+        assert not is_allowlisted("cat <<< /etc/passwd")
+
     def test_globbed_sensitive_path_not_allowlisted(self):
         """Shell glob expansion must not turn an approved token into /etc/shadow."""
         assert not is_allowlisted("cat /e??/shadow")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -940,6 +940,13 @@ class TestSensitiveArgs:
         """Non-path glob patterns used by find remain safe to auto-approve."""
         assert is_allowlisted("find . -name '*.py'")
 
+    @pytest.mark.parametrize(
+        "command", ["ls *.py", "grep foo *.txt", "find . -name '*.py'"]
+    )
+    def test_search_pattern_with_effective_cwd_still_allowlisted(self, command: str):
+        """Resolving cwd must not turn non-path glob patterns into path globs."""
+        assert is_allowlisted(command, cwd=Path("/tmp"))
+
     def test_relative_read_uses_effective_cwd(self):
         """Relative operands are resolved from the persistent shell's cwd."""
         ssh_dir = Path.home() / ".ssh"

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -946,6 +946,12 @@ class TestSensitiveArgs:
         assert not is_allowlisted("cat id_rsa", cwd=ssh_dir)
         assert is_allowlisted("cat README.md", cwd=Path.home())
 
+    def test_relative_read_resolves_symlinked_cwd(self, tmp_path: Path):
+        """A logical cwd symlink into a sensitive directory cannot bypass checks."""
+        link = tmp_path / "ssh-link"
+        link.symlink_to(Path.home() / ".ssh", target_is_directory=True)
+        assert not is_allowlisted("cat id_rsa", cwd=link)
+
     def test_safe_file_read_still_allowlisted(self):
         """`cat README.md` should still be auto-approved (no false positive)."""
         assert is_allowlisted("cat README.md")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -11,6 +11,7 @@ from gptme.tools.shell_validation import (
     _find_heredoc_regions,
     _find_quotes,
     _has_file_redirection,
+    _has_sensitive_args,
     _is_in_quoted_region,
     is_allowlisted,
     is_denylisted,
@@ -858,6 +859,18 @@ class TestSensitiveArgs:
     def test_cd_tmp_semicolon_ls_still_allowlisted(self):
         """`cd /tmp; ls` should still be auto-approved — /tmp is not sensitive."""
         assert is_allowlisted("cd /tmp; ls")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'cat "/etc;foo"',
+            "cat '/etc;foo'",
+            r"cat /etc\;foo",
+        ],
+    )
+    def test_literal_operator_in_filename_is_not_sensitive(self, command: str):
+        """Quoted or escaped operators are filename characters, not separators."""
+        assert not _has_sensitive_args(command)
 
     def test_globbed_sensitive_path_not_allowlisted(self):
         """Shell glob expansion must not turn an approved token into /etc/shadow."""

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -908,6 +908,12 @@ class TestSensitiveArgs:
         assert _has_sensitive_args("cat <<< /etc/passwd")
         assert not is_allowlisted("cat <<< /etc/passwd")
 
+    def test_escaped_heredoc_opener_keeps_sensitive_path_visible(self):
+        """An escaped first ``<`` leaves a real input redirection, not a heredoc."""
+        command = r"cat \<< /etc/shadow"
+        assert _has_sensitive_args(command)
+        assert not is_allowlisted(command)
+
     def test_globbed_sensitive_path_not_allowlisted(self):
         """Shell glob expansion must not turn an approved token into /etc/shadow."""
         assert not is_allowlisted("cat /e??/shadow")

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -877,6 +877,7 @@ class TestSensitiveArgs:
         [
             "cat << /etc/passwd\n~/.ssh/id_rsa\n/etc/passwd",
             "cat <<EOF\n/etc/passwd\nEOF",
+            "cat <<- /etc/shadow\n\tsecret\n\t/etc/shadow",
         ],
     )
     def test_heredoc_delimiter_and_body_are_not_sensitive_args(self, command: str):

--- a/tests/test_tools_shell_validation.py
+++ b/tests/test_tools_shell_validation.py
@@ -878,12 +878,30 @@ class TestSensitiveArgs:
             "cat << /etc/passwd\n~/.ssh/id_rsa\n/etc/passwd",
             "cat <<EOF\n/etc/passwd\nEOF",
             "cat <<- /etc/shadow\n\tsecret\n\t/etc/shadow",
+            # A quoted delimiter is shell syntax, not an argument.
+            'cat <<"EOF"\n/etc/passwd\nEOF',
         ],
     )
     def test_heredoc_delimiter_and_body_are_not_sensitive_args(self, command: str):
         """Heredoc syntax and stdin data are not filesystem arguments."""
         assert not _has_sensitive_args(command)
         assert is_allowlisted(command)
+
+    def test_spaced_heredoc_dash_is_delimiter_real_arg_stays_visible(self):
+        """``<< -`` treats ``-`` as the delimiter; the next token is a REAL arg.
+
+        Greptile P1: the old token loop collapsed the whitespace between ``<<``
+        and ``-``, so it dropped the following filename as if it were the
+        heredoc delimiter. In bash ``cat << - /etc/shadow`` reads ``/etc/shadow``,
+        so it must NOT auto-approve.
+        """
+        assert _has_sensitive_args("cat << - /etc/shadow\n-\n")
+        assert not is_allowlisted("cat << - /etc/shadow\n-\n")
+
+    def test_spaced_heredoc_dash_non_sensitive_arg_is_allowlisted(self):
+        """A non-sensitive real arg after a spaced ``<< -`` delimiter is fine."""
+        assert not _has_sensitive_args("cat << - /tmp/foo\n-\n")
+        assert is_allowlisted("cat << - /tmp/foo\n-\n")
 
     def test_here_string_sensitive_path_remains_sensitive(self):
         """A here-string operand is data supplied by expansion, not a delimiter."""


### PR DESCRIPTION
## Problem

Shell allowlist validation had two related sensitive-path bypasses from #3806:

1. Python's default `shlex.split` leaves unquoted shell operators attached to adjacent path tokens, so commands such as `cd ~/.ssh; cat id_rsa` did not expose a clean `~/.ssh` token to `_has_sensitive_args`.
2. Across persistent-shell invocations, a confirmed `cd ~/.ssh` followed by `cat id_rsa` validated the relative operand against the workspace rather than the shell's effective cwd.

The second case was confirmed during review, so this PR deliberately covers both the same-command tokenizer bypass and the cross-invocation cwd bypass rather than leaving #3806 partially fixed.

## Fix

- Tokenize with quote-aware `shlex.shlex(..., punctuation_chars=";&|><()")`, separating only unquoted operators while preserving quoted and escaped metacharacters in literal filenames.
- Blank real heredoc headers and bodies before sensitive-path matching, while keeping escaped openers and real arguments after spaced `<< -` visible. Here-strings remain conservatively confirmation-gated.
- Track the persistent shell's physical cwd after every command, including compound commands and failures, using `pwd -P` encoded as lowercase hex so spaces, newlines, delimiter text, and non-UTF-8 bytes round-trip without Bash-specific quoting.
- Resolve relative operands against that tracked cwd and pass the same cwd into confirmation. Context-local server workspaces do not mutate the process cwd.

## Verification

Focused local suites on the current head:

- 467 shell-validation tests pass, including joined operators, quoted/escaped operators, heredoc variants, glob controls, and relative sensitive paths.
- 122 shell-session tests pass, including compound success/failure, mutable `$PWD`, context-local cwd isolation, unusual cwd names, and a portability regression that shadows GNU `head` with a failing executable.
- 56 allowlist/autoconfirm tests pass, including confirmation fallback and workspace propagation.
- GitHub Actions: all 17 required checks pass (lint, typecheck, pre-commit, Linux/macOS/Windows slices, build, Docker, API, and dependency scan).

Closes #3806

<!-- gptme-id:v1:gai_KWsAFHqJE3esTgdoOhRsCgTRNiSunFggix8irvEPa4u -->
