### PR TITLE
refactor(shell): parse Bash with tree-sitter and retain legacy fallback

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -88,6 +88,8 @@ from .shell_validation import (
 )
 
 if TYPE_CHECKING:
+    from tree_sitter import Node
+
     from ..hooks import StopPropagation
     from ..logmanager import LogManager
 
@@ -95,6 +97,14 @@ _is_windows = os.name == "nt"
 
 # ANSI escape sequence pattern for stripping terminal formatting
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+def _parse_bash(source: bytes) -> "Node":
+    """Parse lazily so shell grammar loading does not affect CLI startup."""
+    import tree_sitter_bash
+    from tree_sitter import Language, Parser
+
+    return Parser(Language(tree_sitter_bash.language())).parse(source).root_node
 
 
 def _redirect_background_stdin(command: str) -> str:
@@ -106,6 +116,33 @@ def _redirect_background_stdin(command: str) -> str:
     the asynchronous list has a trailing foreground command, redirect that
     command as well.
     """
+    source = command.encode("utf-8")
+    root = _parse_bash(source)
+    if root.has_error:
+        return _redirect_background_stdin_bashlex(command)
+
+    positions: list[int] = []
+    pending = [root]
+    while pending:
+        node = pending.pop()
+        if (
+            node.type == "&"
+            and not node.is_named
+            and node.parent is not None
+            and node.parent.type != "binary_expression"
+        ):
+            positions.append(node.start_byte)
+        pending.extend(node.children)
+
+    for position in sorted(positions, reverse=True):
+        source = source[:position].rstrip() + b" < /dev/null " + source[position:]
+    if positions and not source.rstrip().endswith(b"&"):
+        source += b" < /dev/null"
+    return source.decode("utf-8")
+
+
+def _redirect_background_stdin_bashlex(command: str) -> str:
+    """Legacy fallback for background operators in tree-sitter grammar gaps."""
     import bashlex
 
     try:
@@ -2479,6 +2516,56 @@ def _bash_syntax_error(script: str, fallback: str) -> str | None:
 
 
 def split_commands(script: str) -> list[str]:
+    """Split at top-level newlines, preserving Bash lists and original source.
+
+    Tree-sitter spans include heredoc bodies and use byte offsets, so slicing
+    UTF-8 source preserves quoted delimiters and non-ASCII text without rewrites.
+    Keep bashlex as a compatibility fallback for one release: tree-sitter's
+    error recovery must never turn an incomplete tree into executable fragments.
+    """
+    source = script.encode("utf-8")
+    root = _parse_bash(source)
+    if root.has_error:
+        return _split_commands_bashlex(script)
+
+    commands: list[str] = []
+    start: int | None = None
+    end = 0
+    after_comment = False
+    for node in root.children:
+        if node.type == "comment":
+            after_comment = True
+            continue
+        # Semicolon/background lists stay together on the same logical line.
+        # Newlines inside compound statements, pipelines, and heredocs are
+        # already contained by their top-level node.
+        gap = source[end : node.start_byte]
+        if not after_comment:
+            gap = gap.replace(b"\\\n", b"")
+        if start is not None and b"\n" in gap:
+            commands.append(source[start:end].decode("utf-8"))
+            start = None
+        if start is None:
+            start = node.start_byte
+        end = node.end_byte
+        after_comment = False
+    if start is not None:
+        commands.append(source[start:end].decode("utf-8"))
+
+    # A clean tree is not proof of correct Bash boundaries. In particular,
+    # tree-sitter can parse `time { ... }` as ordinary words, with no ERROR
+    # node. Let Bash reject incomplete fragments before they reach the shell.
+    if len(commands) > 1 and any(
+        _bash_syntax_error(command, fallback="Cannot validate split boundary")
+        is not None
+        for command in commands
+    ):
+        return _split_commands_bashlex(script)
+    return commands
+
+
+def _split_commands_bashlex(script: str) -> list[str]:
+    """Legacy parser retained temporarily for tree-sitter grammar gaps."""
     import bashlex
 
     # Preprocess script to handle quoted heredoc delimiters that bashlex can't parse

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -2492,9 +2492,13 @@ def _bash_syntax_error(script: str, fallback: str) -> str | None:
     executing anything and is the authority.
 
     Returns None when bash accepts the script, bash's own error message when it
-    rejects it, and ``fallback`` when the check could not run.
+    rejects it, and ``fallback`` when the check could not run. Bash is resolved
+    the same way :class:`ShellSession` launches it (via PATH), so the split
+    boundary validation also applies on Windows/Msys2-Git-Bash — otherwise the
+    new splitter would be silently disabled on that supported path and lose
+    stop-on-failure for extended-syntax scripts.
     """
-    bash = None if _is_windows else shutil.which("bash")
+    bash = shutil.which("bash")
     if bash is None:
         return fallback
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -9025,6 +9025,78 @@ video = ["av"]
 vision = ["Pillow (>=10.0.1,<=15.0)", "torchvision"]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.2"
+description = "Python bindings to the Tree-sitter parsing library"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72a510931c3c25f134aac2daf4eb4feca99ffe37a35896d7150e50ac3eee06c7"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44488e0e78146f87baaa009736886516779253d6d6bac3ef636ede72bc6a8234"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2f8e7d6b2f8489d4a9885e3adcaef4bc5ff0a275acd990f120e29c4ab3395c5"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20b570690f87f1da424cd690e51cc56728d21d63f4abd4b326d382a30353acc7"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a0ec41b895da717bc218a42a3a7a0bfcfe9a213d7afaa4255353901e0e21f696"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:7712335855b2307a21ae86efe949c76be36c6068d76df34faa27ce9ee40ff444"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-win_arm64.whl", hash = "sha256:a925364eb7fbb9cdce55a9868f7525a1905af512a559303bd54ef468fd88cb37"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ca72d841215b6573ed0655b3a5cd1133f9b69a6fa561aecad40dca9029d75b"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cc0351cfe5022cec5a77645f647f92a936b38850346ed3f6d6babfbeeeca4d26"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1799609636c0193e16c38f366bda5af15b1ce476df79ddaae7dd274df9e44266"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e65ae456ad0d210ee71a89ee112ac7e72e6c2e5aac1b95846ecc7afa68a194c"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49ee3c348caa459244ec437ccc7ff3831f35977d143f65311572b8ba0a5f265f"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:56ac6602c7d09c2c507c55e58dc7026b8988e0475bd0002f8a386cce5e8e8adc"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-win_arm64.whl", hash = "sha256:b3d11a3a3ac89bb8a2543d75597f905a9926f9c806f40fcca8242922d1cc6ad5"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f"},
+]
+
+[package.extras]
+docs = ["sphinx (>=8.1,<9.0)", "sphinx-book-theme"]
+tests = ["tree-sitter-html (>=0.23.2)", "tree-sitter-javascript (>=0.23.1)", "tree-sitter-json (>=0.24.8)", "tree-sitter-python (>=0.23.6)", "tree-sitter-rust (>=0.23.2)"]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+description = "Bash grammar for tree-sitter"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6"},
+    {file = "tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb"},
+    {file = "tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14"},
+]
+
+[package.extras]
+core = ["tree-sitter (>=0.24,<1.0)"]
+
+[[package]]
 name = "triton"
 version = "3.7.0"
 description = "A language and compiler for custom Deep Learning operations"
@@ -10066,4 +10138,4 @@ tui = ["textual"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "a1b799f8f4520e808b6308e0ab6a03e10990706c4e26d6c06ffdbf4ecb041891"
+content-hash = "be5306fa2ded9cebcd555b6a0311da03f4a238ce7be912f7cb955cdb37db0b91"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,9 @@ anthropic = "^0.120"
 
 # tools
 ipython = "^8.39.0"
-bashlex = "^0.18"
+bashlex = "^0.18"  # compatibility fallback for the tree-sitter migration
+tree-sitter = ">=0.25,<0.26"
+tree-sitter-bash = ">=0.25.1,<0.26"
 playwright = {version = "1.61.0", optional=true}  # version constrained due to annoying to have to run `playwright install` on every update
 wasmtime = {version = ">=47.0.1", optional=true}  # Wasmtime WASI Python sandbox (GPTME_SANDBOX=wasmtime)
 python-xlib = {version = "^0.33", optional=true}  # for X11 interaction

--- a/tests/test_shell_parser.py
+++ b/tests/test_shell_parser.py
@@ -1,0 +1,118 @@
+"""Bash parser migration: source fidelity, boundaries, and compatibility."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from gptme.tools.shell import _split_commands_bashlex, split_commands
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="Requires Bash")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "[[ -f /etc/hostname ]] && echo yes",
+        "echo $((6*7))",
+        "case x in x) echo a;; esac",
+        "time (\n echo a\n echo b\n)",
+        "cat <<-'EOF'\n\tbody\n\tEOF",
+        "diff <(ls) <(ls)",
+        "coproc cat",
+        "select x in a b; do echo $x; done",
+        "for ((i=0;i<2;i++)); do echo $i; done",
+    ],
+)
+def test_extended_grammar_splits_surrounding_commands(command: str) -> None:
+    assert split_commands(f"echo before\n{command}\necho after") == [
+        "echo before",
+        command,
+        "echo after",
+    ]
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "echo a\necho b",
+        "echo a; echo b\necho c",
+        "sleep 1 &\necho done",
+        "sleep 1 & echo done",
+        "ls &&\n pwd\necho end",
+        "ls |\n wc -l\necho end",
+        "f() {\n echo hi\n}\nf",
+        "(echo a\necho b)\necho c",
+        "{ echo a\necho b; }\necho c",
+        "for x in a b; do\n echo $x\ndone\necho c",
+        "if true; then\n echo a\nfi\necho c",
+        "echo héj\necho 世界",
+        "cat <<'EOF' > out\nbody\nEOF\necho end",
+        "# before\necho a # inline\n# between\necho b",
+    ],
+)
+def test_bashlex_differential_corpus(script: str) -> None:
+    assert split_commands(script) == _split_commands_bashlex(script)
+
+
+def test_quoted_heredocs_preserve_source_and_expansion() -> None:
+    # The old rewrite/restore path changes literal <<EOF inside a quoted body
+    # and can also change an unquoted heredoc sharing the same delimiter.
+    first = "cat << 'EOF'\nliteral <<EOF and $HOME\nEOF"
+    second = "cat <<EOF\nexpanded $((6*7))\nEOF"
+    assert split_commands(first + "\n" + second) == [first, second]
+    outputs = [
+        subprocess.run(
+            ["bash"], input=command, text=True, capture_output=True, check=True
+        ).stdout
+        for command in split_commands(first + "\n" + second)
+    ]
+    assert outputs == ["literal <<EOF and $HOME\n", "expanded 42\n"]
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "time {\n echo a\n echo b\n}\necho done",
+        "cat <<A <<B\na\nA\nb\nB\necho done",
+    ],
+)
+def test_grammar_gaps_keep_complete_commands(script: str) -> None:
+    commands = split_commands(script)
+    assert commands == _split_commands_bashlex(script)
+    for command in commands:
+        subprocess.run(
+            ["bash", "-n"], input=command, text=True, capture_output=True, check=True
+        )
+
+
+@pytest.mark.parametrize("script", ["echo 'unclosed", "ls |", "if true; then\necho x"])
+def test_error_recovery_never_executes_partial_tree(script: str) -> None:
+    with pytest.raises(ValueError, match="Shell syntax error"):
+        split_commands(script)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("echo héj &", "echo héj < /dev/null &"),
+        ("echo $((6*7)) &", "echo $((6*7)) < /dev/null &"),
+        ("[[ -f x ]] && cat x &", "[[ -f x ]] && cat x < /dev/null &"),
+        ("echo '&'", "echo '&'"),
+        ("echo a && echo b", "echo a && echo b"),
+        ("echo $((1 & 2))", "echo $((1 & 2))"),
+        ("echo a 2>&1", "echo a 2>&1"),
+        ("cat <<'EOF'\n&\nEOF", "cat <<'EOF'\n&\nEOF"),
+    ],
+)
+def test_background_operator_grammar(command: str, expected: str) -> None:
+    from gptme.tools.shell import _redirect_background_stdin
+
+    assert _redirect_background_stdin(command) == expected
+
+
+def test_logical_line_continuation_and_comment_boundaries() -> None:
+    continued = "echo a; " + "\\\n" + "echo b"
+    assert split_commands(continued + "\necho c") == [continued, "echo c"]
+    commented = "echo a # comment " + "\\\n" + "echo b"
+    assert split_commands(commented) == ["echo a", "echo b"]

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -272,7 +272,7 @@ content
 EOF"""
     commands = split_commands(script_space_single)
     assert len(commands) == 1
-    assert "<<'EOF'" in commands[0]
+    assert commands == [script_space_single]
 
     script_space_double = """cat > /tmp/test.sh << "EOF"
 #!/bin/bash
@@ -280,7 +280,7 @@ content
 EOF"""
     commands = split_commands(script_space_double)
     assert len(commands) == 1
-    assert '<<"EOF"' in commands[0]
+    assert commands == [script_space_double]
 
 
 def test_split_commands_bash_reserved_words():
@@ -388,8 +388,7 @@ def test_split_commands_syntax_errors_raise():
 def test_split_commands_mixed_reserved_and_normal():
     """A ``time`` keyword no longer collapses the whole script into one command.
 
-    bashlex cannot parse ``time``; split_commands masks it before parsing so
-    the surrounding commands still split normally.
+    The parser preserves the keyword and splits surrounding commands normally.
     """
     script_mixed = """
 time echo "timed"
@@ -453,15 +452,15 @@ def test_split_commands_syntax_error_uses_bash_message():
         split_commands("ls |")
 
 
-def test_split_commands_without_bash_keeps_bashlex_error(monkeypatch):
-    """When bash cannot be consulted, a bashlex parse error is still a syntax error."""
+def test_split_commands_without_bash_rejects_invalid_syntax(monkeypatch):
+    """A parser error still fails closed when Bash is unavailable."""
     import pytest
 
     from gptme.tools import shell as shell_module
 
     monkeypatch.setattr(shell_module.shutil, "which", lambda _name: None)
-    with pytest.raises(ValueError, match="Shell syntax error: unexpected token"):
-        split_commands("[[ -f x ]] && ls")
+    with pytest.raises(ValueError, match="Shell syntax error: unexpected EOF"):
+        split_commands("ls |")
 
 
 def test_split_commands_heredoc_followed_by_redirect_keeps_body():

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -463,6 +463,27 @@ def test_split_commands_without_bash_rejects_invalid_syntax(monkeypatch):
         split_commands("ls |")
 
 
+def test_split_commands_windows_with_bash_keeps_stop_on_failure(monkeypatch):
+    """On windows, the split boundary validation must still run when Bash is on PATH.
+
+    ShellSession launches ``bash`` via PATH on Windows too (Msys2/Git Bash), so
+    a valid extended-syntax script (``[[ ]]``) must keep stop-on-failure
+    splitting rather than degrade to a single fragment via the bashlex
+    fallback. Regression for the Greptile P1 on gptme/gptme#3808.
+    """
+    import shutil
+
+    import gptme.tools.shell as shell_module
+
+    monkeypatch.setattr(shell_module, "_is_windows", True)
+    bash = shutil.which("bash")
+    assert bash, "test requires a bash on PATH"
+    monkeypatch.setattr(shell_module.shutil, "which", lambda _name: bash)
+
+    script = "false\n[[ -f x ]]\necho after"
+    assert split_commands(script) == ["false", "[[ -f x ]]", "echo after"]
+
+
 def test_split_commands_heredoc_followed_by_redirect_keeps_body():
     """A redirect after the heredoc operator must not drop the heredoc body.
 


### PR DESCRIPTION
Scripts containing `[[ ... ]]`, arithmetic, `case`, or coprocesses currently fall back to one opaque command, losing stop-on-failure between top-level commands. Use tree-sitter-bash for command splitting and background stdin redirection, preserving original UTF-8 source and quoted heredocs. This also fixes the old heredoc restoration loop changing literal body text and quoting an unrelated unquoted delimiter.

Keep bashlex as a compatibility fallback for the first release. Tree-sitter error trees fall back directly; proposed split fragments are checked with `bash -n` because the grammar can accept `time { ... }` without recognizing its compound structure. This costs one parse-only Bash process per proposed fragment when there is more than one. Permission checks still inspect the original script.

Validation:
- 928 shell tests passed, including allowlist/denylist, background jobs, source fidelity, and grammar-gap regressions.
- Differential capture covered 190 unique scripts: 173 identical results; 8 preserve heredoc spacing, 8 gain intended top-level splitting, and 1 fixes heredoc source mutation.
- Changed files pass mypy; pre-commit hooks and Poetry lock validation pass. The full `make typecheck` still reports three missing optional ML imports (`torch`, `transformers`, `sentence_transformers`); the changed-file check passes independently.
- Production-config local review: 5/5, no open findings, on `a2dbb31e2272c52e8c5d44748606a5aaf66a0f11`.

This is the parser replacement following #3803. #3802 changes the background-job dispatch/lifecycle in the same files; its behavior is a separate change. Legacy parser removal follows after the compatibility release.
