### PR TITLE
fix(gh): dispatch structured 'command' kwarg calls

### DIFF
--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -556,6 +556,17 @@ def execute_gh(
     Native handlers for high-value operations (issue view, pr view/status/checks/merge,
     run view).  Everything else passes through to the gh CLI unchanged.
     """
+    # Structured ("tool"-format) callers supply the whole command as a single
+    # ``command`` kwarg and leave ``args`` empty. Recover the positional args so
+    # the native dispatch below works for both invocation styles (markdown
+    # blocks set ``args`` positionally).
+    if not args and kwargs and kwargs.get("command"):
+        try:
+            args = shlex.split(kwargs["command"])
+        except ValueError as e:
+            yield Message("system", f"Error parsing command: {e}")
+            return
+
     if args and len(args) >= 2 and args[0] == "pr" and args[1] == "merge":
         yield from _handle_pr_merge(args, kwargs)
 
@@ -667,22 +678,30 @@ Native paths help avoid hallucination:
 - `gh pr merge <ref> ...` adds squash-by-default and optional head-commit protection
 - `gh run view <run-id>` extracts failed-job logs
 
-All other `gh` subcommands pass through unchanged."""
+All other `gh` subcommands pass through unchanged.
+
+Structured tool calls pass the whole command as `command`, e.g.
+`{"command": "issue view owner/repo#42"}`."""
 
 
 def examples(tool_format):
+    def render(args: list[str]) -> str:
+        # Native ("tool") calls carry a single `command` string parameter;
+        # markdown/XML carry the command positionally.
+        if tool_format == "tool":
+            return ToolUse("gh", None, None, {"command": shlex.join(args)}).to_output(
+                tool_format
+            )
+        return ToolUse("gh", args, None).to_output(tool_format)
+
     return f"""
 > User: read PR #123 on owner/repo
 > Assistant:
-{ToolUse("gh", ["pr", "view", "owner/repo#123"], None).to_output(tool_format)}
+{render(["pr", "view", "owner/repo#123"])}
 
 > User: check CI status for this PR
 > Assistant:
-{
-        ToolUse(
-            "gh", ["pr", "status", "https://github.com/owner/repo/pull/123"], None
-        ).to_output(tool_format)
-    }
+{render(["pr", "status", "https://github.com/owner/repo/pull/123"])}
 > System:
 PR #123 checks (abc1234):
 Total: 6 checks
@@ -697,37 +716,27 @@ View logs: gh run view <run_id> --log-failed
 
 > User: show me the failed build logs
 > Assistant:
-{ToolUse("gh", ["run", "view", "12345678"], None).to_output(tool_format)}
+{render(["run", "view", "12345678"])}
 
 > User: wait for CI checks to complete on a PR
 > Assistant:
-{
-        ToolUse(
-            "gh", ["pr", "checks", "https://github.com/owner/repo/pull/123"], None
-        ).to_output(tool_format)
-    }
+{render(["pr", "checks", "https://github.com/owner/repo/pull/123"])}
 
 > User: merge PR #123 on owner/repo
 > Assistant:
-{ToolUse("gh", ["pr", "merge", "owner/repo#123"], None).to_output(tool_format)}
+{render(["pr", "merge", "owner/repo#123"])}
 
 > User: auto-merge PR when checks pass, and delete the branch
 > Assistant:
-{
-        ToolUse(
-            "gh",
-            ["pr", "merge", "owner/repo#123", "--squash", "--auto", "--delete-branch"],
-            None,
-        ).to_output(tool_format)
-    }
+{render(["pr", "merge", "owner/repo#123", "--squash", "--auto", "--delete-branch"])}
 
 > User: read issue #42 on owner/repo
 > Assistant:
-{ToolUse("gh", ["issue", "view", "owner/repo#42"], None).to_output(tool_format)}
+{render(["issue", "view", "owner/repo#42"])}
 
 > User: show issues (pass-through to gh CLI)
 > Assistant:
-{ToolUse("gh", ["issue", "list", "--repo", "owner/repo"], None).to_output(tool_format)}
+{render(["issue", "list", "--repo", "owner/repo"])}
 
 > User: post a multi-line comment on issue 42
 > Assistant:
@@ -759,9 +768,12 @@ tool: ToolSpec = ToolSpec(
     block_types=["gh"],
     parameters=[
         Parameter(
-            name="url",
+            name="command",
             type="string",
-            description="GitHub reference: URL, owner/repo#N, #N, or bare number",
+            description=(
+                "The gh command and its arguments, e.g. "
+                "'issue view owner/repo#42' or 'pr checks owner/repo#5'."
+            ),
             required=True,
         ),
     ],

--- a/tests/test_tools_gh.py
+++ b/tests/test_tools_gh.py
@@ -763,6 +763,55 @@ class TestExecuteGh:
         assert len(messages) == 1
         assert messages[0].content == "(no output)"
 
+    @patch("gptme.tools.gh._handle_pr_status")
+    def test_command_kwarg_dispatches_native_handler(self, mock_status):
+        """A structured `command` kwarg is split and dispatched natively.
+
+        Regression: native ("tool"-format) callers pass the command as a single
+        kwarg and leave `args` empty; before the fix every such call fell
+        through to the pass-through and failed with "No command provided".
+        """
+        mock_status.return_value = iter([])
+        list(execute_gh(None, None, {"command": "pr status owner/repo#1"}))
+        mock_status.assert_called_once()
+        assert mock_status.call_args[0][0] == ["pr", "status", "owner/repo#1"]
+
+    @patch("gptme.tools.gh._passthrough_gh")
+    def test_command_kwarg_passes_through(self, mock_passthrough):
+        """A structured `command` kwarg is split before reaching the CLI."""
+        mock_passthrough.return_value = iter([])
+        list(execute_gh(None, None, {"command": "issue list --repo owner/repo"}))
+        mock_passthrough.assert_called_once_with(
+            ["issue", "list", "--repo", "owner/repo"], None
+        )
+
+    def test_command_kwarg_unclosed_quote_reports_parse_error(self):
+        """Malformed quoting is reported, not swallowed or crashed on."""
+        messages = list(execute_gh(None, None, {"command": "pr view 'unclosed"}))
+        assert len(messages) == 1
+        assert "Error parsing command" in messages[0].content
+
+    def test_no_args_no_command_reports_usage_error(self):
+        """Empty invocations keep reporting the explicit usage error."""
+        messages = list(execute_gh(None, None, None))
+        assert len(messages) == 1
+        assert messages[0].content == "Error: No command provided"
+
+    def test_tool_spec_exposes_command_parameter(self):
+        """The structured schema advertises `command`, matching execution."""
+        from gptme.tools.gh import tool
+
+        assert [p.name for p in tool.parameters] == ["command"]
+        assert tool.parameters[0].required
+
+    def test_examples_use_command_kwarg_in_tool_format(self):
+        """Tool-format examples render the `command` parameter, not `{}`."""
+        from gptme.tools.gh import examples
+
+        output = examples("tool")
+        assert '"command"' in output
+        assert output.count("@gh:") >= 1
+
 
 # --- _resolve_ref ---
 


### PR DESCRIPTION
## Problem

The `gh` tool's structured (native "tool"-format) schema advertises a single
`url` parameter, but `execute_gh` dispatches on positional `args`. Native
callers therefore arrive as `args=None, kwargs={"url": ...}`, fall through every
native handler, and reach `_passthrough_gh(None, None)`:

```
Error: No command provided
```

This reproduces on current master (and installed v0.33.0):

```python
>>> from gptme.tools.gh import execute_gh
>>> [m.content for m in execute_gh(None, None, {"url": "gptme/gptme#1"})]
['Error: No command provided']
```

Two separate sessions hit this on 2026-09-10 and vented it to the friction
ledger (`resolution_owner=tooling`): *"Native gh tool rejects every documented
invocation with 'No command provided' although its schema exposes only url"*.

## Fix

- `execute_gh` now accepts a `command` kwarg and `shlex.split`s it into the
  positional args before dispatch, so both invocation styles work.
- Malformed quoting is reported instead of silently falling through.
- The exposed parameter changes from `url` to `command` — a bare ref cannot
  express *which* subcommand to run, so `url`-only calls could never work.
- Tool-format examples now render with `command` (they previously rendered as an
  empty `{}`).

## Testing

- `pytest tests/test_tools_gh.py -q` → **78 passed** (6 new tests covering native
  dispatch, pass-through, quoting errors, and the exposed schema).
- `ruff check` / `ruff format --check` clean.
- mypy reports no new errors in `gptme/tools/gh.py`.
- Manual repro now succeeds: `execute_gh(None, None, {"command": "issue view gptme/gptme#1"})`
  returns the issue content.