### PR TITLE
fix(shell): scope set -e per block to prevent persistent errexit deaths

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -934,9 +934,15 @@ class ShellSession:
         cmd_id = f"{time.time_ns()}"
         start_marker_pattern = f"{self.start_marker}_{cmd_id}"
 
+        # Reset errexit after each block so that `set -e` set by the user does
+        # not persist to later blocks. 41% of shell timeouts involve errexit
+        # left on from a prior command. When errexit causes a failure the shell
+        # process dies and is restarted, so we only need to clear it on the
+        # success path.
         full_command = f"echo {start_marker_pattern}\n"  # Start marker first
         full_command += f"{command}\n"
         full_command += f"echo ReturnCode:$? {self.delimiter}\n"
+        full_command += "set +e\n"
         try:
             self.process.stdin.write(full_command)
         except BrokenPipeError:

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -942,7 +942,7 @@ class ShellSession:
         full_command = f"echo {start_marker_pattern}\n"  # Start marker first
         full_command += f"{command}\n"
         full_command += f"echo ReturnCode:$? {self.delimiter}\n"
-        full_command += "set +e\n"
+        full_command += "builtin set +e\n"
         try:
             self.process.stdin.write(full_command)
         except BrokenPipeError:

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2206,8 +2206,9 @@ def test_shell_bare_cd_updates_working_directory(tmp_path):
 def test_set_e_does_not_persist_across_blocks(shell):
     """set -e set in one block must not persist to later blocks."""
     # Define a function that would defeat a plain `set +e` cleanup, then enable
-    # errexit and succeed. The cleanup must call the Bash builtin explicitly.
-    ret, out, err = shell.run("set() { :; }; set -e; true; echo block1_done")
+    # errexit through the builtin and succeed. The cleanup must also call the
+    # Bash builtin explicitly.
+    ret, out, err = shell.run("set() { :; }; builtin set -e; true; echo block1_done")
     assert ret == 0
     assert "block1_done" in out
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2205,9 +2205,9 @@ def test_shell_bare_cd_updates_working_directory(tmp_path):
 
 def test_set_e_does_not_persist_across_blocks(shell):
     """set -e set in one block must not persist to later blocks."""
-    # First block: enable errexit and succeed.  The `set +e` appended by
-    # _run_pipe should clear errexit before the next block.
-    ret, out, err = shell.run("set -e; true; echo block1_done")
+    # Define a function that would defeat a plain `set +e` cleanup, then enable
+    # errexit and succeed. The cleanup must call the Bash builtin explicitly.
+    ret, out, err = shell.run("set() { :; }; set -e; true; echo block1_done")
     assert ret == 0
     assert "block1_done" in out
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -2201,3 +2201,18 @@ def test_shell_bare_cd_updates_working_directory(tmp_path):
     finally:
         os.chdir(original_cwd)
         shell.close()
+
+
+def test_set_e_does_not_persist_across_blocks(shell):
+    """set -e set in one block must not persist to later blocks."""
+    # First block: enable errexit and succeed.  The `set +e` appended by
+    # _run_pipe should clear errexit before the next block.
+    ret, out, err = shell.run("set -e; true; echo block1_done")
+    assert ret == 0
+    assert "block1_done" in out
+
+    # Second block: `false` alone should NOT kill the shell, because
+    # set -e was scoped to the first block only.
+    ret, out, err = shell.run("false; echo block2_done")
+    assert ret == 0, f"Expected rc=0 (errexit scoped), got rc={ret}"
+    assert "block2_done" in out


### PR DESCRIPTION
set -e (errexit) is sticky in gptme's persistent bash shell. Once a block sets it, every subsequent block runs with errexit active. This is the dominant self-inflicted cause of bash deaths (41% of timeouts).

Append set +e after each command block to clear errexit on the success path. When errexit causes a failure the shell process dies and is restarted by existing #3805 logic, so we only need to clear it on success.

Fixes #3805 follow-up.