### PR TITLE
feat(compaction): recover once from provider context overflow

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -22,7 +22,7 @@ from .constants import (
 )
 from .hooks import HookType, trigger_hook
 from .init import init
-from .llm import is_provider_error, reply
+from .llm import is_context_length_error, is_provider_error, reply
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
@@ -38,6 +38,7 @@ from .prompt_queue import drain_prompt_queue
 from .telemetry import set_conversation_context, trace_function
 from .tools import (
     ToolFormat,
+    ToolSpec,
     ToolUse,
     execute_msg,
     get_tools,
@@ -723,6 +724,102 @@ def _get_user_input(log: Log, workspace: Path | None) -> Message | None:
         return None
 
 
+def _reply_with_overflow_recovery(
+    *,
+    log: Log,
+    msgs: list[Message],
+    model: str,
+    stream: bool,
+    tools: list[ToolSpec] | None,
+    workspace: Path | None,
+    output_schema: type | None,
+    on_token: Callable[[str], None] | None,
+    on_thinking: Callable[[bool], None] | None,
+    logdir: Path | None,
+) -> Message:
+    """Generate once, compacting to a lossless view and retrying on overflow."""
+
+    def generate(messages: list[Message]) -> Message:
+        return reply(
+            messages,
+            get_model(model).full,
+            stream,
+            tools,
+            workspace,
+            output_schema,
+            on_token=on_token,
+            on_thinking=on_thinking,
+        )
+
+    try:
+        return generate(msgs)
+    except Exception as first_error:
+        if not is_context_length_error(first_error) or logdir is None:
+            raise
+
+        from time import monotonic
+
+        from .logmanager import LogManager
+        from .tools.autocompact.events import append_compaction_event
+        from .tools.autocompact.recovery import compact_for_overflow
+
+        manager = LogManager.get_current_log()
+        if (
+            manager is None
+            or manager.log is not log
+            or manager.logdir.resolve() != logdir.resolve()
+        ):
+            raise
+
+        started = monotonic()
+        before_messages = manager.log.messages
+        before_tokens = len_tokens(before_messages, get_model(model).model)
+        compacted_messages = compact_for_overflow(manager)
+        after_tokens = len_tokens(compacted_messages, get_model(model).model)
+        if after_tokens >= before_tokens:
+            logger.warning(
+                "Overflow compaction did not shrink context (%d -> %d tokens); "
+                "skipping retry",
+                before_tokens,
+                after_tokens,
+            )
+            append_compaction_event(
+                logdir,
+                trigger="overflow",
+                method="trim",
+                tokens_before=before_tokens,
+                tokens_after=after_tokens,
+                messages_before=len(before_messages),
+                messages_after=len(compacted_messages),
+                elapsed_seconds=monotonic() - started,
+                retry_success=False,
+            )
+            raise
+        view_name = manager.get_next_view_name()
+        manager.create_view(view_name, compacted_messages)
+        manager.switch_view(view_name)
+        retry_success = False
+        try:
+            retry_messages = prepare_messages(
+                manager.log.messages, workspace, logdir=logdir
+            )
+            response = generate(retry_messages)
+            retry_success = True
+            return response
+        finally:
+            append_compaction_event(
+                logdir,
+                trigger="overflow",
+                method="trim",
+                tokens_before=before_tokens,
+                tokens_after=after_tokens,
+                messages_before=len(before_messages),
+                messages_after=len(compacted_messages),
+                elapsed_seconds=monotonic() - started,
+                retry_success=retry_success,
+            )
+
+
 @trace_function(name="chat.step", attributes={"component": "chat"})
 def step(
     log: Log | list[Message],
@@ -760,15 +857,17 @@ def step(
         # generate response — `reply()` tags only the provider call, after
         # GENERATION_PRE hooks, so tool/hook failures still propagate.
         with terminal_state_title("🤔 generating"):
-            msg_response = reply(
-                msgs,
-                get_model(model).full,
-                stream,
-                tools,
-                workspace,
-                output_schema,
+            msg_response = _reply_with_overflow_recovery(
+                log=log,
+                msgs=msgs,
+                model=model,
+                stream=stream,
+                tools=tools,
+                workspace=workspace,
+                output_schema=output_schema,
                 on_token=on_token,
                 on_thinking=on_thinking,
+                logdir=logdir,
             )
         if get_config().get_env_bool("GPTME_COSTS"):
             log_costs(msgs + [msg_response])

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -789,37 +789,26 @@ def _reply_with_overflow_recovery(
         view_name = manager.get_next_view_name()
         manager.create_view(view_name, compacted_messages)
         manager.switch_view(view_name)
-        retry_messages = prepare_messages(
-            manager.log.messages, workspace, logdir=logdir
-        )
-        provider_tokens_before = len_tokens(msgs, get_model(model).model)
-        provider_tokens_after = len_tokens(retry_messages, get_model(model).model)
-        if provider_tokens_after >= provider_tokens_before:
-            logger.warning(
-                "Overflow compaction did not shrink provider input "
-                "(%d -> %d tokens); skipping retry",
-                provider_tokens_before,
-                provider_tokens_after,
-            )
-            append_compaction_event(
-                logdir,
-                trigger="overflow",
-                method="trim",
-                tokens_before=before_tokens,
-                tokens_after=after_tokens,
-                messages_before=len(before_messages),
-                messages_after=len(compacted_messages),
-                elapsed_seconds=monotonic() - started,
-                retry_success=False,
-                provider_tokens_before=provider_tokens_before,
-                provider_tokens_after=provider_tokens_after,
-            )
-            manager.switch_to_master()
-            raise
         retry_success = False
+        keep_compacted_view = False
+        provider_tokens_before = len_tokens(msgs, get_model(model).model)
+        provider_tokens_after = None
         try:
+            retry_messages = prepare_messages(
+                manager.log.messages, workspace, logdir=logdir
+            )
+            provider_tokens_after = len_tokens(retry_messages, get_model(model).model)
+            if provider_tokens_after >= provider_tokens_before:
+                logger.warning(
+                    "Overflow compaction did not shrink provider input "
+                    "(%d -> %d tokens); skipping retry",
+                    provider_tokens_before,
+                    provider_tokens_after,
+                )
+                raise first_error
             response = generate(retry_messages)
             retry_success = True
+            keep_compacted_view = True
             return response
         finally:
             append_compaction_event(
@@ -835,6 +824,8 @@ def _reply_with_overflow_recovery(
                 provider_tokens_before=provider_tokens_before,
                 provider_tokens_after=provider_tokens_after,
             )
+            if not keep_compacted_view:
+                manager.switch_to_master()
 
 
 @trace_function(name="chat.step", attributes={"component": "chat"})

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -771,6 +771,13 @@ def _reply_with_overflow_recovery(
         ):
             raise
 
+        if stream:
+            # A streaming provider may have emitted user-visible bytes before
+            # raising. Retrying would duplicate an unknown prefix because the
+            # callback/display API has no rollback signal. Non-streaming calls
+            # are atomic and safe to retry.
+            raise
+
         started = monotonic()
         before_messages = manager.log.messages
         before_tokens = len_tokens(before_messages, get_model(model).model)
@@ -869,6 +876,12 @@ def step(
                 on_thinking=on_thinking,
                 logdir=logdir,
             )
+        # Overflow recovery may have switched the active LogManager to a
+        # compacted view. Use that active log for tool execution below.
+        manager = LogManager.get_current_log()
+        if manager is not None and manager.logdir == logdir:
+            log = manager.log
+
         if get_config().get_env_bool("GPTME_COSTS"):
             log_costs(msgs + [msg_response])
         if get_config().get_env_bool("GPTME_TRACK_TOKENS"):

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -22,7 +22,12 @@ from .constants import (
 )
 from .hooks import HookType, trigger_hook
 from .init import init
-from .llm import is_context_length_error, is_provider_error, reply
+from .llm import (
+    did_llm_reply_emit_visible_output,
+    is_context_length_error,
+    is_provider_error,
+    reply,
+)
 from .llm.models import get_default_model, get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import (
@@ -771,11 +776,9 @@ def _reply_with_overflow_recovery(
         ):
             raise
 
-        if stream:
-            # A streaming provider may have emitted user-visible bytes before
-            # raising. Retrying would duplicate an unknown prefix because the
-            # callback/display API has no rollback signal. Non-streaming calls
-            # are atomic and safe to retry.
+        # Retrying after a visible streaming prefix would duplicate output. A
+        # context rejection before the first provider chunk is still atomic.
+        if did_llm_reply_emit_visible_output(first_error):
             raise
 
         started = monotonic()
@@ -783,12 +786,20 @@ def _reply_with_overflow_recovery(
         before_tokens = len_tokens(before_messages, get_model(model).model)
         compacted_messages = compact_for_overflow(manager)
         after_tokens = len_tokens(compacted_messages, get_model(model).model)
-        if after_tokens >= before_tokens:
+        view_name = manager.get_next_view_name()
+        manager.create_view(view_name, compacted_messages)
+        manager.switch_view(view_name)
+        retry_messages = prepare_messages(
+            manager.log.messages, workspace, logdir=logdir
+        )
+        provider_tokens_before = len_tokens(msgs, get_model(model).model)
+        provider_tokens_after = len_tokens(retry_messages, get_model(model).model)
+        if provider_tokens_after >= provider_tokens_before:
             logger.warning(
-                "Overflow compaction did not shrink context (%d -> %d tokens); "
-                "skipping retry",
-                before_tokens,
-                after_tokens,
+                "Overflow compaction did not shrink provider input "
+                "(%d -> %d tokens); skipping retry",
+                provider_tokens_before,
+                provider_tokens_after,
             )
             append_compaction_event(
                 logdir,
@@ -800,16 +811,13 @@ def _reply_with_overflow_recovery(
                 messages_after=len(compacted_messages),
                 elapsed_seconds=monotonic() - started,
                 retry_success=False,
+                provider_tokens_before=provider_tokens_before,
+                provider_tokens_after=provider_tokens_after,
             )
+            manager.switch_to_master()
             raise
-        view_name = manager.get_next_view_name()
-        manager.create_view(view_name, compacted_messages)
-        manager.switch_view(view_name)
         retry_success = False
         try:
-            retry_messages = prepare_messages(
-                manager.log.messages, workspace, logdir=logdir
-            )
             response = generate(retry_messages)
             retry_success = True
             return response
@@ -824,6 +832,8 @@ def _reply_with_overflow_recovery(
                 messages_after=len(compacted_messages),
                 elapsed_seconds=monotonic() - started,
                 retry_success=retry_success,
+                provider_tokens_before=provider_tokens_before,
+                provider_tokens_after=provider_tokens_after,
             )
 
 

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -879,7 +879,11 @@ def step(
         # Overflow recovery may have switched the active LogManager to a
         # compacted view. Use that active log for tool execution below.
         manager = LogManager.get_current_log()
-        if manager is not None and manager.logdir == logdir:
+        if (
+            manager is not None
+            and logdir is not None
+            and manager.logdir.resolve() == logdir.resolve()
+        ):
             log = manager.log
 
         if get_config().get_env_bool("GPTME_COSTS"):

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -283,6 +283,8 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
 # after those hooks have already run. See https://github.com/gptme/gptme/issues/3668
 _PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx", "requests"})
 _LLM_REPLY_ORIGIN_ATTR = "_gptme_from_llm_reply"
+_LLM_REPLY_OUTPUT_EMITTED_ATTR = "_gptme_llm_reply_output_emitted"
+_LLM_REPLY_VISIBLE_OUTPUT_EMITTED_ATTR = "_gptme_llm_reply_visible_output_emitted"
 _CONTEXT_LENGTH_ERROR_CODES = frozenset(
     {"context_length_exceeded", "context_window_exceeded", "request_too_large"}
 )
@@ -296,13 +298,30 @@ _CONTEXT_LENGTH_ERROR_PHRASES = (
 )
 
 
-def mark_llm_reply_origin(exc: BaseException) -> None:
+def mark_llm_reply_origin(
+    exc: BaseException,
+    *,
+    output_emitted: bool = False,
+    visible_output_emitted: bool | None = None,
+) -> None:
     """Mark an exception as raised from the provider call inside `reply()`.
 
     Applied after GENERATION_PRE hooks so a hook/tool failure is not treated
-    as a recoverable LLM outage.
+    as a recoverable LLM outage. ``output_emitted`` distinguishes atomic
+    request failures from streaming failures that already reached a consumer.
     """
     setattr(exc, _LLM_REPLY_ORIGIN_ATTR, True)
+    setattr(exc, _LLM_REPLY_OUTPUT_EMITTED_ATTR, output_emitted)
+    setattr(
+        exc,
+        _LLM_REPLY_VISIBLE_OUTPUT_EMITTED_ATTR,
+        output_emitted if visible_output_emitted is None else visible_output_emitted,
+    )
+
+
+def did_llm_reply_emit_visible_output(exc: BaseException) -> bool:
+    """Whether a failing stream already emitted output to a user consumer."""
+    return bool(getattr(exc, _LLM_REPLY_VISIBLE_OUTPUT_EMITTED_ATTR, False))
 
 
 def is_provider_error(e: BaseException) -> bool:
@@ -388,7 +407,13 @@ def reply(
             top_p,
         )
     except Exception as e:
-        mark_llm_reply_origin(e)
+        mark_llm_reply_origin(
+            e,
+            output_emitted=bool(getattr(e, _LLM_REPLY_OUTPUT_EMITTED_ATTR, False)),
+            visible_output_emitted=bool(
+                getattr(e, _LLM_REPLY_VISIBLE_OUTPUT_EMITTED_ATTR, False)
+            ),
+        )
         raise
 
 
@@ -1058,6 +1083,14 @@ def _reply_stream(
             _emit_chunk("".join(line_buffer))
             line_buffer.clear()
 
+    except Exception as exc:
+        setattr(exc, _LLM_REPLY_OUTPUT_EMITTED_ATTR, bool(output))
+        setattr(
+            exc,
+            _LLM_REPLY_VISIBLE_OUTPUT_EMITTED_ATTR,
+            bool(output) and (display_enabled or emit_active),
+        )
+        raise
     except KeyboardInterrupt:
         # Flush any chars buffered since the last chunk boundary so the terminal
         # shows everything received before the interrupt.

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -291,7 +291,7 @@ _CONTEXT_LENGTH_ERROR_PHRASES = (
     "context length exceeded",
     "context window exceeded",
     "prompt is too long",
-    "input is too long",
+    "input is too long for the model",
     "too many input tokens",
 )
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -283,6 +283,17 @@ def _resolve_max_tokens(model: str, max_tokens: int | None) -> int | None:
 # after those hooks have already run. See https://github.com/gptme/gptme/issues/3668
 _PROVIDER_ERROR_MODULES = frozenset({"openai", "anthropic", "httpx", "requests"})
 _LLM_REPLY_ORIGIN_ATTR = "_gptme_from_llm_reply"
+_CONTEXT_LENGTH_ERROR_CODES = frozenset(
+    {"context_length_exceeded", "context_window_exceeded", "request_too_large"}
+)
+_CONTEXT_LENGTH_ERROR_PHRASES = (
+    "maximum context length",
+    "context length exceeded",
+    "context window exceeded",
+    "prompt is too long",
+    "input is too long",
+    "too many input tokens",
+)
 
 
 def mark_llm_reply_origin(exc: BaseException) -> None:
@@ -306,6 +317,26 @@ def is_provider_error(e: BaseException) -> bool:
         return False
     modules = {(cls.__module__ or "").split(".", 1)[0] for cls in type(e).__mro__}
     return bool(modules & _PROVIDER_ERROR_MODULES)
+
+
+def is_context_length_error(e: BaseException) -> bool:
+    """Whether a provider call failed because its input exceeded context."""
+    if not is_provider_error(e):
+        return False
+
+    body = getattr(e, "body", None)
+    codes: set[str] = set()
+    if isinstance(body, dict):
+        candidates: list[object] = [body.get("code"), body.get("type")]
+        nested = body.get("error")
+        if isinstance(nested, dict):
+            candidates.extend((nested.get("code"), nested.get("type")))
+        codes = {str(value).lower() for value in candidates if value is not None}
+    if codes & _CONTEXT_LENGTH_ERROR_CODES:
+        return True
+
+    text = " ".join((str(e), str(body))).lower()
+    return any(phrase in text for phrase in _CONTEXT_LENGTH_ERROR_PHRASES)
 
 
 @trace_function(name="llm.reply", attributes={"component": "llm"})

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -290,7 +290,7 @@ _CONTEXT_LENGTH_ERROR_PHRASES = (
     "maximum context length",
     "context length exceeded",
     "context window exceeded",
-    "prompt is too long",
+    "prompt is too long for the model",
     "input is too long for the model",
     "too many input tokens",
 )

--- a/gptme/tools/autocompact/__init__.py
+++ b/gptme/tools/autocompact/__init__.py
@@ -12,6 +12,7 @@ from .decision import (
     should_auto_compact,
 )
 from .engine import auto_compact_log
+from .events import append_compaction_event, read_compaction_events
 from .handlers import (
     _compact_resume,
     _compact_summarize,
@@ -44,6 +45,9 @@ __all__ = [
     "should_auto_compact",
     # Engine
     "auto_compact_log",
+    # Observability
+    "append_compaction_event",
+    "read_compaction_events",
     # Resume
     "_parse_context_files",
     "_load_context_files",

--- a/gptme/tools/autocompact/events.py
+++ b/gptme/tools/autocompact/events.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import threading
-import weakref
 from datetime import datetime, timezone
 from os import PathLike
 from pathlib import Path
@@ -15,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 EVENT_LOG_NAME = "compaction.jsonl"
 _event_locks_guard = threading.Lock()
-_event_locks: weakref.WeakValueDictionary[Path, threading.Lock] = (
-    weakref.WeakValueDictionary()
-)
+_event_locks: dict[Path, threading.Lock] = {}
 
 
 def _event_lock(logdir: Path) -> threading.Lock:

--- a/gptme/tools/autocompact/events.py
+++ b/gptme/tools/autocompact/events.py
@@ -2,29 +2,73 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
+import os
 import threading
+import weakref
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from os import PathLike
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logging.getLogger(__name__)
 
 EVENT_LOG_NAME = "compaction.jsonl"
 _event_locks_guard = threading.Lock()
-_event_locks: dict[Path, threading.Lock] = {}
+_event_locks: weakref.WeakValueDictionary[Path, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
+
+try:
+    fcntl: Any = importlib.import_module("fcntl")
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    msvcrt: Any = importlib.import_module("msvcrt")
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None
 
 
-def _event_lock(logdir: Path) -> threading.Lock:
-    path = (logdir / EVENT_LOG_NAME).resolve()
+def _event_thread_lock(path: Path) -> threading.Lock:
+    key = path.resolve()
     with _event_locks_guard:
-        lock = _event_locks.get(path)
+        lock = _event_locks.get(key)
         if lock is None:
             lock = threading.Lock()
-            _event_locks[path] = lock
+            _event_locks[key] = lock
         return lock
+
+
+@contextmanager
+def _event_lock(logdir: Path) -> Iterator[None]:
+    """Serialize event appends across threads and processes."""
+    path = logdir / EVENT_LOG_NAME
+    lock_path = logdir / f".{EVENT_LOG_NAME}.lock"
+    thread_lock = _event_thread_lock(path)
+    with thread_lock, lock_path.open("a+b") as lock:
+        if fcntl is not None:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            if lock.seek(0, os.SEEK_END) == 0:
+                lock.write(b"\0")
+                lock.flush()
+            lock.seek(0)
+            msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 def append_compaction_event(

--- a/gptme/tools/autocompact/events.py
+++ b/gptme/tools/autocompact/events.py
@@ -1,0 +1,110 @@
+"""Append-only observability for explicit context compaction events."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import weakref
+from datetime import datetime, timezone
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+EVENT_LOG_NAME = "compaction.jsonl"
+_event_locks_guard = threading.Lock()
+_event_locks: weakref.WeakValueDictionary[Path, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
+
+
+def _event_lock(logdir: Path) -> threading.Lock:
+    path = (logdir / EVENT_LOG_NAME).resolve()
+    with _event_locks_guard:
+        lock = _event_locks.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _event_locks[path] = lock
+        return lock
+
+
+def append_compaction_event(
+    logdir: str | PathLike[str] | None,
+    *,
+    trigger: str,
+    method: str,
+    tokens_before: int,
+    tokens_after: int,
+    messages_before: int,
+    messages_after: int,
+    elapsed_seconds: float,
+    retry_success: bool | None = None,
+    provider_tokens_before: int | None = None,
+    provider_tokens_after: int | None = None,
+    checkpoint_tokens: int | None = None,
+    files_reloaded: list[str] | None = None,
+    cache_read_tokens_next: int | None = None,
+    cache_write_tokens_next: int | None = None,
+) -> dict[str, Any]:
+    """Append one compaction event and return the written record.
+
+    Logging is best-effort: inability to write observability must never prevent
+    recovery from an already-failing provider request.
+    """
+    saved = tokens_before - tokens_after
+    event: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "trigger": trigger,
+        "method": method,
+        "tokens": {
+            "before_estimated": tokens_before,
+            "after_estimated": tokens_after,
+        },
+        "messages": {"before": messages_before, "after": messages_after},
+        "savings": {
+            "tokens": saved,
+            "ratio": saved / tokens_before if tokens_before else 0.0,
+        },
+        "elapsed_seconds": elapsed_seconds,
+    }
+    optional = {
+        "retry_success": retry_success,
+        "provider_tokens_before": provider_tokens_before,
+        "provider_tokens_after": provider_tokens_after,
+        "checkpoint_tokens": checkpoint_tokens,
+        "files_reloaded": files_reloaded,
+        "cache_read_tokens_next": cache_read_tokens_next,
+        "cache_write_tokens_next": cache_write_tokens_next,
+    }
+    event.update({key: value for key, value in optional.items() if value is not None})
+
+    if logdir is None or not isinstance(logdir, (str, PathLike)):
+        return event
+    logdir = Path(logdir)
+    try:
+        logdir.mkdir(parents=True, exist_ok=True)
+        with (
+            _event_lock(logdir),
+            (logdir / EVENT_LOG_NAME).open("a", encoding="utf-8") as file,
+        ):
+            file.write(json.dumps(event, separators=(",", ":")) + "\n")
+    except OSError as exc:
+        logger.warning("Failed to append compaction event: %s", exc)
+    return event
+
+
+def read_compaction_events(logdir: Path) -> list[dict[str, Any]]:
+    """Read valid events from ``compaction.jsonl`` in append order."""
+    path = logdir / EVENT_LOG_NAME
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as file:
+        for line in file:
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed compaction event in %s", path)
+    return events

--- a/gptme/tools/autocompact/handlers.py
+++ b/gptme/tools/autocompact/handlers.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Generator
+from time import monotonic
 
 from ...llm.models import get_default_model
 from ...logmanager import Log
@@ -9,6 +10,7 @@ from ...message import Message, len_tokens
 from .config import _get_keep_head
 from .context_provider import CompressionConfig, get_context_provider
 from .decision import should_auto_compact
+from .events import append_compaction_event
 from .resume import _resume_via_llm
 
 logger = logging.getLogger(__name__)
@@ -78,6 +80,7 @@ def _compact_trim(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
         return
 
     # Apply auto-compacting using the provider interface
+    started = monotonic()
     provider = get_context_provider("default")
     config = CompressionConfig(logdir=ctx.manager.logdir, keep_head=_get_keep_head())
     compacted_msgs = provider.compress(msgs, config).messages
@@ -98,6 +101,16 @@ def _compact_trim(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
         if original_tokens > 0
         else 0.0
     )
+    append_compaction_event(
+        ctx.manager.logdir,
+        trigger="manual",
+        method="trim",
+        tokens_before=original_tokens,
+        tokens_after=compacted_tokens,
+        messages_before=original_count,
+        messages_after=compacted_count,
+        elapsed_seconds=monotonic() - started,
+    )
     yield Message(
         "system",
         f"✅ Trim compaction completed:\n"
@@ -114,8 +127,25 @@ _compact_auto = _compact_trim
 def _compact_summarize(ctx, msgs: list[Message]) -> Generator[Message, None, None]:
     """LLM-powered summarization: creates RESUME.md, extracts key files, and starts a new conversation with the context."""
 
+    started = monotonic()
+    m = get_default_model()
+    original_tokens = len_tokens(msgs, m.model) if m else 0
     try:
         yield from _resume_via_llm(ctx.manager, msgs, use_view_branch=False)
+        compacted_messages = ctx.manager.log.messages
+        if not isinstance(compacted_messages, list):
+            return
+        compacted_tokens = len_tokens(compacted_messages, m.model) if m else 0
+        append_compaction_event(
+            ctx.manager.logdir,
+            trigger="manual",
+            method="summarize",
+            tokens_before=original_tokens,
+            tokens_after=compacted_tokens,
+            messages_before=len(msgs),
+            messages_after=len(compacted_messages),
+            elapsed_seconds=monotonic() - started,
+        )
     except Exception as e:
         # Include exception type for better debugging when message is empty
         error_msg = str(e).strip() or f"({type(e).__name__})"

--- a/gptme/tools/autocompact/hook.py
+++ b/gptme/tools/autocompact/hook.py
@@ -18,6 +18,7 @@ from ..base import ToolSpec
 from .config import _get_keep_head
 from .context_provider import CompressionConfig, get_context_provider
 from .decision import should_auto_compact
+from .events import append_compaction_event
 from .handlers import cmd_compact_handler
 from .resume import _resume_via_llm
 
@@ -152,6 +153,16 @@ def autocompact_hook(
                 if original_tokens > 0
                 else 0.0
             )
+            append_compaction_event(
+                manager.logdir,
+                trigger="budget",
+                method="trim",
+                tokens_before=original_tokens,
+                tokens_after=compacted_tokens,
+                messages_before=original_count,
+                messages_after=compacted_count,
+                elapsed_seconds=time.time() - current_time,
+            )
             # Yield a message indicating what happened
             yield Message(
                 "system",
@@ -172,10 +183,21 @@ def autocompact_hook(
         try:
             m = get_default_model()
             original_tokens = len_tokens(messages, m.model) if m else 0
+            original_count = len(messages)
 
             yield from _resume_via_llm(manager, messages, use_view_branch=True)
 
             compacted_tokens = len_tokens(manager.log.messages, m.model) if m else 0
+            append_compaction_event(
+                manager.logdir,
+                trigger="budget",
+                method="summarize",
+                tokens_before=original_tokens,
+                tokens_after=compacted_tokens,
+                messages_before=original_count,
+                messages_after=len(manager.log.messages),
+                elapsed_seconds=time.time() - current_time,
+            )
 
             # Trigger CACHE_INVALIDATED hook — resume is even more aggressive
             # than rule-based compaction, so plugins need to know

--- a/gptme/tools/autocompact/recovery.py
+++ b/gptme/tools/autocompact/recovery.py
@@ -1,0 +1,28 @@
+"""Context-overflow recovery using the existing rule-based compactor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .config import _get_keep_head
+from .context_provider import CompressionConfig, get_context_provider
+
+if TYPE_CHECKING:
+    from ...logmanager import LogManager
+    from ...message import Message
+
+
+def compact_for_overflow(manager: LogManager) -> list[Message]:
+    """Build a compacted view for an over-window provider request.
+
+    Overflow bypasses the normal savings decision: the original request already
+    failed, so any smaller request is preferable to terminating the session.
+    The caller persists the result as a view, preserving the master log.
+    """
+    config = CompressionConfig(
+        logdir=manager.logdir,
+        keep_head=_get_keep_head(),
+    )
+    return (
+        get_context_provider("default").compress(manager.log.messages, config).messages
+    )

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1467,6 +1467,101 @@ def test_cmd_compact_invalid_mode_error():
     assert "summarize" in results[0].content
 
 
+def test_compaction_event_log_round_trip(tmp_path):
+    from gptme.tools.autocompact.events import (
+        append_compaction_event,
+        read_compaction_events,
+    )
+
+    append_compaction_event(
+        tmp_path,
+        trigger="manual",
+        method="trim",
+        tokens_before=100,
+        tokens_after=60,
+        messages_before=5,
+        messages_after=3,
+        elapsed_seconds=0.25,
+    )
+
+    events = read_compaction_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["trigger"] == "manual"
+    assert events[0]["method"] == "trim"
+    assert events[0]["tokens"] == {
+        "before_estimated": 100,
+        "after_estimated": 60,
+    }
+    assert events[0]["savings"] == {"tokens": 40, "ratio": 0.4}
+    assert events[0]["elapsed_seconds"] == 0.25
+
+
+def test_manual_trim_writes_compaction_event(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+
+    from gptme.logmanager import LogManager
+    from gptme.tools.autocompact.events import read_compaction_events
+    from gptme.tools.autocompact.handlers import _compact_trim
+
+    manager = LogManager(
+        [
+            Message("system", "system prompt"),
+            Message("user", "task"),
+            Message("system", "large output " * 100),
+        ],
+        logdir=tmp_path / "conversation",
+    )
+    ctx = MagicMock()
+    ctx.manager = manager
+    compacted = manager.log.messages[:2]
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.handlers.should_auto_compact",
+        lambda _msgs: "rule_based",
+    )
+    provider = MagicMock()
+    provider.compress.return_value.messages = compacted
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.handlers.get_context_provider",
+        lambda _name: provider,
+    )
+
+    list(_compact_trim(ctx, manager.log.messages))
+
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["trigger"] == "manual"
+    assert events[0]["method"] == "trim"
+    assert events[0]["messages"] == {"before": 3, "after": 2}
+
+
+def test_manual_summarize_writes_compaction_event(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+
+    from gptme.logmanager import Log, LogManager
+    from gptme.tools.autocompact.events import read_compaction_events
+    from gptme.tools.autocompact.handlers import _compact_summarize
+
+    messages = [Message("system", "system prompt"), Message("user", "task")]
+    manager = LogManager(messages, logdir=tmp_path / "conversation")
+    ctx = MagicMock()
+    ctx.manager = manager
+
+    def fake_resume(active_manager, _msgs, *, use_view_branch):
+        assert use_view_branch is False
+        active_manager.log = Log([Message("system", "summary")])
+        yield Message("system", "done")
+
+    monkeypatch.setattr("gptme.tools.autocompact.handlers._resume_via_llm", fake_resume)
+
+    list(_compact_summarize(ctx, messages))
+
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["trigger"] == "manual"
+    assert events[0]["method"] == "summarize"
+    assert events[0]["messages"] == {"before": 2, "after": 1}
+
+
 def test_compact_trim_handler_honors_env_keep_head(monkeypatch):
     """The /compact trim handler must use _get_keep_head(), not a hardcoded default.
 

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -1496,6 +1496,26 @@ def test_compaction_event_log_round_trip(tmp_path):
     assert events[0]["elapsed_seconds"] == 0.25
 
 
+def test_compaction_event_lock_registry_releases_unused_paths(tmp_path):
+    import gc
+
+    from gptme.tools.autocompact import events
+
+    events.append_compaction_event(
+        tmp_path,
+        trigger="manual",
+        method="trim",
+        tokens_before=100,
+        tokens_after=60,
+        messages_before=5,
+        messages_after=3,
+        elapsed_seconds=0.25,
+    )
+
+    gc.collect()
+    assert not events._event_locks
+
+
 def test_manual_trim_writes_compaction_event(tmp_path, monkeypatch):
     from unittest.mock import MagicMock
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1555,6 +1555,74 @@ def test_step_skips_retry_when_prepared_provider_input_does_not_shrink(
     assert manager.current_view is None
 
 
+def test_step_restores_master_when_retry_preparation_fails(tmp_path, monkeypatch):
+    """A failed retry preparation must not leave the compacted view active."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+    from gptme.tools.autocompact.events import read_compaction_events
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [
+            Message("system", "system prompt"),
+            Message("user", "task"),
+            Message("system", "large output " * 100),
+        ],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise overflow
+
+    prepare_calls = 0
+
+    def fail_retry_preparation(msgs, *_args, **_kwargs):
+        nonlocal prepare_calls
+        prepare_calls += 1
+        if prepare_calls == 1:
+            return msgs
+        raise RuntimeError("evidence reload failed")
+
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", fail_retry_preparation)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:2],
+    )
+
+    with pytest.raises(RuntimeError, match="evidence reload failed"):
+        list(
+            chat_module.step(
+                manager.log,
+                stream=False,
+                model="openai/gpt-4",
+                logdir=manager.logdir,
+            )
+        )
+
+    assert calls == 1
+    assert manager.current_view is None
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["retry_success"] is False
+
+
 def test_step_context_overflow_without_manager_is_not_recovered(tmp_path, monkeypatch):
     """Library callers without a LogManager keep the original failure."""
     import importlib

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1338,8 +1338,10 @@ def test_step_overflow_recovery_uses_compacted_log_for_tool_execution(
     )
 
 
-def test_step_streaming_context_overflow_is_not_retried(tmp_path, monkeypatch):
-    """Streaming output has no rollback signal, so retrying could duplicate bytes."""
+def test_step_streaming_context_overflow_before_output_is_retried(
+    tmp_path, monkeypatch
+):
+    """A streaming request rejected before its first chunk is safe to retry."""
     import importlib
 
     import httpx
@@ -1361,6 +1363,112 @@ def test_step_streaming_context_overflow_is_not_retried(tmp_path, monkeypatch):
         response=httpx.Response(400),
     )
     mark_llm_reply_origin(overflow)
+    replies = iter([overflow, Message("assistant", "recovered")])
+
+    def fake_reply(*_args, **_kwargs):
+        result = next(replies)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(chat_module, "reply", fake_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:1],
+    )
+
+    yielded = list(
+        chat_module.step(
+            manager.log,
+            stream=True,
+            model="openai/gpt-4",
+            logdir=manager.logdir,
+        )
+    )
+
+    assert [msg.content for msg in yielded] == ["recovered"]
+    assert manager.current_view == "compacted-001"
+
+
+def test_step_headless_streaming_overflow_after_buffered_output_is_retried(
+    tmp_path, monkeypatch
+):
+    """Buffered output with no display/callback has not reached a consumer."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [Message("system", "system prompt"), Message("user", "task")],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow, output_emitted=True, visible_output_emitted=False)
+    replies = iter([overflow, Message("assistant", "recovered")])
+
+    def fake_reply(*_args, **_kwargs):
+        result = next(replies)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(chat_module, "reply", fake_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:1],
+    )
+
+    yielded = list(
+        chat_module.step(
+            manager.log,
+            stream=True,
+            model="openai/gpt-4",
+            logdir=manager.logdir,
+        )
+    )
+
+    assert [msg.content for msg in yielded] == ["recovered"]
+    assert manager.current_view == "compacted-001"
+
+
+def test_step_streaming_context_overflow_after_output_is_not_retried(
+    tmp_path, monkeypatch
+):
+    """Retrying after a visible stream prefix would duplicate output."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [Message("system", "system prompt"), Message("user", "task")],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow, output_emitted=True)
     calls = 0
 
     def fail_reply(*_args, **_kwargs):
@@ -1376,6 +1484,68 @@ def test_step_streaming_context_overflow_is_not_retried(tmp_path, monkeypatch):
             chat_module.step(
                 manager.log,
                 stream=True,
+                model="openai/gpt-4",
+                logdir=manager.logdir,
+            )
+        )
+
+    assert calls == 1
+    assert manager.current_view is None
+
+
+def test_step_skips_retry_when_prepared_provider_input_does_not_shrink(
+    tmp_path, monkeypatch
+):
+    """Compare provider-bound input, including evidence replay, before retrying."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [
+            Message("system", "system prompt"),
+            Message("user", "task"),
+            Message("system", "large output " * 100),
+        ],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise overflow
+
+    original_provider_input = manager.log.messages.copy()
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(
+        chat_module,
+        "prepare_messages",
+        lambda _msgs, *_a, **_k: original_provider_input,
+    )
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:2],
+    )
+
+    with pytest.raises(httpx.HTTPStatusError, match="maximum context length"):
+        list(
+            chat_module.step(
+                manager.log,
+                stream=False,
                 model="openai/gpt-4",
                 logdir=manager.logdir,
             )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1268,6 +1268,123 @@ def test_step_compacts_and_retries_once_after_context_overflow(tmp_path, monkeyp
     assert events[0]["retry_success"] is True
 
 
+def test_step_overflow_recovery_uses_compacted_log_for_tool_execution(
+    tmp_path, monkeypatch
+):
+    """Recovered tool execution must see the active compacted view, not stale history."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [
+            Message("system", "system prompt"),
+            Message("user", "task"),
+            Message("system", "stale large output " * 100),
+        ],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    replies = iter(
+        [
+            overflow,
+            Message("assistant", "```shell\nprintf recovered\n```\n"),
+        ]
+    )
+    seen_logs = []
+
+    def fake_reply(*_args, **_kwargs):
+        result = next(replies)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def fake_execute(_msg, *, log, **_kwargs):
+        seen_logs.append(log)
+        return iter([])
+
+    monkeypatch.setattr(chat_module, "reply", fake_reply)
+    monkeypatch.setattr(chat_module, "execute_msg", fake_execute)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:2],
+    )
+
+    list(
+        chat_module.step(
+            manager.log,
+            stream=False,
+            model="openai/gpt-4",
+            logdir=manager.logdir,
+        )
+    )
+
+    assert seen_logs == [manager.log]
+    assert "stale large output" not in " ".join(
+        msg.content for msg in seen_logs[0].messages
+    )
+
+
+def test_step_streaming_context_overflow_is_not_retried(tmp_path, monkeypatch):
+    """Streaming output has no rollback signal, so retrying could duplicate bytes."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [Message("system", "system prompt"), Message("user", "task")],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise overflow
+
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+
+    with pytest.raises(httpx.HTTPStatusError, match="maximum context length"):
+        list(
+            chat_module.step(
+                manager.log,
+                stream=True,
+                model="openai/gpt-4",
+                logdir=manager.logdir,
+            )
+        )
+
+    assert calls == 1
+    assert manager.current_view is None
+
+
 def test_step_context_overflow_without_manager_is_not_recovered(tmp_path, monkeypatch):
     """Library callers without a LogManager keep the original failure."""
     import importlib

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1206,6 +1206,230 @@ def test_step_marks_httpx_from_reply_as_provider_error():
     assert is_provider_error(tool_err)
 
 
+def test_step_compacts_and_retries_once_after_context_overflow(tmp_path, monkeypatch):
+    """A provider overflow creates a compacted view and retries exactly once."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+    from gptme.tools.autocompact.events import read_compaction_events
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [
+            Message("system", "system prompt"),
+            Message("user", "original task"),
+            Message("system", "large tool result " * 1000),
+        ],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    replies = iter([overflow, Message("assistant", "recovered")])
+
+    def fake_reply(*_args, **_kwargs):
+        result = next(replies)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(chat_module, "reply", fake_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:2],
+    )
+
+    yielded = list(
+        chat_module.step(
+            manager.log,
+            stream=False,
+            model="openai/gpt-4",
+            logdir=manager.logdir,
+        )
+    )
+
+    assert [msg.content for msg in yielded] == ["recovered"]
+    assert manager.current_view == "compacted-001"
+    assert manager.master_log.messages[-1].content.startswith("large tool result")
+    assert len(manager.log.messages) == 2
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["trigger"] == "overflow"
+    assert events[0]["retry_success"] is True
+
+
+def test_step_context_overflow_without_manager_is_not_recovered(tmp_path, monkeypatch):
+    """Library callers without a LogManager keep the original failure."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import _current_log_var
+    from gptme.message import Message
+    from gptme.tools import init_tools
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise overflow
+
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    token = _current_log_var.set(None)
+    try:
+        with pytest.raises(httpx.HTTPStatusError, match="maximum context length"):
+            list(
+                chat_module.step(
+                    [Message("user", "task")],
+                    stream=False,
+                    model="openai/gpt-4",
+                    logdir=tmp_path,
+                )
+            )
+    finally:
+        _current_log_var.reset(token)
+
+    assert calls == 1
+    assert not (tmp_path / "compaction.jsonl").exists()
+
+
+def test_step_skips_retry_when_overflow_compaction_does_not_shrink(
+    tmp_path, monkeypatch
+):
+    """Do not pay for a guaranteed-identical retry when compaction is a no-op."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+    from gptme.tools.autocompact.events import read_compaction_events
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [Message("system", "system prompt"), Message("user", "task")],
+        logdir=tmp_path / "conversation",
+    )
+    overflow = httpx.HTTPStatusError(
+        "maximum context length exceeded",
+        request=httpx.Request("POST", "https://example.test"),
+        response=httpx.Response(400),
+    )
+    mark_llm_reply_origin(overflow)
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise overflow
+
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError, match="maximum context length"):
+        list(
+            chat_module.step(
+                manager.log,
+                stream=False,
+                model="openai/gpt-4",
+                logdir=manager.logdir,
+            )
+        )
+
+    assert calls == 1
+    assert manager.current_view is None
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["retry_success"] is False
+
+
+def test_step_does_not_retry_context_overflow_twice(tmp_path, monkeypatch):
+    """The recovery retry is bounded to one extra provider request."""
+    import importlib
+
+    import httpx
+
+    from gptme.llm import mark_llm_reply_origin
+    from gptme.logmanager import LogManager
+    from gptme.message import Message
+    from gptme.tools import init_tools
+    from gptme.tools.autocompact.events import read_compaction_events
+
+    init_tools(allowlist=["shell"])
+    chat_module = importlib.import_module("gptme.chat")
+    manager = LogManager(
+        [Message("system", "system prompt"), Message("user", "task")],
+        logdir=tmp_path / "conversation",
+    )
+    errors = []
+    for _ in range(2):
+        error = httpx.HTTPStatusError(
+            "maximum context length exceeded",
+            request=httpx.Request("POST", "https://example.test"),
+            response=httpx.Response(400),
+        )
+        mark_llm_reply_origin(error)
+        errors.append(error)
+
+    calls = 0
+
+    def fail_reply(*_args, **_kwargs):
+        nonlocal calls
+        error = errors[calls]
+        calls += 1
+        raise error
+
+    monkeypatch.setattr(chat_module, "reply", fail_reply)
+    monkeypatch.setattr(chat_module, "prepare_messages", lambda msgs, *_a, **_k: msgs)
+    monkeypatch.setattr(
+        "gptme.tools.autocompact.recovery.compact_for_overflow",
+        lambda active_manager: active_manager.log.messages[:1],
+    )
+
+    with pytest.raises(httpx.HTTPStatusError, match="maximum context length"):
+        list(
+            chat_module.step(
+                manager.log,
+                stream=False,
+                model="openai/gpt-4",
+                logdir=manager.logdir,
+            )
+        )
+
+    assert calls == 2
+    events = read_compaction_events(manager.logdir)
+    assert len(events) == 1
+    assert events[0]["retry_success"] is False
+
+
 def test_get_user_input_interruptible_during_include_paths(monkeypatch):
     """Path inclusion after prompt_user must run in an interruptible state."""
     import sys

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -223,6 +223,34 @@ def test_reply_tags_provider_call_errors(monkeypatch):
     assert is_provider_error(ei.value)
 
 
+def test_is_context_length_error_requires_provider_origin():
+    """Only provider-call context overflows qualify for compaction recovery."""
+    from unittest.mock import MagicMock
+
+    from openai import BadRequestError
+
+    from gptme.llm import is_context_length_error, mark_llm_reply_origin
+
+    response = MagicMock()
+    response.status_code = 400
+    overflow = BadRequestError(
+        "maximum context length is 200000 tokens",
+        response=response,
+        body={"error": {"code": "context_length_exceeded"}},
+    )
+    assert not is_context_length_error(overflow)
+    mark_llm_reply_origin(overflow)
+    assert is_context_length_error(overflow)
+
+    unrelated = BadRequestError(
+        "max_tokens must be a positive integer",
+        response=response,
+        body={"error": {"code": "invalid_request_error"}},
+    )
+    mark_llm_reply_origin(unrelated)
+    assert not is_context_length_error(unrelated)
+
+
 def test_anthropic_clients_have_sdk_retries_disabled():
     """The Anthropic clients are constructed with SDK retries disabled."""
     import inspect

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -245,6 +245,7 @@ def test_is_context_length_error_requires_provider_origin():
     for message in (
         "max_tokens must be a positive integer",
         "input is too long: maximum field length is 1000 characters",
+        "prompt is too long: maximum field length is 1000 characters",
     ):
         unrelated = BadRequestError(
             message,

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -146,6 +146,90 @@ def test_openai_compat_providers_disable_sdk_retries(
     assert client._kwargs["max_retries"] == SDK_MAX_RETRIES
 
 
+def test_streaming_provider_error_records_whether_output_was_emitted(monkeypatch):
+    import httpx
+
+    from gptme.llm import did_llm_reply_emit_visible_output, reply
+    from gptme.message import Message
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *_a, **_k: iter([]))
+    monkeypatch.setattr("gptme.llm.init_llm", lambda *_a, **_k: None)
+
+    class FakeStream:
+        def __init__(self, generate):
+            self.gen = generate()
+            self.metadata = None
+
+        def __iter__(self):
+            return self.gen
+
+    def fail_before_output(*_args, **_kwargs):
+        def generate():
+            raise httpx.HTTPStatusError(
+                "maximum context length exceeded",
+                request=httpx.Request("POST", "https://example.test"),
+                response=httpx.Response(400),
+            )
+            yield "unreachable"
+
+        return FakeStream(generate)
+
+    monkeypatch.setattr("gptme.llm._stream", fail_before_output)
+    with pytest.raises(httpx.HTTPStatusError) as before:
+        reply([Message("user", "hi")], "openai/gpt-4", stream=True)
+    assert not did_llm_reply_emit_visible_output(before.value)
+
+    def fail_after_output(*_args, **_kwargs):
+        def generate():
+            yield "visible prefix"
+            raise httpx.HTTPStatusError(
+                "maximum context length exceeded",
+                request=httpx.Request("POST", "https://example.test"),
+                response=httpx.Response(400),
+            )
+
+        return FakeStream(generate)
+
+    monkeypatch.setattr("gptme.llm._stream", fail_after_output)
+    with pytest.raises(httpx.HTTPStatusError) as after:
+        reply([Message("user", "hi")], "openai/gpt-4", stream=True)
+    assert did_llm_reply_emit_visible_output(after.value)
+
+
+def test_headless_stream_error_does_not_mark_buffered_output_visible(monkeypatch):
+    import httpx
+
+    from gptme.llm import did_llm_reply_emit_visible_output, reply
+    from gptme.message import Message
+
+    monkeypatch.setattr("gptme.hooks.trigger_hook", lambda *_a, **_k: iter([]))
+    monkeypatch.setattr("gptme.llm.init_llm", lambda *_a, **_k: None)
+    monkeypatch.setattr("gptme.llm.is_output_quiet", lambda: True)
+
+    class FakeStream:
+        def __init__(self):
+            self.gen = self._generate()
+            self.metadata = None
+
+        def __iter__(self):
+            return self.gen
+
+        @staticmethod
+        def _generate():
+            yield "buffered prefix"
+            raise httpx.HTTPStatusError(
+                "maximum context length exceeded",
+                request=httpx.Request("POST", "https://example.test"),
+                response=httpx.Response(400),
+            )
+
+    monkeypatch.setattr("gptme.llm._stream", lambda *_a, **_k: FakeStream())
+    with pytest.raises(httpx.HTTPStatusError) as error:
+        reply([Message("user", "hi")], "openai/gpt-4", stream=True)
+
+    assert not did_llm_reply_emit_visible_output(error.value)
+
+
 def test_is_provider_error_requires_reply_origin_tag():
     """Untagged SDK/httpx errors (tools, hooks) do not recover; tagged ones do."""
     from unittest.mock import MagicMock

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -242,13 +242,17 @@ def test_is_context_length_error_requires_provider_origin():
     mark_llm_reply_origin(overflow)
     assert is_context_length_error(overflow)
 
-    unrelated = BadRequestError(
+    for message in (
         "max_tokens must be a positive integer",
-        response=response,
-        body={"error": {"code": "invalid_request_error"}},
-    )
-    mark_llm_reply_origin(unrelated)
-    assert not is_context_length_error(unrelated)
+        "input is too long: maximum field length is 1000 characters",
+    ):
+        unrelated = BadRequestError(
+            message,
+            response=response,
+            body={"error": {"code": "invalid_request_error"}},
+        )
+        mark_llm_reply_origin(unrelated)
+        assert not is_context_length_error(unrelated)
 
 
 def test_anthropic_clients_have_sdk_retries_disabled():


### PR DESCRIPTION
## Summary

Phase 0 of gptme/gptme#3812:

- classify provider-origin context-length errors separately from other provider failures
- compact the active conversation into a view and retry the failed generation exactly once
- preserve the lossless master log and skip retry when compaction does not shrink the request
- append `compaction.jsonl` records for manual, budget-triggered, and overflow-triggered compactions

## Scope

This intentionally reuses the existing rule-based compactor. It does **not** introduce the Phase 1 context budget/default-on policy or Phase 2 model-written checkpoint flow.

## Verification

- `181 passed` across `test_llm_retry_policy.py`, `test_chat.py`, `test_auto_compact.py`, and `test_context_providers.py`
- mypy clean on the six touched source modules
- ruff clean
- pre-commit hooks clean
- Bob PR quality gate: 100/100

Refs gptme/gptme#3812