### PR TITLE
fix(config): align CLI model precedence

### DIFF
--- a/gptme/config/cli_setup.py
+++ b/gptme/config/cli_setup.py
@@ -16,7 +16,13 @@ from ..tools._allowlist import (
     expand_tool_allowlist_presets,
 )
 from .chat import ChatConfig
-from .core import Config, get_config, set_config, set_config_from_workspace
+from .core import (
+    Config,
+    ModelSourceKind,
+    get_config,
+    set_config,
+    set_config_from_workspace,
+)
 
 if TYPE_CHECKING:
     from ..tools.base import ToolFormat
@@ -114,7 +120,8 @@ def setup_config_from_cli(
     """
     Initialize and return a complete config from CLI arguments and workspace.
 
-    Handles the precedence: CLI args -> saved conversation config -> env vars -> config files -> defaults
+    Handles the model precedence: CLI args -> saved conversation config ->
+    ``[models].default`` -> ``MODEL`` -> auto-detection.
     """
 
     # Load base config from workspace
@@ -127,18 +134,29 @@ def setup_config_from_cli(
         existing_chat_config = ChatConfig.from_logdir(logdir)
 
     # Resolve configuration values with proper precedence
-    # For resuming: CLI args -> saved conversation config -> env vars/config files
-    # For new conversations: CLI args -> env vars/config files -> defaults
     resolved_model: str | None
+    resolved_model_source: ModelSourceKind | None
     if model is not None:
         # CLI override always takes precedence
         resolved_model = model
+        resolved_model_source = "cli"
     elif existing_chat_config and existing_chat_config.model:
         # When resuming, use saved conversation model unless CLI override provided
         resolved_model = existing_chat_config.model
+        resolved_model_source = "chat_config"
+    elif config.user.models.default:
+        resolved_model = config.user.models.default
+        resolved_model_source = "models.default"
     else:
-        # Fall back to env/config for new conversations or when no saved model
+        # Fall back to the process/project/user MODEL layers, then auto-detection.
         resolved_model = config.get_env("MODEL")
+        resolved_model_source = "MODEL" if resolved_model is not None else None
+
+    config._model_source = (
+        (resolved_model_source, resolved_model)
+        if resolved_model_source is not None and resolved_model is not None
+        else None
+    )
 
     resolved_gear = parse_gear(gear)
     if (

--- a/gptme/config/core.py
+++ b/gptme/config/core.py
@@ -9,6 +9,7 @@ import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -29,6 +30,8 @@ from .user import load_user_config
 
 logger = logging.getLogger(__name__)
 
+ModelSourceKind = Literal["cli", "chat_config", "models.default", "MODEL"]
+
 
 @dataclass()
 class Config:
@@ -42,6 +45,9 @@ class Config:
     user: UserConfig = field(default_factory=load_user_config)
     project: ProjectConfig | None = None
     chat: ChatConfig | None = None
+    # Runtime-only provenance for a model already resolved into chat.model.
+    # The value guard prevents a later explicit model from inheriting stale provenance.
+    _model_source: tuple[ModelSourceKind, str] | None = field(default=None, repr=False)
 
     @classmethod
     def from_workspace(cls, workspace: Path) -> Self:

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -300,8 +300,16 @@ def _record_selection_trace(
     """Create and store a ModelSelectionTrace for this session."""
     from .model_attestation import create_selection_trace, set_selection_trace
 
-    # Infer source kind from the precedence chain.
-    if requested_model is not None:
+    # setup_config_from_cli resolves the model before it reaches init_model, so
+    # keep that runtime-only source when it still describes this exact value.
+    tracked_source = config._model_source
+    if (
+        requested_model is not None
+        and tracked_source is not None
+        and tracked_source[1] == requested_model
+    ):
+        source_kind, source_value = tracked_source
+    elif requested_model is not None:
         source_kind = "cli"
         source_value = requested_model
     elif config.chat and config.chat.model:
@@ -356,7 +364,7 @@ def _record_selection_trace(
     trace = create_selection_trace(
         requested_model=source_value,
         resolved_model=resolved_model,
-        source_kind=source_kind,  # type: ignore[arg-type]
+        source_kind=source_kind,
         source_value=source_value,
         transport_provider=transport_provider,
         backend_provider=backend_provider,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -988,6 +988,73 @@ workspace = "{workspace.as_posix()}"
         )
 
 
+@pytest.mark.parametrize(
+    (
+        "cli_model",
+        "saved_model",
+        "default_model",
+        "expected_model",
+        "expected_source",
+    ),
+    [
+        (
+            "openai/gpt-5",
+            "openrouter/openai/gpt-5-mini",
+            "anthropic/claude-sonnet-4-6",
+            "openai/gpt-5",
+            "cli",
+        ),
+        (
+            None,
+            "openrouter/openai/gpt-5-mini",
+            "anthropic/claude-sonnet-4-6",
+            "openrouter/openai/gpt-5-mini",
+            "chat_config",
+        ),
+        (
+            None,
+            None,
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-sonnet-4-6",
+            "models.default",
+        ),
+        (None, None, None, "xai/grok-4", "MODEL"),
+    ],
+)
+def test_setup_config_model_precedence_and_source(
+    tmp_path,
+    monkeypatch,
+    cli_model,
+    saved_model,
+    default_model,
+    expected_model,
+    expected_source,
+):
+    """CLI, saved, default, and environment models use one precedence chain."""
+    from gptme.config import user as user_mod
+
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        f'[models]\ndefault = "{default_model}"\n' if default_model else "",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(user_mod, "config_path", str(config_file))
+    monkeypatch.setenv("MODEL", "xai/grok-4")
+    monkeypatch.delenv("GPTME_MODEL", raising=False)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    logdir = tmp_path / "conversation"
+    if saved_model:
+        ChatConfig(_logdir=logdir, model=saved_model, workspace=workspace).save()
+
+    config = setup_config_from_cli(workspace=workspace, logdir=logdir, model=cli_model)
+
+    assert config.chat is not None
+    assert config.chat.model == expected_model
+    assert config._model_source == (expected_source, expected_model)
+
+
 def test_reload_config_clears_tools(monkeypatch, tmp_path):
     """Test that reload_config() clears the tools cache so MCP tools are recreated."""
     from unittest.mock import MagicMock

--- a/tests/test_model_attestation.py
+++ b/tests/test_model_attestation.py
@@ -163,6 +163,57 @@ def test_source_kinds():
         assert trace.selection.source.kind == kind
 
 
+def test_record_selection_trace_uses_tracked_config_source():
+    from gptme.init import _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    model = "anthropic/claude-sonnet-4-6"
+    config = _config()
+    config.chat.model = model
+    config._model_source = ("models.default", model)
+
+    _record_selection_trace(
+        config,
+        model,
+        model,
+        model,
+        "anthropic",
+        ModelMeta(provider="anthropic", model="claude-sonnet-4-6", context=200_000),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.source.kind == "models.default"
+    assert trace.selection.source.value == model
+
+
+def test_record_selection_trace_ignores_stale_tracked_source():
+    from gptme.init import _record_selection_trace
+    from gptme.llm.models import ModelMeta
+
+    requested = "openai/gpt-5"
+    config = _config()
+    config.chat.model = requested
+    config._model_source = (
+        "models.default",
+        "anthropic/claude-sonnet-4-6",
+    )
+
+    _record_selection_trace(
+        config,
+        requested,
+        requested,
+        requested,
+        "openai",
+        ModelMeta(provider="openai", model="gpt-5", context=400_000),
+    )
+
+    trace = get_selection_trace()
+    assert trace is not None and trace.selection is not None
+    assert trace.selection.source.kind == "cli"
+    assert trace.selection.source.value == requested
+
+
 def _config() -> MagicMock:
     config = MagicMock()
     config.chat = MagicMock(model=None)


### PR DESCRIPTION
## Summary

Fixes #3814.

- make the CLI/TUI setup path use the documented model precedence: explicit CLI model, saved conversation model, `[models].default`, then `MODEL`
- retain the resolved model's source as runtime-only `(kind, value)` metadata so model selection traces report the real source instead of labelling every pre-resolved value as `cli`
- guard the tracked source by value so a later explicit model change cannot inherit stale provenance
- cover all four precedence levels plus correct and stale trace metadata

The API v2 request model path is already explicit, and ACP's per-project `MODEL` override is an intentional per-workspace behavior, so neither is changed here.

## Validation

- `python -m pytest tests/test_config.py tests/test_init.py tests/test_model_attestation.py -q` — 208 passed, 1 skipped
- focused new regressions — 6 passed
- `ruff check` and `ruff format --check` on all five changed files — passed (Ruff 0.15.2)
- focused Mypy on the three changed source files with missing imports skipped — passed; the complete local Mypy invocation is blocked by unavailable optional dependencies and Windows-only POSIX API diagnostics

Full-suite attempts exposed pre-existing Windows harness limitations: without `PYTHONUTF8=1`, collection stops in `tests/test_reduce.py` on a GBK decode error; with UTF-8 mode, the run progressed into `tests/test_agent.py::test_create_template_mode_e2e` and stalled in its template subprocess. No full-suite pass is claimed.