### PR TITLE
feat(subagent): continue completed child conversations

### DIFF
--- a/gptme/acp/client.py
+++ b/gptme/acp/client.py
@@ -257,6 +257,7 @@ class GptmeAcpClient:
         self._process: Any = None
         self._ctx: Any = None
         self._client_handler: Any = None
+        self.last_session_id: str | None = None
 
     # -- context manager ----------------------------------------------------
 
@@ -347,6 +348,25 @@ class GptmeAcpClient:
         logger.debug("ACP new_session → session_id=%s", resp.session_id)
         return resp.session_id
 
+    async def load_session(
+        self,
+        session_id: str,
+        cwd: str | Path | None = None,
+        mcp_servers: list[Any] | None = None,
+    ) -> Any:
+        """Load a durable ACP session into this client process."""
+        if self._conn is None:
+            raise RuntimeError(
+                "GptmeAcpClient is not connected; use as async context manager"
+            )
+        response = await self._conn.load_session(
+            cwd=str(cwd or self.workspace),
+            session_id=session_id,
+            mcp_servers=mcp_servers or [],
+        )
+        logger.debug("ACP load_session → session_id=%s", session_id)
+        return response
+
     async def prompt(
         self,
         session_id: str,
@@ -415,6 +435,7 @@ class GptmeAcpClient:
         session control.
         """
         session_id = await self.new_session(cwd=cwd)
+        self.last_session_id = session_id
         return await self.prompt(session_id, message)
 
 

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -400,7 +400,7 @@ Key features:
 - subagent_pipeline(items, *stages, timeout): Multi-stage fan-out with no barrier between stages — item A advances to stage 2 while item B is still in stage 1; each stage callable receives (item_prompt, prev_result) and returns the next stage's prompt
 - subagent_batch(): Start multiple subagents and return a BatchJob for explicit synchronization
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
-- subagent_continue(agent_id, message): Continue a finished subagent in its existing conversation/session, preserving its full prior context (thread, subprocess, or ACP).
+- subagent_continue(agent_id, message): Reuse a finished non-isolated child for related follow-up work. Prefer this over spawning a new child when its prior findings or decisions matter: the child keeps its full conversation/session context, avoiding a repeated briefing and improving continuity (thread, subprocess, or ACP).
 - subagent_steer(agent_id, message): Inject a steering message into a RUNNING subagent's conversation — redirect, clarify, or course-correct mid-run without restarting. Works for thread-mode and subprocess-mode subagents. Distinct from subagent_reply() which only works on finished clarification_needed subagents.
 - subagent_wait_any(agent_ids, timeout): Wait for the first of N subagents to complete — returns (agent_id, result). Useful for race/hedging patterns.
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent (for subagents that already stopped with clarification_needed status)

--- a/gptme/tools/subagent/__init__.py
+++ b/gptme/tools/subagent/__init__.py
@@ -16,6 +16,7 @@ from ..base import ToolFunction, ToolSpec, ToolUse
 from .api import (
     subagent,
     subagent_cancel,
+    subagent_continue,
     subagent_list,
     subagent_read_log,
     subagent_reply,
@@ -399,6 +400,7 @@ Key features:
 - subagent_pipeline(items, *stages, timeout): Multi-stage fan-out with no barrier between stages — item A advances to stage 2 while item B is still in stage 1; each stage callable receives (item_prompt, prev_result) and returns the next stage's prompt
 - subagent_batch(): Start multiple subagents and return a BatchJob for explicit synchronization
 - subagent_cancel(): Cancel a running subagent (SIGTERM for subprocess, marks result for threads)
+- subagent_continue(agent_id, message): Continue a finished subagent in its existing conversation/session, preserving its full prior context (thread, subprocess, or ACP).
 - subagent_steer(agent_id, message): Inject a steering message into a RUNNING subagent's conversation — redirect, clarify, or course-correct mid-run without restarting. Works for thread-mode and subprocess-mode subagents. Distinct from subagent_reply() which only works on finished clarification_needed subagents.
 - subagent_wait_any(agent_ids, timeout): Wait for the first of N subagents to complete — returns (agent_id, result). Useful for race/hedging patterns.
 - subagent_reply(agent_id, reply): Answer a clarification request and re-spawn the subagent (for subagents that already stopped with clarification_needed status)
@@ -534,6 +536,7 @@ tool = ToolSpec(
         for f in [
             subagent,
             subagent_cancel,
+            subagent_continue,
             subagent_steer,
             subagent_list,
             subagent_reply,
@@ -571,6 +574,7 @@ __all__ = [
     # Public API
     "subagent",
     "subagent_cancel",
+    "subagent_continue",
     "subagent_steer",
     "subagent_list",
     "subagent_reply",

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -503,6 +503,10 @@ def subagent(
             # Fallback to logdir's parent if cwd doesn't exist
             workspace = logdir.parent
 
+    # Preserve the pre-isolation workspace so clarification replies can recreate
+    # isolation even when the original workspace was not a Git repository.
+    base_workdir = workspace
+
     # Set up worktree isolation if requested
     worktree_path: Path | None = None
     repo_path: Path | None = None
@@ -732,6 +736,7 @@ def subagent(
             execution_mode="acp",
             acp_command=acp_command,
             workdir=workspace,
+            base_workdir=base_workdir,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -859,6 +864,7 @@ def subagent(
             process=None,
             execution_mode="subprocess",
             workdir=workspace,
+            base_workdir=base_workdir,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -1016,6 +1022,7 @@ def subagent(
             process=None,
             execution_mode="thread",
             workdir=workspace,
+            base_workdir=base_workdir,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -1503,6 +1510,7 @@ def subagent_continue(agent_id: str, message: str) -> None:
         acp_command=sa.acp_command,
         acp_session_id=sa.acp_session_id,
         workdir=sa.workdir,
+        base_workdir=sa.base_workdir,
         execution_mode=sa.execution_mode,
         isolated=sa.isolated,
         isolation_mode=sa.isolation_mode,
@@ -1600,9 +1608,9 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             existing for existing in _subagents if existing.agent_id != agent_id
         ]
 
-    # Isolation cleanup removes the child workspace. Re-create a fresh isolated
-    # workspace from the original repo/cwd instead of passing the deleted path.
-    reply_workdir = sa.repo_path if sa.isolated else sa.workdir
+    # Isolation cleanup removes the child workspace. Re-create fresh isolation
+    # from the original workspace instead of passing the deleted child path.
+    reply_workdir = sa.base_workdir if sa.isolated else sa.workdir
 
     # Re-spawn with the same parameters, augmented prompt.
     # On failure, restore the old state so the caller can retry.

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -455,7 +455,7 @@ def subagent(
         _timer = None
         if max_time is not None:
             _timer = threading.Timer(
-                max_time, _timeout_subagent, args=(agent_id, max_time)
+                max_time, _timeout_subagent, args=(agent_id, max_time, sa)
             )
             _timer.daemon = True
             _timer.start()
@@ -579,6 +579,15 @@ def subagent(
                 context_turns,
             )
 
+        def _save_acp_session_id(client: Any) -> None:
+            session_id = getattr(client, "last_session_id", None)
+            if not isinstance(session_id, str):
+                return
+            with _subagents_lock:
+                sa_ref = next((s for s in _subagents if s.agent_id == agent_id), None)
+            if sa_ref is not None:
+                object.__setattr__(sa_ref, "acp_session_id", session_id)
+
         def run_acp_subagent():
             # Bind retry generation at thread birth so test-teardown interrupts
             # abort backoffs even for LLM calls that start after teardown.
@@ -621,45 +630,38 @@ def subagent(
                                 if text:
                                     collected_text.append(text)
 
-                    async with GptmeAcpClient(
+                    client = GptmeAcpClient(
                         workspace=workspace,
                         command=acp_command,
                         auto_confirm=True,
                         on_update=on_update,
-                    ) as client:
-                        result = await client.run(prompt, cwd=workspace)
-                        session_id = getattr(client, "last_session_id", None)
-                        if isinstance(session_id, str):
-                            with _subagents_lock:
-                                sa_ref = next(
-                                    (s for s in _subagents if s.agent_id == agent_id),
-                                    None,
-                                )
-                            if sa_ref is not None:
-                                object.__setattr__(sa_ref, "acp_session_id", session_id)
-                        stop_reason = getattr(result, "stop_reason", "unknown")
-                        result_text = (
-                            "".join(collected_text) if collected_text else None
-                        )
+                    )
+                    try:
+                        async with client:
+                            result = await client.run(prompt, cwd=workspace)
+                    finally:
+                        # run() records the ID immediately after new_session(), so
+                        # retain it even when prompt() or connection teardown fails.
+                        _save_acp_session_id(client)
+                    stop_reason = getattr(result, "stop_reason", "unknown")
+                    result_text = "".join(collected_text) if collected_text else None
 
-                        clarification_result = (
-                            clarification_result_from_content(result_text)
+                    clarification_result = (
+                        clarification_result_from_content(result_text)
+                        if result_text
+                        else None
+                    )
+                    if clarification_result:
+                        status = clarification_result.status
+                        summary = clarification_result.result
+                    else:
+                        status = "success" if stop_reason == "end_turn" else "failure"
+                        summary = (
+                            result_text[:500]
                             if result_text
-                            else None
+                            else f"ACP stop_reason={stop_reason}"
                         )
-                        if clarification_result:
-                            status = clarification_result.status
-                            summary = clarification_result.result
-                        else:
-                            status = (
-                                "success" if stop_reason == "end_turn" else "failure"
-                            )
-                            summary = (
-                                result_text[:500]
-                                if result_text
-                                else f"ACP stop_reason={stop_reason}"
-                            )
-                        return status, summary
+                    return status, summary
 
                 try:
                     status, summary = asyncio.run(_acp_run())
@@ -1034,22 +1036,29 @@ def subagent(
     # The watchdog fires _timeout_subagent() after max_time seconds, which marks
     # a timeout result and delivers a notification via the LOOP_CONTINUE hook.
     if max_time is not None:
-        _timer = threading.Timer(max_time, _timeout_subagent, args=(agent_id, max_time))
+        _timer = threading.Timer(
+            max_time, _timeout_subagent, args=(agent_id, max_time, sa)
+        )
         _timer.daemon = True
         _timer.start()
 
 
-def _timeout_subagent(agent_id: str, max_time: float) -> None:
+def _timeout_subagent(
+    agent_id: str, max_time: float, expected_run: Subagent | None = None
+) -> None:
     """Internal: auto-cancel a subagent that exceeded its max_time wall-clock budget.
 
     Called by the watchdog timer launched in subagent(). Uses set_subagent_result_if_absent
     so a subagent that already completed normally is not affected (the race is handled
-    atomically).
+    atomically). ``expected_run`` prevents a stale timer from timing out a later run that
+    reused the same agent ID.
     """
     with _subagents_lock:
         sa = next((s for s in _subagents if s.agent_id == agent_id), None)
 
-    if sa is None or not sa.is_running():
+    if sa is None or (expected_run is not None and sa is not expected_run):
+        return  # Agent ID now belongs to another run
+    if not sa.is_running():
         return  # Already finished normally before the timer fired
 
     timeout_result = ReturnType(
@@ -1527,7 +1536,9 @@ def subagent_continue(agent_id: str, message: str) -> None:
     start_gate.set()
     if sa.max_time is not None:
         timer = threading.Timer(
-            sa.max_time, _timeout_subagent, args=(agent_id, sa.max_time)
+            sa.max_time,
+            _timeout_subagent,
+            args=(agent_id, sa.max_time, continued),
         )
         timer.daemon = True
         timer.start()
@@ -1589,6 +1600,10 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             existing for existing in _subagents if existing.agent_id != agent_id
         ]
 
+    # Isolation cleanup removes the child workspace. Re-create a fresh isolated
+    # workspace from the original repo/cwd instead of passing the deleted path.
+    reply_workdir = sa.repo_path if sa.isolated else sa.workdir
+
     # Re-spawn with the same parameters, augmented prompt.
     # On failure, restore the old state so the caller can retry.
     try:
@@ -1603,8 +1618,9 @@ def subagent_reply(agent_id: str, reply: str) -> None:
             use_acp=sa.use_acp,
             acp_command=sa.acp_command or "gptme-acp",
             profile=sa.profile,
-            workdir=sa.workdir,
+            workdir=reply_workdir,
             isolated=sa.isolated,
+            isolation=sa.isolation_mode,
             timeout=sa.timeout,
             role=sa.role,
             redact_secrets=sa.redact_secrets,

--- a/gptme/tools/subagent/api.py
+++ b/gptme/tools/subagent/api.py
@@ -628,6 +628,15 @@ def subagent(
                         on_update=on_update,
                     ) as client:
                         result = await client.run(prompt, cwd=workspace)
+                        session_id = getattr(client, "last_session_id", None)
+                        if isinstance(session_id, str):
+                            with _subagents_lock:
+                                sa_ref = next(
+                                    (s for s in _subagents if s.agent_id == agent_id),
+                                    None,
+                                )
+                            if sa_ref is not None:
+                                object.__setattr__(sa_ref, "acp_session_id", session_id)
                         stop_reason = getattr(result, "stop_reason", "unknown")
                         result_text = (
                             "".join(collected_text) if collected_text else None
@@ -720,7 +729,7 @@ def subagent(
             process=None,
             execution_mode="acp",
             acp_command=acp_command,
-            workdir=workdir_path,
+            workdir=workspace,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -847,7 +856,7 @@ def subagent(
             output_schema=output_schema,
             process=None,
             execution_mode="subprocess",
-            workdir=workdir_path,
+            workdir=workspace,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -1004,7 +1013,7 @@ def subagent(
             output_schema=output_schema,
             process=None,
             execution_mode="thread",
-            workdir=workdir_path,
+            workdir=workspace,
             isolated=isolated,
             isolation_mode=isolation,
             worktree_path=worktree_path,
@@ -1291,6 +1300,237 @@ def subagent_steer(agent_id: str, message: str) -> str:
         "It will be injected at the subagent's next STEP_PRE checkpoint "
         "(before the next LLM call in the current agentic turn)."
     )
+
+
+def _collect_acp_update_text(update: Any, chunks: list[str]) -> None:
+    """Append text from an ACP agent-message update to ``chunks``."""
+    if getattr(update, "type", None) != "agent_message_chunk":
+        return
+    chunk = getattr(update, "chunk", None)
+    text = getattr(chunk, "text", None) or (
+        chunk.get("text") if isinstance(chunk, dict) else None
+    )
+    if text:
+        chunks.append(text)
+
+
+def _acp_result(response: Any, chunks: list[str]) -> ReturnType:
+    """Build a subagent result from ACP response metadata and text chunks."""
+    text = "".join(chunks) or None
+    clarification = clarification_result_from_content(text) if text else None
+    if clarification:
+        return clarification
+    if getattr(response, "stop_reason", None) == "end_turn":
+        return ReturnType("success", text)
+    return ReturnType("failure", text)
+
+
+def subagent_continue(agent_id: str, message: str) -> None:
+    """Continue a finished subagent in its existing conversation.
+
+    Thread and subprocess children append the follow-up to their original gptme
+    conversation log. ACP children reload their durable ACP session before the
+    prompt. Isolated children cannot be continued after their workspace cleanup.
+
+    Args:
+        agent_id: The completed subagent to continue.
+        message: Follow-up instruction for the child.
+    """
+    with _subagents_lock:
+        sa = next((s for s in _subagents if s.agent_id == agent_id), None)
+
+    if sa is None:
+        raise ValueError(f"Subagent with ID {agent_id!r} not found.")
+    # Cached timeout/cancel results can coexist with a thread that is still
+    # unwinding. Check the execution primitive directly before allowing a second
+    # writer into the same conversation.
+    if sa.is_running():
+        raise ValueError(
+            f"Subagent '{agent_id}' is still running. Use subagent_steer() instead."
+        )
+    if sa.execution_mode != "acp" and not (sa.logdir / "conversation.jsonl").exists():
+        raise ValueError(f"Subagent '{agent_id}' has no conversation log to continue.")
+    if sa.execution_mode == "acp" and sa.acp_session_id is None:
+        raise ValueError(f"ACP subagent '{agent_id}' has no session ID to continue.")
+    if sa.isolated:
+        raise ValueError(
+            f"Subagent '{agent_id}' used an isolated workspace that was cleaned up "
+            "after completion and cannot be continued."
+        )
+    try:
+        workspace = sa.workdir or Path.cwd()
+    except FileNotFoundError:
+        workspace = sa.logdir.parent
+
+    prompt_queue_closed = threading.Event()
+    start_gate = threading.Event()
+
+    def run_continuation() -> None:
+        bind_thread_generation()
+        # The registry entry is published before cached terminal state is cleared.
+        # Wait until that handoff is complete before producing a new result.
+        start_gate.wait()
+        sem = get_slot_sem()
+        sem.acquire()
+        result: ReturnType
+        completion_notified = False
+        try:
+            try:
+                if sa.execution_mode == "thread":
+                    _exec._create_subagent_thread(
+                        prompt=message,
+                        logdir=sa.logdir,
+                        model=sa.model,
+                        context_mode=sa.context_mode,
+                        context_include=sa.context_include,
+                        workspace=workspace,
+                        target="parent",
+                        output_schema=sa.output_schema,
+                        profile_name=sa.profile,
+                        agent_id=agent_id,
+                        redact_secrets=sa.redact_secrets,
+                        context_window=sa.context_window,
+                        prompt_queue_closed=prompt_queue_closed,
+                        resume=True,
+                    )
+                elif sa.execution_mode == "subprocess":
+                    process = _exec._run_subagent_subprocess(
+                        prompt=message,
+                        logdir=sa.logdir,
+                        model=sa.model,
+                        workspace=workspace,
+                        context_mode=sa.context_mode,
+                        context_include=sa.context_include,
+                        profile=sa.profile,
+                        resume=True,
+                    )
+                    with _subagents_lock:
+                        current = next(
+                            (s for s in _subagents if s.agent_id == agent_id), None
+                        )
+                    if current is None:
+                        raise RuntimeError(
+                            f"Subagent '{agent_id}' disappeared during continuation."
+                        )
+                    object.__setattr__(current, "process", process)
+                    _exec._monitor_subprocess(current)
+                    completion_notified = True
+                elif sa.execution_mode == "acp":
+                    import asyncio
+
+                    assert sa.acp_session_id is not None
+                    acp_session_id = sa.acp_session_id
+
+                    async def continue_acp() -> ReturnType:
+                        from ...acp.client import GptmeAcpClient
+
+                        collected_text: list[str] = []
+
+                        def on_update(_session_id: str, update: Any) -> None:
+                            _collect_acp_update_text(update, collected_text)
+
+                        async with GptmeAcpClient(
+                            workspace=workspace,
+                            command=sa.acp_command or "gptme-acp",
+                            auto_confirm=True,
+                            on_update=on_update,
+                        ) as client:
+                            await client.load_session(acp_session_id, cwd=workspace)
+                            response = await client.prompt(acp_session_id, message)
+                        return _acp_result(response, collected_text)
+
+                    result = asyncio.run(continue_acp())
+                else:
+                    raise ValueError(
+                        f"Unsupported subagent execution mode: {sa.execution_mode!r}"
+                    )
+            except Exception as e:
+                logger.error(f"Subagent {agent_id} continuation failed: {e}")
+                result = ReturnType("failure", str(e))
+            else:
+                if sa.execution_mode == "thread":
+                    with _subagents_lock:
+                        current = next(
+                            (s for s in _subagents if s.agent_id == agent_id), None
+                        )
+                    # This callback is still running on the continuation thread, so
+                    # status() would report "running". Read the completed log directly.
+                    result = (current or sa)._read_log()
+                elif sa.execution_mode == "subprocess":
+                    with _subagent_results_lock:
+                        result = _subagent_results.get(
+                            agent_id,
+                            ReturnType(
+                                "failure",
+                                "Subprocess continuation exited without a result.",
+                            ),
+                        )
+
+            with _subagent_results_lock:
+                _subagent_results[agent_id] = result
+            if not completion_notified:
+                notify_completion(
+                    agent_id,
+                    result.status,
+                    _exec._summarize_result(result, max_chars=200),
+                )
+        finally:
+            prompt_queue_closed.set()
+            release_thread()
+            sem.release()
+
+    thread = threading.Thread(target=run_continuation, daemon=True)
+    continued = Subagent(
+        agent_id=sa.agent_id,
+        prompt=sa.prompt,
+        thread=thread,
+        logdir=sa.logdir,
+        model=sa.model,
+        context_mode=sa.context_mode,
+        context_include=sa.context_include,
+        profile=sa.profile,
+        output_schema=sa.output_schema,
+        use_acp=sa.use_acp,
+        acp_command=sa.acp_command,
+        acp_session_id=sa.acp_session_id,
+        workdir=sa.workdir,
+        execution_mode=sa.execution_mode,
+        isolated=sa.isolated,
+        isolation_mode=sa.isolation_mode,
+        worktree_path=sa.worktree_path,
+        repo_path=sa.repo_path,
+        timeout=sa.timeout,
+        role=sa.role,
+        redact_secrets=sa.redact_secrets,
+        context_window=sa.context_window,
+        max_time=sa.max_time,
+        context_turns=sa.context_turns,
+        parent_logdir=sa.parent_logdir,
+        prompt_queue_closed=prompt_queue_closed,
+    )
+    # Re-check while replacing the registry entry: two callers can otherwise
+    # both observe the same terminal child and launch concurrent writers against
+    # one conversation log.
+    with _subagents_lock:
+        current = next((s for s in _subagents if s.agent_id == agent_id), None)
+        if current is not sa:
+            raise ValueError(
+                f"Subagent '{agent_id}' changed while continuation was starting."
+            )
+        _subagents[:] = [s for s in _subagents if s.agent_id != agent_id]
+        _subagents.append(continued)
+        # Start while holding the registry lock. A concurrent caller will then
+        # observe a live thread instead of the not-yet-started handoff object.
+        thread.start()
+    with _subagent_results_lock:
+        _subagent_results.pop(agent_id, None)
+    start_gate.set()
+    if sa.max_time is not None:
+        timer = threading.Timer(
+            sa.max_time, _timeout_subagent, args=(agent_id, sa.max_time)
+        )
+        timer.daemon = True
+        timer.start()
 
 
 def subagent_reply(agent_id: str, reply: str) -> None:

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -170,6 +170,8 @@ def _create_subagent_thread(
     context_window: int | None = None,
     parent_messages: list[Message] | None = None,
     prompt_queue_closed: threading.Event | None = None,
+    *,
+    resume: bool = False,
 ) -> None:
     """Shared function for running subagent threads.
 
@@ -192,6 +194,8 @@ def _create_subagent_thread(
         prompt_queue_closed: Optional event to set immediately when chat() returns.
             Passed by run_subagent() so the event fires before the caller acquires
             _subagents_lock to find sa — closing the lock+lookup window.
+        resume: Continue the conversation already stored in ``logdir``. When true,
+            skip rebuilding startup context because the existing log owns it.
     """
     # Store agent_id in thread-local so the progress tool can identify this subagent
     if agent_id is not None:
@@ -302,8 +306,11 @@ def _create_subagent_thread(
 
     prompt_msgs = [Message("user", prompt)]
 
-    # Build initial messages based on context_mode and context_window
-    if context_window == 0:
+    # Build initial messages based on context_mode and context_window. Existing
+    # conversations already contain their startup context.
+    if resume:
+        initial_msgs = []
+    elif context_window == 0:
         # Minimal context: just agent identity and tools, no workspace files.
         # This is the context isolation mode requested by the --isolate flag.
         # Note: if context_mode="selective" is also set, context_window=0 takes
@@ -390,43 +397,44 @@ def _create_subagent_thread(
 
         initial_msgs = redact_secrets_from_messages(initial_msgs)
 
-    # Append profile system prompt if specified
-    if profile and profile.system_prompt:
-        profile_msg = Message(
+    if not resume:
+        # Append profile system prompt if specified
+        if profile and profile.system_prompt:
+            profile_msg = Message(
+                "system",
+                f"# Agent Profile: {profile.name}\n\n{profile.system_prompt}",
+            )
+            initial_msgs.append(profile_msg)
+
+        # Load and inject persistent memory for this profile
+        memory_content, memory_dir = _load_agent_memory(profile_name)
+        if memory_dir is not None:
+            memory_msg = _build_memory_system_message(memory_content, memory_dir)
+            initial_msgs.append(memory_msg)
+
+        # Inject parent conversation context if provided
+        # Redact secrets from parent messages to prevent leaking API keys/tokens
+        # that may appear in parent conversation output (e.g., shell output, env reads).
+        if parent_messages:
+            if redact_secrets:
+                from .context import redact_secrets_from_messages
+
+                parent_messages = redact_secrets_from_messages(parent_messages)
+            initial_msgs.append(_build_parent_context_message(parent_messages))
+
+        # Add completion instruction as a system message.
+        # When output_schema is set, the instruction is extended with the expected
+        # JSON schema so the subagent knows the format to use in its complete block.
+        # output_schema is intentionally NOT passed to chat() here — the LLM-level
+        # response_format (structured JSON output) conflicts with markdown tool_format
+        # because the model can't write markdown code blocks while also being forced to
+        # output raw JSON. Schema contract is enforced at the complete-block layer in
+        # Subagent._read_log() instead.
+        complete_instruction = Message(
             "system",
-            f"# Agent Profile: {profile.name}\n\n{profile.system_prompt}",
+            _get_complete_instruction(target, output_schema=output_schema),
         )
-        initial_msgs.append(profile_msg)
-
-    # Load and inject persistent memory for this profile
-    memory_content, memory_dir = _load_agent_memory(profile_name)
-    if memory_dir is not None:
-        memory_msg = _build_memory_system_message(memory_content, memory_dir)
-        initial_msgs.append(memory_msg)
-
-    # Inject parent conversation context if provided
-    # Redact secrets from parent messages to prevent leaking API keys/tokens
-    # that may appear in parent conversation output (e.g., shell output, env reads).
-    if parent_messages:
-        if redact_secrets:
-            from .context import redact_secrets_from_messages
-
-            parent_messages = redact_secrets_from_messages(parent_messages)
-        initial_msgs.append(_build_parent_context_message(parent_messages))
-
-    # Add completion instruction as a system message.
-    # When output_schema is set, the instruction is extended with the expected
-    # JSON schema so the subagent knows the format to use in its complete block.
-    # output_schema is intentionally NOT passed to chat() here — the LLM-level
-    # response_format (structured JSON output) conflicts with markdown tool_format
-    # because the model can't write markdown code blocks while also being forced to
-    # output raw JSON. Schema contract is enforced at the complete-block layer in
-    # Subagent._read_log() instead.
-    complete_instruction = Message(
-        "system",
-        _get_complete_instruction(target, output_schema=output_schema),
-    )
-    initial_msgs.append(complete_instruction)
+        initial_msgs.append(complete_instruction)
 
     # Note: workspace parameter is always passed to chat() (required parameter)
     # Workspace context in messages is controlled by initial_msgs
@@ -486,6 +494,8 @@ def _run_subagent_subprocess(
     output_schema: str | None = None,
     output_schema_dict: dict | None = None,
     profile: str | None = None,
+    *,
+    resume: bool = False,
 ) -> subprocess.Popen:
     """Run a subagent in a subprocess for output isolation.
 
@@ -509,6 +519,7 @@ def _run_subagent_subprocess(
             Injected into the prompt via ``_get_complete_instruction`` rather than
             the CLI flag, because the CLI only accepts ``module:ClassName`` format.
         profile: Agent profile name to apply via --agent-profile flag
+        resume: Continue the conversation already stored in ``logdir``.
 
     Returns:
         The subprocess.Popen object for monitoring
@@ -523,6 +534,9 @@ def _run_subagent_subprocess(
         "--no-confirm",
         f"--name={logdir.name}",  # Just the folder name, not full path
     ]
+
+    if resume:
+        cmd.append("--resume")
 
     if model:
         cmd.extend(["--model", model])
@@ -567,19 +581,21 @@ def _run_subagent_subprocess(
     if output_schema:
         cmd.extend(["--output-schema", output_schema])
 
-    # Load persistent memory and prepend to prompt for subprocess mode
-    memory_content, memory_dir = _load_agent_memory(profile)
-    if memory_dir is not None:
-        memory_section = f"\n\n[Agent Memory - stored at {memory_dir}/MEMORY.md]\n"
-        if memory_content:
-            memory_section += f"{memory_content}\n"
-        else:
-            memory_section += "No memories saved yet.\n"
-        memory_section += (
-            "You can save learnings to your memory by writing to "
-            f"{memory_dir}/MEMORY.md\n"
-        )
-        prompt = prompt + memory_section
+    # The initial run snapshots memory and completion instructions into its log.
+    # Do not duplicate them on every continuation.
+    if not resume:
+        memory_content, memory_dir = _load_agent_memory(profile)
+        if memory_dir is not None:
+            memory_section = f"\n\n[Agent Memory - stored at {memory_dir}/MEMORY.md]\n"
+            if memory_content:
+                memory_section += f"{memory_content}\n"
+            else:
+                memory_section += "No memories saved yet.\n"
+            memory_section += (
+                "You can save learnings to your memory by writing to "
+                f"{memory_dir}/MEMORY.md\n"
+            )
+            prompt = prompt + memory_section
 
     # Progress file for subprocess-mode progress delivery.
     # The subprocess writes JSON lines here; _monitor_subprocess polls and
@@ -591,11 +607,12 @@ def _run_subagent_subprocess(
     # Subprocess mode supports progress via the file channel, so enable it.
     # Pass output_schema_dict (plain-dict callers) so the schema hint is
     # injected here — the CLI --output-schema flag only accepts module:ClassName.
-    complete_section = (
-        "\n\n[Completion Instructions]\n"
-        f"{_get_complete_instruction('orchestrator', supports_progress=True, output_schema=output_schema_dict)}\n"
-    )
-    prompt = prompt + complete_section
+    if not resume:
+        complete_section = (
+            "\n\n[Completion Instructions]\n"
+            f"{_get_complete_instruction('orchestrator', supports_progress=True, output_schema=output_schema_dict)}\n"
+        )
+        prompt = prompt + complete_section
 
     # Pass prompt via stdin (piped from a temp file) instead of as a CLI argument.
     # This avoids ARG_MAX limits for large prompts and keeps argv clean.

--- a/gptme/tools/subagent/execution.py
+++ b/gptme/tools/subagent/execution.py
@@ -1023,6 +1023,10 @@ def _run_planner(
             except FileNotFoundError:
                 workspace = logdir.parent
 
+        # Keep the requested workspace separate from the disposable isolated
+        # workspace so clarification replies can recreate isolation after cleanup.
+        base_workdir = workspace
+
         # Set up worktree isolation if the resolved role requires it
         worktree_path: Path | None = None
         repo_path: Path | None = None
@@ -1074,6 +1078,8 @@ def _run_planner(
                 profile=resolved_profile,
                 process=None,
                 execution_mode="subprocess",
+                workdir=workspace,
+                base_workdir=base_workdir,
                 isolated=resolved_isolated,
                 worktree_path=worktree_path,
                 repo_path=repo_path,
@@ -1158,6 +1164,8 @@ def _run_planner(
                 None,
                 logdir,
                 model,
+                workdir=workspace,
+                base_workdir=base_workdir,
                 isolated=resolved_isolated,
                 worktree_path=worktree_path,
                 repo_path=repo_path,
@@ -1221,6 +1229,8 @@ def _run_planner(
                 context_mode=context_mode,
                 context_include=context_include,
                 profile=resolved_profile,
+                workdir=workspace,
+                base_workdir=base_workdir,
                 isolated=resolved_isolated,
                 worktree_path=worktree_path,
                 repo_path=repo_path,

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -292,9 +292,11 @@ class Subagent:
     acp_command: str | None = None
     # Durable ACP session identifier, used to reload a child in a fresh process.
     acp_session_id: str | None = None
-    # Effective working directory used at spawn time. Stored so continuation and
-    # clarification replies do not depend on the parent's later cwd.
+    # Effective working directory used by the child at spawn time.
     workdir: Path | None = None
+    # Original workspace requested before isolation replaced it with a temporary
+    # directory/worktree. Needed to recreate cleaned isolation for replies.
+    base_workdir: Path | None = None
     # Worktree isolation fields
     isolated: bool = False
     worktree_path: Path | None = None

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -290,8 +290,10 @@ class Subagent:
     execution_mode: Literal["thread", "subprocess", "acp"] = "thread"
     # ACP mode fields
     acp_command: str | None = None
-    # Working directory: the resolved path passed via workdir=; None means cwd at spawn time.
-    # Stored so subagent_reply() can re-spawn in the same directory.
+    # Durable ACP session identifier, used to reload a child in a fresh process.
+    acp_session_id: str | None = None
+    # Effective working directory used at spawn time. Stored so continuation and
+    # clarification replies do not depend on the parent's later cwd.
     workdir: Path | None = None
     # Worktree isolation fields
     isolated: bool = False

--- a/gptme/tools/subagent/types.py
+++ b/gptme/tools/subagent/types.py
@@ -301,7 +301,7 @@ class Subagent:
     repo_path: Path | None = None
     # String isolation mode ("worktree" or None). When set, cleanup uses smart
     # behaviour: auto-remove if unchanged, preserve branch if changes exist.
-    isolation_mode: str | None = None
+    isolation_mode: Literal["worktree"] | None = None
     # Maximum time (seconds) the subprocess monitor will wait before killing
     timeout: int = 1800  # 30 minutes
     role: Role | None = None

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -230,6 +230,18 @@ class TestGptmeAcpClientInterface:
             assert _run(client.run("hello")) == "result"
         assert client.last_session_id == "session-123"
 
+    def test_run_keeps_created_session_id_when_prompt_fails(self, tmp_path):
+        client = self.GptmeAcpClient(workspace=tmp_path)
+        with (
+            patch.object(client, "new_session", AsyncMock(return_value="session-123")),
+            patch.object(
+                client, "prompt", AsyncMock(side_effect=RuntimeError("prompt failed"))
+            ),
+            pytest.raises(RuntimeError, match="prompt failed"),
+        ):
+            _run(client.run("hello"))
+        assert client.last_session_id == "session-123"
+
     def test_missing_command_raises(self, tmp_path):
         """Should raise FileNotFoundError if command isn't on PATH."""
         client = self.GptmeAcpClient(

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -205,6 +205,30 @@ class TestGptmeAcpClientInterface:
         client = self.GptmeAcpClient(workspace=tmp_path)
         with pytest.raises(RuntimeError, match="not connected"):
             _run(client.new_session())
+
+    def test_load_session_without_connect_raises(self, tmp_path):
+        client = self.GptmeAcpClient(workspace=tmp_path)
+        with pytest.raises(RuntimeError, match="not connected"):
+            _run(client.load_session("fake-session"))
+
+    def test_load_session_calls_protocol(self, tmp_path):
+        client = self.GptmeAcpClient(workspace=tmp_path)
+        client._conn = MagicMock()
+        client._conn.load_session = AsyncMock(return_value="loaded")
+
+        assert _run(client.load_session("session-123")) == "loaded"
+        client._conn.load_session.assert_awaited_once_with(
+            cwd=str(tmp_path), session_id="session-123", mcp_servers=[]
+        )
+
+    def test_run_records_created_session_id(self, tmp_path):
+        client = self.GptmeAcpClient(workspace=tmp_path)
+        with (
+            patch.object(client, "new_session", AsyncMock(return_value="session-123")),
+            patch.object(client, "prompt", AsyncMock(return_value="result")),
+        ):
+            assert _run(client.run("hello")) == "result"
+        assert client.last_session_id == "session-123"
 
     def test_missing_command_raises(self, tmp_path):
         """Should raise FileNotFoundError if command isn't on PATH."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2076,6 +2076,7 @@ class TestClarifyBlock:
             isolation_mode="worktree",
             worktree_path=deleted_worktree,
             repo_path=repo_path,
+            base_workdir=repo_path,
         )
         with _subagents_lock:
             _subagents.append(sa)
@@ -2095,6 +2096,57 @@ class TestClarifyBlock:
         assert captured["workdir"] == repo_path
         assert captured["isolated"] is True
         assert captured["isolation"] == "worktree"
+
+    def test_subagent_reply_recreates_non_git_isolation_from_original_workdir(
+        self, tmp_path, monkeypatch
+    ):
+        import importlib
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        original_workdir = tmp_path / "original-non-git-workdir"
+        original_workdir.mkdir()
+        isolated_dir = tmp_path / "isolated-dir"
+        isolated_dir.mkdir()
+
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(
+            "gptme.util.git_worktree.get_git_root", lambda workspace: None
+        )
+        monkeypatch.setattr("tempfile.mkdtemp", lambda **kwargs: str(isolated_dir))
+        monkeypatch.setattr(
+            subagent_execution, "_create_subagent_thread", lambda **kw: None
+        )
+        monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+
+        subagent(
+            "isolated-non-git-clarify",
+            "original task",
+            workdir=original_workdir,
+            isolated=True,
+        )
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "isolated-non-git-clarify")
+        assert sa.thread is not None
+        sa.thread.join(timeout=1)
+        assert sa.workdir == isolated_dir
+        assert sa.base_workdir == original_workdir
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType(
+                "clarification_needed", "Which format?"
+            )
+
+        captured: dict = {}
+        monkeypatch.setattr(
+            subagent_api, "subagent", lambda **kwargs: captured.update(kwargs)
+        )
+        subagent_api.subagent_reply(sa.agent_id, "Use JSON.")
+
+        assert captured["workdir"] == original_workdir
+        assert captured["isolated"] is True
 
     def test_subagent_reply_rejects_excessive_clarifications(self, tmp_path):
         """subagent_reply() must reject after too many clarification rounds."""

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -2097,6 +2097,54 @@ class TestClarifyBlock:
         assert captured["isolated"] is True
         assert captured["isolation"] == "worktree"
 
+    def test_subagent_reply_recreates_planner_executor_isolation_from_workdir(
+        self, tmp_path, monkeypatch
+    ):
+        original_workdir = tmp_path / "planner-workdir"
+        original_workdir.mkdir()
+        isolated_dir = tmp_path / "planner-isolation"
+        isolated_dir.mkdir()
+
+        cli_main = importlib.import_module("gptme.cli.main")
+        git_worktree = importlib.import_module("gptme.util.git_worktree")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(git_worktree, "get_git_root", lambda workspace: None)
+        monkeypatch.setattr("tempfile.mkdtemp", lambda **kwargs: str(isolated_dir))
+        monkeypatch.setattr(
+            subagent_execution,
+            "_run_subagent_subprocess",
+            lambda **kwargs: MagicMock(),
+        )
+        monkeypatch.setattr(subagent_execution, "_monitor_subprocess", lambda sa: None)
+        monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+
+        subagent_execution._run_planner(
+            agent_id="planner",
+            prompt="coordinate",
+            subtasks=[{"id": "verify", "description": "verify it", "role": "verify"}],
+            execution_mode="sequential",
+            workdir=original_workdir,
+        )
+
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "planner-verify")
+        assert sa.workdir == isolated_dir
+        assert sa.base_workdir == original_workdir
+        assert sa.isolated is True
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType(
+                "clarification_needed", "Which format?"
+            )
+
+        captured: dict = {}
+        monkeypatch.setattr(
+            subagent_api, "subagent", lambda **kwargs: captured.update(kwargs)
+        )
+        subagent_api.subagent_reply(sa.agent_id, "Use JSON.")
+
+        assert captured["workdir"] == original_workdir
+        assert captured["isolated"] is True
+
     def test_subagent_reply_recreates_non_git_isolation_from_original_workdir(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1415,6 +1415,319 @@ class TestSubagentCancel:
 
 
 # ---------------------------------------------------------------------------
+# Completed subagent continuation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentContinue:
+    """Tests for resuming a completed child in its existing conversation."""
+
+    def setup_method(self):
+        with _subagents_lock:
+            _subagents.clear()
+        with _subagent_results_lock:
+            _subagent_results.clear()
+
+    def test_rejects_running_agent(self, tmp_path):
+        from gptme.tools.subagent.api import subagent_continue
+
+        thread = MagicMock(spec=threading.Thread)
+        thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="running-agent",
+            prompt="task",
+            thread=thread,
+            logdir=tmp_path,
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        with pytest.raises(ValueError, match="still running"):
+            subagent_continue(sa.agent_id, "follow up")
+
+    def test_rejects_timed_out_thread_that_is_still_unwinding(self, tmp_path):
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "timed-out-log"
+        logdir.mkdir()
+        (logdir / "conversation.jsonl").write_text(
+            '{"role":"assistant","content":"done"}\n'
+        )
+        thread = MagicMock(spec=threading.Thread)
+        thread.is_alive.return_value = True
+        sa = Subagent(
+            agent_id="timed-out-agent",
+            prompt="task",
+            thread=thread,
+            logdir=logdir,
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType("timeout", "timed out")
+
+        with pytest.raises(ValueError, match="still running"):
+            subagent_continue(sa.agent_id, "follow up")
+
+    def test_rejects_concurrent_continuation(self, tmp_path, monkeypatch):
+        from gptme.logmanager import Log
+        from gptme.message import Message
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "concurrent-log"
+        logdir.mkdir()
+        Log([Message("assistant", "```complete\ndone\n```")]).write_jsonl(
+            logdir / "conversation.jsonl"
+        )
+        sa = Subagent(
+            agent_id="concurrent-agent",
+            prompt="task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_continuation(**kwargs):
+            started.set()
+            assert release.wait(timeout=1)
+
+        monkeypatch.setattr(
+            subagent_execution, "_create_subagent_thread", blocking_continuation
+        )
+        subagent_continue(sa.agent_id, "first follow up")
+        assert started.wait(timeout=1)
+        with pytest.raises(ValueError, match="still running"):
+            subagent_continue(sa.agent_id, "second follow up")
+        release.set()
+        with _subagents_lock:
+            continued = next(s for s in _subagents if s.agent_id == sa.agent_id)
+        assert continued.thread is not None
+        continued.thread.join(timeout=1)
+
+    def test_reuses_existing_conversation_log(self, tmp_path, monkeypatch):
+        from gptme.logmanager import Log
+        from gptme.message import Message
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "subagent-log"
+        logdir.mkdir()
+        Log(
+            [
+                Message("user", "Remember that the launch code is ORBIT-41."),
+                Message("assistant", "```complete\nStored the launch code.\n```"),
+            ]
+        ).write_jsonl(logdir / "conversation.jsonl")
+
+        sa = Subagent(
+            agent_id="memory-agent",
+            prompt="Remember the launch code.",
+            thread=None,
+            logdir=logdir,
+            model="openai/gpt-4o-mini",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType("success", "Stored it")
+
+        captured: dict = {}
+
+        def fake_create_subagent_thread(**kwargs):
+            captured.update(kwargs)
+            Log(
+                list(Log.read_jsonl(logdir / "conversation.jsonl"))
+                + [
+                    Message("user", kwargs["prompt"]),
+                    Message("assistant", "```complete\nThe code was ORBIT-41.\n```"),
+                ]
+            ).write_jsonl(logdir / "conversation.jsonl")
+
+        monkeypatch.setattr(
+            subagent_execution, "_create_subagent_thread", fake_create_subagent_thread
+        )
+
+        subagent_continue("memory-agent", "What was the launch code?")
+
+        with _subagents_lock:
+            continued = next(s for s in _subagents if s.agent_id == sa.agent_id)
+        assert continued.thread is not None
+        continued.thread.join(timeout=1)
+        assert not continued.thread.is_alive()
+
+        assert captured["logdir"] == logdir
+        assert captured["prompt"] == "What was the launch code?"
+        assert captured["resume"] is True
+        persisted = Log.read_jsonl(logdir / "conversation.jsonl")
+        assert len(persisted) == 4
+        assert "ORBIT-41" in persisted[-1].content
+        with _subagent_results_lock:
+            assert _subagent_results[sa.agent_id].status == "success"
+
+    def test_rejects_missing_conversation_log(self, tmp_path):
+        from gptme.tools.subagent.api import subagent_continue
+
+        sa = Subagent(
+            agent_id="missing-log-agent",
+            prompt="task",
+            thread=None,
+            logdir=tmp_path,
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType("failure", "no log")
+
+        with pytest.raises(ValueError, match="no conversation log"):
+            subagent_continue(sa.agent_id, "follow up")
+
+    def test_rejects_cleaned_isolated_agent(self, tmp_path):
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "isolated-log"
+        logdir.mkdir()
+        (logdir / "conversation.jsonl").write_text(
+            '{"role":"assistant","content":"done"}\n'
+        )
+        sa = Subagent(
+            agent_id="isolated-agent",
+            prompt="task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+            isolated=True,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        with pytest.raises(ValueError, match="isolated workspace"):
+            subagent_continue(sa.agent_id, "follow up")
+
+    def test_subprocess_reuses_existing_conversation(self, tmp_path, monkeypatch):
+        from gptme.logmanager import Log
+        from gptme.message import Message
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "subprocess-log"
+        logdir.mkdir()
+        Log([Message("assistant", "```complete\nFirst result\n```")]).write_jsonl(
+            logdir / "conversation.jsonl"
+        )
+        sa = Subagent(
+            agent_id="subprocess-agent",
+            prompt="first task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+            execution_mode="subprocess",
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        captured: dict = {}
+        process = MagicMock()
+
+        def fake_run_subprocess(**kwargs):
+            captured.update(kwargs)
+            return process
+
+        def fake_monitor(current):
+            assert current.process is process
+            with _subagent_results_lock:
+                _subagent_results[current.agent_id] = ReturnType(
+                    "success", "Second result"
+                )
+
+        monkeypatch.setattr(
+            subagent_execution, "_run_subagent_subprocess", fake_run_subprocess
+        )
+        monkeypatch.setattr(subagent_execution, "_monitor_subprocess", fake_monitor)
+
+        subagent_continue(sa.agent_id, "follow up")
+        with _subagents_lock:
+            continued = next(s for s in _subagents if s.agent_id == sa.agent_id)
+        assert continued.thread is not None
+        continued.thread.join(timeout=1)
+
+        assert captured["logdir"] == logdir
+        assert captured["resume"] is True
+        assert captured["prompt"] == "follow up"
+
+    def test_acp_reloads_existing_session(self, tmp_path, monkeypatch):
+        from gptme.logmanager import Log
+        from gptme.message import Message
+        from gptme.tools.subagent.api import subagent_continue
+
+        logdir = tmp_path / "acp-log"
+        logdir.mkdir()
+        Log([Message("assistant", "```complete\nFirst result\n```")]).write_jsonl(
+            logdir / "conversation.jsonl"
+        )
+        sa = Subagent(
+            agent_id="acp-agent",
+            prompt="first task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+            use_acp=True,
+            execution_mode="acp",
+            acp_command="fake-acp",
+            acp_session_id="session-123",
+            workdir=tmp_path,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+
+        calls: list[tuple] = []
+
+        class FakeAcpClient:
+            def __init__(self, *args, on_update=None, **kwargs):
+                self.on_update = on_update
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def load_session(self, session_id, cwd=None):
+                calls.append(("load", session_id, cwd))
+
+            async def prompt(self, session_id, message):
+                calls.append(("prompt", session_id, message))
+                chunk = MagicMock(text="Continued result")
+                self.on_update(
+                    session_id,
+                    MagicMock(type="agent_message_chunk", chunk=chunk),
+                )
+                return MagicMock(stop_reason="end_turn")
+
+        import gptme.acp.client as acp_client
+
+        monkeypatch.setattr(acp_client, "GptmeAcpClient", FakeAcpClient)
+        subagent_continue(sa.agent_id, "follow up")
+        with _subagents_lock:
+            continued = next(s for s in _subagents if s.agent_id == sa.agent_id)
+        assert continued.thread is not None
+        continued.thread.join(timeout=1)
+
+        assert calls == [
+            ("load", "session-123", tmp_path),
+            ("prompt", "session-123", "follow up"),
+        ]
+        with _subagent_results_lock:
+            assert _subagent_results[sa.agent_id] == ReturnType(
+                "success", "Continued result"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Clarification mechanism tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_subagent_unit.py
+++ b/tests/test_subagent_unit.py
@@ -1428,6 +1428,42 @@ class TestSubagentContinue:
         with _subagent_results_lock:
             _subagent_results.clear()
 
+    def test_acp_failure_keeps_session_id_for_continuation(self, tmp_path, monkeypatch):
+        cli_main = importlib.import_module("gptme.cli.main")
+        llm_models = importlib.import_module("gptme.llm.models")
+        profiles = importlib.import_module("gptme.profiles")
+        monkeypatch.setattr(cli_main, "get_logdir", lambda name: tmp_path / name)
+        monkeypatch.setattr(llm_models, "get_default_model", lambda: None)
+        monkeypatch.setattr(profiles, "get_profile", lambda _: None)
+        monkeypatch.setattr(subagent_execution, "_cleanup_isolation", lambda sa: None)
+
+        class FailingAcpClient:
+            def __init__(self, *args, **kwargs):
+                self.last_session_id = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def run(self, prompt, cwd=None):
+                self.last_session_id = "session-after-new"
+                raise RuntimeError("prompt failed")
+
+        import gptme.acp.client as acp_client
+
+        monkeypatch.setattr(acp_client, "GptmeAcpClient", FailingAcpClient)
+        subagent("acp-failure", "task", use_acp=True)
+        with _subagents_lock:
+            sa = next(s for s in _subagents if s.agent_id == "acp-failure")
+        assert sa.thread is not None
+        sa.thread.join(timeout=1)
+        assert not sa.thread.is_alive()
+        assert sa.acp_session_id == "session-after-new"
+        with _subagent_results_lock:
+            assert _subagent_results[sa.agent_id].status == "failure"
+
     def test_rejects_running_agent(self, tmp_path):
         from gptme.tools.subagent.api import subagent_continue
 
@@ -1509,6 +1545,47 @@ class TestSubagentContinue:
             continued = next(s for s in _subagents if s.agent_id == sa.agent_id)
         assert continued.thread is not None
         continued.thread.join(timeout=1)
+
+    def test_stale_watchdog_does_not_timeout_continuation(self, tmp_path, monkeypatch):
+        from gptme.tools.subagent.api import _timeout_subagent, subagent_continue
+
+        logdir = tmp_path / "watchdog-log"
+        logdir.mkdir()
+        (logdir / "conversation.jsonl").write_text(
+            '{"role":"assistant","content":"done"}\n'
+        )
+        old_run = Subagent(
+            agent_id="watchdog-agent",
+            prompt="task",
+            thread=None,
+            logdir=logdir,
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(old_run)
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_continuation(**kwargs):
+            started.set()
+            assert release.wait(timeout=1)
+
+        monkeypatch.setattr(
+            subagent_execution, "_create_subagent_thread", blocking_continuation
+        )
+        subagent_continue(old_run.agent_id, "follow up")
+        assert started.wait(timeout=1)
+
+        _timeout_subagent(old_run.agent_id, 30, old_run)
+
+        with _subagent_results_lock:
+            assert old_run.agent_id not in _subagent_results
+        release.set()
+        with _subagents_lock:
+            continued = next(s for s in _subagents if s.agent_id == old_run.agent_id)
+        assert continued.thread is not None
+        continued.thread.join(timeout=1)
+        assert not continued.thread.is_alive()
 
     def test_reuses_existing_conversation_log(self, tmp_path, monkeypatch):
         from gptme.logmanager import Log
@@ -1961,6 +2038,7 @@ class TestClarifyBlock:
             "profile": "custom-reviewer",
             "workdir": None,
             "isolated": True,
+            "isolation": None,
             "timeout": 42,
             "role": "verify",
             "redact_secrets": True,
@@ -1978,6 +2056,45 @@ class TestClarifyBlock:
         assert matching[0].context_include == ["workspace", "tools"]
         assert matching[0].profile == "custom-reviewer"
         assert matching[0].execution_mode == "acp"
+
+    def test_subagent_reply_recreates_cleaned_isolated_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        from gptme.tools.subagent.api import subagent_reply
+
+        deleted_worktree = tmp_path / "removed-worktree"
+        repo_path = tmp_path / "repo"
+        repo_path.mkdir()
+        sa = Subagent(
+            agent_id="isolated-clarify",
+            prompt="original task",
+            thread=None,
+            logdir=tmp_path / "old-log",
+            model=None,
+            workdir=deleted_worktree,
+            isolated=True,
+            isolation_mode="worktree",
+            worktree_path=deleted_worktree,
+            repo_path=repo_path,
+        )
+        with _subagents_lock:
+            _subagents.append(sa)
+        with _subagent_results_lock:
+            _subagent_results[sa.agent_id] = ReturnType(
+                "clarification_needed", "Which format?"
+            )
+        captured: dict = {}
+
+        def fake_subagent(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(subagent_api, "subagent", fake_subagent)
+
+        subagent_reply(sa.agent_id, "Use JSON.")
+
+        assert captured["workdir"] == repo_path
+        assert captured["isolated"] is True
+        assert captured["isolation"] == "worktree"
 
     def test_subagent_reply_rejects_excessive_clarifications(self, tmp_path):
         """subagent_reply() must reject after too many clarification rounds."""
@@ -3176,6 +3293,33 @@ class TestMaxTimeWatchdog:
         assert result.status == "success", (
             "timeout must not overwrite an already-finished result"
         )
+
+    def test_timeout_subagent_noop_for_replaced_run(self, tmp_path):
+        from gptme.tools.subagent.api import _timeout_subagent
+
+        old_run = Subagent(
+            agent_id="reused-agent",
+            prompt="old",
+            thread=None,
+            logdir=tmp_path / "old",
+            model=None,
+        )
+        thread = MagicMock(spec=threading.Thread)
+        thread.is_alive.return_value = True
+        new_run = Subagent(
+            agent_id="reused-agent",
+            prompt="new",
+            thread=thread,
+            logdir=tmp_path / "new",
+            model=None,
+        )
+        with _subagents_lock:
+            _subagents.append(new_run)
+
+        _timeout_subagent("reused-agent", 5.0, old_run)
+
+        with _subagent_results_lock:
+            assert "reused-agent" not in _subagent_results
 
     def test_timeout_subagent_noop_when_not_found(self):
         """_timeout_subagent() is a no-op when the agent_id is unknown."""


### PR DESCRIPTION
## Summary

- add `subagent_continue(agent_id, message)` to resume completed thread, subprocess, and ACP children with their prior context intact
- keep thread/subprocess continuations on the existing conversation log and persist ACP session IDs for protocol-level reload
- reject concurrent and cleaned-isolation continuations rather than risking two writers or a missing workspace

## Verification

- `pytest tests/test_subagent_unit.py tests/test_tools_subagent.py tests/test_acp_client.py -q` (434 passed)
- targeted pre-commit hooks over all changed files
- mypy on the changed subagent/ACP modules

## Scope

This lands phase 1.1 only. Registry rehydration from `meta.json` after a parent restart remains the next phase.
